### PR TITLE
build: Eliminate need for x86-linux-gnu cross file

### DIFF
--- a/build-linux32.txt
+++ b/build-linux32.txt
@@ -1,0 +1,24 @@
+[binaries]
+c = 'gcc'
+cpp = 'g++'
+ar = 'gcc-ar'
+strip = 'strip'
+
+[properties]
+c_args = ['-m32']
+c_link_args = ['-m32']
+cpp_args = ['-m32']
+cpp_link_args = ['-m32']
+pkg_config_path = ['/usr/lib32/pkgconfig']
+pkg_config_libdir = ['/usr/lib32/pkgconfig']
+
+[paths]
+prefix = '/usr'
+libdir = 'lib32'
+bindir = 'bin'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'x86'
+cpu = 'i686'
+endian = 'little'

--- a/package-release.sh
+++ b/package-release.sh
@@ -87,7 +87,7 @@ if [ $opt_native -eq 0 ]; then
   build_script
 else
   build_arch 64
-  build_arch 86 "--cross-file x86-linux-gnu"
+  build_arch 86 "--cross-file build-linux32.txt"
 fi
 
 if [ $opt_nopackage -eq 0 ]; then


### PR DESCRIPTION
Replace this with our own build-linux32.txt

Closes: #336

Signed-off-by: Joshua Ashton <joshua@froggi.es>