### PR TITLE
vkd3d: Fix suspended render pass state tracking.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2322,7 +2322,7 @@ static void d3d12_command_list_end_current_render_pass(struct d3d12_command_list
      * no draw got executed after the clear operation. */
     d3d12_command_list_flush_deferred_clears(list);
 
-    list->render_pass_suspended = suspend && list->current_render_pass;
+    list->render_pass_suspended = suspend && (list->current_render_pass || list->render_pass_suspended);
     list->current_render_pass = VK_NULL_HANDLE;
 
     if (list->xfb_enabled)


### PR DESCRIPTION
Otherwise, if a render pass gets suspended twice in a row, we never emit the barrier because render_pass_suspended will be
set to false the second time. Fixes some validation errors in Hitman 2.