### PR TITLE
Binary occlusion query fixup

### DIFF
--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -12,6 +12,7 @@ vkd3d_shaders =[
   'shaders/cs_clear_uav_image_2d_uint.comp',
   'shaders/cs_clear_uav_image_3d_float.comp',
   'shaders/cs_clear_uav_image_3d_uint.comp',
+  'shaders/cs_resolve_binary_queries.comp',
 
   'shaders/fs_copy_image_float.frag',
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -1009,7 +1009,9 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
     if (heap_type == D3D12_HEAP_TYPE_UPLOAD)
         buffer_info.usage &= ~VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     else if (heap_type == D3D12_HEAP_TYPE_READBACK)
-        buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    {
+        buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    }
 
     if (device->device_info.buffer_device_address_features.bufferDeviceAddress)
         buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;

--- a/libs/vkd3d/shaders/cs_resolve_binary_queries.comp
+++ b/libs/vkd3d/shaders/cs_resolve_binary_queries.comp
@@ -1,0 +1,26 @@
+#version 450
+
+layout(local_size_x = 64) in;
+
+layout(binding = 0, std430)
+buffer s_query_buffer_t {
+  uvec2 data[];
+} s_query_buffer;
+
+layout(push_constant)
+uniform u_info_t {
+  uint query_offset;
+  uint query_count;
+} u_info;
+
+void main() {
+  uint thread_id = gl_GlobalInvocationID.x;
+
+  if (thread_id < u_info.query_count) {
+    uint query_id = u_info.query_offset + thread_id;
+    uvec2 query_data = s_query_buffer.data[query_id];
+
+    if (any(greaterThan(query_data, uvec2(1, 0))))
+      s_query_buffer.data[query_id] = uvec2(1, 0);
+  }
+}

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1781,6 +1781,26 @@ HRESULT vkd3d_swapchain_ops_init(struct vkd3d_swapchain_ops *meta_swapchain_ops,
 void vkd3d_swapchain_ops_cleanup(struct vkd3d_swapchain_ops *meta_swapchain_ops,
         struct d3d12_device *device);
 
+#define VKD3D_QUERY_OP_WORKGROUP_SIZE (64)
+
+struct vkd3d_query_op_args
+{
+    uint32_t query_offset;
+    uint32_t query_count;
+};
+
+struct vkd3d_query_ops
+{
+    VkDescriptorSetLayout vk_set_layout;
+    VkPipelineLayout vk_pipeline_layout;
+    VkPipeline vk_resolve_binary_pipeline;
+};
+
+HRESULT vkd3d_query_ops_init(struct vkd3d_query_ops *meta_query_ops,
+        struct d3d12_device *device);
+void vkd3d_query_ops_cleanup(struct vkd3d_query_ops *meta_query_ops,
+        struct d3d12_device *device);
+
 struct vkd3d_meta_ops_common
 {
     VkShaderModule vk_module_fullscreen_vs;
@@ -1794,6 +1814,7 @@ struct vkd3d_meta_ops
     struct vkd3d_clear_uav_ops clear_uav;
     struct vkd3d_copy_image_ops copy_image;
     struct vkd3d_swapchain_ops swapchain;
+    struct vkd3d_query_ops query;
 };
 
 HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device *device);

--- a/libs/vkd3d/vkd3d_shaders.h
+++ b/libs/vkd3d/vkd3d_shaders.h
@@ -41,6 +41,7 @@ enum vkd3d_meta_copy_mode
 #include <cs_clear_uav_image_2d_uint.h>
 #include <cs_clear_uav_image_3d_float.h>
 #include <cs_clear_uav_image_3d_uint.h>
+#include <cs_resolve_binary_queries.h>
 #include <vs_fullscreen_layer.h>
 #include <vs_fullscreen.h>
 #include <gs_fullscreen.h>

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -23985,7 +23985,6 @@ static void test_query_occlusion(void)
         else
             expected_result = samples_passed ? 640 * 480 : 0;
 
-        todo_if(expected_result && tests[i].type == D3D12_QUERY_TYPE_BINARY_OCCLUSION)
         ok(result == expected_result, "Test %u: Got unexpected result %"PRIu64".\n", i, result);
     }
     release_resource_readback(&rb);


### PR DESCRIPTION
Replaces non-zero sample counts with 1 in order to match D3D12 behaviour.