### PR TITLE
build: Use the commit hash as fallback for the built-in version.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,7 +83,7 @@ if cpu_family == 'x86'
 endif
 
 vkd3d_version = vcs_tag(
-  command : ['git', 'describe', '--dirty=+'],
+  command : ['git', 'describe', '--always', '--dirty=+'],
   input   : 'vkd3d_version.c.in',
   output  : 'vkd3d_version.c')
 


### PR DESCRIPTION
The `git describe` command currently fails because there are no tags yet. Using `--always` lets it fall back to the current commit hash.

Signed-off-by: Jens Peters <jp7677@gmail.com>