### PR TITLE
Use virtual descriptor heap GPU VAs

### DIFF
--- a/include/private/vkd3d_memory.h
+++ b/include/private/vkd3d_memory.h
@@ -57,4 +57,22 @@ static inline void vkd3d_free(void *ptr)
 bool vkd3d_array_reserve(void **elements, size_t *capacity,
         size_t element_count, size_t element_size);
 
+static inline void *vkd3d_malloc_aligned(size_t size, size_t align)
+{
+#ifdef _WIN32
+    return _aligned_malloc(size, align);
+#else
+    return aligned_alloc(align, size);
+#endif
+}
+
+static inline void vkd3d_free_aligned(void *ptr)
+{
+#ifdef _WIN32
+    _aligned_free(ptr);
+#else
+    free(ptr);
+#endif
+}
+
 #endif  /* __VKD3D_MEMORY_H */

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -251,6 +251,7 @@ struct vkd3d_shader_interface_local_info
     unsigned int shader_record_buffer_count;
     const struct vkd3d_shader_resource_binding *bindings;
     unsigned int binding_count;
+    uint32_t descriptor_size;
 };
 
 struct vkd3d_shader_transform_feedback_element

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -985,6 +985,19 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
     }
 
     {
+        const struct dxil_spv_option_sbt_descriptor_size_log2 helper =
+                { { DXIL_SPV_OPTION_SBT_DESCRIPTOR_SIZE_LOG2 },
+                    vkd3d_bitmask_tzcnt32(shader_interface_local_info->descriptor_size),
+                    vkd3d_bitmask_tzcnt32(shader_interface_local_info->descriptor_size) };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            ERR("dxil-spirv does not support SBT_DESCRIPTOR_SIZE_LOG2.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
+    {
         const struct dxil_spv_option_bindless_offset_buffer_layout helper =
                 { { DXIL_SPV_OPTION_BINDLESS_OFFSET_BUFFER_LAYOUT },
                   0, 1, 2 };

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4127,7 +4127,6 @@ static void d3d12_command_list_update_descriptor_table_offsets(struct d3d12_comm
     const struct d3d12_root_signature *root_signature = bindings->root_signature;
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     const struct vkd3d_shader_descriptor_table *table;
-    const struct d3d12_desc *base_descriptor;
     uint32_t table_offsets[D3D12_MAX_ROOT_COST];
     unsigned int root_parameter_index;
     uint64_t descriptor_table_mask;
@@ -4138,11 +4137,8 @@ static void d3d12_command_list_update_descriptor_table_offsets(struct d3d12_comm
     while (descriptor_table_mask)
     {
         root_parameter_index = vkd3d_bitmask_iter64(&descriptor_table_mask);
-        base_descriptor = d3d12_desc_from_gpu_handle(bindings->descriptor_tables[root_parameter_index]);
-
         table = root_signature_get_descriptor_table(root_signature, root_parameter_index);
-
-        table_offsets[table->table_index] = d3d12_desc_heap_offset(base_descriptor);
+        table_offsets[table->table_index] = bindings->descriptor_tables[root_parameter_index];
     }
 
     /* Set descriptor offsets */
@@ -4293,7 +4289,6 @@ static void d3d12_command_list_fetch_inline_uniform_block_data(struct d3d12_comm
     const struct vkd3d_shader_root_constant *root_constant;
     const uint32_t *src_data = bindings->root_constants;
     const struct vkd3d_shader_descriptor_table *table;
-    const struct d3d12_desc *base_descriptor;
     unsigned int root_parameter_index;
     uint64_t descriptor_table_mask;
     uint32_t first_table_offset;
@@ -4316,11 +4311,9 @@ static void d3d12_command_list_fetch_inline_uniform_block_data(struct d3d12_comm
     while (descriptor_table_mask)
     {
         root_parameter_index = vkd3d_bitmask_iter64(&descriptor_table_mask);
-        base_descriptor = d3d12_desc_from_gpu_handle(bindings->descriptor_tables[root_parameter_index]);
-
         table = root_signature_get_descriptor_table(root_signature, root_parameter_index);
-
-        dst_data->root_constants[first_table_offset + table->table_index] = d3d12_desc_heap_offset(base_descriptor);
+        dst_data->root_constants[first_table_offset + table->table_index] =
+                bindings->descriptor_tables[root_parameter_index];
     }
 
     /* Reset dirty flags to avoid redundant updates in the future */
@@ -6262,7 +6255,7 @@ static void d3d12_command_list_set_descriptor_table(struct d3d12_command_list *l
     table = root_signature_get_descriptor_table(root_signature, index);
 
     assert(table && index < ARRAY_SIZE(bindings->descriptor_tables));
-    bindings->descriptor_tables[index] = base_descriptor;
+    bindings->descriptor_tables[index] = d3d12_desc_heap_offset_from_gpu_handle(base_descriptor);
     bindings->descriptor_table_active_mask |= (uint64_t)1 << index;
 
     if (root_signature->descriptor_table_count)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4757,8 +4757,6 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     HRESULT hr;
     int rc;
 
-    memset(device, 0, sizeof(*device));
-
 #ifdef VKD3D_ENABLE_PROFILING
     if (vkd3d_uses_profiling())
         device->ID3D12Device_iface.lpVtbl = &d3d12_device_vtbl_profiled;
@@ -4874,7 +4872,7 @@ HRESULT d3d12_device_create(struct vkd3d_instance *instance,
         return S_OK;
     }
 
-    if (!(object = vkd3d_malloc(sizeof(*object))))
+    if (!(object = vkd3d_calloc(1, sizeof(*object))))
     {
         pthread_mutex_unlock(&d3d12_device_map_mutex);
         return E_OUTOFMEMORY;

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -576,6 +576,8 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
     else
         memset(&shader_interface_local_info, 0, sizeof(shader_interface_local_info));
 
+    shader_interface_local_info.descriptor_size = sizeof(struct d3d12_desc);
+
     for (i = 0; i < data->entry_points_count; i++)
     {
         entry = &data->entry_points[i];

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4625,7 +4625,7 @@ static ULONG STDMETHODCALLTYPE d3d12_descriptor_heap_Release(ID3D12DescriptorHea
 
         d3d12_descriptor_heap_cleanup(heap);
         vkd3d_private_store_destroy(&heap->private_store);
-        vkd3d_free(heap);
+        vkd3d_free_aligned(heap);
 
         d3d12_device_release(device);
     }
@@ -5172,8 +5172,8 @@ HRESULT d3d12_descriptor_heap_create(struct d3d12_device *device,
         return E_OUTOFMEMORY;
     }
 
-    if (!(object = vkd3d_malloc(offsetof(struct d3d12_descriptor_heap,
-            descriptors[descriptor_size * desc->NumDescriptors]))))
+    if (!(object = vkd3d_malloc_aligned(offsetof(struct d3d12_descriptor_heap,
+            descriptors[descriptor_size * desc->NumDescriptors]), D3D12_DESC_ALIGNMENT)))
         return E_OUTOFMEMORY;
 
     if (FAILED(hr = d3d12_descriptor_heap_init(object, device, desc)))

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -836,9 +836,16 @@ struct vkd3d_descriptor_data
     uint32_t flags;
 };
 
+#define D3D12_DESC_ALIGNMENT 64
 struct d3d12_desc
 {
-    struct vkd3d_descriptor_data metadata;
+    /* Align d3d12_desc to 64 bytes for two reasons.
+     * - We need a POT size when reporting GPU addresses.
+     *   In DXR, we will need to handle app-placed VAs in a local root signature,
+     *   and the fastest approach we can use is uint(VA) >> 6 to derive an index.
+     * - Can avoid false sharing on cache lines if multiple threads
+     *   modify adjacent descriptors somehow. */
+    DECLSPEC_ALIGN(D3D12_DESC_ALIGNMENT) struct vkd3d_descriptor_data metadata;
     struct d3d12_descriptor_heap *heap;
     uint32_t heap_offset;
     union
@@ -847,6 +854,7 @@ struct d3d12_desc
         struct vkd3d_view *view;
     } info;
 };
+STATIC_ASSERT(sizeof(struct d3d12_desc) == 64);
 
 static inline struct d3d12_desc *d3d12_desc_from_cpu_handle(D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle)
 {
@@ -936,7 +944,7 @@ struct d3d12_descriptor_heap
 
     struct vkd3d_private_store private_store;
 
-    BYTE descriptors[];
+    DECLSPEC_ALIGN(D3D12_DESC_ALIGNMENT) BYTE descriptors[];
 };
 
 HRESULT d3d12_descriptor_heap_create(struct d3d12_device *device,


### PR DESCRIPTION
This is required for DXR since we will need to be able to place table VAs directly in shader record buffers.
This is also a decent CPU optimization since we no longer need to make potentially cold derefs to resolve heap_offset when recording command buffers.