### PR TITLE
Use scratch buffer for binary query fixup

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2256,6 +2256,98 @@ static void d3d12_remove_device_singleton(LUID luid)
     }
 }
 
+static HRESULT d3d12_device_create_scratch_buffer(struct d3d12_device *device, VkDeviceSize size, struct vkd3d_scratch_buffer *scratch)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    VkDeviceMemory vk_memory = VK_NULL_HANDLE;
+    VkBuffer vk_buffer = VK_NULL_HANDLE;
+    D3D12_RESOURCE_DESC resource_desc;
+    D3D12_HEAP_PROPERTIES heap_desc;
+    HRESULT hr;
+
+    TRACE("device %p, size %llu, scratch %p.\n", device, size, scratch);
+
+    memset(&heap_desc, 0, sizeof(heap_desc));
+    heap_desc.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+    resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+    resource_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+    resource_desc.Width = size;
+    resource_desc.Height = 1;
+    resource_desc.DepthOrArraySize = 1;
+    resource_desc.MipLevels = 1;
+    resource_desc.Format = DXGI_FORMAT_UNKNOWN;
+    resource_desc.SampleDesc.Count = 1;
+    resource_desc.SampleDesc.Quality = 0;
+    resource_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+
+    if (FAILED(hr = vkd3d_create_buffer(device, &heap_desc, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS, &resource_desc, &vk_buffer)))
+        return hr;
+
+    if (FAILED(hr = vkd3d_allocate_buffer_memory(device, vk_buffer, NULL,
+            &heap_desc, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS, &vk_memory, NULL, NULL)))
+    {
+        VK_CALL(vkDestroyBuffer(device->vk_device, vk_buffer, NULL));
+        return hr;
+    }
+
+    scratch->vk_buffer = vk_buffer;
+    scratch->vk_memory = vk_memory;
+    scratch->size = size;
+    scratch->offset = 0;
+    scratch->va = device->device_info.buffer_device_address_features.bufferDeviceAddress
+            ? vkd3d_get_buffer_device_address(device, vk_buffer) : 0ull;
+    return S_OK;
+}
+
+static void d3d12_device_destroy_scratch_buffer(struct d3d12_device *device, const struct vkd3d_scratch_buffer *scratch)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+
+    TRACE("device %p, scratch %p.\n", device, scratch);
+
+    VK_CALL(vkFreeMemory(device->vk_device, scratch->vk_memory, NULL));
+    VK_CALL(vkDestroyBuffer(device->vk_device, scratch->vk_buffer, NULL));
+}
+
+HRESULT d3d12_device_get_scratch_buffer(struct d3d12_device *device, VkDeviceSize min_size, struct vkd3d_scratch_buffer *scratch)
+{
+    if (min_size > VKD3D_SCRATCH_BUFFER_SIZE)
+        return d3d12_device_create_scratch_buffer(device, min_size, scratch);
+
+    pthread_mutex_lock(&device->mutex);
+
+    if (device->scratch_buffer_count)
+    {
+        *scratch = device->scratch_buffers[--device->scratch_buffer_count];
+        scratch->offset = 0;
+        pthread_mutex_unlock(&device->mutex);
+        return S_OK;
+    }
+    else
+    {
+        pthread_mutex_unlock(&device->mutex);
+        return d3d12_device_create_scratch_buffer(device, VKD3D_SCRATCH_BUFFER_SIZE, scratch);
+    }
+}
+
+void d3d12_device_return_scratch_buffer(struct d3d12_device *device, const struct vkd3d_scratch_buffer *scratch)
+{
+    pthread_mutex_lock(&device->mutex);
+
+    if (scratch->size == VKD3D_SCRATCH_BUFFER_SIZE && device->scratch_buffer_count < VKD3D_SCRATCH_BUFFER_COUNT)
+    {
+        device->scratch_buffers[device->scratch_buffer_count++] = *scratch;
+        pthread_mutex_unlock(&device->mutex);
+    }
+    else
+    {
+        pthread_mutex_unlock(&device->mutex);
+        d3d12_device_destroy_scratch_buffer(device, scratch);
+    }
+}
+
 /* ID3D12Device */
 static inline struct d3d12_device *impl_from_ID3D12Device(d3d12_device_iface *iface)
 {
@@ -2301,6 +2393,10 @@ static ULONG STDMETHODCALLTYPE d3d12_device_AddRef(d3d12_device_iface *iface)
 static void d3d12_device_destroy(struct d3d12_device *device)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    size_t i;
+
+    for (i = 0; i < device->scratch_buffer_count; i++)
+        d3d12_device_destroy_scratch_buffer(device, &device->scratch_buffers[i]);
 
     vkd3d_private_store_destroy(&device->private_store);
 

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -1074,24 +1074,13 @@ HRESULT vkd3d_query_ops_init(struct vkd3d_query_ops *meta_query_ops,
         struct d3d12_device *device)
 {
     VkPushConstantRange push_constant_range;
-    VkDescriptorSetLayoutBinding binding;
     VkResult vr;
-
-    binding.binding = 0;
-    binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    binding.descriptorCount = 1;
-    binding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    binding.pImmutableSamplers = NULL;
 
     push_constant_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     push_constant_range.offset = 0;
     push_constant_range.size = sizeof(struct vkd3d_query_op_args);
 
-    if ((vr = vkd3d_meta_create_descriptor_set_layout(device, 1, &binding, &meta_query_ops->vk_set_layout)) < 0)
-        goto fail;
-
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 1, &meta_query_ops->vk_set_layout,
-            1, &push_constant_range, &meta_query_ops->vk_pipeline_layout)) < 0)
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL, 1, &push_constant_range, &meta_query_ops->vk_pipeline_layout)) < 0)
         goto fail;
 
     if ((vr = vkd3d_meta_create_compute_pipeline(device, sizeof(cs_resolve_binary_queries), cs_resolve_binary_queries,
@@ -1110,7 +1099,6 @@ void vkd3d_query_ops_cleanup(struct vkd3d_query_ops *meta_query_ops,
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
 
-    VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, meta_query_ops->vk_set_layout, NULL));
     VK_CALL(vkDestroyPipelineLayout(device->vk_device, meta_query_ops->vk_pipeline_layout, NULL));
     VK_CALL(vkDestroyPipeline(device->vk_device, meta_query_ops->vk_resolve_binary_pipeline, NULL));
 }

--- a/libs/vkd3d/shaders/cs_resolve_binary_queries.comp
+++ b/libs/vkd3d/shaders/cs_resolve_binary_queries.comp
@@ -1,26 +1,30 @@
 #version 450
 
+#extension GL_EXT_buffer_reference : require
+
 layout(local_size_x = 64) in;
 
-layout(binding = 0, std430)
-buffer s_query_buffer_t {
+layout(buffer_reference, std430, buffer_reference_align = 8)
+buffer query_buffer_t {
   uvec2 data[];
-} s_query_buffer;
+};
 
 layout(push_constant)
 uniform u_info_t {
-  uint query_offset;
+  query_buffer_t src_queries;
+  query_buffer_t dst_queries;
   uint query_count;
-} u_info;
+};
 
 void main() {
   uint thread_id = gl_GlobalInvocationID.x;
 
-  if (thread_id < u_info.query_count) {
-    uint query_id = u_info.query_offset + thread_id;
-    uvec2 query_data = s_query_buffer.data[query_id];
+  if (thread_id < query_count) {
+    uvec2 query_data = src_queries.data[thread_id];
 
     if (any(greaterThan(query_data, uvec2(1, 0))))
-      s_query_buffer.data[query_id] = uvec2(1, 0);
+      query_data = uvec2(1, 0);
+
+    dst_queries.data[thread_id] = query_data;
   }
 }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1801,13 +1801,13 @@ void vkd3d_swapchain_ops_cleanup(struct vkd3d_swapchain_ops *meta_swapchain_ops,
 
 struct vkd3d_query_op_args
 {
-    uint32_t query_offset;
+    VkDeviceAddress src_queries;
+    VkDeviceAddress dst_queries;
     uint32_t query_count;
 };
 
 struct vkd3d_query_ops
 {
-    VkDescriptorSetLayout vk_set_layout;
     VkPipelineLayout vk_pipeline_layout;
     VkPipeline vk_resolve_binary_pipeline;
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2178,6 +2178,13 @@ static inline unsigned int d3d12_resource_desc_get_sub_resource_count(const D3D1
     return d3d12_resource_desc_get_layer_count(desc) * desc->MipLevels;
 }
 
+VkDeviceAddress vkd3d_get_buffer_device_address(struct d3d12_device *device, VkBuffer vk_buffer);
+
+static inline VkDeviceAddress d3d12_resource_get_va(const struct d3d12_resource *resource, VkDeviceSize offset)
+{
+    return vkd3d_get_buffer_device_address(resource->device, resource->vk_buffer) + resource->heap_offset + offset;
+}
+
 static inline unsigned int vkd3d_compute_workgroup_count(unsigned int thread_count, unsigned int workgroup_size)
 {
     return (thread_count + workgroup_size - 1) / workgroup_size;
@@ -2231,8 +2238,6 @@ static inline void vk_prepend_struct(void *header, void *structure)
     vk_structure->pNext = vk_header->pNext;
     vk_header->pNext = vk_structure;
 }
-
-VkDeviceAddress vkd3d_get_buffer_device_address(struct d3d12_device *device, VkBuffer vk_buffer);
 
 #define VKD3D_NULL_BUFFER_SIZE 16
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1107,6 +1107,18 @@ enum vkd3d_descriptor_pool_types
     VKD3D_DESCRIPTOR_POOL_TYPE_COUNT
 };
 
+#define VKD3D_SCRATCH_BUFFER_SIZE (1ull << 20)
+#define VKD3D_SCRATCH_BUFFER_COUNT (32u)
+
+struct vkd3d_scratch_buffer
+{
+    VkBuffer vk_buffer;
+    VkDeviceMemory vk_memory;
+    VkDeviceSize size;
+    VkDeviceSize offset;
+    VkDeviceAddress va;
+};
+
 /* ID3D12CommandAllocator */
 struct d3d12_command_allocator
 {
@@ -1139,6 +1151,10 @@ struct d3d12_command_allocator
     VkCommandBuffer *command_buffers;
     size_t command_buffers_size;
     size_t command_buffer_count;
+
+    struct vkd3d_scratch_buffer *scratch_buffers;
+    size_t scratch_buffers_size;
+    size_t scratch_buffer_count;
 
     LONG outstanding_submissions_count;
 
@@ -1954,6 +1970,9 @@ struct d3d12_device
     struct vkd3d_private_store private_store;
     struct d3d12_caps d3d12_caps;
 
+    struct vkd3d_scratch_buffer scratch_buffers[VKD3D_SCRATCH_BUFFER_COUNT];
+    size_t scratch_buffer_count;
+
     HRESULT removed_reason;
 
     const struct vkd3d_format *depth_stencil_formats;
@@ -1976,6 +1995,9 @@ bool d3d12_device_is_uma(struct d3d12_device *device, bool *coherent);
 void d3d12_device_mark_as_removed(struct d3d12_device *device, HRESULT reason,
         const char *message, ...) VKD3D_PRINTF_FUNC(3, 4);
 struct d3d12_device *unsafe_impl_from_ID3D12Device(d3d12_device_iface *iface);
+
+HRESULT d3d12_device_get_scratch_buffer(struct d3d12_device *device, VkDeviceSize min_size, struct vkd3d_scratch_buffer *scratch);
+void d3d12_device_return_scratch_buffer(struct d3d12_device *device, const struct vkd3d_scratch_buffer *scratch);
 
 static inline HRESULT d3d12_device_query_interface(struct d3d12_device *device, REFIID iid, void **object)
 {


### PR DESCRIPTION
Paves the way for a potential predication rework, and potentially improves performance in case the app directly resolves queries into host memory.