### PR TITLE
Batch vkCmdResetQueryPool calls in separate command buffer

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1271,6 +1271,19 @@ struct vkd3d_initial_transition
     };
 };
 
+enum vkd3d_query_range_flag
+{
+    VKD3D_QUERY_RANGE_RESET = 0x1,
+};
+
+struct vkd3d_query_range
+{
+    VkQueryPool vk_pool;
+    uint32_t index;
+    uint32_t count;
+    uint32_t flags;
+};
+
 struct d3d12_command_list
 {
     d3d12_command_list_iface ID3D12GraphicsCommandList_iface;
@@ -1334,6 +1347,10 @@ struct d3d12_command_list
     struct vkd3d_initial_transition *init_transitions;
     size_t init_transitions_size;
     size_t init_transitions_count;
+
+    struct vkd3d_query_range *query_ranges;
+    size_t query_ranges_size;
+    size_t query_ranges_count;
 
     LONG *outstanding_submissions_count;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1298,6 +1298,7 @@ struct d3d12_command_list
     bool has_replaced_shaders;
     bool has_valid_index_buffer;
     VkCommandBuffer vk_command_buffer;
+    VkCommandBuffer vk_init_commands;
 
     DXGI_FORMAT index_buffer_format;
 


### PR DESCRIPTION
Improves performance in Ghostrunner a bit (~47 -> 50 FPS in the very beginning of the game on my Polaris).
The next step would be to begin/end occlusion queries without interrupting the current render pass.