### PR TITLE
Descriptor rework, Part 1

### DIFF
--- a/include/private/hashmap.h
+++ b/include/private/hashmap.h
@@ -1,0 +1,215 @@
+/*
+ * Hash map support
+ *
+ * Copyright 2020 Philip Rebohle for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef __VKD3D_HASHMAP_H
+#define __VKD3D_HASHMAP_H
+
+#include <stddef.h>
+
+#include "memory.h"
+
+enum hash_map_entry_flag
+{
+    HASH_MAP_ENTRY_OCCUPIED = (1 << 0),
+};
+
+struct hash_map_entry
+{
+    uint32_t hash_value;
+    uint32_t flags;
+};
+
+typedef uint32_t (*pfn_hash_func)(const void* key);
+typedef bool (*pfn_hash_compare_func)(const void *key, const struct hash_map_entry *entry);
+
+/* Open-addressing hash table */
+struct hash_map
+{
+    pfn_hash_func hash_func;
+    pfn_hash_compare_func compare_func;
+    void *entries;
+    size_t entry_size;
+    uint32_t entry_count;
+    uint32_t used_count;
+};
+
+static inline void *hash_map_ptr_offset(void *ptr, size_t offset)
+{
+    return ((char*)ptr) + offset;
+}
+
+static inline struct hash_map_entry *hash_map_get_entry(struct hash_map *hash_map, uint32_t entry_idx)
+{
+    return hash_map_ptr_offset(hash_map->entries, hash_map->entry_size * entry_idx);
+}
+
+static inline uint32_t hash_map_get_entry_idx(struct hash_map *hash_map, uint32_t hash_value)
+{
+    return hash_value % hash_map->entry_count;
+}
+
+static inline uint32_t hash_map_next_entry_idx(struct hash_map *hash_map, uint32_t entry_idx)
+{
+    uint32_t next_idx = entry_idx + 1;
+    return next_idx < hash_map->entry_count ? next_idx : 0;
+}
+
+static inline uint32_t hash_map_next_size(uint32_t old_size)
+{
+    /* This yields a sequence of primes and numbers with two
+     * relatively large prime factors for any reasonable hash
+     * table size */
+    return old_size ? (old_size * 2 + 5) : 37;
+}
+
+static inline bool hash_map_grow(struct hash_map *hash_map)
+{
+    uint32_t i, old_count, new_count;
+    void *new_entries, *old_entries;
+
+    old_count = hash_map->entry_count;
+    old_entries = hash_map->entries;
+
+    new_count = hash_map_next_size(hash_map->entry_count);
+
+    if (!(new_entries = vkd3d_calloc(new_count, hash_map->entry_size)))
+        return false;
+
+    hash_map->entry_count = new_count;
+    hash_map->entries = new_entries;
+
+    for (i = 0; i < old_count; i++)
+    {
+        /* Relocate existing entries one by one */
+        struct hash_map_entry *old_entry = hash_map_ptr_offset(old_entries, i * hash_map->entry_size);
+
+        if (old_entry->flags & HASH_MAP_ENTRY_OCCUPIED)
+        {
+            uint32_t entry_idx = hash_map_get_entry_idx(hash_map, old_entry->hash_value);
+            struct hash_map_entry *new_entry = hash_map_get_entry(hash_map, entry_idx);
+
+            while (new_entry->flags & HASH_MAP_ENTRY_OCCUPIED)
+            {
+                entry_idx = hash_map_next_entry_idx(hash_map, entry_idx);
+                new_entry = hash_map_get_entry(hash_map, entry_idx);
+            }
+
+            memcpy(new_entry, old_entry, hash_map->entry_size);
+        }
+    }
+
+    vkd3d_free(old_entries);
+    return true;
+}
+
+static inline bool hash_map_should_grow_before_insert(struct hash_map *hash_map)
+{
+    /* Allow a load factor of 0.7 for performance reasons */
+    return 10 * hash_map->used_count >= 7 * hash_map->entry_count;
+}
+
+static inline struct hash_map_entry *hash_map_find(struct hash_map *hash_map, const void *key)
+{
+    uint32_t hash_value, entry_idx;
+    
+    if (!hash_map->entries)
+        return NULL;
+
+    hash_value = hash_map->hash_func(key);
+    entry_idx = hash_map_get_entry_idx(hash_map, hash_value);
+
+    /* We never allow the hash table to be completely
+     * populated, so this is guaranteed to return */
+    while (true)
+    {
+        struct hash_map_entry *entry = hash_map_get_entry(hash_map, entry_idx);
+
+        if (!(entry->flags & HASH_MAP_ENTRY_OCCUPIED))
+            return NULL;
+
+        if (entry->hash_value == hash_value && hash_map->compare_func(key, entry))
+            return entry;
+
+        entry_idx = hash_map_next_entry_idx(hash_map, entry_idx);
+    }
+}
+
+static inline struct hash_map_entry *hash_map_insert(struct hash_map *hash_map, const void *key, const struct hash_map_entry *entry)
+{
+    struct hash_map_entry *target = NULL;
+    uint32_t hash_value, entry_idx;
+
+    if (hash_map_should_grow_before_insert(hash_map))
+    {
+        if (!hash_map_grow(hash_map))
+            return NULL;
+    }
+
+    hash_value = hash_map->hash_func(key);
+    entry_idx = hash_map_get_entry_idx(hash_map, hash_value);
+
+    while (!target)
+    {
+        struct hash_map_entry *current = hash_map_get_entry(hash_map, entry_idx);
+
+        if (!(current->flags & HASH_MAP_ENTRY_OCCUPIED) ||
+                (current->hash_value == hash_value && hash_map->compare_func(key, entry)))
+            target = current;
+
+        entry_idx = hash_map_next_entry_idx(hash_map, entry_idx);
+    }
+
+    if (!(target->flags & HASH_MAP_ENTRY_OCCUPIED))
+        hash_map->used_count += 1;
+
+    memcpy(target, entry, hash_map->entry_size);
+    target->flags = HASH_MAP_ENTRY_OCCUPIED;
+    target->hash_value = hash_value;
+    return target;
+}
+
+static inline void hash_map_init(struct hash_map *hash_map, pfn_hash_func hash_func, pfn_hash_compare_func compare_func, size_t entry_size)
+{
+    hash_map->hash_func = hash_func;
+    hash_map->compare_func = compare_func;
+    hash_map->entries = NULL;
+    hash_map->entry_size = entry_size;
+    hash_map->entry_count = 0;
+    hash_map->used_count = 0;
+}
+
+static inline void hash_map_clear(struct hash_map *hash_map)
+{
+    vkd3d_free(hash_map->entries);
+    hash_map->entries = NULL;
+    hash_map->entry_count = 0;
+    hash_map->used_count = 0;
+}
+
+static inline uint32_t hash_combine(uint32_t old_hash, uint32_t new_hash) {
+    return old_hash ^ (new_hash + 0x9e3779b9 + (old_hash << 6) + (old_hash >> 2));
+}
+
+static inline uint32_t hash_uint64(uint64_t n)
+{
+    return hash_combine((uint32_t)n, (uint32_t)(n >> 32));
+}
+
+#endif  /* __VKD3D_HASHMAP_H */

