### PR TITLE
build: Use widl from mingw-tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ in order to pull in all the submodules which are needed for building.
 ## Building VKD3D
 
 ### Requirements:
-- [wine](https://www.winehq.org/) (for `widl`)
+- [wine](https://www.winehq.org/) (for `widl`) [for native builds]
   - On Windows this may be substituted for [Strawberry Perl](http://strawberryperl.com/) as it ships `widl` and is easy to find and install -- although this dependency may be eliminated in the future.
 - [Meson](http://mesonbuild.com/) build system (at least version 0.51)
 - [glslang](https://github.com/KhronosGroup/glslang) compiler
-- [Mingw-w64](http://mingw-w64.org/) compiler and headers (at least version 7.0) [for cross-builds for d3d12.dll which are default]
+- [Mingw-w64](http://mingw-w64.org/) compiler, headers and tools (at least version 7.0) [for cross-builds for d3d12.dll which are default]
 
 ### Building:
 #### The simple way

--- a/build-win32.txt
+++ b/build-win32.txt
@@ -3,6 +3,7 @@ c = 'i686-w64-mingw32-gcc'
 cpp = 'i686-w64-mingw32-g++'
 ar = 'i686-w64-mingw32-ar'
 strip = 'i686-w64-mingw32-strip'
+widl = 'i686-w64-mingw32-widl'
 
 [properties]
 c_args=['-msse', '-msse2']

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -3,6 +3,7 @@ c = 'x86_64-w64-mingw32-gcc'
 cpp = 'x86_64-w64-mingw32-g++'
 ar = 'x86_64-w64-mingw32-ar'
 strip = 'x86_64-w64-mingw32-strip'
+widl = 'x86_64-w64-mingw32-widl'
 
 [properties]
 c_link_args = ['-static', '-static-libgcc']


### PR DESCRIPTION
This removes the wine dependency for cross-builds but adds a dependency for mingw-tools instead.

Signed-off-by: Jens Peters <jp7677@gmail.com>