### PR TITLE
vkd3d: Do not attempt to enable anything RT related.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -113,9 +113,6 @@ struct vkd3d_vulkan_info
     bool KHR_timeline_semaphore;
     bool KHR_shader_float16_int8;
     bool KHR_shader_subgroup_extended_types;
-    bool KHR_ray_tracing_pipeline;
-    bool KHR_acceleration_structure;
-    bool KHR_deferred_host_operations;
     bool KHR_spirv_1_4;
     bool KHR_shader_float_controls;
     bool KHR_fragment_shading_rate;
@@ -2213,8 +2210,6 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT sampler_filter_minmax_properties;
     VkPhysicalDeviceRobustness2PropertiesEXT robustness2_properties;
     VkPhysicalDeviceExternalMemoryHostPropertiesEXT external_memory_host_properties;
-    VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_pipeline_properties;
-    VkPhysicalDeviceAccelerationStructurePropertiesKHR acceleration_structure_properties;
     VkPhysicalDeviceFloatControlsPropertiesKHR float_control_properties;
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_properties;
 
@@ -2238,8 +2233,6 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features;
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features;
     VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE mutable_descriptor_features;
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline_features;
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure_features;
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragment_shading_rate_features;
 
     VkPhysicalDeviceFeatures2 features2;


### PR DESCRIPTION
Temporary workaround for release build to avoid causing vkCreateDevice failures on Ampere
with Steam Linux runtime.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>