### PR TITLE
Move UAV counter address binding to bindless descriptor sets.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2359,9 +2359,6 @@ static void d3d12_command_list_invalidate_root_parameters(struct d3d12_command_l
     if (bindings->root_signature->descriptor_table_count)
         bindings->dirty_flags |= VKD3D_PIPELINE_DIRTY_DESCRIPTOR_TABLE_OFFSETS;
 
-    if (bindings->root_signature->flags & VKD3D_ROOT_SIGNATURE_USE_RAW_VA_UAV_COUNTERS)
-        bindings->dirty_flags |= VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING;
-
     bindings->root_descriptor_dirty_mask = bindings->root_signature->root_descriptor_mask;
     bindings->root_constant_dirty_mask = bindings->root_signature->root_constant_mask;
 
@@ -2820,7 +2817,6 @@ static void d3d12_command_list_reset_state(struct d3d12_command_list *list,
     list->command_buffer_pipeline = VK_NULL_HANDLE;
     list->pso_render_pass = VK_NULL_HANDLE;
     list->current_render_pass = VK_NULL_HANDLE;
-    list->uav_counter_address_buffer = VK_NULL_HANDLE;
 
     memset(&list->dynamic_state, 0, sizeof(list->dynamic_state));
     list->dynamic_state.blend_constants[0] = D3D12_DEFAULT_BLEND_FACTOR_RED;
@@ -3282,35 +3278,6 @@ static void d3d12_command_list_fetch_inline_uniform_block_data(struct d3d12_comm
     bindings->root_constant_dirty_mask = 0;
 }
 
-static bool vk_write_descriptor_set_from_uav_counter_binding(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point, VkDescriptorSet vk_descriptor_set,
-        VkWriteDescriptorSet *vk_descriptor_write, VkDescriptorBufferInfo *vk_buffer_info)
-{
-    struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
-    const struct d3d12_root_signature *root_signature = bindings->root_signature;
-
-    bindings->dirty_flags &= ~VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING;
-
-    if (!list->uav_counter_address_buffer || !(root_signature->flags & VKD3D_ROOT_SIGNATURE_USE_RAW_VA_UAV_COUNTERS))
-        return false;
-
-    vk_buffer_info->buffer = list->uav_counter_address_buffer;
-    vk_buffer_info->offset = 0;
-    vk_buffer_info->range = VK_WHOLE_SIZE;
-
-    vk_descriptor_write->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    vk_descriptor_write->pNext = NULL;
-    vk_descriptor_write->dstSet = vk_descriptor_set;
-    vk_descriptor_write->dstBinding = root_signature->uav_counter_binding.binding;
-    vk_descriptor_write->dstArrayElement = 0;
-    vk_descriptor_write->descriptorCount = 1;
-    vk_descriptor_write->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    vk_descriptor_write->pImageInfo = NULL;
-    vk_descriptor_write->pBufferInfo = vk_buffer_info;
-    vk_descriptor_write->pTexelBufferView = NULL;
-    return true;
-}
-
 static void d3d12_command_list_update_root_descriptors(struct d3d12_command_list *list,
         VkPipelineBindPoint bind_point)
 {
@@ -3322,14 +3289,12 @@ static void d3d12_command_list_update_root_descriptors(struct d3d12_command_list
     uint32_t inline_uniform_block_data[D3D12_MAX_ROOT_COST];
     const struct d3d12_root_parameter *root_parameter;
     VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
-    VkDescriptorBufferInfo uav_counter_descriptor;
     unsigned int descriptor_write_count = 0;
     unsigned int root_parameter_index;
 
     if (!(root_signature->flags & VKD3D_ROOT_SIGNATURE_USE_PUSH_DESCRIPTORS))
     {
         /* Ensure that we populate all descriptors if push descriptors cannot be used */
-        bindings->dirty_flags |= VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING;
         bindings->root_descriptor_dirty_mask |= bindings->root_descriptor_active_mask & root_signature->root_descriptor_mask;
 
         descriptor_set = d3d12_command_allocator_allocate_descriptor_set(
@@ -3350,13 +3315,6 @@ static void d3d12_command_list_update_root_descriptors(struct d3d12_command_list
             continue;
 
         descriptor_write_count += 1;
-    }
-
-    if (bindings->dirty_flags & VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING)
-    {
-        if (vk_write_descriptor_set_from_uav_counter_binding(list, bind_point,
-                descriptor_set, &descriptor_writes[descriptor_write_count], &uav_counter_descriptor))
-            descriptor_write_count += 1;
     }
 
     if (root_signature->flags & VKD3D_ROOT_SIGNATURE_USE_INLINE_UNIFORM_BLOCK)
@@ -3407,12 +3365,12 @@ static void d3d12_command_list_update_descriptors(struct d3d12_command_list *lis
     {
         /* Root constants and descriptor table offsets are part of the root descriptor set */
         if (bindings->root_descriptor_dirty_mask || bindings->root_constant_dirty_mask
-                || (bindings->dirty_flags & (VKD3D_PIPELINE_DIRTY_DESCRIPTOR_TABLE_OFFSETS | VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING)))
+                || (bindings->dirty_flags & VKD3D_PIPELINE_DIRTY_DESCRIPTOR_TABLE_OFFSETS))
             d3d12_command_list_update_root_descriptors(list, bind_point);
     }
     else
     {
-        if (bindings->root_descriptor_dirty_mask || (bindings->dirty_flags & VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING))
+        if (bindings->root_descriptor_dirty_mask)
             d3d12_command_list_update_root_descriptors(list, bind_point);
 
         if (bindings->root_constant_dirty_mask)
@@ -5020,7 +4978,6 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetDescriptorHeaps(d3d12_comman
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
     struct vkd3d_bindless_state *bindless_state = &list->device->bindless_state;
-    bool dirty_uav_counters = false;
     uint64_t dirty_mask = 0;
     unsigned int i, j;
 
@@ -5042,22 +4999,12 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetDescriptorHeaps(d3d12_comman
             list->descriptor_heaps[j] = heap->vk_descriptor_sets[set_index++];
             dirty_mask |= 1ull << j;
         }
-
-        if (heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
-        {
-            list->uav_counter_address_buffer = heap->uav_counters.vk_buffer;
-            dirty_uav_counters = true;
-        }
     }
 
     for (i = 0; i < ARRAY_SIZE(list->pipeline_bindings); i++)
     {
         struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[i];
         bindings->descriptor_heap_dirty_mask = dirty_mask;
-
-        if (dirty_uav_counters && bindings->root_signature &&
-                (bindings->root_signature->flags & VKD3D_ROOT_SIGNATURE_USE_RAW_VA_UAV_COUNTERS))
-            bindings->dirty_flags |= VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING;
     }
 }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1176,7 +1176,6 @@ enum vkd3d_pipeline_dirty_flag
 {
     VKD3D_PIPELINE_DIRTY_STATIC_SAMPLER_SET       = 0x00000001u,
     VKD3D_PIPELINE_DIRTY_DESCRIPTOR_TABLE_OFFSETS = 0x00000002u,
-    VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING      = 0x00000004u,
 };
 
 union vkd3d_descriptor_info
@@ -1303,7 +1302,6 @@ struct d3d12_command_list
 
     VkRenderPass pso_render_pass;
     VkRenderPass current_render_pass;
-    VkBuffer uav_counter_address_buffer;
     struct vkd3d_dynamic_state dynamic_state;
     struct vkd3d_pipeline_bindings pipeline_bindings[VKD3D_PIPELINE_BIND_POINT_COUNT];
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -631,10 +631,16 @@ enum vkd3d_descriptor_flag
     VKD3D_DESCRIPTOR_FLAG_UAV_COUNTER = (1 << 2),
 };
 
+struct vkd3d_descriptor_binding
+{
+    uint16_t set;
+    uint16_t binding;
+};
+
 struct vkd3d_descriptor_data
 {
     uint64_t cookie;
-    uint32_t set_index;
+    struct vkd3d_descriptor_binding binding;
     uint32_t flags;
 };
 
@@ -1589,6 +1595,7 @@ struct vkd3d_bindless_set_info
     VkDescriptorType vk_descriptor_type;
     D3D12_DESCRIPTOR_HEAP_TYPE heap_type;
     uint32_t flags; /* vkd3d_bindless_set_flag */
+    uint32_t binding_index;
 
     VkDescriptorSetLayout vk_set_layout;
     VkDescriptorSetLayout vk_host_set_layout;
@@ -1608,7 +1615,7 @@ void vkd3d_bindless_state_cleanup(struct vkd3d_bindless_state *bindless_state,
         struct d3d12_device *device);
 bool vkd3d_bindless_state_find_binding(const struct vkd3d_bindless_state *bindless_state,
         uint32_t flags, struct vkd3d_shader_descriptor_binding *binding);
-unsigned int vkd3d_bindless_state_find_set(const struct vkd3d_bindless_state *bindless_state, uint32_t flags);
+struct vkd3d_descriptor_binding vkd3d_bindless_state_find_set(const struct vkd3d_bindless_state *bindless_state, uint32_t flags);
 
 static inline VkDescriptorType vkd3d_bindless_state_get_cbv_descriptor_type(const struct vkd3d_bindless_state *bindless_state)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1578,6 +1578,8 @@ enum vkd3d_bindless_flags
     VKD3D_BINDLESS_RAW_SSBO     = (1u << 6),
 };
 
+#define VKD3D_BINDLESS_SET_MAX_EXTRA_BINDINGS 8
+
 enum vkd3d_bindless_set_flag
 {
     VKD3D_BINDLESS_SET_SAMPLER  = (1u << 0),
@@ -1588,6 +1590,9 @@ enum vkd3d_bindless_set_flag
     VKD3D_BINDLESS_SET_BUFFER   = (1u << 5),
     VKD3D_BINDLESS_SET_COUNTER  = (1u << 6),
     VKD3D_BINDLESS_SET_RAW_SSBO = (1u << 7),
+
+    VKD3D_BINDLESS_SET_EXTRA_UAV_COUNTER_BUFFER = (1u << 24),
+    VKD3D_BINDLESS_SET_EXTRA_MASK = 0xff000000u
 };
 
 struct vkd3d_bindless_set_info


### PR DESCRIPTION
Now that bindless is a hard requirement for all D3D12 descriptor types, and after the introduction of binding set flags with the Raw SSBO work, we can just pick an arbitrary set to cram extra bindings into, such as the UAV counter address buffer, and soon the offset buffer for raw SSBOs. This way  we don't have to track and bind these at draw time.