### PR TITLE
Switch to the portable shebang

### DIFF
--- a/package-release.sh
+++ b/package-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/setup_vkd3d_proton.sh
+++ b/setup_vkd3d_proton.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # default directories
 vkd3d_lib32=${vkd3d_lib32:-"x86"}


### PR DESCRIPTION
Hi.
We should go for the [portable shebang-form](https://en.wikipedia.org/w/index.php?title=Shebang_(Unix)&oldid=878552871#Portability) to get the bash environment. /bin/bash is also not a real thing on most distros anymore¹. This will bring compatiblity for distros who don't create the compat-symlink.

¹ Most distros:

```
file /bin
/bin: symbolic link to usr/bin
```

Signed-off-by: Fabian Bornschein <fabiscafe@mailbox.org>