### PR TITLE
vkd3d: Support offset buffers for raw/structured texel buffers.

### DIFF
--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -8921,7 +8921,7 @@ static void vkd3d_dxbc_compiler_emit_ld_raw_structured_srv_uav(struct vkd3d_dxbc
         access_mask = SpvMemoryAccessAlignedMask;
     else if (image.ssbo)
         base_coordinate_id = vkd3d_dxbc_compiler_adjust_ssbo_offset(compiler, &resource->reg, base_coordinate_id);
-    else if (!image.raw && !image.structure_stride)
+    else
         base_coordinate_id = vkd3d_dxbc_compiler_adjust_typed_buffer_offset(compiler, &resource->reg, base_coordinate_id);
 
     texel_type_id = vkd3d_spirv_get_type_id(builder, image.sampled_type, VKD3D_VEC4_SIZE);
@@ -9062,7 +9062,7 @@ static void vkd3d_dxbc_compiler_emit_store_uav_raw_structured(struct vkd3d_dxbc_
         access_mask = SpvMemoryAccessAlignedMask;
     else if (image.ssbo)
         base_coordinate_id = vkd3d_dxbc_compiler_adjust_ssbo_offset(compiler, &dst->reg, base_coordinate_id);
-    else if (!image.raw && !image.structure_stride)
+    else
         base_coordinate_id = vkd3d_dxbc_compiler_adjust_typed_buffer_offset(compiler, &dst->reg, base_coordinate_id);
 
     texel = &src[instruction->src_count - 1];
@@ -9413,8 +9413,13 @@ static void vkd3d_dxbc_compiler_emit_atomic_instruction(struct vkd3d_dxbc_compil
                 type_id, structure_stride, &src[0], VKD3DSP_WRITEMASK_0,
                 &src[0], VKD3DSP_WRITEMASK_1);
 
-        if (resource->reg.type != VKD3DSPR_GROUPSHAREDMEM && image.ssbo && reg_info.storage_class != SpvStorageClassPhysicalStorageBuffer)
-            coordinate_id = vkd3d_dxbc_compiler_adjust_ssbo_offset(compiler, &resource->reg, coordinate_id);
+        if (resource->reg.type != VKD3DSPR_GROUPSHAREDMEM && reg_info.storage_class != SpvStorageClassPhysicalStorageBuffer)
+        {
+            if (image.ssbo)
+                coordinate_id = vkd3d_dxbc_compiler_adjust_ssbo_offset(compiler, &resource->reg, coordinate_id);
+            else
+                coordinate_id = vkd3d_dxbc_compiler_adjust_typed_buffer_offset(compiler, &resource->reg, coordinate_id);
+        }
     }
     else
     {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3988,7 +3988,6 @@ static bool vkd3d_buffer_view_get_aligned_view(struct d3d12_desc *descriptor,
         VkDeviceSize structured_stride, struct vkd3d_view **view)
 {
     struct vkd3d_bound_buffer_range typed_range = { 0, 0 };
-    bool is_untyped_buffer, is_typed_buffer;
     const struct vkd3d_format *vkd3d_format;
     VkDeviceSize max_resource_elements;
     VkDeviceSize max_element_headroom;
@@ -3997,12 +3996,7 @@ static bool vkd3d_buffer_view_get_aligned_view(struct d3d12_desc *descriptor,
     VkDeviceSize begin_range;
     VkDeviceSize end_range;
 
-    is_untyped_buffer =
-            (structured_stride && format == DXGI_FORMAT_UNKNOWN) ||
-            (vk_flags & VKD3D_VIEW_RAW_BUFFER) != 0;
-    is_typed_buffer = !is_untyped_buffer;
-
-    if (is_typed_buffer && (device->bindless_state.flags & VKD3D_TYPED_OFFSET_BUFFER))
+    if (device->bindless_state.flags & VKD3D_TYPED_OFFSET_BUFFER)
     {
         /* For typed buffers, we will try to remove two cases of extreme hashmap contention, i.e.
          * first_element and num_elements. By quantizing these two and relying on offset buffers,


### PR DESCRIPTION
DXBC only, will need DXIL support.