### PR TITLE
Rework force_bindless_texel_buffer workaround

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6566,8 +6566,8 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list, const 
         {
             if (list->device->bindless_state.flags & VKD3D_TYPED_OFFSET_BUFFER)
             {
-                extra_offset = ranges[desc->heap_offset].offset;
-                full_rect.right = ranges[desc->heap_offset].length;
+                extra_offset = ranges[desc->heap_offset].element_offset;
+                full_rect.right = ranges[desc->heap_offset].element_count;
             }
             else
             {
@@ -6579,8 +6579,8 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list, const 
         }
         else if (list->device->bindless_state.flags & VKD3D_SSBO_OFFSET_BUFFER)
         {
-            extra_offset = ranges[desc->heap_offset].offset / sizeof(uint32_t);
-            full_rect.right = ranges[desc->heap_offset].length / sizeof(uint32_t);
+            extra_offset = ranges[desc->heap_offset].byte_offset / sizeof(uint32_t);
+            full_rect.right = ranges[desc->heap_offset].byte_count / sizeof(uint32_t);
         }
         else
             full_rect.right = args->u.buffer.range / sizeof(uint32_t);

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4091,8 +4091,8 @@ static void vkd3d_buffer_view_get_bound_range_ssbo(struct d3d12_desc *descriptor
         vk_buffer->offset = resource->heap_offset + aligned_begin;
         vk_buffer->range = aligned_end - aligned_begin;
 
-        ssbo_range.offset = offset - aligned_begin;
-        ssbo_range.length = range;
+        ssbo_range.byte_offset = offset - aligned_begin;
+        ssbo_range.byte_count = range;
     }
     else
     {
@@ -4100,9 +4100,12 @@ static void vkd3d_buffer_view_get_bound_range_ssbo(struct d3d12_desc *descriptor
         vk_buffer->offset = 0;
         vk_buffer->range = VK_WHOLE_SIZE;
 
-        ssbo_range.offset = 0;
-        ssbo_range.length = 0;
+        ssbo_range.byte_offset = 0;
+        ssbo_range.byte_count = 0;
     }
+
+    ssbo_range.element_offset = 0;
+    ssbo_range.element_count = 0;
 
     if (device->bindless_state.flags & VKD3D_SSBO_OFFSET_BUFFER)
     {
@@ -4117,12 +4120,13 @@ static bool vkd3d_buffer_view_get_aligned_view(struct d3d12_desc *descriptor,
         VkDeviceSize first_element, VkDeviceSize num_elements,
         VkDeviceSize structured_stride, struct vkd3d_view **view)
 {
-    struct vkd3d_bound_buffer_range typed_range = { 0, 0 };
+    struct vkd3d_bound_buffer_range typed_range = { 0, 0, 0, 0 };
     const struct vkd3d_format *vkd3d_format;
     VkDeviceSize max_resource_elements;
     VkDeviceSize max_element_headroom;
     VkDeviceSize element_align;
     VkDeviceSize max_elements;
+    VkDeviceSize element_size;
     VkDeviceSize begin_range;
     VkDeviceSize end_range;
 
@@ -4136,7 +4140,8 @@ static bool vkd3d_buffer_view_get_aligned_view(struct d3d12_desc *descriptor,
         if (format)
         {
             vkd3d_format = vkd3d_get_format(device, format, false);
-            max_resource_elements = resource->desc.Width / vkd3d_format->byte_count;
+            element_size = vkd3d_format->byte_count;
+            max_resource_elements = resource->desc.Width / element_size;
         }
         else
         {
@@ -4144,6 +4149,7 @@ static bool vkd3d_buffer_view_get_aligned_view(struct d3d12_desc *descriptor,
              * be in terms of u32 since the offset buffer must be in terms of words.
              * When using typed buffers, the offset buffer is in format of u32
              * (element offset, element size). */
+            element_size = sizeof(uint32_t);
             first_element = (first_element * structured_stride) / sizeof(uint32_t);
             num_elements = (num_elements * structured_stride) / sizeof(uint32_t);
             structured_stride = sizeof(uint32_t);
@@ -4157,13 +4163,13 @@ static bool vkd3d_buffer_view_get_aligned_view(struct d3d12_desc *descriptor,
         {
             FIXME("Application is attempting to use more elements in a typed buffer (%llu) than supported by device (%llu).\n",
                   (unsigned long long)num_elements, (unsigned long long)max_elements);
-            typed_range.offset = 0;
-            typed_range.length = num_elements;
+            typed_range.element_offset = 0;
+            typed_range.element_count = num_elements;
         }
         else if (num_elements >= max_resource_elements)
         {
-            typed_range.offset = 0;
-            typed_range.length = num_elements;
+            typed_range.element_offset = 0;
+            typed_range.element_count = num_elements;
         }
         else
         {
@@ -4177,12 +4183,15 @@ static bool vkd3d_buffer_view_get_aligned_view(struct d3d12_desc *descriptor,
             end_range = (first_element + num_elements + element_align - 1) & ~(element_align - 1);
             end_range = min(end_range, max_resource_elements);
 
-            typed_range.offset = first_element - begin_range;
-            typed_range.length = num_elements;
+            typed_range.element_offset = first_element - begin_range;
+            typed_range.element_count = num_elements;
 
             first_element = begin_range;
             num_elements = end_range - begin_range;
         }
+
+        typed_range.byte_offset = typed_range.element_offset * element_size;
+        typed_range.byte_count = typed_range.element_count * element_size;
     }
 
     if (!vkd3d_create_buffer_view_for_resource(device, resource, format,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2147,6 +2147,12 @@ static inline bool d3d12_device_use_ssbo_root_descriptors(struct d3d12_device *d
             d3d12_device_get_ssbo_alignment(device) <= 4;
 }
 
+static inline unsigned int d3d12_device_get_shader_min_ssbo_alignment(struct d3d12_device *device)
+{
+    return (device->vkd3d_instance->config_flags & VKD3D_CONFIG_FLAG_FORCE_BINDLESS_TEXEL_BUFFER)
+            ? ~0u : d3d12_device_get_ssbo_alignment(device);
+}
+
 /* ID3DBlob */
 struct d3d_blob
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -718,8 +718,10 @@ void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_dev
 
 struct vkd3d_bound_buffer_range
 {
-    uint32_t offset;  /* offset to first byte for SSBO, or offset in elements for typed views. */
-    uint32_t length;  /* bound size in bytes, or size in elements for typed views. */
+    uint32_t byte_offset;
+    uint32_t byte_count;
+    uint32_t element_offset;
+    uint32_t element_count;
 };
 
 struct vkd3d_host_visible_buffer_range


### PR DESCRIPTION
Passes all DXBC tests, but will need DXIL support. Haven't come up with a new name yet.