### PR TITLE
build: Warn about VLA usage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,9 @@ endif
 
 add_project_arguments(vkd3d_compiler.get_supported_arguments([
     '-fvisibility=hidden',
+    # For some reason, the use of VLAs isn't in all+extra+pedantic
+    # We don't want to use these accidentally from consts...
+    '-Wvla',
     '-Wno-format',
     '-Wno-missing-field-initializers',
     '-Wno-unused-parameter',


### PR DESCRIPTION
Using consts for array sizes is a C++-ism, and in GCC in C-mode it won't fold literal constants, and will instead prefer to make a VLA.

Signed-off-by: Joshua Ashton <joshua@froggi.es>