### PR TITLE
Enable debug_utils conditionally, disable tracing for Release

### DIFF
--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -67,7 +67,6 @@ enum vkd3d_structure_type
 
     /* 1.2 */
     VKD3D_STRUCTURE_TYPE_OPTIONAL_DEVICE_EXTENSIONS_INFO,
-    VKD3D_STRUCTURE_TYPE_APPLICATION_INFO,
 
     VKD3D_FORCE_32_BIT_ENUM(VKD3D_STRUCTURE_TYPE),
 };
@@ -105,19 +104,6 @@ struct vkd3d_optional_instance_extensions_info
 
     const char * const *extensions;
     uint32_t extension_count;
-};
-
-/* Extends vkd3d_instance_create_info. Available since 1.2. */
-struct vkd3d_application_info
-{
-    enum vkd3d_structure_type type;
-    const void *next;
-
-    const char *application_name;
-    uint32_t application_version;
-
-    const char *engine_name; /* "vkd3d" if NULL */
-    uint32_t engine_version; /* vkd3d version if engine_name is NULL */
 };
 
 struct vkd3d_device_create_info

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -75,7 +75,7 @@ struct vkd3d_optional_extension_info
 static const struct vkd3d_optional_extension_info optional_instance_extensions[] =
 {
     /* EXT extensions */
-    VK_EXTENSION(EXT_DEBUG_UTILS, EXT_debug_utils),
+    VK_EXTENSION_COND(EXT_DEBUG_UTILS, EXT_debug_utils, VKD3D_CONFIG_FLAG_DEBUG_UTILS),
 };
 
 static const struct vkd3d_optional_extension_info optional_device_extensions[] =
@@ -475,6 +475,7 @@ static const struct vkd3d_debug_option vkd3d_config_options[] =
     /* Enable Vulkan debug extensions. */
     {"vk_debug", VKD3D_CONFIG_FLAG_VULKAN_DEBUG},
     {"skip_application_workarounds", VKD3D_CONFIG_FLAG_SKIP_APPLICATION_WORKAROUNDS},
+    {"debug_utils", VKD3D_CONFIG_FLAG_DEBUG_UTILS},
 };
 
 static void vkd3d_config_flags_init_once(void)
@@ -486,6 +487,12 @@ static void vkd3d_config_flags_init_once(void)
 
     if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_SKIP_APPLICATION_WORKAROUNDS))
         vkd3d_instance_apply_application_workarounds();
+
+#ifdef VKD3D_ENABLE_RENDERDOC
+    /* Enable debug utils by default for Renderdoc builds */
+    TRACE("Renderdoc build implies VKD3D_CONFIG_FLAG_DEBUG_UTILS.\n");
+    vkd3d_config_flags |= VKD3D_CONFIG_FLAG_DEBUG_UTILS;
+#endif
 
     if (vkd3d_config_flags)
         TRACE("VKD3D_CONFIG='%s'.\n", config);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -485,7 +485,6 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     const struct vkd3d_vk_global_procs *vk_global_procs = &instance->vk_global_procs;
     const struct vkd3d_optional_instance_extensions_info *optional_extensions;
     const char *debug_layer_name = "VK_LAYER_KHRONOS_validation";
-    const struct vkd3d_application_info *vkd3d_application_info;
     bool *user_extension_supported = NULL;
     VkApplicationInfo application_info;
     VkInstanceCreateInfo instance_info;
@@ -559,17 +558,7 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
 
     INFO("vkd3d-proton - build: %"PRIx64".\n", vkd3d_build);
 
-    if ((vkd3d_application_info = vkd3d_find_struct(create_info->next, APPLICATION_INFO)))
-    {
-        application_info.pApplicationName = vkd3d_application_info->application_name;
-        application_info.applicationVersion = vkd3d_application_info->application_version;
-        if (vkd3d_application_info->engine_name)
-        {
-            application_info.pEngineName = vkd3d_application_info->engine_name;
-            application_info.engineVersion = vkd3d_application_info->engine_version;
-        }
-    }
-    else if (vkd3d_get_program_name(application_name))
+    if (vkd3d_get_program_name(application_name))
     {
         application_info.pApplicationName = application_name;
     }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -167,6 +167,7 @@ enum vkd3d_config_flags
 {
     VKD3D_CONFIG_FLAG_VULKAN_DEBUG = 0x00000001,
     VKD3D_CONFIG_FLAG_SKIP_APPLICATION_WORKAROUNDS = 0x00000002,
+    VKD3D_CONFIG_FLAG_DEBUG_UTILS = 0x00000004,
 };
 
 struct vkd3d_instance
@@ -436,6 +437,13 @@ static inline bool vkd3d_private_data_object_name_ptr(REFGUID guid,
 {
     if (out_name)
         *out_name = NULL;
+
+    /* This is also handled in the object_name implementation
+     * but this avoids an additional, needless allocation
+     * and some games may spam SetName.
+     */
+    if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_DEBUG_UTILS))
+        return false;
 
     if (IsEqualGUID(guid, &WKPDID_D3DDebugObjectName))
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -183,12 +183,12 @@ struct vkd3d_instance
     struct vkd3d_vk_global_procs vk_global_procs;
     void *libvulkan;
 
-    uint64_t config_flags;
-
     VkDebugUtilsMessengerEXT vk_debug_callback;
 
     LONG refcount;
 };
