### PR TITLE
vkd3d: Fix potential hang in d3d12_command_queue_Release.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -349,7 +349,7 @@ static void *vkd3d_fence_worker_main(void *arg)
             break;
         }
 
-        if (!worker->enqueued_fence_count)
+        if (!worker->enqueued_fence_count && !worker->should_exit)
         {
             if ((rc = pthread_cond_wait(&worker->cond, &worker->mutex)))
             {


### PR DESCRIPTION
Found while running the Windows version of our test suite with wine.