### PR TITLE
vkd3d: Fix stack overflow in debug_vk_memory_property_flags.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1139,6 +1139,7 @@ static void vkd3d_trace_physical_device(VkPhysicalDevice device,
         const struct vkd3d_physical_device_info *info,
         const struct vkd3d_vk_instance_procs *vk_procs)
 {
+    VKD3D_UNUSED char debug_buffer[VKD3D_DEBUG_FLAGS_BUFFER_SIZE];
     VkPhysicalDeviceMemoryProperties memory_properties;
     VkQueueFamilyProperties *queue_properties;
     unsigned int i, j;
@@ -1156,7 +1157,7 @@ static void vkd3d_trace_physical_device(VkPhysicalDevice device,
     for (i = 0; i < count; ++i)
     {
         TRACE(" Queue family [%u]: flags %s, count %u, timestamp bits %u, image transfer granularity %s.\n",
-                i, debug_vk_queue_flags(queue_properties[i].queueFlags),
+                i, debug_vk_queue_flags(queue_properties[i].queueFlags, debug_buffer),
                 queue_properties[i].queueCount, queue_properties[i].timestampValidBits,
                 debug_vk_extent_3d(queue_properties[i].minImageTransferGranularity));
     }
@@ -1167,13 +1168,13 @@ static void vkd3d_trace_physical_device(VkPhysicalDevice device,
     {
         VKD3D_UNUSED const VkMemoryHeap *heap = &memory_properties.memoryHeaps[i];
         TRACE("Memory heap [%u]: size %#"PRIx64" (%"PRIu64" MiB), flags %s, memory types:\n",
-                i, heap->size, heap->size / 1024 / 1024, debug_vk_memory_heap_flags(heap->flags));
+                i, heap->size, heap->size / 1024 / 1024, debug_vk_memory_heap_flags(heap->flags, debug_buffer));
         for (j = 0; j < memory_properties.memoryTypeCount; ++j)
         {
             const VkMemoryType *type = &memory_properties.memoryTypes[j];
             if (type->heapIndex != i)
                 continue;
-            TRACE("  Memory type [%u]: flags %s.\n", j, debug_vk_memory_property_flags(type->propertyFlags));
+            TRACE("  Memory type [%u]: flags %s.\n", j, debug_vk_memory_property_flags(type->propertyFlags, debug_buffer));
         }
     }
 }

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -822,10 +822,8 @@ const char *debug_vk_extent_3d(VkExtent3D extent)
             (unsigned int)extent.depth);
 }
 
-const char *debug_vk_queue_flags(VkQueueFlags flags)
+const char *debug_vk_queue_flags(VkQueueFlags flags, char buffer[VKD3D_DEBUG_FLAGS_BUFFER_SIZE])
 {
-    char buffer[120];
-
     buffer[0] = '\0';
 #define FLAG_TO_STR(f) if (flags & f) { strcat(buffer, " | "#f); flags &= ~f; }
     FLAG_TO_STR(VK_QUEUE_GRAPHICS_BIT)
@@ -842,10 +840,8 @@ const char *debug_vk_queue_flags(VkQueueFlags flags)
     return vkd3d_dbg_sprintf("%s", &buffer[3]);
 }
 
-const char *debug_vk_memory_heap_flags(VkMemoryHeapFlags flags)
+const char *debug_vk_memory_heap_flags(VkMemoryHeapFlags flags, char buffer[VKD3D_DEBUG_FLAGS_BUFFER_SIZE])
 {
-    char buffer[50];
-
     buffer[0] = '\0';
 #define FLAG_TO_STR(f) if (flags & f) { strcat(buffer, " | "#f); flags &= ~f; }
     FLAG_TO_STR(VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
@@ -859,10 +855,8 @@ const char *debug_vk_memory_heap_flags(VkMemoryHeapFlags flags)
     return vkd3d_dbg_sprintf("%s", &buffer[3]);
 }
 
-const char *debug_vk_memory_property_flags(VkMemoryPropertyFlags flags)
+const char *debug_vk_memory_property_flags(VkMemoryPropertyFlags flags, char buffer[VKD3D_DEBUG_FLAGS_BUFFER_SIZE])
 {
-    char buffer[200];
-
     buffer[0] = '\0';
 #define FLAG_TO_STR(f) if (flags & f) { strcat(buffer, " | "#f); flags &= ~f; }
     FLAG_TO_STR(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2858,9 +2858,11 @@ const char *debug_dxgi_format(DXGI_FORMAT format);
 const char *debug_d3d12_box(const D3D12_BOX *box);
 const char *debug_d3d12_shader_component_mapping(unsigned int mapping);
 const char *debug_vk_extent_3d(VkExtent3D extent);
-const char *debug_vk_memory_heap_flags(VkMemoryHeapFlags flags);
-const char *debug_vk_memory_property_flags(VkMemoryPropertyFlags flags);
-const char *debug_vk_queue_flags(VkQueueFlags flags);
+
+#define VKD3D_DEBUG_FLAGS_BUFFER_SIZE 1024
+const char *debug_vk_memory_heap_flags(VkMemoryHeapFlags flags, char buffer[VKD3D_DEBUG_FLAGS_BUFFER_SIZE]);
+const char *debug_vk_memory_property_flags(VkMemoryPropertyFlags flags, char buffer[VKD3D_DEBUG_FLAGS_BUFFER_SIZE]);
+const char *debug_vk_queue_flags(VkQueueFlags flags, char buffer[VKD3D_DEBUG_FLAGS_BUFFER_SIZE]);
 
 static inline void debug_ignored_node_mask(unsigned int mask)
 {


### PR DESCRIPTION
C is fun, yo.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>