+
+extern uint64_t vkd3d_config_flags;
 
 union vkd3d_thread_handle
 {

--- a/meson.build
+++ b/meson.build
@@ -10,17 +10,27 @@ vkd3d_clang    = vkd3d_compiler.get_id() == 'clang'
 vkd3d_c_std    = 'c11'
 vkd3d_platform = target_machine.system()
 
+vkd3d_buildtype = get_option('buildtype')
+vkd3d_debug     = vkd3d_buildtype == 'debug' or vkd3d_buildtype == 'debugoptimized'
+
 enable_tests             = get_option('enable_tests')
 enable_extras            = get_option('enable_extras')
 enable_d3d12             = get_option('enable_d3d12')
 enable_profiling         = get_option('enable_profiling')
 enable_renderdoc         = get_option('enable_renderdoc')
 enable_descriptor_qa     = get_option('enable_descriptor_qa')
+enable_trace             = get_option('enable_trace')
 
 if enable_d3d12 == 'auto'
   enable_d3d12 = vkd3d_platform == 'windows'
 else
   enable_d3d12 = enable_d3d12 == 'true'
+endif
+
+if enable_trace == 'auto'
+  enable_trace = vkd3d_debug
+else
+  enable_trace = enable_trace == 'true'
 endif
 
 if vkd3d_platform != 'windows' and enable_d3d12
@@ -48,6 +58,10 @@ endif
 
 if enable_descriptor_qa
   add_project_arguments('-DVKD3D_ENABLE_DESCRIPTOR_QA', language : 'c')
+endif
+
+if not enable_trace
+  add_project_arguments('-DVKD3D_NO_TRACE_MESSAGES', language : 'c')
 endif
 
 vkd3d_external_includes = [ './subprojects/Vulkan-Headers/include', './subprojects/SPIRV-Headers/include' ]

--- a/meson.build
+++ b/meson.build
@@ -18,9 +18,9 @@ enable_renderdoc         = get_option('enable_renderdoc')
 enable_descriptor_qa     = get_option('enable_descriptor_qa')
 
 if enable_d3d12 == 'auto'
-    enable_d3d12 = (vkd3d_platform == 'windows')
+  enable_d3d12 = vkd3d_platform == 'windows'
 else
-    enable_d3d12 = (enable_d3d12 == 'true')
+  enable_d3d12 = enable_d3d12 == 'true'
 endif
 
 if vkd3d_platform != 'windows' and enable_d3d12

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('enable_d3d12',            type : 'combo',   value : 'auto', choices : ['
 option('enable_profiling',        type : 'boolean', value : false)
 option('enable_renderdoc',        type : 'boolean', value : false)
 option('enable_descriptor_qa',    type : 'boolean', value : false)
+option('enable_trace',            type : 'combo',   value : 'auto', choices : ['false', 'true', 'auto'])

--- a/tests/vkd3d_api.c
+++ b/tests/vkd3d_api.c
@@ -1058,49 +1058,6 @@ static void test_formats(void)
     }
 }
 
-static void test_application_info(void)
-{
-    struct vkd3d_instance_create_info create_info;
-    struct vkd3d_application_info app_info;
-    struct vkd3d_instance *instance;
-    ULONG refcount;
-    HRESULT hr;
-
-    app_info.type = VKD3D_STRUCTURE_TYPE_APPLICATION_INFO;
-    app_info.next = NULL;
-    app_info.engine_name = NULL;
-    app_info.engine_version = 0;
-    app_info.application_name = NULL;
-    app_info.application_version = 0;
-
-    create_info = instance_default_create_info;
-    create_info.next = &app_info;
-    hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
-    refcount = vkd3d_instance_decref(instance);
-    ok(!refcount, "Instance has %u references left.\n", refcount);
-
-    app_info.application_name = "vkd3d_api_tests";
-    app_info.application_version = 0xdeadbeef;
-    hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
-    refcount = vkd3d_instance_decref(instance);
-    ok(!refcount, "Instance has %u references left.\n", refcount);
-
-    app_info.engine_name = "engine_name";
-    hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
-    refcount = vkd3d_instance_decref(instance);
-    ok(!refcount, "Instance has %u references left.\n", refcount);
-
-    app_info.engine_name = "engine_name";
-    app_info.engine_version = 2;
-    hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
-    refcount = vkd3d_instance_decref(instance);
-    ok(!refcount, "Instance has %u references left.\n", refcount);
-}
-
 static bool have_d3d12_device(void)
 {
     ID3D12Device *device;
@@ -1132,5 +1089,4 @@ START_TEST(vkd3d_api)
     run_test(test_external_resource_map);
     run_test(test_external_resource_present_state);
     run_test(test_formats);
-    run_test(test_application_info);
 }


### PR DESCRIPTION
## Enable VK_EXT_debug_utils conditionally

Enabling VK_EXT_debug_utils comes at some overhead in Wine due to the object tracking required. There is also likely a non-zero overhead in some native implementations also.

By enabling this conditionally, we can also avoid additional overhead from apps that set debug labels on both the Vulkan and front-end side.

The default condition is to enable it when building with Renderdoc integration or in debug builds.

## Disable TRACE calls in release builds

It's needless overhead to have control flow at the start of every entrypoint. Branch predictors are good but there's no reason to keep what is essentially dead code behind an if sitting around (especially given we aren't marking it as unlikely).

## Other minor cleanup stuff to get compiling without warnings...