### PR TITLE
vkd3d: Implement some MinGW workarounds

### DIFF
--- a/include/private/vkd3d_threads.h
+++ b/include/private/vkd3d_threads.h
@@ -21,7 +21,7 @@
 
 #include "vkd3d_memory.h"
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -431,6 +431,8 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
 
     TRACE("Build: %s.\n", vkd3d_build);
 
+    memset(instance, 0, sizeof(*instance));
+
     if (!create_info->pfn_signal_event)
     {
         ERR("Invalid signal event function pointer.\n");
@@ -4717,6 +4719,8 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
 {
     const struct vkd3d_vk_device_procs *vk_procs;
     HRESULT hr;
+
+    memset(device, 0, sizeof(*device));
 
 #ifdef VKD3D_ENABLE_PROFILING
     if (vkd3d_uses_profiling())

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,10 @@ add_project_arguments('-DHAVE_DXIL_SPV', language : 'c')
 add_project_arguments('-D_GNU_SOURCE',   language : 'c')
 add_project_arguments('-DPACKAGE_VERSION="' + meson.project_version() + '"',   language : 'c')
 
+if vkd3d_platform == 'windows'
+  add_project_arguments('-D_WIN32_WINNT=0x600', language : 'c')
+endif
+
 if enable_standalone_d3d12
   add_project_arguments('-DVKD3D_BUILD_STANDALONE_D3D12', language : 'c')
 endif


### PR DESCRIPTION
Works around a winpthread bug with pthread_mutex_init on garbage data and improves performance by using raw SRW locks on all Win32 targets.

The memsets are a bit more dubious, but was reported to influence HZD behavior (the caps struct), and can't hurt ...