### PR TITLE
Use descriptor cookies to avoid comparing against stale pointers

### DIFF
--- a/include/private/vkd3d_atomic.h
+++ b/include/private/vkd3d_atomic.h
@@ -125,6 +125,7 @@ FORCEINLINE uint32_t vkd3d_atomic_uint32_decrement(uint32_t *target, vkd3d_memor
 # ifndef __MINGW32__
 #  define InterlockedIncrement(target) vkd3d_atomic_uint32_increment(target, vkd3d_memory_order_seq_cst)
 #  define InterlockedDecrement(target) vkd3d_atomic_uint32_decrement(target, vkd3d_memory_order_seq_cst)
+#  define InterlockedIncrement64(target) __atomic_add_fetch(target, 1, vkd3d_memory_order_seq_cst)
 # endif
 
 #else

--- a/include/vkd3d_windows.h
+++ b/include/vkd3d_windows.h
@@ -77,6 +77,7 @@ typedef unsigned long UINT64;
 typedef long long DECLSPEC_ALIGN(8) INT64;
 typedef unsigned long long DECLSPEC_ALIGN(8) UINT64;
 # endif
+typedef INT64 LONG64;
 typedef long LONG_PTR;
 typedef unsigned long ULONG_PTR;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -488,6 +488,8 @@ struct d3d12_resource
     LONG refcount;
     LONG internal_refcount;
 
+    uint64_t cookie;
+
     D3D12_RESOURCE_DESC desc;
 
     D3D12_GPU_VIRTUAL_ADDRESS gpu_address;
@@ -570,6 +572,8 @@ struct vkd3d_view
 {
     LONG refcount;
     enum vkd3d_view_type type;
+    uint64_t cookie;
+
     union
     {
         VkBufferView vk_buffer_view;
@@ -636,15 +640,16 @@ enum vkd3d_descriptor_flag
 
 struct vkd3d_descriptor_data
 {
+    uint64_t cookie;
     uint32_t set_index;
     uint32_t flags;
 };
 
 struct d3d12_desc
 {
+    struct vkd3d_descriptor_data metadata;
     struct d3d12_descriptor_heap *heap;
     uint32_t heap_offset;
-    struct vkd3d_descriptor_data metadata;
     union
     {
         VkDescriptorBufferInfo vk_cbv_info;


### PR DESCRIPTION
We cannot compare resource pointers or view pointers,
since the pointers might have been recycled.
This leads to a scenario where we're not updating descriptors we're
supposed to, and the GPU reads a stale descriptor.

Fixes a GPU hang in Death Stranding (and possibly lots of other weird
crashes as well).