### PR TITLE
Support raw SSBO path for root descriptors

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1182,6 +1182,12 @@ union vkd3d_descriptor_info
     VkDescriptorImageInfo image;
 };
 
+struct vkd3d_root_descriptor_info
+{
+    VkDescriptorType vk_descriptor_type;
+    union vkd3d_descriptor_info info;
+};
+
 struct vkd3d_pipeline_bindings
 {
     const struct d3d12_root_signature *root_signature;
@@ -1194,7 +1200,7 @@ struct vkd3d_pipeline_bindings
     uint64_t descriptor_heap_dirty_mask;
 
     /* Needed when VK_KHR_push_descriptor is not available. */
-    union vkd3d_descriptor_info root_descriptors[D3D12_MAX_ROOT_COST / 2];
+    struct vkd3d_root_descriptor_info root_descriptors[D3D12_MAX_ROOT_COST / 2];
     uint64_t root_descriptor_dirty_mask;
     uint64_t root_descriptor_active_mask;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1974,6 +1974,13 @@ static inline VkDeviceSize d3d12_device_get_ssbo_alignment(struct d3d12_device *
             : ~0ull;
 }
 
+static inline bool d3d12_device_use_ssbo_root_descriptors(struct d3d12_device *device)
+{
+    /* We only know the VA of root SRV/UAVs, so we cannot
+     * make any better assumptions about the alignment */
+    return d3d12_device_get_ssbo_alignment(device) <= 4;
+}
+
 /* ID3DBlob */
 struct d3d_blob
 {


### PR DESCRIPTION
Only on hardware where `minStorageBufferAlignment <= 4`, since we know nothing about root descriptors except their VA.