### PR TITLE
vkd3d: Do not interrupt render pass for occlusion queries.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1271,6 +1271,21 @@ struct vkd3d_initial_transition
     };
 };
 
+enum vkd3d_active_query_state
+{
+    VKD3D_ACTIVE_QUERY_RESET,
+    VKD3D_ACTIVE_QUERY_BEGUN,
+    VKD3D_ACTIVE_QUERY_ENDED,
+};
+
+struct vkd3d_active_query
+{
+    VkQueryPool vk_pool;
+    uint32_t index;
+    uint32_t flags;
+    enum vkd3d_active_query_state state;
+};
+
 enum vkd3d_query_range_flag
 {
     VKD3D_QUERY_RANGE_RESET = 0x1,
@@ -1352,6 +1367,10 @@ struct d3d12_command_list
     struct vkd3d_query_range *query_ranges;
     size_t query_ranges_size;
     size_t query_ranges_count;
+
+    struct vkd3d_active_query *active_queries;
+    size_t active_queries_size;
+    size_t active_queries_count;
 
     LONG *outstanding_submissions_count;
 


### PR DESCRIPTION
Further increases performance in Ghostrunner. This works by deferring `vkCmdBeginQuery` to draw time, and ending these queries 

We should probably do a lot of real-world testing before merging this and see if we ever hit the `FIXME`, since the behaviour in that case is technically incorrect. We can't easily virtualize queries like DXVK does since D3D12 queries work quite similarly to Vulkan query pools; it's not completely impossible to do some local remapping for any command list that runs into this problem and allocate multiple queries per d3d12 query, but doing so would make resolving queries significantly harder.