### PR TITLE
Add heap suballocation stress test

### DIFF
--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -421,11 +421,11 @@ static bool init_vulkan_loader(void)
         return true;
 
 #ifdef _WIN32
-    mod = LoadLibraryA(SONAME_LIBVULKAN);
-    if (!mod)
+    hmod = LoadLibraryA(SONAME_LIBVULKAN);
+    if (!hmod)
         return false;
 
-    pfn_vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)GetProcAddress(mod, "vkGetInstanceProcAddr");
+    pfn_vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)GetProcAddress(hmod, "vkGetInstanceProcAddr");
 #else
     mod = dlopen(SONAME_LIBVULKAN, RTLD_LAZY);
     if (!mod)


### PR DESCRIPTION
Stress tests internal implementation details which we will hit internally with CreateCommittedResource and CreateHeap.

Creates many allocations, aims to either clear all of them to a fixed value, or does nothing, which should return 0.

Also verifies safety when attempting to free an idle ID3D12Heap, since it might be attempting to zero memory on a GPU queue.