### PR TITLE
Optimize sparse binding

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2155,6 +2155,7 @@ static HRESULT d3d12_resource_init_sparse_info(struct d3d12_resource *resource,
             region->subresource.aspectMask = vk_memory_requirements.formatProperties.aspectMask;
             region->subresource.mipLevel = subresource % resource->desc.MipLevels;
             region->subresource.arrayLayer = subresource / resource->desc.MipLevels;
+            region->subresource_index = subresource;
 
             region->offset.x = tile_offset.x * block_extent.width;
             region->offset.y = tile_offset.y * block_extent.height;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -636,6 +636,7 @@ enum vkd3d_resource_flag
 struct d3d12_sparse_image_region
 {
     VkImageSubresource subresource;
+    uint32_t subresource_index;
     VkOffset3D offset;
     VkExtent3D extent;
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1674,6 +1674,14 @@ struct vkd3d_sparse_memory_bind
     VkDeviceSize vk_offset;
 };
 
+struct vkd3d_sparse_memory_bind_range
+{
+    uint32_t tile_index;
+    uint32_t tile_count;
+    VkDeviceMemory vk_memory;
+    VkDeviceSize vk_offset;
+};
+
 struct d3d12_command_queue_submission_wait
 {
     struct d3d12_fence *fence;


### PR DESCRIPTION
Detects updates of adjacent buffer tiles and full image subresource updates, which should reduce the number of `VkSparseMemoryBind` and `VkSparseImageMemoryBind` structures passes to the driver. We don't do anything fancy for adjacent image tile updates etc.

Passes tests and works with AC:Valhalla.