### PR TITLE
vkd3d: Eliminate wchar_size, use UTF-16 string literals

### DIFF
--- a/demos/demo_win32.h
+++ b/demos/demo_win32.h
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define DEMO_WINDOW_CLASS_NAME L"demo_wc"
+#define DEMO_WINDOW_CLASS_NAME u"demo_wc"
 
 struct demo
 {

--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -253,21 +253,13 @@ static inline uint32_t float_bits_to_uint32(float f)
     return u;
 }
 
-static inline size_t vkd3d_wcslen(const WCHAR *wstr, size_t wchar_size)
+static inline size_t vkd3d_wcslen(const WCHAR *wstr)
 {
-    const uint16_t *data_16 = (const uint16_t*)wstr;
-    const uint32_t *data_32 = (const uint32_t*)wstr;
-    uint32_t curr_char;
     size_t length = 0;
 
     while (true)
     {
-        if (wchar_size == sizeof(uint16_t))
-            curr_char = data_16[length];
-        else /* if (wchar_size == sizeof(uint32_t)) */
-            curr_char = data_32[length];
-
-        if (!curr_char)
+        if (!wstr[length])
             return length;
 
         length += 1;

--- a/include/private/vkd3d_debug.h
+++ b/include/private/vkd3d_debug.h
@@ -65,7 +65,7 @@ void vkd3d_dbg_printf(enum vkd3d_dbg_channel channel, enum vkd3d_dbg_level level
 const char *vkd3d_dbg_sprintf(const char *fmt, ...) VKD3D_PRINTF_FUNC(1, 2);
 const char *vkd3d_dbg_vsprintf(const char *fmt, va_list args);
 const char *debugstr_a(const char *str);
-const char *debugstr_w(const WCHAR *wstr, size_t wchar_size);
+const char *debugstr_w(const WCHAR *wstr);
 
 #define VKD3D_DBG_LOG(level) \
         do { \

--- a/include/private/vkd3d_utf8.h
+++ b/include/private/vkd3d_utf8.h
@@ -23,6 +23,6 @@
 
 /* max_elements is 0 if only nul-terminator should be used.
  * Otherwise, terminate the string after either a nul-termination byte or max_elements. */
-char *vkd3d_strdup_w_utf8(const WCHAR *wstr, size_t wchar_size, size_t max_elements);
+char *vkd3d_strdup_w_utf8(const WCHAR *wstr, size_t max_elements);
 
 #endif /* __VKD3D_UTF8_H */

--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -89,7 +89,6 @@ struct vkd3d_instance_create_info
     PFN_vkd3d_signal_event pfn_signal_event;
     PFN_vkd3d_create_thread pfn_create_thread;
     PFN_vkd3d_join_thread pfn_join_thread;
-    size_t wchar_size;
 
     /* If set to NULL, libvkd3d loads libvulkan. */
     PFN_vkGetInstanceProcAddr pfn_vkGetInstanceProcAddr;

--- a/include/vkd3d_d3d12.idl
+++ b/include/vkd3d_d3d12.idl
@@ -2979,9 +2979,9 @@ typedef enum D3D12_AUTO_BREADCRUMB_OP
 typedef struct D3D12_AUTO_BREADCRUMB_NODE
 {
     const char *pCommandListDebugNameA;
-    const wchar_t *pCommandListDebugNameW;
+    const WCHAR *pCommandListDebugNameW;
     const char *pCommandQueueDebugNameA;
-    const wchar_t *pCommandQueueDebugNameW;
+    const WCHAR *pCommandQueueDebugNameW;
     ID3D12GraphicsCommandList *pCommandList;
     ID3D12CommandQueue *pCommandQueue;
     UINT32 BreadcrumbCount;
@@ -2993,15 +2993,15 @@ typedef struct D3D12_AUTO_BREADCRUMB_NODE
 typedef struct D3D12_DRED_BREADCRUMB_CONTEXT
 {
     UINT BreadcrumbIndex;
-    const wchar_t *pContextString;
+    const WCHAR *pContextString;
 } D3D12_DRED_BREADCRUMB_CONTEXT;
 
 typedef struct D3D12_AUTO_BREADCRUMB_NODE1
 {
     const char *pCommandListDebugNameA;
-    const wchar_t *pCommandListDebugNameW;
+    const WCHAR *pCommandListDebugNameW;
     const char *pCommandQueueDebugNameA;
-    const wchar_t *pCommandQueueDebugNameW;
+    const WCHAR *pCommandQueueDebugNameW;
     ID3D12GraphicsCommandList *pCommandList;
     ID3D12CommandQueue *pCommandQueue;
     UINT BreadcrumbCount;
@@ -3074,7 +3074,7 @@ typedef enum D3D12_DRED_ALLOCATION_TYPE
 typedef struct D3D12_DRED_ALLOCATION_NODE
 {
     const char *ObjectNameA;
-    const wchar_t *ObjectNameW;
+    const WCHAR *ObjectNameW;
     D3D12_DRED_ALLOCATION_TYPE AllocationType;
     const struct D3D12_DRED_ALLOCATION_NODE *pNext;
 } D3D12_DRED_ALLOCATION_NODE;
@@ -3082,7 +3082,7 @@ typedef struct D3D12_DRED_ALLOCATION_NODE
 typedef struct D3D12_DRED_ALLOCATION_NODE1
 {
     const char *ObjectNameA;
-    const wchar_t *ObjectNameW;
+    const WCHAR *ObjectNameW;
     D3D12_DRED_ALLOCATION_TYPE AllocationType;
     const struct D3D12_DRED_ALLOCATION_NODE1 *pNext;
     const IUnknown *pObject;

--- a/libs/d3d12/main.c
+++ b/libs/d3d12/main.c
@@ -335,7 +335,6 @@ HRESULT WINAPI DLLEXPORT D3D12CreateDevice(IUnknown *adapter, D3D_FEATURE_LEVEL 
     instance_create_info.pfn_signal_event = d3d12_signal_event;
     instance_create_info.pfn_create_thread = d3d12_create_thread;
     instance_create_info.pfn_join_thread = d3d12_join_thread;
-    instance_create_info.wchar_size = sizeof(WCHAR);
     instance_create_info.pfn_vkGetInstanceProcAddr = pfn_vkGetInstanceProcAddr;
     instance_create_info.instance_extensions = instance_extensions;
     instance_create_info.instance_extension_count = ARRAYSIZE(instance_extensions);

--- a/libs/vkd3d-common/debug.c
+++ b/libs/vkd3d-common/debug.c
@@ -219,10 +219,10 @@ const char *debugstr_a(const char *str)
     return buffer;
 }
 
-static const char *debugstr_w16(const uint16_t *wstr)
+const char *debugstr_w(const WCHAR *wstr)
 {
     char *buffer, *ptr;
-    uint16_t c;
+    WCHAR c;
 
     if (!wstr)
         return "(null)";
@@ -277,73 +277,6 @@ static const char *debugstr_w16(const uint16_t *wstr)
     *ptr = '\0';
 
     return buffer;
-}
-
-static const char *debugstr_w32(const uint32_t *wstr)
-{
-    char *buffer, *ptr;
-    uint32_t c;
-
-    if (!wstr)
-        return "(null)";
-
-    ptr = buffer = get_buffer();
-
-    *ptr++ = '"';
-    while ((c = *wstr++) && ptr <= buffer + VKD3D_DEBUG_BUFFER_SIZE - 10)
-    {
-        int escape_char;
-
-        switch (c)
-        {
-            case '"':
-            case '\\':
-            case '\n':
-            case '\r':
-            case '\t':
-                escape_char = c;
-                break;
-            default:
-                escape_char = 0;
-                break;
-        }
-
-        if (escape_char)
-        {
-            *ptr++ = '\\';
-            *ptr++ = escape_char;
-            continue;
-        }
-
-        if (isprint(c))
-        {
-            *ptr++ = c;
-        }
-        else
-        {
-            *ptr++ = '\\';
-            sprintf(ptr, "%04x", c);
-            ptr += 4;
-        }
-    }
-    *ptr++ = '"';
-
-    if (c)
-    {
-        *ptr++ = '.';
-        *ptr++ = '.';
-        *ptr++ = '.';
-    }
-    *ptr = '\0';
-
-    return buffer;
-}
-
-const char *debugstr_w(const WCHAR *wstr, size_t wchar_size)
-{
-    if (wchar_size == 2)
-        return debugstr_w16((const uint16_t *)wstr);
-    return debugstr_w32((const uint32_t *)wstr);
 }
 
 unsigned int vkd3d_env_var_as_uint(const char *name, unsigned int default_value)

--- a/libs/vkd3d-common/string.c
+++ b/libs/vkd3d-common/string.c
@@ -21,6 +21,8 @@
 #include "vkd3d_string.h"
 #include "vkd3d_memory.h"
 
+STATIC_ASSERT(sizeof(WCHAR) == sizeof(uint16_t));
+
 char *vkd3d_strdup(const char *str)
 {
     /* strdup() is actually not standard. */
@@ -40,7 +42,7 @@ WCHAR *vkd3d_wstrdup(const WCHAR *str)
     WCHAR *duped;
     size_t len;
 
-    len = vkd3d_wcslen(str, sizeof(WCHAR)) + 1;
+    len = vkd3d_wcslen(str) + 1;
 
     duped = vkd3d_malloc(len * sizeof(WCHAR));
     if (duped)

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -1153,9 +1153,9 @@ int vkd3d_shader_dxil_append_library_entry_points(
         for (i = 0; i < library_desc->NumExports; i++)
         {
             if (library_desc->pExports[i].ExportToRename)
-                ascii_entry = vkd3d_strdup_w_utf8(library_desc->pExports[i].ExportToRename, sizeof(WCHAR), 0);
+                ascii_entry = vkd3d_strdup_w_utf8(library_desc->pExports[i].ExportToRename, 0);
             else
-                ascii_entry = vkd3d_strdup_w_utf8(library_desc->pExports[i].Name, sizeof(WCHAR), 0);
+                ascii_entry = vkd3d_strdup_w_utf8(library_desc->pExports[i].Name, 0);
 
             stage = dxil_spv_parsed_blob_get_shader_stage_for_entry(blob, ascii_entry);
             if (stage == DXIL_SPV_STAGE_UNKNOWN)

--- a/libs/vkd3d-utils/vkd3d_utils_main.c
+++ b/libs/vkd3d-utils/vkd3d_utils_main.c
@@ -64,7 +64,6 @@ VKD3D_UTILS_EXPORT HRESULT WINAPI D3D12CreateDevice(IUnknown *adapter,
     instance_create_info.type = VKD3D_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     instance_create_info.next = &optional_extensions_info;
     instance_create_info.pfn_signal_event = vkd3d_signal_event;
-    instance_create_info.wchar_size = sizeof(WCHAR);
     instance_create_info.instance_extensions = instance_extensions;
     instance_create_info.instance_extension_count = ARRAY_SIZE(instance_extensions);
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -845,9 +845,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_SetPrivateDataInterface(d3d12_fence
 
 static HRESULT STDMETHODCALLTYPE d3d12_fence_SetName(d3d12_fence_iface *iface, const WCHAR *name)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
-
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, fence->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return name ? S_OK : E_INVALIDARG;
 }
@@ -1596,7 +1594,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_allocator_SetName(ID3D12CommandAl
 {
     struct d3d12_command_allocator *allocator = impl_from_ID3D12CommandAllocator(iface);
 
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, allocator->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return vkd3d_set_vk_object_name(allocator->device, (uint64_t)allocator->vk_command_pool,
             VK_OBJECT_TYPE_COMMAND_POOL, name);
@@ -3502,9 +3500,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_SetPrivateDataInterface(d3d1
 
 static HRESULT STDMETHODCALLTYPE d3d12_command_list_SetName(d3d12_command_list_iface *iface, const WCHAR *name)
 {
-    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, list->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return name ? S_OK : E_INVALIDARG;
 }
@@ -7663,7 +7659,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPredication(d3d12_command_li
     }
 }
 
-static char *decode_pix_string(size_t wchar_size, UINT metadata, const void *data, size_t size)
+static char *decode_pix_string(UINT metadata, const void *data, size_t size)
 {
     char *label_str;
 
@@ -7682,7 +7678,7 @@ static char *decode_pix_string(size_t wchar_size, UINT metadata, const void *dat
         break;
 
     case PIX_EVENT_UNICODE_VERSION:
-        label_str = vkd3d_strdup_w_utf8(data, wchar_size, size / wchar_size);
+        label_str = vkd3d_strdup_w_utf8(data, size / sizeof(WCHAR));
         if (!label_str)
             return NULL;
         break;
@@ -7711,7 +7707,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetMarker(d3d12_command_list_if
     if (!list->device->vk_info.EXT_debug_utils)
         return;
 
-    label_str = decode_pix_string(list->device->wchar_size, metadata, data, size);
+    label_str = decode_pix_string(metadata, data, size);
     if (!label_str)
     {
         FIXME("Failed to decode PIX debug event.\n");
@@ -7743,7 +7739,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_BeginEvent(d3d12_command_list_i
     if (!list->device->vk_info.EXT_debug_utils)
         return;
 
-    label_str = decode_pix_string(list->device->wchar_size, metadata, data, size);
+    label_str = decode_pix_string(metadata, data, size);
     if (!label_str)
     {
         FIXME("Failed to decode PIX debug event.\n");
@@ -8431,7 +8427,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_queue_SetName(ID3D12CommandQueue 
     VkQueue vk_queue;
     HRESULT hr;
 
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, command_queue->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     if (!(vk_queue = vkd3d_queue_acquire(command_queue->vkd3d_queue)))
     {
@@ -10032,9 +10028,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_signature_SetPrivateDataInterface
 
 static HRESULT STDMETHODCALLTYPE d3d12_command_signature_SetName(ID3D12CommandSignature *iface, const WCHAR *name)
 {
-    struct d3d12_command_signature *signature = impl_from_ID3D12CommandSignature(iface);
-
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, signature->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return name ? S_OK : E_INVALIDARG;
 }

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -492,16 +492,10 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
         ERR("Invalid create/join thread function pointers.\n");
         return E_INVALIDARG;
     }
-    if (create_info->wchar_size != 2 && create_info->wchar_size != 4)
-    {
-        ERR("Unexpected WCHAR size %zu.\n", create_info->wchar_size);
-        return E_INVALIDARG;
-    }
 
     instance->signal_event = create_info->pfn_signal_event;
     instance->create_thread = create_info->pfn_create_thread;
     instance->join_thread = create_info->pfn_join_thread;
-    instance->wchar_size = create_info->wchar_size;
 
     instance->config_flags = vkd3d_init_config_flags();
 
@@ -2676,7 +2670,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_SetName(d3d12_device_iface *iface,
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return vkd3d_set_vk_object_name(device, (uint64_t)(uintptr_t)device->vk_device,
             VK_OBJECT_TYPE_DEVICE, name);
@@ -3842,10 +3836,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateSharedHandle(d3d12_device_if
         ID3D12DeviceChild *object, const SECURITY_ATTRIBUTES *attributes, DWORD access,
         const WCHAR *name, HANDLE *handle)
 {
-    struct d3d12_device *device = impl_from_ID3D12Device(iface);
-
     FIXME("iface %p, object %p, attributes %p, access %#x, name %s, handle %p stub!\n",
-            iface, object, attributes, access, debugstr_w(name, device->wchar_size), handle);
+            iface, object, attributes, access, debugstr_w(name), handle);
 
     return E_NOTIMPL;
 }
@@ -3862,10 +3854,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_OpenSharedHandle(d3d12_device_ifac
 static HRESULT STDMETHODCALLTYPE d3d12_device_OpenSharedHandleByName(d3d12_device_iface *iface,
         const WCHAR *name, DWORD access, HANDLE *handle)
 {
-    struct d3d12_device *device = impl_from_ID3D12Device(iface);
-
     FIXME("iface %p, name %s, access %#x, handle %p stub!\n",
-            iface, debugstr_w(name, device->wchar_size), access, handle);
+            iface, debugstr_w(name), access, handle);
 
     return E_NOTIMPL;
 }
@@ -5046,7 +5036,6 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     vkd3d_instance_incref(device->vkd3d_instance = instance);
     device->vk_info = instance->vk_info;
     device->signal_event = instance->signal_event;
-    device->wchar_size = instance->wchar_size;
 
     device->adapter_luid = create_info->adapter_luid;
     device->removed_reason = S_OK;

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -164,9 +164,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_state_object_SetPrivateDataInterface(ID3D
 
 static HRESULT STDMETHODCALLTYPE d3d12_state_object_SetName(ID3D12StateObject *iface, const WCHAR *name)
 {
-    struct d3d12_state_object *state_object = impl_from_ID3D12StateObject(iface);
-
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, state_object->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return name ? S_OK : E_INVALIDARG;
 }
@@ -205,10 +203,7 @@ static void * STDMETHODCALLTYPE d3d12_state_object_properties_GetShaderIdentifie
 static UINT64 STDMETHODCALLTYPE d3d12_state_object_properties_GetShaderStackSize(ID3D12StateObjectProperties *iface,
         LPCWSTR export_name)
 {
-    static const WCHAR intersection[] = { ':', ':', 'i', 'n', 't', 'e', 'r', 's', 'e', 'c', 't', 'i', 'o', 'n', '\0' };
-    static const WCHAR closesthit[] = { ':', ':', 'c', 'l', 'o', 's', 'e', 's', 't', 'h', 'i', 't', '\0' };
     struct d3d12_state_object *object = impl_from_ID3D12StateObjectProperties(iface);
-    static const WCHAR anyhit[] = { ':', ':', 'a', 'n', 'y', 'h', 'i', 't', '\0' };
     const WCHAR *subtype = NULL;
     size_t i, n;
 
@@ -229,11 +224,11 @@ static UINT64 STDMETHODCALLTYPE d3d12_state_object_properties_GetShaderStackSize
         {
             if (subtype)
             {
-                if (vkd3d_export_strequal(subtype, intersection))
+                if (vkd3d_export_strequal(subtype, u"::intersection"))
                     return object->exports[i].stack_size_intersection;
-                else if (vkd3d_export_strequal(subtype, anyhit))
+                else if (vkd3d_export_strequal(subtype, u"::anyhit"))
                     return object->exports[i].stack_size_any;
-                else if (vkd3d_export_strequal(subtype, closesthit))
+                else if (vkd3d_export_strequal(subtype, u"::closesthit"))
                     return object->exports[i].stack_size_closest;
                 else
                     return 0xffffffff;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -506,7 +506,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_SetName(d3d12_heap_iface *iface, con
 {
     struct d3d12_heap *heap = impl_from_ID3D12Heap(iface);
 
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, heap->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return vkd3d_set_vk_object_name(heap->device, (uint64_t)heap->vk_memory,
             VK_OBJECT_TYPE_DEVICE_MEMORY, name);
@@ -2172,7 +2172,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_SetName(d3d12_resource_iface *if
     struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
     HRESULT hr;
 
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, resource->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     if (resource->flags & VKD3D_RESOURCE_DEDICATED_HEAP)
     {
@@ -5457,9 +5457,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_descriptor_heap_SetPrivateDataInterface(I
 
 static HRESULT STDMETHODCALLTYPE d3d12_descriptor_heap_SetName(ID3D12DescriptorHeap *iface, const WCHAR *name)
 {
-    struct d3d12_descriptor_heap *heap = impl_from_ID3D12DescriptorHeap(iface);
-
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, heap->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return name ? S_OK : E_INVALIDARG;
 }
@@ -6104,7 +6102,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_query_heap_SetName(ID3D12QueryHeap *iface
 {
     struct d3d12_query_heap *heap = impl_from_ID3D12QueryHeap(iface);
 
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, heap->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return vkd3d_set_vk_object_name(heap->device, (uint64_t)heap->vk_query_pool,
             VK_OBJECT_TYPE_QUERY_POOL, name);

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -128,9 +128,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_root_signature_SetPrivateDataInterface(ID
 
 static HRESULT STDMETHODCALLTYPE d3d12_root_signature_SetName(ID3D12RootSignature *iface, const WCHAR *name)
 {
-    struct d3d12_root_signature *root_signature = impl_from_ID3D12RootSignature(iface);
-
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, root_signature->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     return name ? S_OK : E_INVALIDARG;
 }
@@ -1733,7 +1731,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_pipeline_state_SetName(ID3D12PipelineStat
 {
     struct d3d12_pipeline_state *state = impl_from_ID3D12PipelineState(iface);
 
-    TRACE("iface %p, name %s.\n", iface, debugstr_w(name, state->device->wchar_size));
+    TRACE("iface %p, name %s.\n", iface, debugstr_w(name));
 
     if (d3d12_pipeline_state_is_compute(state))
     {

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -1172,7 +1172,7 @@ HRESULT vkd3d_set_vk_object_name(struct d3d12_device *device, uint64_t vk_object
     if (!device->vk_info.EXT_debug_utils)
         return S_OK;
 
-    if (!(name_utf8 = vkd3d_strdup_w_utf8(name, device->wchar_size, 0)))
+    if (!(name_utf8 = vkd3d_strdup_w_utf8(name, 0)))
         return E_OUTOFMEMORY;
 
     vr = vkd3d_set_vk_object_name_utf8(device, vk_object, vk_object_type, name_utf8);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -176,7 +176,6 @@ struct vkd3d_instance
     PFN_vkd3d_signal_event signal_event;
     PFN_vkd3d_create_thread create_thread;
     PFN_vkd3d_join_thread join_thread;
-    size_t wchar_size;
 
     struct vkd3d_vulkan_info vk_info;
     struct vkd3d_vk_global_procs vk_global_procs;
@@ -2100,7 +2099,6 @@ struct d3d12_device
     VkPhysicalDevice vk_physical_device;
     struct vkd3d_vk_device_procs vk_procs;
     PFN_vkd3d_signal_event signal_event;
-    size_t wchar_size;
 
     struct vkd3d_gpu_va_allocator gpu_va_allocator;
     struct vkd3d_fence_worker fence_worker;

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ cpu_family = target_machine.cpu_family()
 
 vkd3d_compiler = meson.get_compiler('c')
 vkd3d_msvc     = vkd3d_compiler.get_id() == 'msvc'
-vkd3d_c_std    = 'c99'
+vkd3d_c_std    = 'c11'
 vkd3d_platform = target_machine.system()
 
 enable_tests             = get_option('enable_tests')

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -3844,8 +3844,6 @@ static void test_object_interface(void)
     static const GUID test_guid2
             = {0x2e5afac2, 0x87b5, 0x4c10, {0x9b, 0x4b, 0x89, 0xd7, 0xd1, 0x12, 0xe7, 0x2b}};
     static const DWORD data[] = {1, 2, 3, 4};
-    static const WCHAR deadbeefW[] = {'d', 'e', 'a', 'd', 'b', 'e', 'e', 'f', 0};
-    static const WCHAR emptyW[] = {0};
     static const GUID *tests[] =
     {
         &IID_ID3D12CommandAllocator,
@@ -4072,10 +4070,10 @@ static void test_object_interface(void)
             ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
         }
 
-        hr = ID3D12Object_SetName(object, emptyW);
+        hr = ID3D12Object_SetName(object, u"");
         ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
 
-        hr = ID3D12Object_SetName(object, deadbeefW);
+        hr = ID3D12Object_SetName(object, u"deadbeef");
         ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
 
         ID3D12Object_Release(object);
@@ -42173,16 +42171,8 @@ static void test_raytracing(void)
 
         memset(&hit_group, 0, sizeof(hit_group));
         hit_group.Type = D3D12_HIT_GROUP_TYPE_TRIANGLES;
-        {
-            /* For some weird reason, the exports are WCHAR, even though localization is irrelevant for internal, mangled symbols ...
-               Deal with ABI uncertainty around WCHAR with array of u16.
-               wchar_t is typically 4 bytes on Linux/MinGW unless special compiler flags are used. */
-            static const uint16_t ray_closest[] = { 'R', 'a', 'y', 'C', 'l', 'o', 's', 'e', 's', 't', '\0' };
-            static const uint16_t ray_hit[] = { 'R', 'a', 'y', 'H', 'i', 't', '\0' };
-
-            hit_group.ClosestHitShaderImport = ray_closest;
-            hit_group.HitGroupExport = ray_hit;
-        }
+        hit_group.ClosestHitShaderImport = u"RayClosest";
+        hit_group.HitGroupExport = u"RayHit";
 
         memset(&desc, 0, sizeof(desc));
         desc.Type = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE;
@@ -46191,8 +46181,8 @@ static void test_pipeline_library(void)
         0x3f800000, 0x3f800000, 0x3f800000, 0x3f800000, 0x0100003e,
     };
 
-    static const WCHAR graphics_name[] = {'G','R','A','P','H','I','C','S',0};
-    static const WCHAR compute_name[] = {'C','O','M','P','U','T','E',0};
+    const WCHAR *graphics_name = u"GRAPHICS";
+    const WCHAR *compute_name  = u"COMPUTE";
 
     if (!init_test_context(&context, NULL))
         return;

--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -495,7 +495,6 @@ static HRESULT create_vkd3d_instance(struct vkd3d_instance **instance)
     instance_create_info.type = VKD3D_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     instance_create_info.next = &optional_extensions_info;
     instance_create_info.pfn_signal_event = vkd3d_signal_event;
-    instance_create_info.wchar_size = sizeof(WCHAR);
 
     return vkd3d_create_instance(&instance_create_info, instance);
 }

--- a/tests/vkd3d_api.c
+++ b/tests/vkd3d_api.c
@@ -61,7 +61,6 @@ static HRESULT signal_event(HANDLE event)
 static const struct vkd3d_instance_create_info instance_default_create_info =
 {
     .type = VKD3D_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-    .wchar_size = sizeof(WCHAR),
     .pfn_signal_event = signal_event,
 };
 
@@ -97,11 +96,6 @@ static void test_create_instance(void)
     vkd3d_instance_decref(instance);
     refcount = vkd3d_instance_decref(instance);
     ok(!refcount, "Instance has %u references left.\n", refcount);
-
-    create_info = instance_default_create_info;
-    create_info.wchar_size = 1;
-    hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
 
     create_info = instance_default_create_info;
     create_info.pfn_signal_event = NULL;


### PR DESCRIPTION
Achieves this with C standard stuff alone, and no compiler hacks.

Signed-off-by: Joshua Ashton <joshua@froggi.es>