### PR TITLE
build: Drop minimum meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('vkd3d', ['c'], version : '1.1', meson_version : '>= 0.51', default_options : [
+project('vkd3d', ['c'], version : '1.1', meson_version : '>= 0.49', default_options : [
   'warning_level=2',
 ])
 


### PR DESCRIPTION
Debian 10 ships 0.49.

Signed-off-by: Andrew Eikum <aeikum@codeweavers.com>