### PR TITLE
vkd3d: Include correct memory header in hashmap 

### DIFF
--- a/include/private/hashmap.h
+++ b/include/private/hashmap.h
@@ -23,7 +23,7 @@
 
 #include <stddef.h>
 
-#include "memory.h"
+#include "vkd3d_memory.h"
 
 enum hash_map_entry_flag
 {

--- a/programs/vkd3d-compiler/main.c
+++ b/programs/vkd3d-compiler/main.c
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixes warnings about implicit declaration of these functions
when building demos/programs which could be very bad on x64 if used.

Signed-off-by: Joshua Ashton <joshua@froggi.es>