### PR TITLE
vkd3d: Use pipeline barrier command buffers for queue serialization.

### DIFF
--- a/libs/vkd3d/debug_ring.c
+++ b/libs/vkd3d/debug_ring.c
@@ -312,10 +312,6 @@ void vkd3d_shader_debug_ring_end_command_buffer(struct d3d12_command_list *list)
                                 list->device->debug_ring.host_buffer,
                                 1, &buffer_copy));
 
-        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-        barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
-        VK_CALL(vkCmdPipelineBarrier(list->vk_command_buffer,
-                                     VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_HOST_BIT, 0,
-                                     1, &barrier, 0, NULL, 0, NULL));
+        /* Host barrier is taken care of automatically. */
     }
 }

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -624,34 +624,6 @@ static HRESULT d3d12_resource_create(struct d3d12_device *device,
                                      const D3D12_CLEAR_VALUE *optimized_clear_value, bool placed,
                                      struct d3d12_resource **resource);
 
-bool d3d12_heap_needs_host_barrier_for_write(struct d3d12_heap *heap)
-{
-    if (!heap)
-    {
-        /* This is a reserved resource and we have no guarantee
-         * it's not mapped to something with readback. */
-        return true;
-    }
-
-    switch (heap->desc.Properties.Type)
-    {
-    case D3D12_HEAP_TYPE_DEFAULT:
-    case D3D12_HEAP_TYPE_UPLOAD:
-        return false;
-
-    case D3D12_HEAP_TYPE_READBACK:
-        return true;
-
-    case D3D12_HEAP_TYPE_CUSTOM:
-        return heap->desc.Properties.CPUPageProperty != D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE;
-
-    default:
-        break;
-    }
-
-    return false;
-}
-
 static HRESULT d3d12_heap_init_omnipotent_buffer(struct d3d12_heap *heap, struct d3d12_device *device,
         const D3D12_HEAP_DESC *desc)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1266,7 +1266,6 @@ struct d3d12_command_list
 
     bool is_recording;
     bool is_valid;
-    bool need_host_barrier;
     bool debug_capture;
     bool has_replaced_shaders;
     bool has_valid_index_buffer;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1336,6 +1336,10 @@ struct vkd3d_queue
 
     VkQueue vk_queue;
 
+    VkCommandPool barrier_pool;
+    VkCommandBuffer barrier_command_buffer;
+    VkSemaphore serializing_binary_semaphore;
+
     uint32_t vk_family_index;
     VkQueueFlags vk_queue_flags;
     uint32_t timestamp_bits;
@@ -1387,8 +1391,9 @@ struct d3d12_command_queue_submission_signal
 struct d3d12_command_queue_submission_execute
 {
     VkCommandBuffer *cmd;
-    LONG **outstanding_submissions_count;
-    UINT count;
+    LONG **outstanding_submissions_counters;
+    UINT cmd_count;
+    UINT outstanding_submissions_counter_count;
 
     struct d3d12_resource_initial_transition *transitions;
     size_t transition_count;
@@ -1453,8 +1458,6 @@ struct d3d12_command_queue
     size_t submissions_size;
     uint64_t drain_count;
     uint64_t queue_drain_count;
-
-    struct vkd3d_timeline_semaphore submit_timeline;
 
     struct vkd3d_private_store private_store;
 


### PR DESCRIPTION
We have observed a lot of large GPU bubbles when using back-to-back
timeline semaphores to synchronize GPU submissions. Use prebaked
pipeline barrier command buffers instead.

To resolve queue sparse serialization, use two binary semaphore pairs to
resolve this. There is no need to use timeline semaphores in this case.

Fix https://github.com/HansKristian-Work/vkd3d-proton/issues/377.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>