### PR TITLE
Suballocate committed textures if possible.

### DIFF
--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -1159,7 +1159,7 @@ static HRESULT vkd3d_suballocate_memory(struct d3d12_device *device, struct vkd3
     return hr;
 }
 
-static HRESULT vkd3d_allocate_memory(struct d3d12_device *device, struct vkd3d_memory_allocator *allocator,
+HRESULT vkd3d_allocate_memory(struct d3d12_device *device, struct vkd3d_memory_allocator *allocator,
         const struct vkd3d_allocate_memory_info *info, struct vkd3d_memory_allocation *allocation)
 {
     HRESULT hr;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -460,9 +460,8 @@ HRESULT d3d12_fence_create(struct d3d12_device *device,
 enum vkd3d_allocation_flag
 {
     VKD3D_ALLOCATION_FLAG_GLOBAL_BUFFER     = (1u << 0),
-    VKD3D_ALLOCATION_FLAG_DEDICATED_BUFFER  = (1u << 1),
-    VKD3D_ALLOCATION_FLAG_GPU_ADDRESS       = (1u << 2),
-    VKD3D_ALLOCATION_FLAG_CPU_ACCESS        = (1u << 3),
+    VKD3D_ALLOCATION_FLAG_GPU_ADDRESS       = (1u << 1),
+    VKD3D_ALLOCATION_FLAG_CPU_ACCESS        = (1u << 2),
 };
 
 #define VKD3D_MEMORY_CHUNK_SIZE (VKD3D_VA_BLOCK_SIZE * 16)
@@ -474,7 +473,6 @@ struct vkd3d_allocate_memory_info
     VkMemoryRequirements memory_requirements;
     D3D12_HEAP_PROPERTIES heap_properties;
     D3D12_HEAP_FLAGS heap_flags;
-    VkBuffer vk_buffer;
     void *host_ptr;
     const void *pNext;
     uint32_t flags;
@@ -590,8 +588,6 @@ HRESULT vkd3d_allocate_memory(struct d3d12_device *device, struct vkd3d_memory_a
         const struct vkd3d_allocate_memory_info *info, struct vkd3d_memory_allocation *allocation);
 HRESULT vkd3d_allocate_heap_memory(struct d3d12_device *device, struct vkd3d_memory_allocator *allocator,
         const struct vkd3d_allocate_heap_memory_info *info, struct vkd3d_memory_allocation *allocation);
-HRESULT vkd3d_allocate_resource_memory(struct d3d12_device *device, struct vkd3d_memory_allocator *allocator,
-        const struct vkd3d_allocate_resource_memory_info *info, struct vkd3d_memory_allocation *allocation);
 
 HRESULT vkd3d_memory_allocator_init(struct vkd3d_memory_allocator *allocator, struct d3d12_device *device);
 void vkd3d_memory_allocator_cleanup(struct vkd3d_memory_allocator *allocator, struct d3d12_device *device);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -586,6 +586,8 @@ struct vkd3d_memory_allocator
 
 void vkd3d_free_memory(struct d3d12_device *device, struct vkd3d_memory_allocator *allocator,
         const struct vkd3d_memory_allocation *allocation);
+HRESULT vkd3d_allocate_memory(struct d3d12_device *device, struct vkd3d_memory_allocator *allocator,
+        const struct vkd3d_allocate_memory_info *info, struct vkd3d_memory_allocation *allocation);
 HRESULT vkd3d_allocate_heap_memory(struct d3d12_device *device, struct vkd3d_memory_allocator *allocator,
         const struct vkd3d_allocate_heap_memory_info *info, struct vkd3d_memory_allocation *allocation);
 HRESULT vkd3d_allocate_resource_memory(struct d3d12_device *device, struct vkd3d_memory_allocator *allocator,


### PR DESCRIPTION
Drastically reduces the number of allocations in some games, which helps RADV performance.

We still use dedicated allocations if the driver sets the corresponding hint, or if we cannot create a buffer on the same memory type to clear the allocation.