### PR TITLE
build: Replace enable_standalone_d3d12 with tristate enable_d3d12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ ninja install
 #### Compiling manually (cross for d3d12.dll, default)
 ```
 # 64-bit build.
-meson --cross-file build-win64.txt -Denable_standalone_d3d12=True --buildtype release --prefix /your/vkd3d-proton/directory build.64
+meson --cross-file build-win64.txt --buildtype release --prefix /your/vkd3d-proton/directory build.64
 cd build.64
 ninja install
 
 # 32-bit build
-meson --cross-file build-win32.txt -Denable_standalone_d3d12=True  --buildtype release --prefix /your/vkd3d-proton/directory build.86
+meson --cross-file build-win32.txt --buildtype release --prefix /your/vkd3d-proton/directory build.86
 cd build.86
 ninja install
 ```

--- a/libs/meson.build
+++ b/libs/meson.build
@@ -2,6 +2,6 @@ subdir('vkd3d-common')
 subdir('vkd3d-shader')
 subdir('vkd3d')
 subdir('vkd3d-utils')
-if enable_standalone_d3d12
+if enable_d3d12
   subdir('d3d12')
 endif

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -36,7 +36,7 @@ vkd3d_src = [
   'vkd3d_main.c',
 ]
 
-if enable_standalone_d3d12
+if enable_d3d12
   vkd3d_src += 'swapchain.c'
 endif
 
@@ -44,7 +44,7 @@ if enable_renderdoc
   vkd3d_src += ['renderdoc.c']
 endif
 
-if not enable_standalone_d3d12
+if not enable_d3d12
   vkd3d_lib = shared_library('vkd3d-proton', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_build, vkd3d_version,
     dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep ] + vkd3d_extra_libs,
     include_directories : vkd3d_private_includes,

--- a/meson.build
+++ b/meson.build
@@ -11,11 +11,17 @@ vkd3d_platform = target_machine.system()
 
 enable_tests             = get_option('enable_tests')
 enable_extras            = get_option('enable_extras')
-enable_standalone_d3d12  = get_option('enable_standalone_d3d12')
+enable_d3d12             = get_option('enable_d3d12')
 enable_profiling         = get_option('enable_profiling')
 enable_renderdoc         = get_option('enable_renderdoc')
 
-if vkd3d_platform != 'windows' and enable_standalone_d3d12
+if enable_d3d12 == 'auto'
+    enable_d3d12 = (vkd3d_platform == 'windows')
+else
+    enable_d3d12 = (enable_d3d12 == 'true')
+endif
+
+if vkd3d_platform != 'windows' and enable_d3d12
   error('Standalone D3D12 is only supported on Windows.')
 endif
 
@@ -27,7 +33,7 @@ if vkd3d_platform == 'windows'
   add_project_arguments('-D_WIN32_WINNT=0x600', language : 'c')
 endif
 
-if enable_standalone_d3d12
+if enable_d3d12
   add_project_arguments('-DVKD3D_BUILD_STANDALONE_D3D12', language : 'c')
 endif
 
@@ -120,7 +126,7 @@ subdir('include')
 subdir('libs')
 
 if vkd3d_platform == 'windows'
-  if enable_standalone_d3d12
+  if enable_d3d12
     lib_d3d12 = d3d12_dep
   elif not lib_d3d12.found()
     lib_d3d12 = vkd3d_utils_dep

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('enable_tests',            type : 'boolean', value : false)
 option('enable_extras',           type : 'boolean', value : false)
-option('enable_standalone_d3d12', type : 'boolean', value : false)
+option('enable_d3d12',            type : 'combo',   value : 'auto', choices : ['false', 'true', 'auto'])
 option('enable_profiling',        type : 'boolean', value : false)
 option('enable_renderdoc',        type : 'boolean', value : false)

--- a/package-release.sh
+++ b/package-release.sh
@@ -82,8 +82,8 @@ function package {
 }
 
 if [ $opt_native -eq 0 ]; then
-  build_arch 64 "--cross-file build-win64.txt -Denable_standalone_d3d12=True"
-  build_arch 86 "--cross-file build-win32.txt -Denable_standalone_d3d12=True"
+  build_arch 64 "--cross-file build-win64.txt
+  build_arch 86 "--cross-file build-win32.txt
   build_script
 else
   build_arch 64

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,7 +1,7 @@
 
 vkd3d_test_flags = []
 if vkd3d_platform == 'windows'
-  if enable_standalone_d3d12
+  if enable_d3d12
     vkd3d_test_deps = [ lib_d3d12, lib_dxgi, vkd3d_common_dep ]
   else
     vkd3d_test_deps = [ vkd3d_dep, vkd3d_utils_dep ]


### PR DESCRIPTION
Enables d3d12 on windows by default. 
`-Denable_standalone_d3d12=true` will cause a warning, but proton build scripts should keep working.

Tested on linux and with mingw64.

Closes: #335