### PR TITLE
vkd3d: Align d3d12_rtv_desc to D3D12_DESC_ALIGNMENT

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1016,7 +1016,7 @@ HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
 
 struct d3d12_rtv_desc
 {
-    VkSampleCountFlagBits sample_count;
+    DECLSPEC_ALIGN(D3D12_DESC_ALIGNMENT) VkSampleCountFlagBits sample_count;
     const struct vkd3d_format *format;
     unsigned int width;
     unsigned int height;
@@ -1024,6 +1024,7 @@ struct d3d12_rtv_desc
     struct vkd3d_view *view;
     struct d3d12_resource *resource;
 };
+STATIC_ASSERT(sizeof(struct d3d12_rtv_desc) == 64);
 
 void d3d12_rtv_desc_copy(struct d3d12_rtv_desc *dst, struct d3d12_rtv_desc *src, unsigned int count);
 


### PR DESCRIPTION
Otherwise we can do an alligned_malloc with a non-aligned size as the descriptor size is 48 for a d3d12_rtv_desc otherwise.

Signed-off-by: Joshua Ashton <joshua@froggi.es>