### PR TITLE
vkd3d: Implement DiscardResource.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1809,13 +1809,13 @@ static void d3d12_command_list_invalidate_current_pipeline(struct d3d12_command_
 static bool d3d12_command_list_create_framebuffer(struct d3d12_command_list *list, VkRenderPass render_pass,
         uint32_t view_count, const VkImageView *views, VkExtent3D extent, VkFramebuffer *vk_framebuffer);
 
-static D3D12_RECT d3d12_get_view_rect(struct d3d12_resource *resource, struct vkd3d_view *view)
+static D3D12_RECT d3d12_get_image_rect(struct d3d12_resource *resource, unsigned int mip_level)
 {
     D3D12_RECT rect;
     rect.left = 0;
     rect.top = 0;
-    rect.right = d3d12_resource_desc_get_width(&resource->desc, view->info.texture.miplevel_idx);
-    rect.bottom = d3d12_resource_desc_get_height(&resource->desc, view->info.texture.miplevel_idx);
+    rect.right = d3d12_resource_desc_get_width(&resource->desc, mip_level);
+    rect.bottom = d3d12_resource_desc_get_height(&resource->desc, mip_level);
     return rect;
 }
 
@@ -1902,7 +1902,7 @@ static void d3d12_command_list_clear_attachment_inline(struct d3d12_command_list
 
     if (!rect_count)
     {
-        full_rect = d3d12_get_view_rect(resource, view);
+        full_rect = d3d12_get_image_rect(resource, view->info.texture.miplevel_idx);
         rect_count = 1;
         rects = &full_rect;
     }
@@ -5944,7 +5944,7 @@ static void d3d12_command_list_clear_attachment(struct d3d12_command_list *list,
 
     /* If one of the clear rectangles covers the entire image, we
      * may be able to use a fast path and re-initialize the image */
-    full_rect = d3d12_get_view_rect(resource, view);
+    full_rect = d3d12_get_image_rect(resource, view->info.texture.miplevel_idx);
     full_clear = !rect_count;
 
     for (i = 0; i < rect_count && !full_clear; i++)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1209,6 +1209,7 @@ typedef ID3D12GraphicsCommandList5 d3d12_command_list_iface;
 struct vkd3d_clear_attachment
 {
     VkImageAspectFlags aspect_mask;
+    VkImageAspectFlags discard_mask;
     VkClearValue value;
 };
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -514,6 +514,7 @@ static inline VkImageLayout d3d12_resource_pick_layout(const struct d3d12_resour
 
 bool d3d12_resource_is_cpu_accessible(const struct d3d12_resource *resource) DECLSPEC_HIDDEN;
 HRESULT d3d12_resource_validate_desc(const D3D12_RESOURCE_DESC *desc, struct d3d12_device *device) DECLSPEC_HIDDEN;
+VkImageSubresource d3d12_resource_get_vk_subresource(const struct d3d12_resource *resource, uint32_t subresource_idx, bool all_aspects) DECLSPEC_HIDDEN;
 
 HRESULT d3d12_committed_resource_create(struct d3d12_device *device,
         const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags,


### PR DESCRIPTION
Tries to make use of our existing render pass transitions where possible, and otherwise just emits a barrier transitioning away from ``UNDEFINED``.