### PR TITLE
build: Add GCC problem matcher to build tests

### DIFF
--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -13,6 +13,9 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Setup problem matcher
+      uses: Joshua-Ashton/gcc-problem-matcher@v1
+
     - name: Build MinGW x86
       id: build-mingw-x86
       uses: Joshua-Ashton/arch-mingw-github-action@v5


### PR DESCRIPTION
Uses my fork of gcc-problem-matcher to note down warnings and annotate them in files for pushes and PRs