### PR TITLE
vkd3d: Remove dead code from d3d12_command_list.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -3870,8 +3870,6 @@ static void d3d12_command_list_reset_state(struct d3d12_command_list *list,
     list->rt_state = NULL;
     list->active_bind_point = VK_PIPELINE_BIND_POINT_MAX_ENUM;
 
-    list->descriptor_updates_count = 0;
-
     memset(list->so_counter_buffers, 0, sizeof(list->so_counter_buffers));
     memset(list->so_counter_buffer_offsets, 0, sizeof(list->so_counter_buffer_offsets));
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1722,10 +1722,6 @@ struct d3d12_command_list
     VkBuffer so_counter_buffers[D3D12_SO_BUFFER_SLOT_COUNT];
     VkDeviceSize so_counter_buffer_offsets[D3D12_SO_BUFFER_SLOT_COUNT];
 
-    struct d3d12_deferred_descriptor_set_update *descriptor_updates;
-    size_t descriptor_updates_size;
-    size_t descriptor_updates_count;
-
     struct vkd3d_initial_transition *init_transitions;
     size_t init_transitions_size;
     size_t init_transitions_count;


### PR DESCRIPTION
Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>