### PR TITLE
More logging improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,7 @@ libvkd3d_shader_la_SOURCES = \
 	libs/vkd3d-shader/vkd3d_shader_private.h
 libvkd3d_shader_la_CFLAGS = $(AM_CFLAGS) @dxil_spirv_c_shared_CFLAGS@
 libvkd3d_shader_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0
-libvkd3d_shader_la_LIBADD = libvkd3d-common.la @dxil_spirv_c_shared_LIBS@
+libvkd3d_shader_la_LIBADD = libvkd3d-common.la @dxil_spirv_c_shared_LIBS@ @PTHREAD_LIBS@
 if HAVE_LD_VERSION_SCRIPT
 libvkd3d_shader_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libs/vkd3d-shader/vkd3d_shader.map
 EXTRA_libvkd3d_shader_la_DEPENDENCIES = $(srcdir)/libs/vkd3d-shader/vkd3d_shader.map

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ commas or semicolons.
    libvkd3d. Accepts the following values: none, err, fixme, warn, trace.
  - `VKD3D_SHADER_DEBUG` - controls the debug level for log messages produced by
    libvkd3d-shader. See `VKD3D_DEBUG` for accepted values.
+ - `VKD3D_LOG_FILE` - If set, redirects `VKD3D_DEBUG` logging output to a file instead.
  - `VKD3D_VULKAN_DEVICE` - a zero-based device index. Use to force the selected
    Vulkan device.
  - `VKD3D_DISABLE_EXTENSIONS` - a list of Vulkan extensions that libvkd3d should

--- a/include/private/vkd3d_threads.h
+++ b/include/private/vkd3d_threads.h
@@ -147,12 +147,30 @@ static inline void vkd3d_set_thread_name(const char *name)
 {
     (void)name;
 }
+
+typedef INIT_ONCE pthread_once_t;
+#define PTHREAD_ONCE_INIT INIT_ONCE_STATIC_INIT
+
+static inline BOOL CALLBACK pthread_once_wrapper(PINIT_ONCE once, PVOID parameter, PVOID *context)
+{
+    (void)once;
+    (void)context;
+    void (*func)(void) = parameter;
+    func();
+    return TRUE;
+}
+
+static inline void pthread_once(pthread_once_t *once, void (*func)(void))
+{
+    InitOnceExecuteOnce(once, pthread_once_wrapper, func, NULL);
+}
 #else
 #include <pthread.h>
 static inline void vkd3d_set_thread_name(const char *name)
 {
     pthread_setname_np(pthread_self(), name);
 }
+#define PTHREAD_ONCE_CALLBACK
 #endif
 
 

--- a/libs/vkd3d-common/debug.c
+++ b/libs/vkd3d-common/debug.c
@@ -90,6 +90,7 @@ void vkd3d_dbg_printf(enum vkd3d_dbg_channel channel, enum vkd3d_dbg_level level
     va_start(args, fmt);
     vfprintf(stderr, fmt, args);
     va_end(args);
+    fflush(stderr);
 }
 
 static char *get_buffer(void)


### PR DESCRIPTION
Various refactors to be able to use pthread_once_t instead of spinlocks, also adds support for logging to a file instead of always logging to stderr.