### PR TITLE
vkd3d-utils: Fix building under MSVC

### DIFF
--- a/include/vkd3d_utils.h
+++ b/include/vkd3d_utils.h
@@ -31,10 +31,18 @@ extern "C" {
 #define VKD3D_INFINITE (~0u)
 
 #ifdef _WIN32
-# ifdef VKD3D_UTILS_EXPORTS
-#  define VKD3D_UTILS_EXPORT __declspec(dllexport)
+# ifdef _MSC_VER
+#  define VKD3D_UTILS_EXPORT
 # else
-#  define VKD3D_UTILS_EXPORT __declspec(dllimport)
+  /* We need to specify the __declspec(dllexport) attribute
+   * on MinGW because otherwise the stdcall aliases/fixups
+   * don't get exported.
+   */
+#  ifdef VKD3D_UTILS_EXPORTS
+#   define VKD3D_UTILS_EXPORT __declspec(dllexport)
+#  else
+#   define VKD3D_UTILS_EXPORT __declspec(dllimport)
+#  endif
 # endif
 #elif defined(__GNUC__)
 # define VKD3D_UTILS_EXPORT DECLSPEC_VISIBLE

--- a/libs/vkd3d-utils/meson.build
+++ b/libs/vkd3d-utils/meson.build
@@ -6,6 +6,10 @@ vkd3d_utils_lib = shared_library('vkd3d-proton-utils', vkd3d_utils_src, vkd3d_he
   dependencies        : vkd3d_dep,
   include_directories : vkd3d_private_includes,
   install             : true,
+  objects             : not vkd3d_msvc and vkd3d_platform == 'windows'
+                        ? 'vkd3d-proton-utils.def'
+                        : [],
+  vs_module_defs      : 'vkd3d-proton-utils.def',
   version             : '2.0.0',
   c_args              : '-DVKD3D_UTILS_EXPORTS',
   override_options    : [ 'c_std='+vkd3d_c_std ])

--- a/libs/vkd3d-utils/vkd3d-proton-utils.def
+++ b/libs/vkd3d-utils/vkd3d-proton-utils.def
@@ -1,0 +1,16 @@
+LIBRARY vkd3d-proton-utils-2.dll
+
+EXPORTS
+    D3D12CreateDevice @101
+    D3D12GetDebugInterface @102
+    D3D12CreateRootSignatureDeserializer @107
+    D3D12CreateVersionedRootSignatureDeserializer @108
+
+    D3D12EnableExperimentalFeatures @110
+    D3D12SerializeRootSignature @115
+    D3D12SerializeVersionedRootSignature @116
+
+    vkd3d_create_event
+    vkd3d_wait_event
+    vkd3d_signal_event
+    vkd3d_destroy_event

--- a/libs/vkd3d-utils/vkd3d_utils_main.c
+++ b/libs/vkd3d-utils/vkd3d_utils_main.c
@@ -97,6 +97,15 @@ VKD3D_UTILS_EXPORT HRESULT WINAPI D3D12CreateVersionedRootSignatureDeserializer(
     return vkd3d_create_versioned_root_signature_deserializer(data, data_size, iid, deserializer);
 }
 
+VKD3D_UTILS_EXPORT HRESULT WINAPI D3D12EnableExperimentalFeatures(UINT feature_count,
+        const IID *iids, void *configurations, UINT *configurations_sizes)
+{
+    FIXME("feature_count %u, iids %p, configurations %p, configurations_sizes %p stub!\n",
+            feature_count, iids, configurations, configurations_sizes);
+
+    return E_NOINTERFACE;
+}
+
 VKD3D_UTILS_EXPORT HRESULT WINAPI D3D12SerializeRootSignature(const D3D12_ROOT_SIGNATURE_DESC *desc,
         D3D_ROOT_SIGNATURE_VERSION version, ID3DBlob **blob, ID3DBlob **error_blob)
 {


### PR DESCRIPTION
Use .defs for vkd3d-utils exports

Otherwise this won't work in MSVC because it'd technically be re-defining the D3D12 function prototypes with the decltypes.

There is no other nice way around this.

Closes #323