### PR TITLE
Implement WriteBufferImmediate

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6645,20 +6645,64 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetViewInstanceMask(d3d12_comma
     FIXME("iface %p, mask %#x stub!\n", iface, mask);
 }
 
+static bool vk_pipeline_stage_from_wbi_mode(D3D12_WRITEBUFFERIMMEDIATE_MODE mode, VkPipelineStageFlagBits *stage)
+{
+    switch (mode)
+    {
+        /* It is not entirely clear what DEFAULT is supposed
+         * to do exactly, so treat it the same way as IN */
+        case D3D12_WRITEBUFFERIMMEDIATE_MODE_DEFAULT:
+        case D3D12_WRITEBUFFERIMMEDIATE_MODE_MARKER_IN:
+            *stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+            return true;
+
+        case D3D12_WRITEBUFFERIMMEDIATE_MODE_MARKER_OUT:
+            *stage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+            return true;
+
+        default:
+            return false;
+    }
+}
+
 static void STDMETHODCALLTYPE d3d12_command_list_WriteBufferImmediate(d3d12_command_list_iface *iface,
         UINT count, const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER *parameters,
         const D3D12_WRITEBUFFERIMMEDIATE_MODE *modes)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    VkPipelineStageFlagBits stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     struct d3d12_resource *resource;
+    VkDeviceSize offset;
     unsigned int i;
 
-    FIXME("iface %p, count %u, parameters %p, modes %p stub!\n", iface, count, parameters, modes);
+    TRACE("iface %p, count %u, parameters %p, modes %p.\n", iface, count, parameters, modes);
 
     for (i = 0; i < count; ++i)
     {
-        resource = vkd3d_gpu_va_allocator_dereference(&list->device->gpu_va_allocator, parameters[i].Dest);
-        d3d12_command_list_track_resource_usage(list, resource);
+        if (!(resource = vkd3d_gpu_va_allocator_dereference(&list->device->gpu_va_allocator, parameters[i].Dest)))
+        {
+            d3d12_command_list_mark_as_invalid(list, "Invalid target address %p.\n", parameters[i].Dest);
+            return;
+        }
+
+        offset = parameters[i].Dest - resource->gpu_address;
+
+        if (modes && !vk_pipeline_stage_from_wbi_mode(modes[i], &stage))
+        {
+            d3d12_command_list_mark_as_invalid(list, "Invalid mode %u.\n", modes[i]);
+            return;
+        }
+
+        if (list->device->vk_info.AMD_buffer_marker)
+        {
+            VK_CALL(vkCmdWriteBufferMarkerAMD(list->vk_command_buffer, stage,
+                    resource->vk_buffer, offset, parameters[i].Value));
+        }
+        else
+        {
+            FIXME_ONCE("VK_AMD_buffer_marker not supported by device.\n");
+        }
     }
 }
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -94,6 +94,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_EXTENDED_DYNAMIC_STATE, EXT_extended_dynamic_state),
     VK_EXTENSION(EXT_EXTERNAL_MEMORY_HOST, EXT_external_memory_host),
     /* AMD extensions */
+    VK_EXTENSION(AMD_BUFFER_MARKER, AMD_buffer_marker),
     VK_EXTENSION(AMD_SHADER_CORE_PROPERTIES, AMD_shader_core_properties),
     VK_EXTENSION(AMD_SHADER_CORE_PROPERTIES_2, AMD_shader_core_properties2),
     /* NV extensions */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -139,6 +139,7 @@ struct vkd3d_vulkan_info
     bool EXT_extended_dynamic_state;
     bool EXT_external_memory_host;
     /* AMD device extensions */
+    bool AMD_buffer_marker;
     bool AMD_shader_core_properties;
     bool AMD_shader_core_properties2;
     /* NV device extensions */

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -246,6 +246,9 @@ VK_DEVICE_EXT_PFN(vkGetSwapchainImagesKHR)
 VK_DEVICE_EXT_PFN(vkAcquireNextImageKHR)
 VK_DEVICE_EXT_PFN(vkQueuePresentKHR)
 
+/* VK_AMD_buffer_marker */
+VK_DEVICE_EXT_PFN(vkCmdWriteBufferMarkerAMD)
+
 #undef VK_INSTANCE_PFN
 #undef VK_INSTANCE_EXT_PFN
 #undef VK_DEVICE_PFN

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -37991,9 +37991,9 @@ static void test_write_buffer_immediate(void)
 
     get_buffer_readback_with_command_list(buffer, DXGI_FORMAT_R32_UINT, &rb, queue, command_list);
     value = get_readback_uint(&rb, 0, 0, 0);
-    todo ok(value == parameters[0].Value, "Got unexpected value %#x, expected %#x.\n", value, parameters[0].Value);
+    ok(value == parameters[0].Value, "Got unexpected value %#x, expected %#x.\n", value, parameters[0].Value);
     value = get_readback_uint(&rb, 1, 0, 0);
-    todo ok(value == parameters[1].Value, "Got unexpected value %#x, expected %#x.\n", value, parameters[1].Value);
+    ok(value == parameters[1].Value, "Got unexpected value %#x, expected %#x.\n", value, parameters[1].Value);
     release_resource_readback(&rb);
     reset_command_list(command_list, context.allocator);
 
@@ -38010,16 +38010,16 @@ static void test_write_buffer_immediate(void)
 
     get_buffer_readback_with_command_list(buffer, DXGI_FORMAT_R32_UINT, &rb, queue, command_list);
     value = get_readback_uint(&rb, 0, 0, 0);
-    todo ok(value == parameters[0].Value, "Got unexpected value %#x, expected %#x.\n", value, parameters[0].Value);
+    ok(value == parameters[0].Value, "Got unexpected value %#x, expected %#x.\n", value, parameters[0].Value);
     value = get_readback_uint(&rb, 1, 0, 0);
-    todo ok(value == parameters[1].Value, "Got unexpected value %#x, expected %#x.\n", value, parameters[1].Value);
+    ok(value == parameters[1].Value, "Got unexpected value %#x, expected %#x.\n", value, parameters[1].Value);
     release_resource_readback(&rb);
     reset_command_list(command_list, context.allocator);
 
     modes[0] = 0x7fffffff;
     ID3D12GraphicsCommandList2_WriteBufferImmediate(command_list2, ARRAY_SIZE(parameters), parameters, modes);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
 
     ID3D12Resource_Release(buffer);
     ID3D12GraphicsCommandList2_Release(command_list2);


### PR DESCRIPTION
Title. Passes the already existing test for WriteBufferImmediate and silences log spam in Horizon Zero Dawn. Perf impact in that game seems acceptable even with the fallback path.