### PR TITLE
vkd3d: Elide timeline semaphore waits which can be satisfied implicitly.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -417,6 +417,7 @@ struct d3d12_fence_value
 {
     uint64_t virtual_value;
     uint64_t physical_value;
+    const struct vkd3d_queue *signalling_queue;
 };
 
 struct d3d12_fence


### PR DESCRIPTION
If we're signalling and waiting on same physical queue (always true for
current SINGLE_QUEUE define), we can rely on submission boundary
synchronization which doesn't require any extra submissions to resolve.

Avoids awkward GPU driver bubbles with back to back signal -> wait pairs
with timeline.

Observed 2% GPU uplift on RE2 on AMD.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>