### PR TITLE
Implement offset buffers

### DIFF
--- a/include/private/hashmap.h
+++ b/include/private/hashmap.h
@@ -50,14 +50,9 @@ struct hash_map
     uint32_t used_count;
 };
 
-static inline void *hash_map_ptr_offset(void *ptr, size_t offset)
-{
-    return ((char*)ptr) + offset;
-}
-
 static inline struct hash_map_entry *hash_map_get_entry(struct hash_map *hash_map, uint32_t entry_idx)
 {
-    return hash_map_ptr_offset(hash_map->entries, hash_map->entry_size * entry_idx);
+    return void_ptr_offset(hash_map->entries, hash_map->entry_size * entry_idx);
 }
 
 static inline uint32_t hash_map_get_entry_idx(struct hash_map *hash_map, uint32_t hash_value)
@@ -98,7 +93,7 @@ static inline bool hash_map_grow(struct hash_map *hash_map)
     for (i = 0; i < old_count; i++)
     {
         /* Relocate existing entries one by one */
-        struct hash_map_entry *old_entry = hash_map_ptr_offset(old_entries, i * hash_map->entry_size);
+        struct hash_map_entry *old_entry = void_ptr_offset(old_entries, i * hash_map->entry_size);
 
         if (old_entry->flags & HASH_MAP_ENTRY_OCCUPIED)
         {

--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -271,4 +271,9 @@ static inline size_t vkd3d_wcslen(const WCHAR *wstr, size_t wchar_size)
     }
 }
 
+static inline void *void_ptr_offset(void *ptr, size_t offset)
+{
+    return ((char*)ptr) + offset;
+}
+
 #endif  /* __VKD3D_COMMON_H */

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -187,6 +187,7 @@ enum vkd3d_shader_interface_flag
 {
     VKD3D_SHADER_INTERFACE_PUSH_CONSTANTS_AS_UNIFORM_BUFFER = 0x00000001u,
     VKD3D_SHADER_INTERFACE_BINDLESS_CBV_AS_STORAGE_BUFFER   = 0x00000002u,
+    VKD3D_SHADER_INTERFACE_SSBO_OFFSET_BUFFER               = 0x00000004u,
 };
 
 struct vkd3d_shader_interface_info
@@ -205,6 +206,8 @@ struct vkd3d_shader_interface_info
 
     /* Ignored unless VKD3D_SHADER_INTERFACE_PUSH_CONSTANTS_AS_UNIFORM_BUFFER is set */
     const struct vkd3d_shader_descriptor_binding *push_constant_ubo_binding;
