### PR TITLE
Use RW spinlocks for view map.

### DIFF
--- a/include/private/hashmap.h
+++ b/include/private/hashmap.h
@@ -167,16 +167,21 @@ static inline struct hash_map_entry *hash_map_insert(struct hash_map *hash_map, 
         if (!(current->flags & HASH_MAP_ENTRY_OCCUPIED) ||
                 (current->hash_value == hash_value && hash_map->compare_func(key, entry)))
             target = current;
-
-        entry_idx = hash_map_next_entry_idx(hash_map, entry_idx);
+        else
+            entry_idx = hash_map_next_entry_idx(hash_map, entry_idx);
     }
 
     if (!(target->flags & HASH_MAP_ENTRY_OCCUPIED))
+    {
         hash_map->used_count += 1;
+        memcpy(target, entry, hash_map->entry_size);
+        target->flags = HASH_MAP_ENTRY_OCCUPIED;
+        target->hash_value = hash_value;
+    }
 
-    memcpy(target, entry, hash_map->entry_size);
-    target->flags = HASH_MAP_ENTRY_OCCUPIED;
-    target->hash_value = hash_value;
+    /* If target is occupied, we already have an entry in the hashmap.
+     * Return old one, caller is responsible for cleaning up the node we attempted to add. */
+
     return target;
 }
 

--- a/include/private/vkd3d_atomic.h
+++ b/include/private/vkd3d_atomic.h
@@ -108,6 +108,27 @@ FORCEINLINE uint32_t vkd3d_atomic_uint32_decrement(uint32_t *target, vkd3d_memor
     return result;
 }
 
