### PR TITLE
vkd3d: Set VKD3D_DYNAMIC_STATE_VERTEX_BUFFER when changing pipelines

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -3049,6 +3049,12 @@ static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_lis
     {
         VK_CALL(vkCmdBindPipeline(list->vk_command_buffer, list->state->vk_bind_point, vk_pipeline));
 
+        /* The application did set vertex buffers that we didn't bind because of the pipeline vbo mask.
+         * The new pipeline could use those so we need to rebind vertex buffers. */
+        if ((new_active_flags & (VKD3D_DYNAMIC_STATE_VERTEX_BUFFER | VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE))
+          && (list->dynamic_state.dirty_vbos || list->dynamic_state.dirty_vbo_strides))
+          list->dynamic_state.dirty_flags |= VKD3D_DYNAMIC_STATE_VERTEX_BUFFER | VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE;
+
         /* Reapply all dynamic states that were not dynamic in previously bound pipeline.
          * If we didn't use to have dynamic vertex strides, but we then bind a pipeline with dynamic strides,
          * we will need to rebind all VBOs. Mark dynamic stride as dirty in this case. */
@@ -3487,6 +3493,7 @@ static void d3d12_command_list_update_dynamic_state(struct d3d12_command_list *l
     {
         update_vbos = dyn_state->dirty_vbos & list->state->graphics.vertex_buffer_mask;
         dyn_state->dirty_vbos &= ~update_vbos;
+        dyn_state->dirty_vbo_strides &= ~update_vbos;
 
         while (update_vbos)
         {


### PR DESCRIPTION
Fixes textures when inspecting items in the inventory in RE2 and RE3.

RE2 binds 5 vertex buffers and then draws using a pipeline that only uses 3 of those.
Because VKD3D only binds buffers that are in the `vertex_buffer_mask`, we only bind 3 of the 5 buffers. The `VKD3D_DYNAMIC_STATE_VERTEX_BUFFER` gets cleared though so when the game then sets a PSO that uses all 5 vertex buffers we need to actually bind all 5.

When actually binding the vertex buffers we just clear the `dirty_vbos` (or `dirty_vbo_strides`) bits that represent the buffers that actually got bound. So when switching pipelines we check whether there are `dirty_vbo` bits left and set `VKD3D_DYNAMIC_STATE_VERTEX_BUFFER`.


Alternatively we could just get rid of the pipeline vbo mask and bind all vertex buffers in the first place.