### PR TITLE
meson: generate pkgconfig files, install headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,16 @@ vkd3d_version = vcs_tag(
 dxil_spirv = subproject('dxil-spirv')
 dxil_spirv_dep = dxil_spirv.get_variable('dxil_spirv_dep')
 
+if vkd3d_platform == 'linux'
+  pkg = import('pkgconfig')
+  vkd3d = library('vkd3d')
+  pkg.generate(vkd3d, filebase : 'libvkd3d', subdirs : 'vkd3d', description : 'The VKD3D 3D Graphics Library')
+  vkd3dutils = library('vkd3d-utils')
+  pkg.generate(vkd3dutils, filebase : 'libvkd3d-utils', subdirs : 'vkd3d', description : 'The VKD3D 3D Graphics Utility Library')
+
+  install_headers('include/vkd3d.h', 'include/vkd3d_sonames.h', 'include/vkd3d_types.h', 'include/vkd3d_utils.h', 'include/vkd3d_win32.h', 'include/vkd3d_windows.h', subdir : 'vkd3d')
+endif
+
 subdir('include')
 subdir('libs')
 


### PR DESCRIPTION
Generates `/usr/lib64/pkgconfig/libvkd3d.pc` as:

```
prefix=/usr
libdir=${prefix}/lib64
includedir=${prefix}/include

Name: vkd3d
Description: The VKD3D 3D Graphics Library
Version: 1.1
Libs: -L${libdir} -lvkd3d
Cflags:-I${includedir}/vkd3d
```