### PR TITLE
build: Use separate version string and build hash

### DIFF
--- a/libs/vkd3d/cache.c
+++ b/libs/vkd3d/cache.c
@@ -36,14 +36,13 @@ static VkResult vkd3d_create_pipeline_cache(struct d3d12_device *device,
 }
 
 #define VKD3D_CACHE_BLOB_VERSION MAKE_MAGIC('V','K','B',1)
-#define VKD3D_CACHE_BUILD_SIZE 8
 
 struct vkd3d_pipeline_blob
 {
     uint32_t version;
     uint32_t vendor_id;
     uint32_t device_id;
-    char vkd3d_build[VKD3D_CACHE_BUILD_SIZE];
+    uint64_t vkd3d_build;
     uint8_t cache_uuid[VK_UUID_SIZE];
     uint8_t vk_blob[];
 };
@@ -71,7 +70,7 @@ HRESULT vkd3d_create_pipeline_cache_from_d3d12_desc(struct d3d12_device *device,
 
     /* Check the vkd3d build since the shader compiler itself may change,
      * and the driver since that will affect the generated pipeline cache */
-    if (strncmp(blob->vkd3d_build, vkd3d_build, VKD3D_CACHE_BUILD_SIZE) ||
+    if (blob->vkd3d_build != vkd3d_build ||
             memcmp(blob->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE))
         return D3D12_ERROR_DRIVER_VERSION_MISMATCH;
 
@@ -107,7 +106,7 @@ VkResult vkd3d_serialize_pipeline_state(const struct d3d12_pipeline_state *state
         blob->version = VKD3D_CACHE_BLOB_VERSION;
         blob->vendor_id = device_properties->vendorID;
         blob->device_id = device_properties->deviceID;
-        strncpy(blob->vkd3d_build, vkd3d_build, VKD3D_CACHE_BUILD_SIZE);
+        blob->vkd3d_build = vkd3d_build;
         memcpy(blob->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE);
 
         if (state->vk_pso_cache)
@@ -182,7 +181,7 @@ struct vkd3d_serialized_pipeline_library
     uint32_t vendor_id;
     uint32_t device_id;
     uint32_t pipeline_count;
-    char vkd3d_build[VKD3D_CACHE_BUILD_SIZE];
+    uint64_t vkd3d_build;
     uint8_t cache_uuid[VK_UUID_SIZE];
     uint8_t data[];
 };
@@ -551,7 +550,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_pipeline_library_Serialize(d3d12_pipeline
     header->vendor_id = device_properties->vendorID;
     header->device_id = device_properties->deviceID;
     header->pipeline_count = pipeline_library->map.used_count;
-    strncpy(header->vkd3d_build, vkd3d_build, VKD3D_CACHE_BUILD_SIZE);
+    header->vkd3d_build = vkd3d_build;
     memcpy(header->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE);
 
     for (i = 0; i < pipeline_library->map.entry_count; i++)
@@ -643,7 +642,7 @@ static HRESULT d3d12_pipeline_library_read_blob(struct d3d12_pipeline_library *p
     if (header->device_id != device_properties->deviceID || header->vendor_id != device_properties->vendorID)
         return D3D12_ERROR_ADAPTER_NOT_FOUND;
 
-    if (strncmp(header->vkd3d_build, vkd3d_build, VKD3D_CACHE_BUILD_SIZE) ||
+    if (header->vkd3d_build != vkd3d_build ||
             memcmp(header->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE))
         return D3D12_ERROR_DRIVER_VERSION_MISMATCH;
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -433,7 +433,7 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     HRESULT hr;
     uint32_t loader_version = VK_API_VERSION_1_0;
 
-    TRACE("Build: %s.\n", vkd3d_build);
+    TRACE("Build: %s.\n", vkd3d_version);
 
     memset(instance, 0, sizeof(*instance));
 

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -45,7 +45,7 @@ if enable_renderdoc
 endif
 
 if not enable_standalone_d3d12
-  vkd3d_lib = shared_library('vkd3d', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_version, vkd3d_headers,
+  vkd3d_lib = shared_library('vkd3d', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_build, vkd3d_version, vkd3d_headers,
     dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep ] + vkd3d_extra_libs,
     include_directories : vkd3d_private_includes,
     install             : true,
@@ -53,7 +53,7 @@ if not enable_standalone_d3d12
     c_args              : '-DVKD3D_EXPORTS',
     override_options    : [ 'c_std='+vkd3d_c_std ])
 else
-  vkd3d_lib = static_library('vkd3d', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_version, vkd3d_headers,
+  vkd3d_lib = static_library('vkd3d', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_build, vkd3d_version, vkd3d_headers,
     dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep ] + vkd3d_extra_libs,
     include_directories : vkd3d_private_includes,
     override_options    : [ 'c_std='+vkd3d_c_std ])

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -30,6 +30,8 @@
 #include "rbtree.h"
 
 #include "vkd3d.h"
+#include "vkd3d_build.h"
+#include "vkd3d_version.h"
 #include "vkd3d_shader.h"
 #include "vkd3d_threads.h"
 #include "vkd3d_platform.h"
@@ -2162,8 +2164,6 @@ HRESULT vkd3d_load_vk_instance_procs(struct vkd3d_vk_instance_procs *procs,
         const struct vkd3d_vk_global_procs *global_procs, VkInstance instance);
 HRESULT vkd3d_load_vk_device_procs(struct vkd3d_vk_device_procs *procs,
         const struct vkd3d_vk_instance_procs *parent_procs, VkDevice device);
-
-extern const char vkd3d_build[];
 
 VkResult vkd3d_set_vk_object_name_utf8(struct d3d12_device *device, uint64_t vk_object,
         VkObjectType vk_object_type, const char *name);

--- a/meson.build
+++ b/meson.build
@@ -92,10 +92,15 @@ if cpu_family == 'x86'
     language : [ 'c', 'cpp' ])
 endif
 
+vkd3d_build = vcs_tag(
+  command : ['git', 'describe', '--always', '--exclude=*', '--abbrev=15', '--dirty=0'],
+  input   : 'vkd3d_build.h.in',
+  output  : 'vkd3d_build.h')
+
 vkd3d_version = vcs_tag(
-  command : ['git', 'describe', '--always', '--dirty=+'],
-  input   : 'vkd3d_version.c.in',
-  output  : 'vkd3d_version.c')
+  command : ['git', 'describe', '--always', '--tags', '--dirty=+'],
+  input   : 'vkd3d_version.h.in',
+  output  : 'vkd3d_version.h')
 
 dxil_spirv = subproject('dxil-spirv')
 dxil_spirv_dep = dxil_spirv.get_variable('dxil_spirv_dep')

--- a/vkd3d_build.h.in
+++ b/vkd3d_build.h.in
@@ -1,0 +1,3 @@
+#include <stdint.h>
+
+static const uint64_t vkd3d_build = 0x@VCS_TAG@;

--- a/vkd3d_version.c.in
+++ b/vkd3d_version.c.in
@@ -1,1 +1,0 @@
-const char vkd3d_build[] = "@VCS_TAG@";

--- a/vkd3d_version.h.in
+++ b/vkd3d_version.h.in
@@ -1,0 +1,1 @@
+static const char vkd3d_version[] = "@VCS_TAG@";


### PR DESCRIPTION
Version string is used in logging for information purposes, but pipelines blobs and libraries use `uint64_t`–based commit hash. Using fixed–size integer silences warnings about string length and makes storing build info a little more space–efficient.

The hash is obtained separately from version string and is shifted to the left by 4 bits if the working tree is dirty.

Supersedes PR #284.