### PR TITLE
Rework predication

### DIFF
--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -12,7 +12,9 @@ vkd3d_shaders =[
   'shaders/cs_clear_uav_image_2d_uint.comp',
   'shaders/cs_clear_uav_image_3d_float.comp',
   'shaders/cs_clear_uav_image_3d_uint.comp',
+  'shaders/cs_predicate_command.comp',
   'shaders/cs_resolve_binary_queries.comp',
+  'shaders/cs_resolve_predicate.comp',
 
   'shaders/fs_copy_image_float.frag',
 

--- a/libs/vkd3d/shaders/cs_predicate_command.comp
+++ b/libs/vkd3d/shaders/cs_predicate_command.comp
@@ -1,0 +1,40 @@
+#version 450
+
+#extension GL_EXT_buffer_reference : require
+
+layout(local_size_x = 1) in;
+
+layout(constant_id = 0) const uint c_arg_count = 0;
+layout(constant_id = 1) const bool c_arg_indirect = false;
+
+layout(std430, buffer_reference, buffer_reference_align = 4)
+readonly buffer predicate_t {
+  uint data;
+};
+
+layout(std430, buffer_reference, buffer_reference_align = 4)
+readonly buffer src_args_t {
+  uint data[];
+};
+
+layout(std430, buffer_reference, buffer_reference_align = 4)
+writeonly buffer dst_args_t {
+  uint data[];
+};
+
+layout(push_constant)
+uniform u_info_t {
+  predicate_t predicate;
+  src_args_t src_args;
+  dst_args_t dst_args;
+  uint cmd_args[5];
+};
+
+void main() {
+  bool do_exec = predicate.data != 0;
+
+  for (uint i = 0; i < c_arg_count; i++) {
+    uint arg = c_arg_indirect ? src_args.data[i] : cmd_args[i];
+    dst_args.data[i] = do_exec ? arg : 0u;
+  }
+}

--- a/libs/vkd3d/shaders/cs_resolve_predicate.comp
+++ b/libs/vkd3d/shaders/cs_resolve_predicate.comp
@@ -1,0 +1,26 @@
+#version 450
+
+#extension GL_EXT_buffer_reference : require
+
+layout(local_size_x = 1) in;
+
+layout(std430, buffer_reference, buffer_reference_align = 8)
+readonly buffer src_predicate_t {
+  uvec2 data;
+};
+
+layout(std430, buffer_reference, buffer_reference_align = 4)
+writeonly buffer dst_predicate_t {
+  uint data;
+};
+
+layout(push_constant)
+uniform u_info_t {
+  src_predicate_t src;
+  dst_predicate_t dst;
+  bool invert;
+};
+
+void main() {
+  dst.data = (all(equal(src.data, 0u.xx)) != invert) ? 0u : 1u;
+}

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1818,6 +1818,61 @@ HRESULT vkd3d_query_ops_init(struct vkd3d_query_ops *meta_query_ops,
 void vkd3d_query_ops_cleanup(struct vkd3d_query_ops *meta_query_ops,
         struct d3d12_device *device);
 
+union vkd3d_predicate_command_direct_args
+{
+    VkDispatchIndirectCommand dispatch;
+    VkDrawIndirectCommand draw;
+    VkDrawIndexedIndirectCommand draw_indexed;
+    uint32_t draw_count;
+};
+
+struct vkd3d_predicate_command_args
+{
+    VkDeviceAddress predicate_va;
+    VkDeviceAddress src_arg_va;
+    VkDeviceAddress dst_arg_va;
+    union vkd3d_predicate_command_direct_args args;
+};
+
+enum vkd3d_predicate_command_type
+{
+    VKD3D_PREDICATE_COMMAND_DRAW,
+    VKD3D_PREDICATE_COMMAND_DRAW_INDEXED,
+    VKD3D_PREDICATE_COMMAND_DRAW_INDIRECT,
+    VKD3D_PREDICATE_COMMAND_DRAW_INDIRECT_COUNT,
+    VKD3D_PREDICATE_COMMAND_DISPATCH,
+    VKD3D_PREDICATE_COMMAND_DISPATCH_INDIRECT,
+    VKD3D_PREDICATE_COMMAND_COUNT
+};
+
+struct vkd3d_predicate_command_info
+{
+    VkPipelineLayout vk_pipeline_layout;
+    VkPipeline vk_pipeline;
+    uint32_t data_size;
+};
+
+struct vkd3d_predicate_resolve_args
+{
+    VkDeviceAddress src_va;
+    VkDeviceAddress dst_va;
+    VkBool32 invert;
+};
+
+struct vkd3d_predicate_ops
+{
+    VkPipelineLayout vk_command_pipeline_layout;
+    VkPipelineLayout vk_resolve_pipeline_layout;
+    VkPipeline vk_command_pipelines[VKD3D_PREDICATE_COMMAND_COUNT];
+    VkPipeline vk_resolve_pipeline;
+    uint32_t data_sizes[VKD3D_PREDICATE_COMMAND_COUNT];
+};
+
+HRESULT vkd3d_predicate_ops_init(struct vkd3d_predicate_ops *meta_predicate_ops,
+        struct d3d12_device *device);
+void vkd3d_predicate_ops_cleanup(struct vkd3d_predicate_ops *meta_predicate_ops,
+        struct d3d12_device *device);
+
 struct vkd3d_meta_ops_common
 {
     VkShaderModule vk_module_fullscreen_vs;
@@ -1832,6 +1887,7 @@ struct vkd3d_meta_ops
     struct vkd3d_copy_image_ops copy_image;
     struct vkd3d_swapchain_ops swapchain;
     struct vkd3d_query_ops query;
+    struct vkd3d_predicate_ops predicate;
 };
 
 HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device *device);
@@ -1856,6 +1912,9 @@ const struct vkd3d_format *vkd3d_meta_get_copy_image_attachment_format(struct vk
         const struct vkd3d_format *dst_format, const struct vkd3d_format *src_format);
 HRESULT vkd3d_meta_get_swapchain_pipeline(struct vkd3d_meta_ops *meta_ops,
         const struct vkd3d_swapchain_pipeline_key *key, struct vkd3d_swapchain_info *info);
+
+void vkd3d_meta_get_predicate_pipeline(struct vkd3d_meta_ops *meta_ops,
+        enum vkd3d_predicate_command_type command_type, struct vkd3d_predicate_command_info *info);
 
 enum vkd3d_time_domain_flag
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1297,9 +1297,10 @@ struct d3d12_command_list
     unsigned int fb_layer_count;
 
     bool xfb_enabled;
-
-    bool is_predicated;
     bool render_pass_suspended;
+
+    bool predicate_enabled;
+    VkDeviceAddress predicate_va;
 
     VkFramebuffer current_framebuffer;
 

--- a/libs/vkd3d/vkd3d_shaders.h
+++ b/libs/vkd3d/vkd3d_shaders.h
@@ -41,7 +41,9 @@ enum vkd3d_meta_copy_mode
 #include <cs_clear_uav_image_2d_uint.h>
 #include <cs_clear_uav_image_3d_float.h>
 #include <cs_clear_uav_image_3d_uint.h>
+#include <cs_predicate_command.h>
 #include <cs_resolve_binary_queries.h>
+#include <cs_resolve_predicate.h>
 #include <vs_fullscreen_layer.h>
 #include <vs_fullscreen.h>
 #include <gs_fullscreen.h>

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -37533,7 +37533,7 @@ static void test_conditional_rendering(void)
     transition_resource_state(command_list, context.render_target,
             D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    /* 64-bit conditional 0x100000000 - fails due to Vulkan 32-bit values. */
+    /* 64-bit conditional 0x100000000 */
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
     prepare_instanced_draw(&context);
     ID3D12GraphicsCommandList_SetPredication(command_list, conditions,
@@ -37545,7 +37545,7 @@ static void test_conditional_rendering(void)
             D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE);
 
     get_texture_readback_with_command_list(context.render_target, 0, &rb, queue, command_list);
-    todo check_readback_data_uint(&rb, NULL, 0xffffffff, 0);
+    check_readback_data_uint(&rb, NULL, 0xffffffff, 0);
     release_resource_readback(&rb);
     reset_command_list(command_list, context.allocator);
     transition_resource_state(command_list, context.render_target,


### PR DESCRIPTION
This essentially solves three problems:
- D3D12 requires 64-bit predicates, whereas `VK_EXT_conditional_rendering` uses 32-bit conditions. This adds a resolve pass which emits a 32-bit predicate to a scratch buffer.
- Using the scratch buffer also means that changing the predicate value after enabling predication can no longer change the behaviour of predicated draws, as is required by D3D12. This seems to just work™ on Vulkan drivers, but should be undefined behaviour.
- Official AMD drivers do not support `VK_EXT_conditional_rendering`. To support predication on those drivers, we use indirect draws and dispatches (with indirect count for predicated indirect draws) instead.

Was a bit of a failed attempt to get AC:Valhalla to run on AMDVLK, which requires Predication support, unfortunately the game still hangs there.