### PR TITLE
vkd3d: Redirect push constants to their bind point stages.

### DIFF
--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -677,7 +677,7 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
     /* FIXME: What if we have no global root signature? */
     if (!global_signature)
         return E_INVALIDARG;
-    pipeline_create_info.layout = global_signature->vk_pipeline_layout;
+    pipeline_create_info.layout = global_signature->raygen.vk_pipeline_layout;
     pipeline_create_info.basePipelineHandle = VK_NULL_HANDLE;
     pipeline_create_info.basePipelineIndex = -1;
     pipeline_create_info.pGroups = data->groups;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1126,12 +1126,18 @@ enum vkd3d_root_signature_flag
 };
 
 /* ID3D12RootSignature */
+struct d3d12_bind_point_layout
+{
+    VkPipelineLayout vk_pipeline_layout;
+    VkShaderStageFlags vk_push_stages;
+};
+
 struct d3d12_root_signature
 {
     ID3D12RootSignature ID3D12RootSignature_iface;
     LONG refcount;
 
-    VkPipelineLayout vk_pipeline_layout;
+    struct d3d12_bind_point_layout graphics, compute, raygen;
     VkDescriptorSetLayout vk_sampler_descriptor_layout;
     VkDescriptorSetLayout vk_root_descriptor_layout;
 
@@ -1527,6 +1533,7 @@ struct vkd3d_root_descriptor_info
 struct vkd3d_pipeline_bindings
 {
     const struct d3d12_root_signature *root_signature;
+    struct d3d12_bind_point_layout layout;
 
     VkDescriptorSet static_sampler_set;
     uint32_t dirty_flags; /* vkd3d_pipeline_dirty_flags */
@@ -1689,6 +1696,7 @@ struct d3d12_command_list
     VkRenderPass current_render_pass;
     struct vkd3d_dynamic_state dynamic_state;
     struct vkd3d_pipeline_bindings pipeline_bindings[VKD3D_PIPELINE_BIND_POINT_COUNT];
+    VkPipelineBindPoint active_bind_point;
 
     VkDescriptorSet descriptor_heaps[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
 


### PR DESCRIPTION
Gives a massive boost on NVIDIA for some reason.
RADV defers push constant update, so ALL_STAGES doesn't have
that much of a perf hit.

~20% uplift in RE2, ~5% uplift in CP77 from some quick and dirty testing.
Seems to be heavily content dependent either way.

Also a bug fix, since we would clobber graphics push constants from
compute and vice versa if both graphics and compute used the same root
signature.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>