### PR TITLE
vkd3d: Rewrite initial resource state tracking

### DIFF
--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -151,7 +151,6 @@ struct vkd3d_optional_device_extensions_info
 };
 
 /* vkd3d_image_resource_create_info flags */
-#define VKD3D_RESOURCE_INITIAL_STATE_TRANSITION 0x00000001
 #define VKD3D_RESOURCE_PRESENT_STATE_TRANSITION 0x00000002
 
 struct vkd3d_image_resource_create_info

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3063,6 +3063,7 @@ static HRESULT d3d12_resource_init(struct d3d12_resource *resource, struct d3d12
 
     resource->gpu_address = 0;
     resource->flags = 0;
+    resource->initial_layout_transition = 0;
     resource->common_layout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     if (placed && d3d12_resource_is_buffer(resource))
@@ -3104,7 +3105,7 @@ static HRESULT d3d12_resource_init(struct d3d12_resource *resource, struct d3d12
         case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
             if (!resource->desc.MipLevels)
                 resource->desc.MipLevels = max_miplevel_count(desc);
-            resource->flags |= VKD3D_RESOURCE_INITIAL_STATE_TRANSITION;
+            resource->initial_layout_transition = 1;
             if (FAILED(hr = vkd3d_create_image(device, heap_properties, heap_flags,
                     &resource->desc, resource, &resource->vk_image)))
                 return hr;
@@ -3114,8 +3115,6 @@ static HRESULT d3d12_resource_init(struct d3d12_resource *resource, struct d3d12
             WARN("Invalid resource dimension %#x.\n", resource->desc.Dimension);
             return E_INVALIDARG;
     }
-
-    resource->initial_state = initial_state;
 
     if (FAILED(hr = d3d12_resource_init_sparse_info(resource, device, &resource->sparse)))
     {
@@ -3342,7 +3341,7 @@ VKD3D_EXPORT HRESULT vkd3d_create_image_resource(ID3D12Device *device,
     object->vk_image = create_info->vk_image;
     object->flags = VKD3D_RESOURCE_EXTERNAL;
     object->flags |= create_info->flags & VKD3D_RESOURCE_PUBLIC_FLAGS;
-    object->initial_state = D3D12_RESOURCE_STATE_COMMON;
+    object->initial_layout_transition = 1;
     object->common_layout = vk_common_image_layout_from_d3d12_desc(&object->desc);
 
     memset(&object->sparse, 0, sizeof(object->sparse));

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -1047,7 +1047,7 @@ static HRESULT d3d12_swapchain_create_buffers(struct d3d12_swapchain *swapchain,
     resource_info.desc.SampleDesc.Quality = 0;
     resource_info.desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
     resource_info.desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
-    resource_info.flags = VKD3D_RESOURCE_INITIAL_STATE_TRANSITION | VKD3D_RESOURCE_PRESENT_STATE_TRANSITION;
+    resource_info.flags = VKD3D_RESOURCE_PRESENT_STATE_TRANSITION;
 
     queue_desc = ID3D12CommandQueue_GetDesc(queue);
     if (queue_desc.Type != D3D12_COMMAND_LIST_TYPE_DIRECT)


### PR DESCRIPTION
    For correctness, we will need to defer any initial resource state
    handling to the queue timeline. Here, we will build an UNDEFINED ->
    common layout barrier if (and only if):
    
    - The resource is marked to care about initial layout transition.
    - We are the first queue thread to observe that initial_transition
      member is 1 (atomic exchange).
    - The first use of the resource was not marked to be a discard.
      E.g., if the first use of the resource is an alias barrier, we must
      not emit an early barrier. The only we should do here is to clear the
      initial_transition member, and leave it like that.
    
    A command list maintains a list of d3d12_resources which *might* need a
    transition. For the first frame a resource is used (or so), it will not
    have the flag cleared yet, so multiple command lists might add the
    d3d12_resource to its own transition list. This is fine, as the queue
    will resolve it.
    
    If multiple queues see the same initial transition, there might be
    shenanigans, but the application must ensure there is either a
    submission boundary or fence boundary between the uses. Any initial
    layout transition will only be submitted after a Wait() is observed, as
    submission of the transition command buffer will be in-order with other
    submissions.
