### PR TITLE
vkd3d: Do not perform any alignment analysis for SSBOs.

### DIFF
--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -132,15 +132,17 @@ static dxil_spv_bool dxil_srv_remap(void *userdata, const dxil_spv_d3d_binding *
     resource_flags_ssbo = dxil_resource_flags_from_kind(d3d_binding->kind, true);
     resource_flags = dxil_resource_flags_from_kind(d3d_binding->kind, false);
 
-    if (resource_flags_ssbo != resource_flags)
-        use_ssbo = d3d_binding->alignment >= shader_interface_info->min_ssbo_alignment;
-    else
-        use_ssbo = false;
+    use_ssbo = resource_flags_ssbo != resource_flags;
 
     if (use_ssbo && dxil_remap(shader_interface_info, VKD3D_SHADER_DESCRIPTOR_TYPE_SRV,
             d3d_binding, &vk_binding->buffer_binding, resource_flags_ssbo))
     {
         vk_binding->buffer_binding.descriptor_type = DXIL_SPV_VULKAN_DESCRIPTOR_TYPE_SSBO;
+        if (d3d_binding->alignment < shader_interface_info->min_ssbo_alignment)
+        {
+            FIXME("Shader declares resource with alignment of %u bytes, but implementation only supports %u.\n",
+                  d3d_binding->alignment, shader_interface_info->min_ssbo_alignment);
+        }
         return DXIL_SPV_TRUE;
     }
     else

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -5748,10 +5748,11 @@ static uint32_t vkd3d_dxbc_compiler_get_image_type_id(struct vkd3d_dxbc_compiler
 static bool vkd3d_dxbc_compiler_use_ssbo(struct vkd3d_dxbc_compiler *compiler,
         unsigned int structure_stride, bool raw)
 {
-    /* Extract lowest bit from stride to get alignment
-     * in case the stride is not a power of two. */
-    unsigned int dword_alignment = raw ? 4 : (structure_stride & -structure_stride);
-    return dword_alignment * sizeof(uint32_t) >= compiler->shader_interface.min_ssbo_alignment;
+    /* Normally, we would also look at the alignment of these resource types to
+     * deduce if we should emit SSBOs, but this breaks in certain applications,
+     * so we will statically determine if structured buffers or raw buffers should be SSBOs.
+     * TODO: min_ssbo_alignment will be used to determine if we should use a fallback access path with offset. */
+    return structure_stride || raw;
 }
 
 static void vkd3d_dxbc_compiler_emit_resource_declaration(struct vkd3d_dxbc_compiler *compiler,

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5217,7 +5217,7 @@ static void d3d12_command_list_set_root_descriptor(struct d3d12_command_list *li
     bool null_descriptors, ssbo;
     VkDeviceSize max_range;
 
-    ssbo = d3d12_device_use_ssbo_root_descriptors(list->device);
+    ssbo = d3d12_device_use_ssbo_raw_buffer(list->device);
     root_parameter = root_signature_get_root_descriptor(root_signature, index);
     descriptor = &bindings->root_descriptors[root_parameter->descriptor.packed_descriptor];
     null_descriptors = list->device->device_info.robustness2_features.nullDescriptor;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1967,18 +1967,14 @@ static inline unsigned int d3d12_device_get_descriptor_handle_increment_size(str
     return ID3D12Device6_GetDescriptorHandleIncrementSize(&device->ID3D12Device_iface, descriptor_type);
 }
 
-static inline VkDeviceSize d3d12_device_get_ssbo_alignment(struct d3d12_device *device)
+static inline bool d3d12_device_use_ssbo_raw_buffer(struct d3d12_device *device)
 {
-    return (device->bindless_state.flags & VKD3D_BINDLESS_RAW_SSBO)
-            ? device->device_info.properties2.properties.limits.minStorageBufferOffsetAlignment
-            : ~0ull;
+    return (device->bindless_state.flags & VKD3D_BINDLESS_RAW_SSBO) != 0;
 }
 
-static inline bool d3d12_device_use_ssbo_root_descriptors(struct d3d12_device *device)
+static inline VkDeviceSize d3d12_device_get_ssbo_alignment(struct d3d12_device *device)
 {
-    /* We only know the VA of root SRV/UAVs, so we cannot
-     * make any better assumptions about the alignment */
-    return d3d12_device_get_ssbo_alignment(device) <= 4;
+    return device->device_info.properties2.properties.limits.minStorageBufferOffsetAlignment;
 }
 
 /* ID3DBlob */


### PR DESCRIPTION
We cannot rely on alignment analysis since games are buggy and screw up
RAW vs structured on occasion.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>