### PR TITLE
vkd3d-shader: Remove DXIL being optional.

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -679,8 +679,6 @@ struct vkd3d_shader_signature_element *vkd3d_shader_find_signature_element(
         unsigned int semantic_index, unsigned int stream_index);
 void vkd3d_shader_free_shader_signature(struct vkd3d_shader_signature *signature);
 
-int vkd3d_shader_supports_dxil(void);
-
 #endif  /* VKD3D_SHADER_NO_PROTOTYPES */
 
 /*

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -282,12 +282,7 @@ int vkd3d_shader_compile_dxbc(const struct vkd3d_shader_code *dxbc,
     /* DXIL is handled externally through dxil-spirv. */
     if (shader_is_dxil(dxbc->code, dxbc->size))
     {
-#ifdef HAVE_DXIL_SPV
         return vkd3d_shader_compile_dxil(dxbc, spirv, shader_interface_info, compile_args);
-#else
-        ERR("DXIL shader found, but DXIL support is not enabled in vkd3d.\n");
-        return VKD3D_ERROR_INVALID_SHADER;
-#endif
     }
 
     hash = vkd3d_shader_hash(dxbc);
@@ -632,15 +627,6 @@ void vkd3d_shader_free_shader_signature(struct vkd3d_shader_signature *signature
 
     vkd3d_free(signature->elements);
     signature->elements = NULL;
-}
-
-int vkd3d_shader_supports_dxil(void)
-{
-#ifdef HAVE_DXIL_SPV
-    return 1;
-#else
-    return 0;
-#endif
 }
 
 vkd3d_shader_hash_t vkd3d_shader_hash(const struct vkd3d_shader_code *shader)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4741,7 +4741,6 @@ static void d3d12_device_caps_init_shader_model(struct d3d12_device *device)
             VK_SHADER_STAGE_FRAGMENT_BIT;
 
     if (device->api_version >= VK_API_VERSION_1_1 &&
-        vkd3d_shader_supports_dxil() &&
         physical_device_info->subgroup_properties.subgroupSize >= 4 &&
         (physical_device_info->subgroup_properties.supportedOperations & required) == required &&
         (physical_device_info->subgroup_properties.supportedStages & required_stages) == required_stages)

--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,6 @@ if vkd3d_platform != 'windows' and enable_d3d12
   error('Standalone D3D12 is only supported on Windows.')
 endif
 
-add_project_arguments('-DHAVE_DXIL_SPV', language : 'c')
 add_project_arguments('-D_GNU_SOURCE',   language : 'c')
 add_project_arguments('-DPACKAGE_VERSION="' + meson.project_version() + '"',   language : 'c')
 


### PR DESCRIPTION
We always build with DXIL, not using autotools anymore.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>