+    /* Ignored unless VKD3D_SHADER_INTERFACE_SSBO_OFFSET_BUFFER is set */
+    const struct vkd3d_shader_descriptor_binding *offset_buffer_binding;
 };
 
 struct vkd3d_shader_transform_feedback_element

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5164,7 +5164,7 @@ static void d3d12_command_list_set_root_descriptor(struct d3d12_command_list *li
     bool null_descriptors, ssbo;
     VkDeviceSize max_range;
 
-    ssbo = d3d12_device_use_ssbo_raw_buffer(list->device);
+    ssbo = d3d12_device_use_ssbo_root_descriptors(list->device);
     root_parameter = root_signature_get_root_descriptor(root_signature, index);
     descriptor = &bindings->root_descriptors[root_parameter->descriptor.packed_descriptor];
     null_descriptors = list->device->device_info.robustness2_features.nullDescriptor;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5539,6 +5539,10 @@ static void d3d12_descriptor_heap_update_extra_bindings(struct d3d12_descriptor_
                     *vk_buffer = descriptor_heap->uav_counters.descriptor;
                     break;
 
+                case VKD3D_BINDLESS_SET_EXTRA_SSBO_OFFSET_BUFFER:
+                    *vk_buffer = descriptor_heap->ssbo_ranges.descriptor;
+                    break;
+
                 default:
                     ERR("Unsupported etra flags %#x.\n", flag);
                     continue;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3457,12 +3457,16 @@ static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *dev
 
     /* Normally, we would be able to use SSBOs conditionally even when maxSSBOAlignment > 4, but
      * applications (RE2 being one example) are of course buggy and don't match descriptor and shader usage of resources,
-     * so we cannot rely on alignment analysis to select the appropriate resource type.
-     * TODO: Implement an offset buffer system so that we can remove the minStorageBufferOffsetAlignment requirement. */
+     * so we cannot rely on alignment analysis to select the appropriate resource type. */
     if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindStorageBuffers >= 1000000 &&
             device_info->descriptor_indexing_features.descriptorBindingStorageBufferUpdateAfterBind &&
-            device_info->properties2.properties.limits.minStorageBufferOffsetAlignment <= 4)
+            device_info->properties2.properties.limits.minStorageBufferOffsetAlignment <= 16)
+    {
         flags |= VKD3D_BINDLESS_RAW_SSBO;
+
+        if (device_info->properties2.properties.limits.minStorageBufferOffsetAlignment > 4)
+            flags |= VKD3D_SSBO_OFFSET_BUFFER;
+    }
 
     if (device_info->buffer_device_address_features.bufferDeviceAddress && (flags & VKD3D_BINDLESS_UAV))
         flags |= VKD3D_RAW_VA_UAV_COUNTER;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -213,7 +213,7 @@ static enum vkd3d_shader_visibility vkd3d_shader_visibility_from_d3d12(D3D12_SHA
 
 static VkDescriptorType vk_descriptor_type_from_d3d12_root_parameter(struct d3d12_device *device, D3D12_ROOT_PARAMETER_TYPE type)
 {
-    bool use_ssbo = d3d12_device_use_ssbo_raw_buffer(device);
+    bool use_ssbo = d3d12_device_use_ssbo_root_descriptors(device);
 
     switch (type)
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -725,11 +725,10 @@ static inline struct d3d12_dsv_desc *d3d12_dsv_desc_from_cpu_handle(D3D12_CPU_DE
 void d3d12_dsv_desc_create_dsv(struct d3d12_dsv_desc *dsv_desc, struct d3d12_device *device,
         struct d3d12_resource *resource, const D3D12_DEPTH_STENCIL_VIEW_DESC *desc);
 
-struct d3d12_descriptor_heap_uav_counters
+struct vkd3d_host_visible_buffer_range
 {
-    VkDeviceAddress *data;
-    VkDeviceMemory vk_memory;
-    VkBuffer vk_buffer;
+    VkDescriptorBufferInfo descriptor;
+    void *host_ptr;
 };
 
 /* ID3D12DescriptorHeap */
@@ -743,7 +742,12 @@ struct d3d12_descriptor_heap
     VkDescriptorPool vk_descriptor_pool;
     VkDescriptorSet vk_descriptor_sets[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
 
-    struct d3d12_descriptor_heap_uav_counters uav_counters;
+    VkDeviceMemory vk_memory;
+    VkBuffer vk_buffer;
+    void *host_memory;
+
+    struct vkd3d_host_visible_buffer_range uav_counters;
+
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -629,6 +629,7 @@ enum vkd3d_descriptor_flag
     VKD3D_DESCRIPTOR_FLAG_DEFINED     = (1 << 0),
     VKD3D_DESCRIPTOR_FLAG_VIEW        = (1 << 1),
     VKD3D_DESCRIPTOR_FLAG_UAV_COUNTER = (1 << 2),
+    VKD3D_DESCRIPTOR_FLAG_SSBO_OFFSET = (1 << 3),
 };
 
 struct vkd3d_descriptor_binding

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -725,6 +725,12 @@ static inline struct d3d12_dsv_desc *d3d12_dsv_desc_from_cpu_handle(D3D12_CPU_DE
 void d3d12_dsv_desc_create_dsv(struct d3d12_dsv_desc *dsv_desc, struct d3d12_device *device,
         struct d3d12_resource *resource, const D3D12_DEPTH_STENCIL_VIEW_DESC *desc);
 
+struct vkd3d_bound_ssbo_range
+{
+    uint32_t offset;  /* offset to first byte */
+    uint32_t length;  /* bound size in bytes */
+};
+
 struct vkd3d_host_visible_buffer_range
 {
     VkDescriptorBufferInfo descriptor;
@@ -747,6 +753,7 @@ struct d3d12_descriptor_heap
     void *host_memory;
 
     struct vkd3d_host_visible_buffer_range uav_counters;
+    struct vkd3d_host_visible_buffer_range ssbo_ranges;
 
     struct d3d12_device *device;
 
@@ -1578,6 +1585,7 @@ enum vkd3d_bindless_flags
     VKD3D_RAW_VA_UAV_COUNTER    = (1u << 4),
     VKD3D_BINDLESS_CBV_AS_SSBO  = (1u << 5),
     VKD3D_BINDLESS_RAW_SSBO     = (1u << 6),
+    VKD3D_SSBO_OFFSET_BUFFER    = (1u << 7),
 };
 
 #define VKD3D_BINDLESS_SET_MAX_EXTRA_BINDINGS 8

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1985,6 +1985,14 @@ static inline VkDeviceSize d3d12_device_get_ssbo_alignment(struct d3d12_device *
     return device->device_info.properties2.properties.limits.minStorageBufferOffsetAlignment;
 }
 
+static inline bool d3d12_device_use_ssbo_root_descriptors(struct d3d12_device *device)
+{
+    /* We only know the VA of root SRV/UAVs, so we cannot
+     * make any better assumptions about the alignment */
+    return d3d12_device_use_ssbo_raw_buffer(device) &&
+            d3d12_device_get_ssbo_alignment(device) <= 4;
+}
+
 /* ID3DBlob */
 struct d3d_blob
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -815,6 +815,7 @@ enum vkd3d_root_signature_flag
     VKD3D_ROOT_SIGNATURE_USE_PUSH_DESCRIPTORS       = 0x00000001u,
     VKD3D_ROOT_SIGNATURE_USE_INLINE_UNIFORM_BLOCK   = 0x00000002u,
     VKD3D_ROOT_SIGNATURE_USE_RAW_VA_UAV_COUNTERS    = 0x00000004u,
+    VKD3D_ROOT_SIGNATURE_USE_SSBO_OFFSET_BUFFER     = 0x00000008u,
 };
 
 struct d3d12_root_descriptor_table
@@ -883,6 +884,7 @@ struct d3d12_root_signature
     VkPushConstantRange push_constant_range;
     struct vkd3d_shader_descriptor_binding push_constant_ubo_binding;
     struct vkd3d_shader_descriptor_binding uav_counter_binding;
+    struct vkd3d_shader_descriptor_binding offset_buffer_binding;
 
     uint32_t descriptor_table_offset;
     uint32_t descriptor_table_count;
@@ -1602,6 +1604,7 @@ enum vkd3d_bindless_set_flag
     VKD3D_BINDLESS_SET_RAW_SSBO = (1u << 7),
 
     VKD3D_BINDLESS_SET_EXTRA_UAV_COUNTER_BUFFER = (1u << 24),
+    VKD3D_BINDLESS_SET_EXTRA_SSBO_OFFSET_BUFFER = (1u << 25),
     VKD3D_BINDLESS_SET_EXTRA_MASK = 0xff000000u
 };
 


### PR DESCRIPTION
Cursed workaround for SSBO alignment requirements on Nvidia. Should fix #266 for good.

At least the last commit should probably not be merged before DXIL support lands, since it may break games using DXIL shaders.