### PR TITLE
vkd3d: Disable waveops for time being.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4248,7 +4248,9 @@ static void d3d12_device_caps_init_feature_options1(struct d3d12_device *device)
 {
     D3D12_FEATURE_DATA_D3D12_OPTIONS1 *options1 = &device->d3d12_caps.options1;
 
-    options1->WaveOps = device->d3d12_caps.max_shader_model >= D3D_SHADER_MODEL_6_0;
+    /* FIXME: Enabling wave ops breaks HZD, disable for time being. */
+    /*options1->WaveOps = device->d3d12_caps.max_shader_model >= D3D_SHADER_MODEL_6_0;*/
+    options1->WaveOps = FALSE;
 
     if (device->vk_info.EXT_subgroup_size_control)
     {


### PR DESCRIPTION
The fix which enabled waveops detection broke HZD, since we never tested
with that feature enabled.

Keep it disabled until we can figure out what is going on.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>