### PR TITLE
vkd3d-shader: Emit typed format for UAVs which use atomics.

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -556,6 +556,7 @@ enum vkd3d_shader_uav_flag
 {
     VKD3D_SHADER_UAV_FLAG_READ_ACCESS     = 0x00000001,
     VKD3D_SHADER_UAV_FLAG_ATOMIC_COUNTER  = 0x00000002,
+    VKD3D_SHADER_UAV_FLAG_ATOMIC_ACCESS   = 0x00000004,
 };
 
 struct vkd3d_shader_scan_info


### PR DESCRIPTION
Mesa will assert if not, and the format must be known here.

Fix #418.

From spec: "The Image Format of an OpTypeImage declaration must not be Unknown, for variables which are used for OpAtomic* operations."

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>