### PR TITLE
build: Only generate headers once

### DIFF
--- a/demos/meson.build
+++ b/demos/meson.build
@@ -1,5 +1,5 @@
 demo_vkd3d_deps = [
-  threads_dep
+  threads_dep, vkd3d_headers_dep
 ]
 
 if vkd3d_platform != 'windows'
@@ -18,14 +18,14 @@ else
   ]
 endif
 
-executable('gears', 'gears.c', vkd3d_headers,
+executable('gears', 'gears.c',
   dependencies        : demo_vkd3d_deps,
   include_directories : vkd3d_public_includes,
   install             : true,
   gui_app             : true,
   override_options    : [ 'c_std='+vkd3d_c_std ])
 
-executable('triangle', 'triangle.c', vkd3d_headers,
+executable('triangle', 'triangle.c',
   dependencies        : demo_vkd3d_deps,
   include_directories : vkd3d_public_includes,
   install             : true,

--- a/include/meson.build
+++ b/include/meson.build
@@ -12,4 +12,8 @@ vkd3d_idl = [
   'vkd3d_swapchain_factory.idl',
 ]
 
-vkd3d_headers = idl_generator.process(vkd3d_idl)
+vkd3d_header_files = idl_generator.process(vkd3d_idl)
+vkd3d_headers_lib  = static_library('vkd3d-headers', vkd3d_header_files)
+vkd3d_headers_dep  = declare_dependency(
+  link_with           : vkd3d_headers_lib,
+  include_directories : vkd3d_headers_lib.private_dir_include())

--- a/libs/d3d12/meson.build
+++ b/libs/d3d12/meson.build
@@ -2,7 +2,7 @@ d3d12_src = [
   'main.c'
 ]
 
-d3d12_lib = shared_library('d3d12', d3d12_src, vkd3d_headers,
+d3d12_lib = shared_library('d3d12', d3d12_src,
   name_prefix         : '', # libd3d12.dll -> d3d12.dll
   dependencies        : [ vkd3d_dep, lib_dxgi ],
   include_directories : vkd3d_private_includes,

--- a/libs/vkd3d-shader/meson.build
+++ b/libs/vkd3d-shader/meson.build
@@ -7,11 +7,12 @@ vkd3d_shader_src = [
   'vkd3d_shader_main.c',
 ]
 
-vkd3d_shader_lib = static_library('vkd3d-shader', vkd3d_shader_src, vkd3d_headers,
-  dependencies        : [ vkd3d_common_dep, dxil_spirv_dep ],
+vkd3d_shader_lib = static_library('vkd3d-shader', vkd3d_shader_src,
+  dependencies        : [ vkd3d_common_dep, dxil_spirv_dep, vkd3d_headers_dep ],
   include_directories : vkd3d_private_includes,
   override_options    : [ 'c_std='+vkd3d_c_std ])
 
 vkd3d_shader_dep = declare_dependency(
   link_with           : vkd3d_shader_lib,
+  dependencies        : vkd3d_headers_dep,
   include_directories : vkd3d_public_includes)

--- a/libs/vkd3d-utils/meson.build
+++ b/libs/vkd3d-utils/meson.build
@@ -2,7 +2,7 @@ vkd3d_utils_src = [
   'vkd3d_utils_main.c',
 ]
 
-vkd3d_utils_lib = shared_library('vkd3d-proton-utils', vkd3d_utils_src, vkd3d_headers,
+vkd3d_utils_lib = shared_library('vkd3d-proton-utils', vkd3d_utils_src,
   dependencies        : vkd3d_dep,
   include_directories : vkd3d_private_includes,
   install             : true,

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -45,21 +45,21 @@ if enable_renderdoc
 endif
 
 if not enable_standalone_d3d12
-  vkd3d_lib = shared_library('vkd3d-proton', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_build, vkd3d_version, vkd3d_headers,
-    dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep ] + vkd3d_extra_libs,
+  vkd3d_lib = shared_library('vkd3d-proton', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_build, vkd3d_version,
+    dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep, vkd3d_headers_dep ] + vkd3d_extra_libs,
     include_directories : vkd3d_private_includes,
     install             : true,
     version             : '2.0.0',
     c_args              : '-DVKD3D_EXPORTS',
     override_options    : [ 'c_std='+vkd3d_c_std ])
 else
-  vkd3d_lib = static_library('vkd3d-proton', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_build, vkd3d_version, vkd3d_headers,
-    dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep ] + vkd3d_extra_libs,
+  vkd3d_lib = static_library('vkd3d-proton', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_build, vkd3d_version,
+    dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep, vkd3d_headers_dep ] + vkd3d_extra_libs,
     include_directories : vkd3d_private_includes,
     override_options    : [ 'c_std='+vkd3d_c_std ])
 endif
 
 vkd3d_dep = declare_dependency(
   link_with           : [ vkd3d_lib, vkd3d_common_lib ],
-  dependencies        : vkd3d_extra_libs,
+  dependencies        : [ vkd3d_extra_libs, vkd3d_headers_dep ],
   include_directories : vkd3d_public_includes)

--- a/programs/vkd3d-compiler/meson.build
+++ b/programs/vkd3d-compiler/meson.build
@@ -1,4 +1,4 @@
-executable('vkd3d-proton-compiler', 'main.c', vkd3d_headers,
+executable('vkd3d-proton-compiler', 'main.c',
   dependencies        : [ vkd3d_shader_dep, threads_dep ],
   include_directories : vkd3d_private_includes,
   install             : true,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2,7 +2,7 @@
 vkd3d_test_flags = []
 if vkd3d_platform == 'windows'
   if enable_standalone_d3d12
-    vkd3d_test_deps = [ lib_d3d12, lib_dxgi ]
+    vkd3d_test_deps = [ lib_d3d12, lib_dxgi, vkd3d_headers_dep ]
   else
     vkd3d_test_deps = [ vkd3d_dep, vkd3d_utils_dep ]
     vkd3d_test_flags = ['-DVKD3D_FORCE_UTILS_WRAPPER=1']
@@ -11,14 +11,14 @@ else
   vkd3d_test_deps = [ vkd3d_dep, vkd3d_utils_dep ]
 endif
 
-executable('d3d12', 'd3d12.c', vkd3d_headers,
+executable('d3d12', 'd3d12.c',
   dependencies        : vkd3d_test_deps,
   include_directories : vkd3d_private_includes,
   install             : false,
   c_args              : vkd3d_test_flags,
   override_options    : [ 'c_std='+vkd3d_c_std ])
 
-executable('descriptor-performance', 'descriptor_performance.c', vkd3d_headers,
+executable('descriptor-performance', 'descriptor_performance.c',
   dependencies        : vkd3d_test_deps,
   include_directories : vkd3d_private_includes,
   install             : false,


### PR DESCRIPTION
This makes headers a dependency rather than a generator target.
This also means we get proper dependency tracking of them between projects.

Supercedes: #225
Signed-off-by: Joshua Ashton <joshua@froggi.es>