### PR TITLE
programs: Fix building vkd3d-compiler.

### DIFF
--- a/programs/vkd3d-compiler/meson.build
+++ b/programs/vkd3d-compiler/meson.build
@@ -1,5 +1,5 @@
 executable('vkd3d-compiler', 'main.c', vkd3d_headers,
-  dependencies        : vkd3d_shader_dep,
+  dependencies        : [ vkd3d_shader_dep, threads_dep ],
   include_directories : vkd3d_private_includes,
   install             : true,
   override_options    : [ 'c_std='+vkd3d_c_std ])


### PR DESCRIPTION
pthread_once is required everywhere now, so we have to include the threads dependency.