### PR TITLE
vkd3d: Implement calibrated timestamps

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -119,6 +119,7 @@ struct vkd3d_vulkan_info
     bool KHR_shader_float16_int8;
     bool KHR_shader_subgroup_extended_types;
     /* EXT device extensions */
+    bool EXT_calibrated_timestamps;
     bool EXT_conditional_rendering;
     bool EXT_custom_border_color;
     bool EXT_depth_clip_enable;
@@ -1646,6 +1647,12 @@ VkImageViewType vkd3d_meta_get_copy_image_view_type(D3D12_RESOURCE_DIMENSION dim
 const struct vkd3d_format *vkd3d_meta_get_copy_image_attachment_format(struct vkd3d_meta_ops *meta_ops,
         const struct vkd3d_format *dst_format, const struct vkd3d_format *src_format) DECLSPEC_HIDDEN;
 
+enum vkd3d_time_domain_flag
+{
+    VKD3D_TIME_DOMAIN_DEVICE = 0x00000001u,
+    VKD3D_TIME_DOMAIN_QPC    = 0x00000002u,
+};
+
 struct vkd3d_physical_device_info
 {
     /* properties */
@@ -1686,6 +1693,9 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features;
 
     VkPhysicalDeviceFeatures2 features2;
+
+    /* others, for extensions that have no feature bits */
+    uint32_t time_domains;  /* vkd3d_time_domain_flag */
 };
 
 struct d3d12_caps

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -196,6 +196,10 @@ VK_DEVICE_EXT_PFN(vkCmdDrawIndexedIndirectCountKHR)
 /* VK_KHR_push_descriptor */
 VK_DEVICE_EXT_PFN(vkCmdPushDescriptorSetKHR)
 
+/* VK_EXT_calibrated_timestamps */
+VK_DEVICE_EXT_PFN(vkGetCalibratedTimestampsEXT)
+VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceCalibrateableTimeDomainsEXT)
+
 /* VK_EXT_conditional_rendering */
 VK_DEVICE_EXT_PFN(vkCmdBeginConditionalRenderingEXT)
 VK_DEVICE_EXT_PFN(vkCmdEndConditionalRenderingEXT)

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -44869,6 +44869,29 @@ static void test_discard_resource(void)
     destroy_test_context(&context);
 }
 
+static void test_clock_calibration(void)
+{
+    uint64_t cpu_times[2], gpu_times[2];
+    struct test_context context;
+    HRESULT hr;
+
+    if (!init_test_context(&context, NULL))
+        return;
+
+    hr = ID3D12CommandQueue_GetClockCalibration(context.queue, &gpu_times[0], &cpu_times[0]);
+    ok(hr == S_OK, "Failed retrieve calibrated timestamps, hr %#x.\n", hr);
+
+    vkd3d_sleep(100);
+
+    hr = ID3D12CommandQueue_GetClockCalibration(context.queue, &gpu_times[1], &cpu_times[1]);
+    ok(hr == S_OK, "Failed retrieve calibrated timestamps, hr %#x.\n", hr);
+
+    ok(gpu_times[1] > gpu_times[0], "Inconsistent GPU timestamps.\n");
+    ok(cpu_times[1] > cpu_times[0], "Inconsistent CPU timestamps.\n");
+
+    destroy_test_context(&context);
+}
+
 START_TEST(d3d12)
 {
     pfn_D3D12CreateDevice = get_d3d12_pfn(D3D12CreateDevice);
@@ -45088,4 +45111,5 @@ START_TEST(d3d12)
     run_test(test_texture_feedback_instructions_dxil);
     run_test(test_aliasing_barrier);
     run_test(test_discard_resource);
+    run_test(test_clock_calibration);
 }

--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -45,6 +45,7 @@
 
 #if !defined(_WIN32)
 #include <dlfcn.h>
+#include <unistd.h>
 #endif
 
 #include "d3d12_test_utils.h"
@@ -107,6 +108,19 @@ static inline void destroy_event(HANDLE event)
 }
 
 #define get_d3d12_pfn(name) (name)
+#endif
+
+#if defined(_WIN32)
+static inline void vkd3d_sleep(unsigned int ms)
+{
+    Sleep(ms);
+}
+
+#else
+static inline void vkd3d_sleep(unsigned int ms)
+{
+    usleep(1000 * ms);
+}
 #endif
 
 typedef void (*thread_main_pfn)(void *data);


### PR DESCRIPTION
Requires QueryPerformanceCounter to work properly, so no support on native Linux builds at the moment.