+FORCEINLINE uint32_t vkd3d_atomic_uint32_add(uint32_t *target, uint32_t value, vkd3d_memory_order order)
+{
+    uint32_t result;
+    vkd3d_atomic_choose_intrinsic(order, result, InterlockedAdd, /* no suffix */,(LONG*)target, value);
+    return result;
+}
+
+FORCEINLINE uint32_t vkd3d_atomic_uint32_sub(uint32_t *target, uint32_t value, vkd3d_memory_order order)
+{
+    uint32_t result;
+    vkd3d_atomic_choose_intrinsic(order, result, InterlockedAdd, /* no suffix */,(LONG*)target, (uint32_t)(-(int32_t)value));
+    return result;
+}
+
+FORCEINLINE uint32_t vkd3d_atomic_uint32_and(uint32_t *target, uint32_t value, vkd3d_memory_order order)
+{
+    uint32_t result;
+    vkd3d_atomic_choose_intrinsic(order, result, InterlockedAnd, /* no suffix */,(LONG*)target, value);
+    return result;
+}
+
 FORCEINLINE uint32_t vkd3d_atomic_uint32_compare_exchange(uint32_t* target, uint32_t expected, uint32_t desired,
         vkd3d_memory_order success_order, vkd3d_memory_order fail_order)
 {
@@ -183,12 +204,18 @@ typedef enum
 # define vkd3d_atomic_generic_exchange_explicit(target, value, order) __atomic_exchange_n(target, value, order)
 # define vkd3d_atomic_generic_increment(target, order)                __atomic_add_fetch(target, 1, order)
 # define vkd3d_atomic_generic_decrement(target, order)                __atomic_sub_fetch(target, 1, order)
+# define vkd3d_atomic_generic_add(target, value, order)               __atomic_add_fetch(target, value, order)
+# define vkd3d_atomic_generic_sub(target, value, order)               __atomic_sub_fetch(target, value, order)
+# define vkd3d_atomic_generic_and(target, value, order)               __atomic_and_fetch(target, value, order)
 
 # define vkd3d_atomic_uint32_load_explicit(target, order)            vkd3d_atomic_generic_load_explicit(target, order)
 # define vkd3d_atomic_uint32_store_explicit(target, value, order)    vkd3d_atomic_generic_store_explicit(target, value, order)
 # define vkd3d_atomic_uint32_exchange_explicit(target, value, order) vkd3d_atomic_generic_exchange_explicit(target, value, order)
 # define vkd3d_atomic_uint32_increment(target, order)                vkd3d_atomic_generic_increment(target, order)
 # define vkd3d_atomic_uint32_decrement(target, order)                vkd3d_atomic_generic_decrement(target, order)
+# define vkd3d_atomic_uint32_add(target, value, order)               vkd3d_atomic_generic_add(target, value, order)
+# define vkd3d_atomic_uint32_sub(target, value, order)               vkd3d_atomic_generic_sub(target, value, order)
+# define vkd3d_atomic_uint32_and(target, value, order)               vkd3d_atomic_generic_and(target, value, order)
 static inline uint32_t vkd3d_atomic_uint32_compare_exchange(uint32_t* target, uint32_t expected, uint32_t desired,
         vkd3d_memory_order success_order, vkd3d_memory_order fail_order)
 {

--- a/include/private/vkd3d_rw_spinlock.h
+++ b/include/private/vkd3d_rw_spinlock.h
@@ -44,9 +44,10 @@ static inline void rw_spinlock_release_read(spinlock_t *spinlock)
 
 static inline void rw_spinlock_acquire_write(spinlock_t *spinlock)
 {
-    while (vkd3d_atomic_uint32_compare_exchange(spinlock,
-            VKD3D_RW_SPINLOCK_IDLE, VKD3D_RW_SPINLOCK_WRITE,
-            vkd3d_memory_order_acquire, vkd3d_memory_order_relaxed) != VKD3D_RW_SPINLOCK_IDLE)
+    while (vkd3d_atomic_uint32_load_explicit(spinlock, vkd3d_memory_order_relaxed) != VKD3D_RW_SPINLOCK_IDLE ||
+            vkd3d_atomic_uint32_compare_exchange(spinlock,
+                    VKD3D_RW_SPINLOCK_IDLE, VKD3D_RW_SPINLOCK_WRITE,
+                    vkd3d_memory_order_acquire, vkd3d_memory_order_relaxed) != VKD3D_RW_SPINLOCK_IDLE)
     {
 #ifdef __SSE2__
         _mm_pause();

--- a/include/private/vkd3d_rw_spinlock.h
+++ b/include/private/vkd3d_rw_spinlock.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Hans-Kristian Arntzen for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef __VKD3D_RW_SPINLOCK_H
+#define __VKD3D_RW_SPINLOCK_H
+
+#include "vkd3d_spinlock.h"
+
+#define VKD3D_RW_SPINLOCK_WRITE 1u
+#define VKD3D_RW_SPINLOCK_READ 2u
+#define VKD3D_RW_SPINLOCK_IDLE 0u
+
+static inline void rw_spinlock_acquire_read(spinlock_t *spinlock)
+{
+    uint32_t count = vkd3d_atomic_uint32_add(spinlock, VKD3D_RW_SPINLOCK_READ, vkd3d_memory_order_acquire);
+    while (count & VKD3D_RW_SPINLOCK_WRITE)
+    {
+#ifdef __SSE2__
+        _mm_pause();
+#endif
+        count = vkd3d_atomic_uint32_load_explicit(spinlock, vkd3d_memory_order_acquire);
+    }
+}
+
+static inline void rw_spinlock_release_read(spinlock_t *spinlock)
+{
+    vkd3d_atomic_uint32_sub(spinlock, VKD3D_RW_SPINLOCK_READ, vkd3d_memory_order_release);
+}
+
+static inline void rw_spinlock_acquire_write(spinlock_t *spinlock)
+{
+    while (vkd3d_atomic_uint32_compare_exchange(spinlock,
+            VKD3D_RW_SPINLOCK_IDLE, VKD3D_RW_SPINLOCK_WRITE,
+            vkd3d_memory_order_acquire, vkd3d_memory_order_relaxed) != VKD3D_RW_SPINLOCK_IDLE)
+    {
+#ifdef __SSE2__
+        _mm_pause();
+#endif
+    }
+}
+
+static inline void rw_spinlock_release_write(spinlock_t *spinlock)
+{
+    vkd3d_atomic_uint32_and(spinlock, ~VKD3D_RW_SPINLOCK_WRITE, vkd3d_memory_order_release);
+}
+
+#endif

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8270,7 +8270,7 @@ static void d3d12_command_queue_transition_pool_deinit(struct d3d12_command_queu
     VK_CALL(vkDestroyCommandPool(device->vk_device, pool->pool, NULL));
     VK_CALL(vkDestroySemaphore(device->vk_device, pool->timeline, NULL));
     vkd3d_free(pool->barriers);
-    vkd3d_free(pool->query_heaps);
+    vkd3d_free((void*)pool->query_heaps);
 }
 
 static void d3d12_command_queue_transition_pool_add_barrier(struct d3d12_command_queue_transition_pool *pool,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -470,7 +470,7 @@ struct d3d12_sparse_info
 
 struct vkd3d_view_map
 {
-    pthread_mutex_t mutex;
+    spinlock_t spinlock;
     struct hash_map map;
 };
 


### PR DESCRIPTION
The goal here is to avoid the worst contention when the view map is hammered with texel buffers. Generally, the hit rate will be ~100% for texel buffers with offset, so optimizing for that case is a reasonable thing to do.

Tested on DS and HZD which hammer the view map constantly.