### PR TITLE
Rework query initialization

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5883,18 +5883,17 @@ HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_H
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     struct d3d12_query_heap *object;
     VkQueryPoolCreateInfo pool_info;
-    unsigned int element_count;
     VkResult vr;
     HRESULT hr;
 
-    element_count = DIV_ROUND_UP(desc->Count, sizeof(*object->availability_mask) * CHAR_BIT);
-    if (!(object = vkd3d_malloc(offsetof(struct d3d12_query_heap, availability_mask[element_count]))))
+    if (!(object = vkd3d_malloc(sizeof(*object))))
         return E_OUTOFMEMORY;
 
     object->ID3D12QueryHeap_iface.lpVtbl = &d3d12_query_heap_vtbl;
     object->refcount = 1;
     object->device = device;
-    memset(object->availability_mask, 0, element_count * sizeof(*object->availability_mask));
+    object->desc = *desc;
+    object->initialized = 0;
 
     pool_info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
     pool_info.pNext = NULL;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -761,37 +761,18 @@ struct d3d12_query_heap
     ID3D12QueryHeap ID3D12QueryHeap_iface;
     LONG refcount;
 
+    D3D12_QUERY_HEAP_DESC desc;
     VkQueryPool vk_query_pool;
+    uint32_t initialized;
 
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
-
-    uint64_t availability_mask[];
 };
 
 HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_HEAP_DESC *desc,
         struct d3d12_query_heap **heap);
 struct d3d12_query_heap *unsafe_impl_from_ID3D12QueryHeap(ID3D12QueryHeap *iface);
-
-/* A Vulkan query has to be issued at least one time before the result is
- * available. In D3D12 it is legal to get query reults for not issued queries.
- */
-static inline bool d3d12_query_heap_is_result_available(const struct d3d12_query_heap *heap,
-        unsigned int query_index)
-{
-    unsigned int index = query_index / (sizeof(*heap->availability_mask) * CHAR_BIT);
-    unsigned int shift = query_index % (sizeof(*heap->availability_mask) * CHAR_BIT);
-    return heap->availability_mask[index] & ((uint64_t)1 << shift);
-}
-
-static inline void d3d12_query_heap_mark_result_as_available(struct d3d12_query_heap *heap,
-        unsigned int query_index)
-{
-    unsigned int index = query_index / (sizeof(*heap->availability_mask) * CHAR_BIT);
-    unsigned int shift = query_index % (sizeof(*heap->availability_mask) * CHAR_BIT);
-    heap->availability_mask[index] |= (uint64_t)1 << shift;
-}
 
 enum vkd3d_root_signature_flag
 {
@@ -1253,6 +1234,7 @@ struct vkd3d_clear_state
 enum vkd3d_initial_transition_type
 {
     VKD3D_INITIAL_TRANSITION_TYPE_RESOURCE,
+    VKD3D_INITIAL_TRANSITION_TYPE_QUERY_HEAP,
 };
 
 struct vkd3d_initial_transition
@@ -1265,6 +1247,7 @@ struct vkd3d_initial_transition
             struct d3d12_resource *resource;
             bool perform_initial_transition;
         } resource;
+        struct d3d12_query_heap *query_heap;
     };
 };
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1250,10 +1250,22 @@ struct vkd3d_clear_state
     struct vkd3d_clear_attachment attachments[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT + 1];
 };
 
-struct d3d12_resource_initial_transition
+enum vkd3d_initial_transition_type
 {
-    struct d3d12_resource *resource;
-    bool perform_initial_transition;
+    VKD3D_INITIAL_TRANSITION_TYPE_RESOURCE,
+};
+
+struct vkd3d_initial_transition
+{
+    enum vkd3d_initial_transition_type type;
+    union
+    {
+        struct
+        {
+            struct d3d12_resource *resource;
+            bool perform_initial_transition;
+        } resource;
+    };
 };
 
 struct d3d12_command_list
@@ -1315,9 +1327,9 @@ struct d3d12_command_list
     size_t descriptor_updates_size;
     size_t descriptor_updates_count;
 
-    struct d3d12_resource_initial_transition *resource_init_transitions;
-    size_t resource_init_transitions_size;
-    size_t resource_init_transitions_count;
+    struct vkd3d_initial_transition *init_transitions;
+    size_t init_transitions_size;
+    size_t init_transitions_count;
 
     LONG *outstanding_submissions_count;
 
@@ -1394,7 +1406,7 @@ struct d3d12_command_queue_submission_execute
     UINT cmd_count;
     UINT outstanding_submissions_counter_count;
 
-    struct d3d12_resource_initial_transition *transitions;
+    struct vkd3d_initial_transition *transitions;
     size_t transition_count;
 
     bool debug_capture;

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -23980,8 +23980,8 @@ static void test_query_occlusion(void)
         else
             expected_result = samples_passed ? 640 * 480 : 0;
 
-        ok(result == expected_result || (expected_result && result >= expected_result),
-                "Test %u: Got unexpected result %"PRIu64".\n", i, result);
+        todo_if(expected_result && tests[i].type == D3D12_QUERY_TYPE_BINARY_OCCLUSION)
+        ok(result == expected_result, "Test %u: Got unexpected result %"PRIu64".\n", i, result);
     }
     release_resource_readback(&rb);
 
@@ -24033,8 +24033,8 @@ static void test_resolve_non_issued_query_data(void)
     timestamps = get_readback_data(&rb, 0, 0, 0, sizeof(*timestamps));
     ok(timestamps[0] != initial_data[0] && timestamps[0] > 0,
             "Got unexpected timestamp %#"PRIx64".\n", timestamps[0]);
-    ok(!timestamps[1], "Got unexpected timestamp %#"PRIx64".\n", timestamps[1]);
-    ok(!timestamps[2], "Got unexpected timestamp %#"PRIx64".\n", timestamps[2]);
+    todo ok(!timestamps[1], "Got unexpected timestamp %#"PRIx64".\n", timestamps[1]);
+    todo ok(!timestamps[2], "Got unexpected timestamp %#"PRIx64".\n", timestamps[2]);
     ok(timestamps[3] != initial_data[3] && timestamps[3] > 0,
             "Got unexpected timestamp %#"PRIx64".\n", timestamps[3]);
     release_resource_readback(&rb);
@@ -24186,7 +24186,7 @@ static void test_resolve_query_data_in_reordered_command_list(void)
     reset_command_list(command_lists[0], context.allocator);
     get_buffer_readback_with_command_list(readback_buffer, DXGI_FORMAT_UNKNOWN, &rb, queue, command_lists[0]);
     result = get_readback_uint64(&rb, 0, 0);
-    todo ok(result == context.render_target_desc.Width * context.render_target_desc.Height,
+    ok(result == context.render_target_desc.Width * context.render_target_desc.Height,
             "Got unexpected result %"PRIu64".\n", result);
     release_resource_readback(&rb);
 


### PR DESCRIPTION
Extends the initial resource transition framework to allow for query heap initialization, which is necessary because D3D12 queries are immediately considered available. Fixes `test_resolve_query_data_in_reordered_command_list`, but as a compromise, returned values for uninitialized timestamp queries are non-zero, thus breaking another test. `todo`s have been changed accordingly.

This also greatly simplifies our impementation of `ResolveQueryData`.