### PR TITLE
Static sampler rework

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5173,13 +5173,8 @@ static void d3d12_command_list_set_root_signature(struct d3d12_command_list *lis
     bindings->root_signature = root_signature;
     bindings->static_sampler_set = VK_NULL_HANDLE;
 
-    if (root_signature && root_signature->vk_sampler_descriptor_layout)
-    {
-        /* FIXME allocate static sampler sets globally */
-        bindings->static_sampler_set = d3d12_command_allocator_allocate_descriptor_set(
-                list->allocator, root_signature->vk_sampler_descriptor_layout,
-                VKD3D_DESCRIPTOR_POOL_TYPE_IMMUTABLE_SAMPLER);
-    }
+    if (root_signature && root_signature->vk_sampler_set)
+        bindings->static_sampler_set = root_signature->vk_sampler_set;
 
     d3d12_command_list_invalidate_root_parameters(list, bind_point, true);
 }

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1249,10 +1249,7 @@ static VkDescriptorPool d3d12_command_allocator_allocate_descriptor_pool(
 {
     static const VkDescriptorPoolSize pool_sizes[] =
     {
-        /* Must be first in the array. */
-        /* Need at least 2048 so we can allocate an immutable sampler set. */
         {VK_DESCRIPTOR_TYPE_SAMPLER, 2048},
-
         {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1024},
         {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1024},
         {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1024},
@@ -1289,12 +1286,7 @@ static VkDescriptorPool d3d12_command_allocator_allocate_descriptor_pool(
         pool_desc.poolSizeCount = ARRAY_SIZE(pool_sizes);
         pool_desc.pPoolSizes = pool_sizes;
 
-        if (pool_type == VKD3D_DESCRIPTOR_POOL_TYPE_IMMUTABLE_SAMPLER)
-        {
-            /* Only allocate for samplers. */
-            pool_desc.poolSizeCount = 1;
-        }
-        else if (!device->vk_info.EXT_inline_uniform_block ||
+        if (!device->vk_info.EXT_inline_uniform_block ||
                 device->vk_info.device_limits.maxPushConstantsSize >= (D3D12_MAX_ROOT_COST * sizeof(uint32_t)))
         {
             pool_desc.pNext = NULL;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2229,6 +2229,7 @@ static void d3d12_device_destroy(struct d3d12_device *device)
     vkd3d_private_store_destroy(&device->private_store);
 
     vkd3d_cleanup_format_info(device);
+    vkd3d_sampler_state_cleanup(&device->sampler_state, device);
     vkd3d_view_map_destroy(&device->sampler_map, device);
     vkd3d_meta_ops_cleanup(&device->meta_ops, device);
     vkd3d_bindless_state_cleanup(&device->bindless_state, device);
@@ -4767,6 +4768,9 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     if (FAILED(hr = vkd3d_view_map_init(&device->sampler_map)))
         goto out_cleanup_meta_ops;
 
+    if (FAILED(hr = vkd3d_sampler_state_init(&device->sampler_state, device)))
+        goto out_cleanup_view_map;
+
     vkd3d_render_pass_cache_init(&device->render_pass_cache);
     vkd3d_gpu_va_allocator_init(&device->gpu_va_allocator);
 
@@ -4776,6 +4780,8 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     d3d12_device_caps_init(device);
     return S_OK;
 
+out_cleanup_view_map:
+    vkd3d_view_map_destroy(&device->sampler_map, device);
 out_cleanup_meta_ops:
     vkd3d_meta_ops_cleanup(&device->meta_ops, device);
 out_cleanup_bindless_state:

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -62,14 +62,10 @@ static void d3d12_root_signature_cleanup(struct d3d12_root_signature *root_signa
         struct d3d12_device *device)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    unsigned int i;
 
     VK_CALL(vkDestroyPipelineLayout(device->vk_device, root_signature->vk_pipeline_layout, NULL));
     VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, root_signature->vk_sampler_descriptor_layout, NULL));
     VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, root_signature->vk_root_descriptor_layout, NULL));
-
-    for (i = 0; i < root_signature->static_sampler_count; ++i)
-        VK_CALL(vkDestroySampler(device->vk_device, root_signature->static_samplers[i], NULL));
 
     vkd3d_free(root_signature->parameters);
     vkd3d_free(root_signature->bindings);
@@ -695,7 +691,8 @@ static HRESULT d3d12_root_signature_init_static_samplers(struct d3d12_root_signa
     {
         const D3D12_STATIC_SAMPLER_DESC *s = &desc->pStaticSamplers[i];
 
-        if (FAILED(hr = d3d12_create_static_sampler(root_signature->device, s, &root_signature->static_samplers[i])))
+        if (FAILED(hr = vkd3d_sampler_state_create_static_sampler(&root_signature->device->sampler_state,
+                root_signature->device, s, &root_signature->static_samplers[i])))
             goto cleanup;
 
         vk_binding = &vk_binding_info[i];

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -864,6 +864,9 @@ struct d3d12_root_signature
     VkDescriptorSetLayout vk_sampler_descriptor_layout;
     VkDescriptorSetLayout vk_root_descriptor_layout;
 
+    VkDescriptorPool vk_sampler_pool;
+    VkDescriptorSet vk_sampler_set;
+
     struct d3d12_root_parameter *parameters;
     unsigned int parameter_count;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1107,7 +1107,6 @@ struct d3d12_descriptor_pool_cache
 enum vkd3d_descriptor_pool_types
 {
     VKD3D_DESCRIPTOR_POOL_TYPE_STATIC = 0,
-    VKD3D_DESCRIPTOR_POOL_TYPE_IMMUTABLE_SAMPLER,
     VKD3D_DESCRIPTOR_POOL_TYPE_COUNT
 };
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1445,6 +1445,20 @@ HRESULT d3d12_command_signature_create(struct d3d12_device *device, const D3D12_
         struct d3d12_command_signature **signature) DECLSPEC_HIDDEN;
 struct d3d12_command_signature *unsafe_impl_from_ID3D12CommandSignature(ID3D12CommandSignature *iface) DECLSPEC_HIDDEN;
 
+/* Static samplers */
+struct vkd3d_sampler_state
+{
+    pthread_mutex_t mutex;
+    struct hash_map map;
+};
+
+HRESULT vkd3d_sampler_state_init(struct vkd3d_sampler_state *state,
+        struct d3d12_device *device) DECLSPEC_HIDDEN;
+void vkd3d_sampler_state_cleanup(struct vkd3d_sampler_state *state,
+        struct d3d12_device *device) DECLSPEC_HIDDEN;
+HRESULT vkd3d_sampler_state_create_static_sampler(struct vkd3d_sampler_state *state,
+        struct d3d12_device *device, const D3D12_STATIC_SAMPLER_DESC *desc, VkSampler *vk_sampler) DECLSPEC_HIDDEN;
+
 /* NULL resources */
 struct vkd3d_null_resources
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1794,6 +1794,7 @@ struct d3d12_device
     struct vkd3d_memory_info memory_info;
     struct vkd3d_meta_ops meta_ops;
     struct vkd3d_view_map sampler_map;
+    struct vkd3d_sampler_state sampler_state;
 };
 
 HRESULT d3d12_device_create(struct vkd3d_instance *instance,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1450,6 +1450,10 @@ struct vkd3d_sampler_state
 {
     pthread_mutex_t mutex;
     struct hash_map map;
+
+    VkDescriptorPool *vk_descriptor_pools;
+    size_t vk_descriptor_pools_size;
+    size_t vk_descriptor_pool_count;
 };
 
 HRESULT vkd3d_sampler_state_init(struct vkd3d_sampler_state *state,
@@ -1458,6 +1462,11 @@ void vkd3d_sampler_state_cleanup(struct vkd3d_sampler_state *state,
         struct d3d12_device *device) DECLSPEC_HIDDEN;
 HRESULT vkd3d_sampler_state_create_static_sampler(struct vkd3d_sampler_state *state,
         struct d3d12_device *device, const D3D12_STATIC_SAMPLER_DESC *desc, VkSampler *vk_sampler) DECLSPEC_HIDDEN;
+HRESULT vkd3d_sampler_state_allocate_descriptor_set(struct vkd3d_sampler_state *state,
+        struct d3d12_device *device, VkDescriptorSetLayout vk_layout, VkDescriptorSet *vk_set,
+        VkDescriptorPool *vk_pool) DECLSPEC_HIDDEN;
+void vkd3d_sampler_state_free_descriptor_set(struct vkd3d_sampler_state *state,
+        struct d3d12_device *device, VkDescriptorSet vk_set, VkDescriptorPool vk_pool) DECLSPEC_HIDDEN;
 
 /* NULL resources */
 struct vkd3d_null_resources


### PR DESCRIPTION
Deduplicates static samplers and uses a global descriptor pool for the static sampler sets used in root signatures, so we don't have to allocate them at bind time.