### PR TITLE
meson: Drop d3d12_invalid_usage target.

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -9,9 +9,3 @@ executable('d3d12', 'd3d12.c', vkd3d_headers,
   include_directories : vkd3d_private_includes,
   install             : true,
   override_options    : [ 'c_std='+vkd3d_c_std ])
-
-executable('d3d12_invalid_usage', 'd3d12_invalid_usage.c', vkd3d_headers,
-  dependencies        : vkd3d_test_deps + [ vkd3d_shader_dep ],
-  include_directories : vkd3d_private_includes,
-  install             : true,
-  override_options    : [ 'c_std='+vkd3d_c_std ])


### PR DESCRIPTION
Doesn't build, and I can't really be arsed to figure out why right now. I don't think we're using this test anyway.