--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -243,4 +243,11 @@ static inline void vkd3d_parse_version(const char *version, int *major, int *min
     *minor = atoi(version);
 }
 
+static inline uint32_t float_bits_to_uint32(float f)
+{
+    uint32_t u;
+    memcpy(&u, &f, sizeof(u));
+    return u;
+}
+
 #endif  /* __VKD3D_COMMON_H */

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5977,7 +5977,6 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
     struct vkd3d_view *base_view, *uint_view;
-    struct vkd3d_texture_view_desc view_desc;
     const struct vkd3d_format *uint_format;
     struct d3d12_resource *resource_impl;
     VkClearColorValue color;
@@ -6005,7 +6004,9 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
 
         if (d3d12_resource_is_texture(resource_impl))
         {
+            struct vkd3d_texture_view_desc view_desc;
             memset(&view_desc, 0, sizeof(view_desc));
+
             view_desc.view_type = base_view->info.texture.vk_view_type;
             view_desc.layout = base_view->info.texture.vk_layout;
             view_desc.format = uint_format;
@@ -6023,8 +6024,13 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
         }
         else
         {
-            if (!vkd3d_create_buffer_view(list->device, resource_impl->vk_buffer, uint_format,
-                    base_view->info.buffer.offset, base_view->info.buffer.size, &uint_view))
+            struct vkd3d_buffer_view_desc view_desc;
+            view_desc.buffer = resource_impl->vk_buffer;
+            view_desc.format = uint_format;
+            view_desc.offset = base_view->info.buffer.offset;
+            view_desc.size = base_view->info.buffer.size;
+
+            if (!vkd3d_create_buffer_view(list->device, &view_desc, &uint_view))
             {
                 ERR("Failed to create buffer view.\n");
                 return;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4046,6 +4046,7 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_GRAPHICS, true);
 
         memset(&dst_view_desc, 0, sizeof(dst_view_desc));
+        dst_view_desc.image = dst_resource->vk_image;
         dst_view_desc.view_type = pipeline_key.view_type;
         dst_view_desc.layout = dst_layout;
         dst_view_desc.format = dst_format;
@@ -4056,6 +4057,7 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         dst_view_desc.allowed_swizzle = false;
 
         memset(&src_view_desc, 0, sizeof(src_view_desc));
+        src_view_desc.image = src_resource->vk_image;
         src_view_desc.view_type = pipeline_key.view_type;
         src_view_desc.layout = src_layout;
         src_view_desc.format = src_format;
@@ -4065,8 +4067,8 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         src_view_desc.layer_count = region->srcSubresource.layerCount;
         src_view_desc.allowed_swizzle = false;
 
-        if (!vkd3d_create_texture_view(list->device, dst_resource->vk_image, &dst_view_desc, &dst_view) ||
-                !vkd3d_create_texture_view(list->device, src_resource->vk_image, &src_view_desc, &src_view))
+        if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view) ||
+                !vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
         {
             ERR("Failed to create image views.\n");
             goto cleanup;
@@ -6007,6 +6009,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
             struct vkd3d_texture_view_desc view_desc;
             memset(&view_desc, 0, sizeof(view_desc));
 
+            view_desc.image = resource_impl->vk_image;
             view_desc.view_type = base_view->info.texture.vk_view_type;
             view_desc.layout = base_view->info.texture.vk_layout;
             view_desc.format = uint_format;
@@ -6016,7 +6019,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
             view_desc.layer_count = base_view->info.texture.layer_count;
             view_desc.allowed_swizzle = false;
 
-            if (!vkd3d_create_texture_view(list->device, resource_impl->vk_image, &view_desc, &uint_view))
+            if (!vkd3d_create_texture_view(list->device, &view_desc, &uint_view))
             {
                 ERR("Failed to create image view.\n");
                 return;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5858,9 +5858,6 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
     d3d12_command_list_invalidate_current_pipeline(list, true);
     d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
 
-    if (!d3d12_command_allocator_add_view(list->allocator, view))
-        WARN("Failed to add view.\n");
-
     clear_args.clear_color = *clear_color;
 
     write_set.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -6043,9 +6040,6 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
 
     d3d12_command_list_clear_uav(list, resource_impl,
       uint_view ? uint_view : base_view, &color, rect_count, rects);
-
-    if (uint_view)
-        vkd3d_view_decref(uint_view, list->device);
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewFloat(d3d12_command_list_iface *iface,

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2220,6 +2220,7 @@ static void d3d12_device_destroy(struct d3d12_device *device)
     vkd3d_private_store_destroy(&device->private_store);
 
     vkd3d_cleanup_format_info(device);
+    vkd3d_view_map_destroy(&device->sampler_map, device);
     vkd3d_meta_ops_cleanup(&device->meta_ops, device);
     vkd3d_bindless_state_cleanup(&device->bindless_state, device);
     vkd3d_destroy_null_resources(&device->null_resources, device);
@@ -4695,6 +4696,9 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     if (FAILED(hr = vkd3d_meta_ops_init(&device->meta_ops, device)))
         goto out_cleanup_bindless_state;
 
+    if (FAILED(hr = vkd3d_view_map_init(&device->sampler_map)))
+        goto out_cleanup_meta_ops;
+
     vkd3d_render_pass_cache_init(&device->render_pass_cache);
     vkd3d_gpu_va_allocator_init(&device->gpu_va_allocator);
 
@@ -4704,6 +4708,8 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     d3d12_device_caps_init(device);
     return S_OK;
 
+out_cleanup_meta_ops:
+    vkd3d_meta_ops_cleanup(&device->meta_ops, device);
 out_cleanup_bindless_state:
     vkd3d_bindless_state_cleanup(&device->bindless_state, device);
 out_destroy_null_resources:

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4634,7 +4634,10 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_set(struct d3d12_descript
     vk_set_info.pNext = &vk_variable_count_info;
     vk_set_info.descriptorPool = descriptor_heap->vk_descriptor_pool;
     vk_set_info.descriptorSetCount = 1;
-    vk_set_info.pSetLayouts = &binding->vk_set_layout;
+    vk_set_info.pSetLayouts = &binding->vk_host_set_layout;
+
+    if (descriptor_heap->desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
+        vk_set_info.pSetLayouts = &binding->vk_set_layout;
 
     if ((vr = VK_CALL(vkAllocateDescriptorSets(device->vk_device, &vk_set_info, vk_descriptor_set))) < 0)
     {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3047,38 +3047,6 @@ static bool vkd3d_create_vk_buffer_view(struct d3d12_device *device,
     return vr == VK_SUCCESS;
 }
 
-static bool vkd3d_create_vk_image_view(struct d3d12_device *device,
-        VkImage vk_image, const struct vkd3d_format *format, VkImageViewType type,
-        VkImageAspectFlags aspect_mask, uint32_t base_mip, uint32_t mip_count,
-        uint32_t base_layer, uint32_t layer_count, VkImageView *vk_view)
-{
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    VkImageViewCreateInfo view_desc;
-    VkResult vr;
-
-    view_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    view_desc.pNext = NULL;
-    view_desc.flags = 0;
-    view_desc.image = vk_image;
-    view_desc.viewType = type;
-    view_desc.format = format->vk_format;
-
-    view_desc.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
-    view_desc.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
-    view_desc.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
-    view_desc.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
-
-    view_desc.subresourceRange.aspectMask = aspect_mask;
-    view_desc.subresourceRange.baseMipLevel = base_mip;
-    view_desc.subresourceRange.levelCount = mip_count;
-    view_desc.subresourceRange.baseArrayLayer = base_layer;
-    view_desc.subresourceRange.layerCount = layer_count;
-
-    if ((vr = VK_CALL(vkCreateImageView(device->vk_device, &view_desc, NULL, vk_view))) < 0)
-        WARN("Failed to create Vulkan image view, vr %d.\n", vr);
-    return vr == VK_SUCCESS;
-}
-
 bool vkd3d_create_buffer_view(struct d3d12_device *device, VkBuffer vk_buffer, const struct vkd3d_format *format,
         VkDeviceSize offset, VkDeviceSize size, struct vkd3d_view **view)
 {
@@ -5372,11 +5340,6 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
     if (FAILED(hr = vkd3d_allocate_image_memory(device, null_resources->vk_2d_image,
             &heap_properties, D3D12_HEAP_FLAG_NONE, &null_resources->vk_2d_image_memory, NULL, NULL)))
         goto fail;
-    if (!vkd3d_create_vk_image_view(device, null_resources->vk_2d_image,
-            vkd3d_get_format(device, resource_desc.Format, false), VK_IMAGE_VIEW_TYPE_2D,
-            VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
-            &null_resources->vk_2d_image_view))
-        goto fail;
 
     /* 2D UAV */
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
@@ -5398,11 +5361,6 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
     if (!use_sparse_resources && FAILED(hr = vkd3d_allocate_image_memory(device, null_resources->vk_2d_storage_image,
             &heap_properties, D3D12_HEAP_FLAG_NONE, &null_resources->vk_2d_storage_image_memory, NULL, NULL)))
         goto fail;
-    if (!vkd3d_create_vk_image_view(device, null_resources->vk_2d_storage_image,
-            vkd3d_get_format(device, resource_desc.Format, false), VK_IMAGE_VIEW_TYPE_2D,
-            VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
-            &null_resources->vk_2d_storage_image_view))
-        goto fail;
 
     /* set Vulkan object names */
     vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_buffer,
@@ -5417,14 +5375,10 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
             VK_OBJECT_TYPE_BUFFER_VIEW, "NULL UAV buffer view");
     vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_2d_image,
             VK_OBJECT_TYPE_IMAGE, "NULL 2D SRV image");
-    vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_2d_image_view,
-            VK_OBJECT_TYPE_IMAGE_VIEW, "NULL 2D SRV image view");
     vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_2d_image_memory,
             VK_OBJECT_TYPE_DEVICE_MEMORY, "NULL 2D SRV memory");
     vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_2d_storage_image,
             VK_OBJECT_TYPE_IMAGE, "NULL 2D UAV image");
-    vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_2d_storage_image_view,
-            VK_OBJECT_TYPE_IMAGE_VIEW, "NULL 2D UAV image view");
     if (!use_sparse_resources)
     {
         vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_storage_buffer_memory,
@@ -5454,11 +5408,9 @@ void vkd3d_destroy_null_resources(struct vkd3d_null_resources *null_resources,
     VK_CALL(vkDestroyBuffer(device->vk_device, null_resources->vk_storage_buffer, NULL));
     VK_CALL(vkFreeMemory(device->vk_device, null_resources->vk_storage_buffer_memory, NULL));
 
-    VK_CALL(vkDestroyImageView(device->vk_device, null_resources->vk_2d_image_view, NULL));
     VK_CALL(vkDestroyImage(device->vk_device, null_resources->vk_2d_image, NULL));
     VK_CALL(vkFreeMemory(device->vk_device, null_resources->vk_2d_image_memory, NULL));
 
-    VK_CALL(vkDestroyImageView(device->vk_device, null_resources->vk_2d_storage_image_view, NULL));
     VK_CALL(vkDestroyImage(device->vk_device, null_resources->vk_2d_storage_image, NULL));
     VK_CALL(vkFreeMemory(device->vk_device, null_resources->vk_2d_storage_image_memory, NULL));
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4410,6 +4410,7 @@ static HRESULT d3d12_create_sampler(struct d3d12_device *device,
 void d3d12_desc_create_sampler(struct d3d12_desc *sampler,
         struct d3d12_device *device, const D3D12_SAMPLER_DESC *desc)
 {
+    struct vkd3d_view_key key;
     struct vkd3d_view *view;
 
     if (!desc)
@@ -4418,14 +4419,11 @@ void d3d12_desc_create_sampler(struct d3d12_desc *sampler,
         return;
     }
 
-    if (!(view = vkd3d_view_create(VKD3D_VIEW_TYPE_SAMPLER)))
-        return;
+    key.view_type = VKD3D_VIEW_TYPE_SAMPLER;
+    key.u.sampler = *desc;
 
-    if (FAILED(d3d12_create_sampler(device, desc, &view->vk_sampler)))
-    {
-        vkd3d_free(view);
+    if (!(view = vkd3d_view_map_create_view(&device->sampler_map, device, &key)))
         return;
-    }
 
     sampler->magic = VKD3D_DESCRIPTOR_MAGIC_SAMPLER;
     sampler->vk_descriptor_type = VK_DESCRIPTOR_TYPE_SAMPLER;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5665,6 +5665,9 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
                 VK_OBJECT_TYPE_DEVICE_MEMORY, "NULL 2D UAV memory");
     }
 
+    if (FAILED(hr = vkd3d_view_map_init(&null_resources->view_map)))
+        return hr;
+
     return vkd3d_init_null_resources_data(null_resources, device);
 
 fail:
@@ -5677,6 +5680,8 @@ void vkd3d_destroy_null_resources(struct vkd3d_null_resources *null_resources,
         struct d3d12_device *device)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+
+    vkd3d_view_map_destroy(&null_resources->view_map, device);
 
     VK_CALL(vkDestroyBufferView(device->vk_device, null_resources->vk_buffer_view, NULL));
     VK_CALL(vkDestroyBuffer(device->vk_device, null_resources->vk_buffer, NULL));

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -632,7 +632,6 @@ struct d3d12_desc
 {
     struct d3d12_descriptor_heap *heap;
     uint32_t heap_offset;
-    spinlock_t spinlock;
     uint32_t magic;
     VkDescriptorType vk_descriptor_type;
     struct vkd3d_descriptor_data metadata;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1459,6 +1459,8 @@ struct vkd3d_null_resources
 
     VkImage vk_2d_storage_image;
     VkDeviceMemory vk_2d_storage_image_memory;
+
+    struct vkd3d_view_map view_map;
 };
 
 HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1776,6 +1776,7 @@ struct d3d12_device
     struct vkd3d_bindless_state bindless_state;
     struct vkd3d_memory_info memory_info;
     struct vkd3d_meta_ops meta_ops;
+    struct vkd3d_view_map sampler_map;
 };
 
 HRESULT d3d12_device_create(struct vkd3d_instance *instance,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -588,6 +588,7 @@ struct vkd3d_buffer_view_desc
 
 struct vkd3d_texture_view_desc
 {
+    VkImage image;
     VkImageViewType view_type;
     VkImageLayout layout;
     const struct vkd3d_format *format;
@@ -601,7 +602,7 @@ struct vkd3d_texture_view_desc
 
 bool vkd3d_create_buffer_view(struct d3d12_device *device,
         const struct vkd3d_buffer_view_desc *desc, struct vkd3d_view **view) DECLSPEC_HIDDEN;
-bool vkd3d_create_texture_view(struct d3d12_device *device, VkImage vk_image,
+bool vkd3d_create_texture_view(struct d3d12_device *device,
         const struct vkd3d_texture_view_desc *desc, struct vkd3d_view **view) DECLSPEC_HIDDEN;
 
 enum vkd3d_descriptor_flag

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1465,6 +1465,7 @@ struct vkd3d_bindless_set_info
     enum vkd3d_shader_binding_flag binding_flag;
 
     VkDescriptorSetLayout vk_set_layout;
+    VkDescriptorSetLayout vk_host_set_layout;
 };
 
 struct vkd3d_bindless_state

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -578,6 +578,14 @@ struct vkd3d_view
 void vkd3d_view_decref(struct vkd3d_view *view, struct d3d12_device *device) DECLSPEC_HIDDEN;
 void vkd3d_view_incref(struct vkd3d_view *view) DECLSPEC_HIDDEN;
 
+struct vkd3d_buffer_view_desc
+{
+    VkBuffer buffer;
+    const struct vkd3d_format *format;
+    VkDeviceSize offset;
+    VkDeviceSize size;
+};
+
 struct vkd3d_texture_view_desc
 {
     VkImageViewType view_type;
@@ -591,8 +599,8 @@ struct vkd3d_texture_view_desc
     bool allowed_swizzle;
 };
 
-bool vkd3d_create_buffer_view(struct d3d12_device *device, VkBuffer vk_buffer, const struct vkd3d_format *format,
-        VkDeviceSize offset, VkDeviceSize size, struct vkd3d_view **view) DECLSPEC_HIDDEN;
+bool vkd3d_create_buffer_view(struct d3d12_device *device,
+        const struct vkd3d_buffer_view_desc *desc, struct vkd3d_view **view) DECLSPEC_HIDDEN;
 bool vkd3d_create_texture_view(struct d3d12_device *device, VkImage vk_image,
         const struct vkd3d_texture_view_desc *desc, struct vkd3d_view **view) DECLSPEC_HIDDEN;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -596,6 +596,18 @@ bool vkd3d_create_buffer_view(struct d3d12_device *device, VkBuffer vk_buffer, c
 bool vkd3d_create_texture_view(struct d3d12_device *device, VkImage vk_image,
         const struct vkd3d_texture_view_desc *desc, struct vkd3d_view **view) DECLSPEC_HIDDEN;
 
+enum vkd3d_descriptor_flag
+{
+    VKD3D_DESCRIPTOR_FLAG_DEFINED     = (1 << 0),
+    VKD3D_DESCRIPTOR_FLAG_UAV_COUNTER = (1 << 1),
+};
+
+struct vkd3d_descriptor_data
+{
+    uint32_t set_index;
+    uint32_t flags;
+};
+
 struct d3d12_desc
 {
     struct d3d12_descriptor_heap *heap;
@@ -603,6 +615,7 @@ struct d3d12_desc
     spinlock_t spinlock;
     uint32_t magic;
     VkDescriptorType vk_descriptor_type;
+    struct vkd3d_descriptor_data metadata;
     union
     {
         VkDescriptorBufferInfo vk_cbv_info;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1422,11 +1422,9 @@ struct vkd3d_null_resources
     VkDeviceMemory vk_storage_buffer_memory;
 
     VkImage vk_2d_image;
-    VkImageView vk_2d_image_view;
     VkDeviceMemory vk_2d_image_memory;
 
     VkImage vk_2d_storage_image;
-    VkImageView vk_2d_storage_image_view;
     VkDeviceMemory vk_2d_storage_image_memory;
 };
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -25,6 +25,7 @@
 #include "vkd3d_common.h"
 #include "vkd3d_memory.h"
 #include "vkd3d_utf8.h"
+#include "hashmap.h"
 #include "list.h"
 #include "rbtree.h"
 
@@ -464,6 +465,15 @@ struct d3d12_sparse_info
     VkDeviceMemory vk_metadata_memory;
 };
 
+struct vkd3d_view_map
+{
+    pthread_mutex_t mutex;
+    struct hash_map map;
+};
+
+HRESULT vkd3d_view_map_init(struct vkd3d_view_map *view_map) DECLSPEC_HIDDEN;
+void vkd3d_view_map_destroy(struct vkd3d_view_map *view_map, struct d3d12_device *device) DECLSPEC_HIDDEN;
+
 /* ID3D12Resource */
 typedef ID3D12Resource1 d3d12_resource_iface;
 
@@ -491,6 +501,7 @@ struct d3d12_resource
     D3D12_RESOURCE_STATES present_state;
 
     struct d3d12_sparse_info sparse;
+    struct vkd3d_view_map view_map;
 
     struct d3d12_device *device;
 


### PR DESCRIPTION
- Eliminates reference counting views as well as the per-descriptor spin lock, which speeds up descriptor copies by a factor of 5 on RADV according to the microbenchmark.
- Views are now stored in an open addresing hash map as part of the resource they are created from.
- Non-static samplers are now stored globally per device, this also avoids duplicates.

Tested with Shadow of the Tomb Raider, Death Stranding, Control, Monster Hunter World.

Part 2 is going to refactor the actual Vulkan descriptor updates so that we can trim down the `d3d12_desc` struct, which may reduce overhead a bit further.