### PR TITLE
vkd3d: Emit host memory barrier as needed.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2725,6 +2725,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_Close(d3d12_command_list_ifa
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
     const struct vkd3d_vk_device_procs *vk_procs;
+    VkMemoryBarrier barrier;
     VkResult vr;
 
     TRACE("iface %p.\n", iface);
@@ -2740,6 +2741,20 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_Close(d3d12_command_list_ifa
     d3d12_command_list_end_current_render_pass(list, false);
     if (list->is_predicated)
         VK_CALL(vkCmdEndConditionalRenderingEXT(list->vk_command_buffer));
+
+    if (list->need_host_barrier)
+    {
+        /* Need to emit host barrier here. There is no obvious RESOURCE_STATE we can map this to.
+         * Rely on simple tracking to do this. */
+        barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+        barrier.pNext = NULL;
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+
+        VK_CALL(vkCmdPipelineBarrier(list->vk_command_buffer,
+                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_HOST_BIT, 0,
+                1, &barrier, 0, NULL, 0, NULL));
+    }
 
     if ((vr = VK_CALL(vkEndCommandBuffer(list->vk_command_buffer))) < 0)
     {
@@ -2783,6 +2798,7 @@ static void d3d12_command_list_reset_state(struct d3d12_command_list *list,
 
     list->is_predicated = false;
     list->render_pass_suspended = false;
+    list->need_host_barrier = false;
 
     list->current_framebuffer = VK_NULL_HANDLE;
     list->current_pipeline = VK_NULL_HANDLE;
@@ -3702,6 +3718,10 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyBufferRegion(d3d12_command_
 
     VK_CALL(vkCmdCopyBuffer(list->vk_command_buffer,
             src_resource->vk_buffer, dst_resource->vk_buffer, 1, &buffer_copy));
+
+    /* There is no explicit host barrier for readbacks. */
+    if (d3d12_heap_needs_host_barrier_for_write(dst_resource->heap))
+        list->need_host_barrier = true;
 }
 
 static void vk_image_subresource_layers_from_d3d12(VkImageSubresourceLayers *subresource,
@@ -4255,6 +4275,10 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyTextureRegion(d3d12_command
     {
         FIXME("Copy type %#x -> %#x not implemented.\n", src->Type, dst->Type);
     }
+
+    /* There is no explicit host barrier for readbacks. */
+    if (d3d12_heap_needs_host_barrier_for_write(dst_resource->heap))
+        list->need_host_barrier = true;
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_CopyResource(d3d12_command_list_iface *iface,
@@ -4325,6 +4349,10 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyResource(d3d12_command_list
                     src_resource, src_format, &vk_image_copy);
         }
     }
+
+    /* There is no explicit host barrier for readbacks. */
+    if (d3d12_heap_needs_host_barrier_for_write(dst_resource->heap))
+        list->need_host_barrier = true;
 }
 
 static unsigned int vkd3d_get_tile_index_from_region(const struct d3d12_sparse_info *sparse,
@@ -6192,6 +6220,10 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResolveQueryData(d3d12_command_
         VK_CALL(vkCmdCopyQueryPoolResults(list->vk_command_buffer,
                 query_heap->vk_query_pool, first, count, buffer->vk_buffer,
                 buffer->heap_offset + offset, stride, VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT));
+
+        /* There is no explicit host barrier for readbacks. */
+        if (d3d12_heap_needs_host_barrier_for_write(buffer->heap))
+            list->need_host_barrier = true;
     }
 }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -624,6 +624,27 @@ static HRESULT d3d12_resource_create(struct d3d12_device *device,
                                      const D3D12_CLEAR_VALUE *optimized_clear_value, bool placed,
                                      struct d3d12_resource **resource);
 
+bool d3d12_heap_needs_host_barrier_for_write(struct d3d12_heap *heap)
+{
+    switch (heap->desc.Properties.Type)
+    {
+    case D3D12_HEAP_TYPE_DEFAULT:
+    case D3D12_HEAP_TYPE_UPLOAD:
+        return false;
+
+    case D3D12_HEAP_TYPE_READBACK:
+        return true;
+
+    case D3D12_HEAP_TYPE_CUSTOM:
+        return heap->desc.Properties.CPUPageProperty != D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE;
+
+    default:
+        break;
+    }
+
+    return false;
+}
+
 static HRESULT d3d12_heap_init_omnipotent_buffer(struct d3d12_heap *heap, struct d3d12_device *device,
         const D3D12_HEAP_DESC *desc)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -430,6 +430,7 @@ HRESULT d3d12_heap_create(struct d3d12_device *device, const D3D12_HEAP_DESC *de
         const struct d3d12_resource *resource, struct d3d12_heap **heap) DECLSPEC_HIDDEN;
 HRESULT d3d12_heap_create_from_host_pointer(struct d3d12_device *device, void *addr, size_t size,
         struct d3d12_heap **heap) DECLSPEC_HIDDEN;
+bool d3d12_heap_needs_host_barrier_for_write(struct d3d12_heap *heap) DECLSPEC_HIDDEN;
 struct d3d12_heap *unsafe_impl_from_ID3D12Heap(ID3D12Heap *iface) DECLSPEC_HIDDEN;
 
 #define VKD3D_RESOURCE_PUBLIC_FLAGS \
@@ -1248,6 +1249,7 @@ struct d3d12_command_list
 
     bool is_recording;
     bool is_valid;
+    bool need_host_barrier;
     VkCommandBuffer vk_command_buffer;
 
     DXGI_FORMAT index_buffer_format;


### PR DESCRIPTION
There is no resource state associated with this, so emit the barrier at
the end of a command buffer based on trivial tracking.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>