### PR TITLE
vkd3d: Keep a weak reference to resources in views.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2628,6 +2628,12 @@ static bool vkd3d_descriptor_info_from_d3d12_desc(struct d3d12_device *device,
             if (desc->magic != VKD3D_DESCRIPTOR_MAGIC_SRV)
                 return false;
 
+            if (desc->u.view->weak && !desc->u.view->weak->alive)
+            {
+                WARN("SRV descriptor %p references a dead resource.\n", (const void*)desc);
+                break;
+            }
+
             if ((binding->flags & VKD3D_SHADER_BINDING_FLAG_IMAGE)
                     && (desc->u.view->type == VKD3D_VIEW_TYPE_IMAGE))
             {
@@ -2647,6 +2653,12 @@ static bool vkd3d_descriptor_info_from_d3d12_desc(struct d3d12_device *device,
         case VKD3D_SHADER_DESCRIPTOR_TYPE_UAV:
             if (desc->magic != VKD3D_DESCRIPTOR_MAGIC_UAV)
                 return false;
+
+            if (desc->u.view->weak && !desc->u.view->weak->alive)
+            {
+                WARN("UAV descriptor %p references a dead resource.\n", (const void *) desc);
+                break;
+            }
 
             if ((binding->flags & VKD3D_SHADER_BINDING_FLAG_IMAGE)
                     && (desc->u.view->type == VKD3D_VIEW_TYPE_IMAGE))

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -404,12 +404,20 @@ struct d3d12_heap *unsafe_impl_from_ID3D12Heap(ID3D12Heap *iface) DECLSPEC_HIDDE
 #define VKD3D_RESOURCE_LINEAR_TILING  0x00000010
 #define VKD3D_RESOURCE_PLACED_BUFFER  0x00000020
 
+struct d3d12_resource_weak_reference
+{
+    LONG refcount;
+    bool alive;
+};
+
 /* ID3D12Resource */
 struct d3d12_resource
 {
     ID3D12Resource ID3D12Resource_iface;
     LONG refcount;
     LONG internal_refcount;
+
+    struct d3d12_resource_weak_reference *weak;
 
     D3D12_RESOURCE_DESC desc;
 
@@ -478,7 +486,9 @@ enum vkd3d_view_type
 struct vkd3d_view
 {
     LONG refcount;
+    struct d3d12_resource_weak_reference *weak;
     enum vkd3d_view_type type;
+
     union
     {
         VkBufferView vk_buffer_view;


### PR DESCRIPTION
This way we avoid binding descriptors which resources have since been
freed. This can happen in CopyDescriptors and packed descriptor set
update, which will call vkUpdateDescriptors with a potentially dead
VkImage/VkBuffer backing the VkImageView/VkBufferView in d3d12_desc.

This mostly only affects validation layers now. I haven't seen a GPU crash yet because of this, so not sure if we should merge it, or keep it behind debug only runtime, so making this a draft PR for now.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>