### PR TITLE
vkd3d: Never attempt to use PCI-pinned memory types.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1549,6 +1549,7 @@ struct vkd3d_format_compatibility_list
 
 struct vkd3d_memory_info
 {
+    uint32_t global_mask;
     uint32_t buffer_type_mask;
     uint32_t sampled_type_mask;
     uint32_t rt_ds_type_mask;


### PR DESCRIPTION
These memory types might end up being used as fallback memory types,
which is problematic due to their tiny sizes, and unexpected performance
behavior. Generally, when we want to fallback, we should cleanly fall
back to system memory rather than a different device local type.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>