### PR TITLE
vkd3d-utils: vkd3d-utils needs pthread libraries, otherwise it causes…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,7 +135,7 @@ libvkd3d_utils_la_SOURCES = \
 	libs/vkd3d-utils/vkd3d_utils_main.c \
 	libs/vkd3d-utils/vkd3d_utils_private.h
 libvkd3d_utils_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:1:0
-libvkd3d_utils_la_LIBADD = libvkd3d-common.la libvkd3d.la
+libvkd3d_utils_la_LIBADD = libvkd3d-common.la libvkd3d.la @PTHREAD_LIBS@
 if HAVE_LD_VERSION_SCRIPT
 libvkd3d_utils_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libs/vkd3d-utils/vkd3d_utils.map
 EXTRA_libvkd3d_utils_la_DEPENDENCIES = $(srcdir)/libs/vkd3d-utils/vkd3d_utils.map


### PR DESCRIPTION
… compilation of vkd3d-common to fail

Details:

libtool: link: gcc -shared  -fPIC -DPIC  libs/vkd3d-utils/.libs/vkd3d_utils_main.o  -Wl,--whole-archive ./.libs/libvkd3d-common.a -Wl,--no-whole-archive  -Wl,-rpath -Wl,/home/vagrant/build-Proton-5.12-GE-1/obj-vkd3d32/.libs -Wl,-rpath -Wl,/home/vagrant/build-Proton-5.12-GE-1/obj-tools32/lib -L/home/vagrant/build-Proton-5.12-GE-1/obj-tools32/lib ./.libs/libvkd3d.so -lm  -Wl,--no-undefined -g -O2 -march=nocona -mtune=core-avx2 -mfpmath=sse -Wl,--version-script=/home/vagrant/proton/vkd3d/libs/vkd3d-utils/vkd3d_utils.map   -Wl,-soname -Wl,libvkd3d-utils.so.1 -o .libs/libvkd3d-utils.so.1.0.1

./.libs/libvkd3d-common.a(debug.o): In function `vkd3d_dbg_get_level':
debug.c:(.text+0x16b): undefined reference to `pthread_once'
./.libs/libvkd3d-common.a(debug.o): In function `vkd3d_dbg_printf':
debug.c:(.text+0x1d6): undefined reference to `pthread_once'