### PR TITLE
vkd3d: Ignore IASetVertexBuffers for NULL pViews.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6897,6 +6897,10 @@ static void STDMETHODCALLTYPE d3d12_command_list_IASetVertexBuffers(d3d12_comman
         return;
     }
 
+    /* Native drivers appear to ignore this call. Buffer bindings are kept as-is. */
+    if (!views)
+        return;
+
     for (i = 0; i < view_count; ++i)
     {
         bool invalid_va = false;

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -19739,6 +19739,10 @@ static void test_null_vbv(void)
     vbv[1].SizeInBytes = 0;
     ID3D12GraphicsCommandList_IASetVertexBuffers(command_list, 0, ARRAY_SIZE(vbv), vbv);
 
+    /* Call should be ignored. */
+    ID3D12GraphicsCommandList_IASetVertexBuffers(command_list, 0, 1, NULL);
+    ID3D12GraphicsCommandList_IASetVertexBuffers(command_list, 1, 1, NULL);
+
     ID3D12GraphicsCommandList_DrawInstanced(command_list, 4, 4, 0, 0);
 
     transition_resource_state(command_list, context.render_target,


### PR DESCRIPTION
Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>