### PR TITLE
vkd3d: Add fast path for mutable descriptor copies

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3451,7 +3451,8 @@ static inline void d3d12_device_copy_descriptors(struct d3d12_device *device,
             case D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER:
             case D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV:
                 d3d12_desc_copy(d3d12_desc_from_cpu_handle(dst),
-                        d3d12_desc_from_cpu_handle(src), copy_count, device);
+                        d3d12_desc_from_cpu_handle(src), copy_count,
+                        descriptor_heap_type, device);
                 break;
             case D3D12_DESCRIPTOR_HEAP_TYPE_RTV:
             case D3D12_DESCRIPTOR_HEAP_TYPE_DSV:

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3426,7 +3426,7 @@ void vkd3d_view_decref(struct vkd3d_view *view, struct d3d12_device *device)
         vkd3d_view_destroy(view, device);
 }
 
-void d3d12_desc_copy(struct d3d12_desc *dst, struct d3d12_desc *src,
+static void d3d12_desc_copy_single(struct d3d12_desc *dst, struct d3d12_desc *src,
         struct d3d12_device *device)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
@@ -3511,6 +3511,15 @@ void d3d12_desc_copy(struct d3d12_desc *dst, struct d3d12_desc *src,
         struct vkd3d_bound_buffer_range *dst_buffer_ranges = dst->heap->buffer_ranges.host_ptr;
         dst_buffer_ranges[dst->heap_offset] = src_buffer_ranges[src->heap_offset];
     }
+}
+
+void d3d12_desc_copy(struct d3d12_desc *dst, struct d3d12_desc *src,
+        unsigned int count, struct d3d12_device *device)
+{
+    unsigned int i;
+
+    for (i = 0; i < count; i++)
+        d3d12_desc_copy_single(dst + i, src + i, device);
 }
 
 static VkDeviceSize vkd3d_get_required_texel_buffer_alignment(const struct d3d12_device *device,
@@ -4935,9 +4944,9 @@ void d3d12_desc_create_sampler(struct d3d12_desc *sampler,
 }
 
 /* RTVs */
-void d3d12_rtv_desc_copy(struct d3d12_rtv_desc *dst, struct d3d12_rtv_desc *src)
+void d3d12_rtv_desc_copy(struct d3d12_rtv_desc *dst, struct d3d12_rtv_desc *src, unsigned int count)
 {
-    *dst = *src;
+    memcpy(dst, src, sizeof(*dst) * count);
 }
 
 void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_device *device,

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3774,7 +3774,7 @@ HRESULT vkd3d_bindless_state_init(struct vkd3d_bindless_state *bindless_state,
                 VKD3D_BINDLESS_SET_CBV | VKD3D_BINDLESS_SET_UAV | VKD3D_BINDLESS_SET_SRV |
                 VKD3D_BINDLESS_SET_BUFFER | VKD3D_BINDLESS_SET_IMAGE |
                 ((bindless_state->flags & VKD3D_BINDLESS_RAW_SSBO) ? VKD3D_BINDLESS_SET_RAW_SSBO : 0) |
-                extra_bindings,
+                VKD3D_BINDLESS_SET_MUTABLE | extra_bindings,
                 VK_DESCRIPTOR_TYPE_MUTABLE_VALVE)))
             goto fail;
     }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -672,7 +672,7 @@ static inline struct d3d12_desc *d3d12_desc_from_gpu_handle(D3D12_GPU_DESCRIPTOR
 }
 
 void d3d12_desc_copy(struct d3d12_desc *dst, struct d3d12_desc *src,
-        struct d3d12_device *device);
+        unsigned int count, struct d3d12_device *device);
 void d3d12_desc_create_cbv(struct d3d12_desc *descriptor,
         struct d3d12_device *device, const D3D12_CONSTANT_BUFFER_VIEW_DESC *desc);
 void d3d12_desc_create_srv(struct d3d12_desc *descriptor,
@@ -700,7 +700,7 @@ struct d3d12_rtv_desc
     struct d3d12_resource *resource;
 };
 
-void d3d12_rtv_desc_copy(struct d3d12_rtv_desc *dst, struct d3d12_rtv_desc *src);
+void d3d12_rtv_desc_copy(struct d3d12_rtv_desc *dst, struct d3d12_rtv_desc *src, unsigned int count);
 
 static inline struct d3d12_rtv_desc *d3d12_rtv_desc_from_cpu_handle(D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -672,7 +672,7 @@ static inline struct d3d12_desc *d3d12_desc_from_gpu_handle(D3D12_GPU_DESCRIPTOR
 }
 
 void d3d12_desc_copy(struct d3d12_desc *dst, struct d3d12_desc *src,
-        unsigned int count, struct d3d12_device *device);
+        unsigned int count, D3D12_DESCRIPTOR_HEAP_TYPE heap_type, struct d3d12_device *device);
 void d3d12_desc_create_cbv(struct d3d12_desc *descriptor,
         struct d3d12_device *device, const D3D12_CONSTANT_BUFFER_VIEW_DESC *desc);
 void d3d12_desc_create_srv(struct d3d12_desc *descriptor,
@@ -1648,6 +1648,7 @@ enum vkd3d_bindless_set_flag
     VKD3D_BINDLESS_SET_BUFFER   = (1u << 5),
     VKD3D_BINDLESS_SET_COUNTER  = (1u << 6),
     VKD3D_BINDLESS_SET_RAW_SSBO = (1u << 7),
+    VKD3D_BINDLESS_SET_MUTABLE  = (1u << 8),
 
     VKD3D_BINDLESS_SET_EXTRA_UAV_COUNTER_BUFFER = (1u << 24),
     VKD3D_BINDLESS_SET_EXTRA_OFFSET_BUFFER      = (1u << 25),


### PR DESCRIPTION
Passes test suite. Needs testing w.r.t game stability and performance, thus marking as draft.