### PR TITLE
build: Use --file-alignment=4096 with MinGW

### DIFF
--- a/libs/d3d12/meson.build
+++ b/libs/d3d12/meson.build
@@ -7,7 +7,7 @@ d3d12_lib = shared_library('d3d12', d3d12_src,
   dependencies        : [ vkd3d_dep, lib_dxgi ],
   include_directories : vkd3d_private_includes,
   install             : true,
-  objects             : not vkd3d_msvc ? 'd3d12.def' : [],
+  objects             : not vkd3d_is_msvc ? 'd3d12.def' : [],
   vs_module_defs      : 'd3d12.def',
   override_options    : [ 'c_std='+vkd3d_c_std ])
 

--- a/libs/vkd3d-utils/meson.build
+++ b/libs/vkd3d-utils/meson.build
@@ -6,7 +6,7 @@ vkd3d_utils_lib = shared_library('vkd3d-proton-utils', vkd3d_utils_src,
   dependencies        : vkd3d_dep,
   include_directories : vkd3d_private_includes,
   install             : true,
-  objects             : not vkd3d_msvc and vkd3d_platform == 'windows'
+  objects             : not vkd3d_is_msvc and vkd3d_platform == 'windows'
                         ? 'vkd3d-proton-utils.def'
                         : [],
   vs_module_defs      : 'vkd3d-proton-utils.def',

--- a/meson.build
+++ b/meson.build
@@ -125,6 +125,14 @@ if cpu_family == 'x86'
   endif
 endif
 
+if not vkd3d_is_msvc
+  # We need to set the section alignment for debug symbols to
+  # work properly as well as avoiding a memcpy from the Wine loader.
+  if vkd3d_compiler.has_link_argument('-Wl,--file-alignment=4096')
+    add_global_link_arguments('-Wl,--file-alignment=4096', language : [ 'c', 'cpp' ])
+  endif
+endif
+
 vkd3d_build = vcs_tag(
   command : ['git', 'describe', '--always', '--exclude=*', '--abbrev=15', '--dirty=0'],
   input   : 'vkd3d_build.h.in',

--- a/meson.build
+++ b/meson.build
@@ -5,8 +5,8 @@ project('vkd3d-proton', ['c'], version : '2.2', meson_version : '>= 0.49', defau
 cpu_family = target_machine.cpu_family()
 
 vkd3d_compiler = meson.get_compiler('c')
-vkd3d_msvc     = vkd3d_compiler.get_id() == 'msvc'
-vkd3d_clang    = vkd3d_compiler.get_id() == 'clang'
+vkd3d_is_msvc  = vkd3d_compiler.get_id() == 'msvc'
+vkd3d_is_clang = vkd3d_compiler.get_id() == 'clang'
 vkd3d_c_std    = 'c11'
 vkd3d_platform = target_machine.system()
 
@@ -119,7 +119,7 @@ if cpu_family == 'x86'
 
   # Need to link against libatomic for 64-bit atomic emulation on x86
   # when using clang.
-  if vkd3d_clang
+  if vkd3d_is_clang
     lib_atomic = vkd3d_compiler.find_library('atomic')
     vkd3d_extra_libs += lib_atomic
   endif


### PR DESCRIPTION
Avoids a copy in the Wine loader as well as enables debug symbols to work in perf.