### PR TITLE
Rework RTV/DSV descriptors

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1956,9 +1956,6 @@ static void d3d12_command_list_clear_attachment_pass(struct d3d12_command_list *
         return;
     }
 
-    if (!d3d12_command_allocator_add_view(list->allocator, view))
-        WARN("Failed to add view.\n");
-
     extent.width = d3d12_resource_desc_get_width(&resource->desc, view->info.texture.miplevel_idx);
     extent.height = d3d12_resource_desc_get_height(&resource->desc, view->info.texture.miplevel_idx);
     extent.depth = view->info.texture.layer_count;
@@ -5537,10 +5534,6 @@ static void STDMETHODCALLTYPE d3d12_command_list_OMSetRenderTargets(d3d12_comman
 
         d3d12_command_list_track_resource_usage(list, rtv_desc->resource);
 
-        /* In D3D12 CPU descriptors are consumed when a command is recorded. */
-        if (!d3d12_command_allocator_add_view(list->allocator, rtv_desc->view))
-            WARN("Failed to add view.\n");
-
         list->rtvs[i] = *rtv_desc;
         list->fb_width = min(list->fb_width, rtv_desc->width);
         list->fb_height = min(list->fb_height, rtv_desc->height);
@@ -5553,10 +5546,6 @@ static void STDMETHODCALLTYPE d3d12_command_list_OMSetRenderTargets(d3d12_comman
                 && rtv_desc->resource)
         {
             d3d12_command_list_track_resource_usage(list, rtv_desc->resource);
-
-            /* In D3D12 CPU descriptors are consumed when a command is recorded. */
-            if (!d3d12_command_allocator_add_view(list->allocator, rtv_desc->view))
-                WARN("Failed to add view.\n");
 
             list->dsv = *rtv_desc;
             list->fb_width = min(list->fb_width, rtv_desc->width);

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2258,7 +2258,7 @@ static void d3d12_command_list_emit_render_pass_transition(struct d3d12_command_
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkImageMemoryBarrier vk_image_barriers[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT + 1];
     VkPipelineStageFlags stage_mask = 0;
-    struct d3d12_dsv_desc *dsv;
+    struct d3d12_rtv_desc *dsv;
     bool do_clear = false;
     uint32_t i, j;
 
@@ -5490,7 +5490,6 @@ static void STDMETHODCALLTYPE d3d12_command_list_OMSetRenderTargets(d3d12_comman
     const VkPhysicalDeviceLimits *limits = &list->device->vk_info.device_limits;
     VkFormat prev_dsv_format, next_dsv_format;
     const struct d3d12_rtv_desc *rtv_desc;
-    const struct d3d12_dsv_desc *dsv_desc;
     unsigned int i;
 
     TRACE("iface %p, render_target_descriptor_count %u, render_target_descriptors %p, "
@@ -5550,20 +5549,20 @@ static void STDMETHODCALLTYPE d3d12_command_list_OMSetRenderTargets(d3d12_comman
 
     if (depth_stencil_descriptor)
     {
-        if ((dsv_desc = d3d12_dsv_desc_from_cpu_handle(*depth_stencil_descriptor))
-                && dsv_desc->resource)
+        if ((rtv_desc = d3d12_rtv_desc_from_cpu_handle(*depth_stencil_descriptor))
+                && rtv_desc->resource)
         {
-            d3d12_command_list_track_resource_usage(list, dsv_desc->resource);
+            d3d12_command_list_track_resource_usage(list, rtv_desc->resource);
 
             /* In D3D12 CPU descriptors are consumed when a command is recorded. */
-            if (!d3d12_command_allocator_add_view(list->allocator, dsv_desc->view))
+            if (!d3d12_command_allocator_add_view(list->allocator, rtv_desc->view))
                 WARN("Failed to add view.\n");
 
-            list->dsv = *dsv_desc;
-            list->fb_width = min(list->fb_width, dsv_desc->width);
-            list->fb_height = min(list->fb_height, dsv_desc->height);
-            list->fb_layer_count = min(list->fb_layer_count, dsv_desc->layer_count);
-            next_dsv_format = dsv_desc->format->vk_format;
+            list->dsv = *rtv_desc;
+            list->fb_width = min(list->fb_width, rtv_desc->width);
+            list->fb_height = min(list->fb_height, rtv_desc->height);
+            list->fb_layer_count = min(list->fb_layer_count, rtv_desc->layer_count);
+            next_dsv_format = rtv_desc->format->vk_format;
         }
         else
         {
@@ -5633,7 +5632,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearDepthStencilView(d3d12_com
 {
     const union VkClearValue clear_value = {.depthStencil = {depth, stencil}};
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    const struct d3d12_dsv_desc *dsv_desc = d3d12_dsv_desc_from_cpu_handle(dsv);
+    const struct d3d12_rtv_desc *dsv_desc = d3d12_rtv_desc_from_cpu_handle(dsv);
     VkImageAspectFlags clear_aspects = 0;
 
     TRACE("iface %p, dsv %#lx, flags %#x, depth %.8e, stencil 0x%02x, rect_count %u, rects %p.\n",

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3091,10 +3091,8 @@ static UINT STDMETHODCALLTYPE d3d12_device_GetDescriptorHandleIncrementSize(d3d1
             return sizeof(struct d3d12_desc);
 
         case D3D12_DESCRIPTOR_HEAP_TYPE_RTV:
-            return sizeof(struct d3d12_rtv_desc);
-
         case D3D12_DESCRIPTOR_HEAP_TYPE_DSV:
-            return sizeof(struct d3d12_dsv_desc);
+            return sizeof(struct d3d12_rtv_desc);
 
         default:
             FIXME("Unhandled type %#x.\n", descriptor_heap_type);
@@ -3177,7 +3175,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateDepthStencilView(d3d12_device_i
     TRACE("iface %p, resource %p, desc %p, descriptor %#lx.\n",
             iface, resource, desc, descriptor.ptr);
 
-    d3d12_dsv_desc_create_dsv(d3d12_dsv_desc_from_cpu_handle(descriptor),
+    d3d12_rtv_desc_create_dsv(d3d12_rtv_desc_from_cpu_handle(descriptor),
             impl_from_ID3D12Device(iface), unsafe_impl_from_ID3D12Resource(resource), desc);
 }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4845,6 +4845,11 @@ void d3d12_desc_create_sampler(struct d3d12_desc *sampler,
 }
 
 /* RTVs */
+void d3d12_rtv_desc_copy(struct d3d12_rtv_desc *dst, struct d3d12_rtv_desc *src)
+{
+    *dst = *src;
+}
+
 void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_device *device,
         struct d3d12_resource *resource, const D3D12_RENDER_TARGET_VIEW_DESC *desc)
 {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4858,7 +4858,7 @@ void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_dev
 
     if (!resource)
     {
-        FIXME("NULL resource RTV not implemented.\n");
+        memset(rtv_desc, 0, sizeof(*rtv_desc));
         return;
     }
 
@@ -4973,7 +4973,7 @@ void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_dev
 
     if (!resource)
     {
-        FIXME("NULL resource DSV not implemented.\n");
+        memset(dsv_desc, 0, sizeof(*dsv_desc));
         return;
     }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4954,15 +4954,6 @@ void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_dev
 }
 
 /* DSVs */
-static void d3d12_dsv_desc_destroy(struct d3d12_dsv_desc *dsv, struct d3d12_device *device)
-{
-    if (dsv->magic != VKD3D_DESCRIPTOR_MAGIC_DSV)
-        return;
-
-    vkd3d_view_decref(dsv->view, device);
-    memset(dsv, 0, sizeof(*dsv));
-}
-
 static VkImageLayout d3d12_dsv_layout_from_flags(UINT flags)
 {
     const D3D12_DSV_FLAGS mask = D3D12_DSV_FLAG_READ_ONLY_DEPTH | D3D12_DSV_FLAG_READ_ONLY_STENCIL;
@@ -4980,13 +4971,13 @@ static VkImageLayout d3d12_dsv_layout_from_flags(UINT flags)
     }
 }
 
-void d3d12_dsv_desc_create_dsv(struct d3d12_dsv_desc *dsv_desc, struct d3d12_device *device,
+void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_device *device,
         struct d3d12_resource *resource, const D3D12_DEPTH_STENCIL_VIEW_DESC *desc)
 {
     struct vkd3d_texture_view_desc vkd3d_desc;
     struct vkd3d_view *view;
 
-    d3d12_dsv_desc_destroy(dsv_desc, device);
+    d3d12_rtv_desc_destroy(dsv_desc, device);
 
     if (!resource)
     {
@@ -5130,20 +5121,12 @@ static ULONG STDMETHODCALLTYPE d3d12_descriptor_heap_Release(ID3D12DescriptorHea
                 break;
 
             case D3D12_DESCRIPTOR_HEAP_TYPE_RTV:
+            case D3D12_DESCRIPTOR_HEAP_TYPE_DSV:
             {
                 struct d3d12_rtv_desc *rtvs = (struct d3d12_rtv_desc *)heap->descriptors;
 
                 for (i = 0; i < heap->desc.NumDescriptors; ++i)
                     d3d12_rtv_desc_destroy(&rtvs[i], device);
-                break;
-            }
-
-            case D3D12_DESCRIPTOR_HEAP_TYPE_DSV:
-            {
-                struct d3d12_dsv_desc *dsvs = (struct d3d12_dsv_desc *)heap->descriptors;
-
-                for (i = 0; i < heap->desc.NumDescriptors; ++i)
-                    d3d12_dsv_desc_destroy(&dsvs[i], device);
                 break;
             }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4933,7 +4933,6 @@ void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_dev
     if (!(view = vkd3d_view_map_create_view(&resource->view_map, device, &key)))
         return;
 
-    rtv_desc->magic = VKD3D_DESCRIPTOR_MAGIC_RTV;
     rtv_desc->sample_count = vk_samples_from_dxgi_sample_desc(&resource->desc.SampleDesc);
     rtv_desc->format = key.u.texture.format;
     rtv_desc->width = d3d12_resource_desc_get_width(&resource->desc, key.u.texture.miplevel_idx);
@@ -5041,7 +5040,6 @@ void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_dev
     if (!(view = vkd3d_view_map_create_view(&resource->view_map, device, &key)))
         return;
 
-    dsv_desc->magic = VKD3D_DESCRIPTOR_MAGIC_DSV;
     dsv_desc->sample_count = vk_samples_from_dxgi_sample_desc(&resource->desc.SampleDesc);
     dsv_desc->format = key.u.texture.format;
     dsv_desc->width = d3d12_resource_desc_get_width(&resource->desc, key.u.texture.miplevel_idx);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -693,7 +693,7 @@ struct d3d12_rtv_desc
     uint32_t magic;
     VkSampleCountFlagBits sample_count;
     const struct vkd3d_format *format;
-    uint64_t width;
+    unsigned int width;
     unsigned int height;
     unsigned int layer_count;
     struct vkd3d_view *view;
@@ -708,24 +708,7 @@ static inline struct d3d12_rtv_desc *d3d12_rtv_desc_from_cpu_handle(D3D12_CPU_DE
 void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_device *device,
         struct d3d12_resource *resource, const D3D12_RENDER_TARGET_VIEW_DESC *desc);
 
-struct d3d12_dsv_desc
-{
-    uint32_t magic;
-    VkSampleCountFlagBits sample_count;
-    const struct vkd3d_format *format;
-    uint64_t width;
-    unsigned int height;
-    unsigned int layer_count;
-    struct vkd3d_view *view;
-    struct d3d12_resource *resource;
-};
-
-static inline struct d3d12_dsv_desc *d3d12_dsv_desc_from_cpu_handle(D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle)
-{
-    return (struct d3d12_dsv_desc *)cpu_handle.ptr;
-}
-
-void d3d12_dsv_desc_create_dsv(struct d3d12_dsv_desc *dsv_desc, struct d3d12_device *device,
+void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_device *device,
         struct d3d12_resource *resource, const D3D12_DEPTH_STENCIL_VIEW_DESC *desc);
 
 struct vkd3d_bound_ssbo_range
@@ -1294,7 +1277,7 @@ struct d3d12_command_list
     DXGI_FORMAT index_buffer_format;
 
     struct d3d12_rtv_desc rtvs[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
-    struct d3d12_dsv_desc dsv;
+    struct d3d12_rtv_desc dsv;
     struct vkd3d_clear_state clear_state;
     VkImageLayout dsv_layout;
     unsigned int fb_width;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -695,6 +695,8 @@ struct d3d12_rtv_desc
     struct d3d12_resource *resource;
 };
 
+void d3d12_rtv_desc_copy(struct d3d12_rtv_desc *dst, struct d3d12_rtv_desc *src);
+
 static inline struct d3d12_rtv_desc *d3d12_rtv_desc_from_cpu_handle(D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle)
 {
     return (struct d3d12_rtv_desc *)cpu_handle.ptr;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -46,10 +46,6 @@
 
 #define MAKE_MAGIC(a,b,c,d) (((uint32_t)a) | (((uint32_t)b) << 8) | (((uint32_t)c) << 16) | (((uint32_t)d) << 24))
 
-#define VKD3D_DESCRIPTOR_MAGIC_FREE    0x00000000u
-#define VKD3D_DESCRIPTOR_MAGIC_DSV     MAKE_MAGIC('D', 'S', 'V', 0)
-#define VKD3D_DESCRIPTOR_MAGIC_RTV     MAKE_MAGIC('R', 'T', 'V', 0)
-
 #define VKD3D_MAX_COMPATIBLE_FORMAT_COUNT 6u
 #define VKD3D_MAX_SHADER_EXTENSIONS       2u
 #define VKD3D_MAX_SHADER_STAGES           5u
@@ -690,7 +686,6 @@ HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
 
 struct d3d12_rtv_desc
 {
-    uint32_t magic;
     VkSampleCountFlagBits sample_count;
     const struct vkd3d_format *format;
     unsigned int width;


### PR DESCRIPTION
Makes use of the per-resource view map for render targets and implements some missing functionality for these descriptor types, like NULL descriptors (trivial) and descriptor copies.

Closes #325.