### PR TITLE
vkd3d: Remove VKD3D_RESOURCE_PRESENT_STATE_TRANSITION

### DIFF
--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -150,9 +150,6 @@ struct vkd3d_optional_device_extensions_info
     uint32_t extension_count;
 };
 
-/* vkd3d_image_resource_create_info flags */
-#define VKD3D_RESOURCE_PRESENT_STATE_TRANSITION 0x00000002
-
 struct vkd3d_image_resource_create_info
 {
     enum vkd3d_structure_type type;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3342,8 +3342,8 @@ VKD3D_EXPORT HRESULT vkd3d_create_image_resource(ID3D12Device *device,
     object->internal_refcount = 1;
     object->desc = create_info->desc;
     object->vk_image = create_info->vk_image;
-    object->flags = VKD3D_RESOURCE_EXTERNAL;
-    object->flags |= create_info->flags & VKD3D_RESOURCE_PUBLIC_FLAGS;
+    object->flags = create_info->flags;
+    object->flags |= VKD3D_RESOURCE_EXTERNAL;
     object->initial_layout_transition = 1;
     object->common_layout = vk_common_image_layout_from_d3d12_desc(&object->desc);
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3322,12 +3322,6 @@ VKD3D_EXPORT HRESULT vkd3d_create_image_resource(ID3D12Device *device,
 
     TRACE("device %p, create_info %p, resource %p.\n", device, create_info, resource);
 
-    if (create_info->flags & VKD3D_RESOURCE_PRESENT_STATE_TRANSITION)
-    {
-        ERR("Present state transition is broken and is not supported.\n");
-        return E_INVALIDARG;
-    }
-
     if (!create_info || !resource)
         return E_INVALIDARG;
     if (create_info->type != VKD3D_STRUCTURE_TYPE_IMAGE_RESOURCE_CREATE_INFO)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -428,7 +428,7 @@ bool d3d12_heap_needs_host_barrier_for_write(struct d3d12_heap *heap);
 struct d3d12_heap *unsafe_impl_from_ID3D12Heap(ID3D12Heap *iface);
 
 #define VKD3D_RESOURCE_PUBLIC_FLAGS \
-        (VKD3D_RESOURCE_PRESENT_STATE_TRANSITION)
+        (0)
 #define VKD3D_RESOURCE_EXTERNAL       0x00000004
 #define VKD3D_RESOURCE_DEDICATED_HEAP 0x00000008
 #define VKD3D_RESOURCE_LINEAR_TILING  0x00000010

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -427,8 +427,6 @@ HRESULT d3d12_heap_create_from_host_pointer(struct d3d12_device *device, void *a
 bool d3d12_heap_needs_host_barrier_for_write(struct d3d12_heap *heap);
 struct d3d12_heap *unsafe_impl_from_ID3D12Heap(ID3D12Heap *iface);
 
-#define VKD3D_RESOURCE_PUBLIC_FLAGS \
-        (0)
 #define VKD3D_RESOURCE_EXTERNAL       0x00000004
 #define VKD3D_RESOURCE_DEDICATED_HEAP 0x00000008
 #define VKD3D_RESOURCE_LINEAR_TILING  0x00000010

--- a/tests/vkd3d_api.c
+++ b/tests/vkd3d_api.c
@@ -965,7 +965,7 @@ static void test_external_resource_present_state(void)
     resource_create_info.desc.SampleDesc.Quality = 0;
     resource_create_info.desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
     resource_create_info.desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
-    resource_create_info.flags = VKD3D_RESOURCE_INITIAL_STATE_TRANSITION | VKD3D_RESOURCE_PRESENT_STATE_TRANSITION;
+    resource_create_info.flags = 0;
     resource_create_info.present_state = D3D12_RESOURCE_STATE_COPY_SOURCE;
     hr = vkd3d_create_image_resource(device, &resource_create_info, &vk_resource);
     ok(hr == S_OK, "Failed to create D3D12 resource for Vulkan image, hr %#x.\n", hr);

--- a/tests/vkd3d_api.c
+++ b/tests/vkd3d_api.c
@@ -888,7 +888,7 @@ static void test_external_resource_map(void)
     resource_create_info.desc.SampleDesc.Quality = 0;
     resource_create_info.desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
     resource_create_info.desc.Flags = 0;
-    resource_create_info.flags = VKD3D_RESOURCE_INITIAL_STATE_TRANSITION;
+    resource_create_info.flags = 0;
     hr = vkd3d_create_image_resource(device, &resource_create_info, &vk_resource);
     ok(hr == S_OK, "Failed to create D3D12 resource for Vulkan image, hr %#x.\n", hr);
 


### PR DESCRIPTION
All this flag does is make resource creation fail.

Signed-off-by: Joshua Ashton <joshua@froggi.es>