### PR TITLE
vkd3d: Enable VK_KHR_sampler_mirror_clamp_to_edge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ There are some hard requirements on drivers to be able to implement D3D12 in a r
   Essentially all features in `VkPhysicalDeviceDescriptorIndexingFeatures` must be supported.
 - `VK_KHR_timeline_semaphore`
 - `VK_KHR_create_renderpass2`
+- `VK_KHR_sampler_mirror_clamp_to_edge`
 
 Some notable extensions that **should** be supported for optimal or correct behavior.
 These extensions will likely become mandatory later.

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -96,6 +96,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_SHADER_FLOAT_CONTROLS, KHR_shader_float_controls),
     VK_EXTENSION(KHR_FRAGMENT_SHADING_RATE, KHR_fragment_shading_rate),
     VK_EXTENSION(KHR_CREATE_RENDERPASS_2, KHR_create_renderpass2),
+    VK_EXTENSION(KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE, KHR_sampler_mirror_clamp_to_edge),
     /* EXT extensions */
     VK_EXTENSION(EXT_CALIBRATED_TIMESTAMPS, EXT_calibrated_timestamps),
     VK_EXTENSION(EXT_CONDITIONAL_RENDERING, EXT_conditional_rendering),
@@ -1672,6 +1673,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     if (!vulkan_info->KHR_create_renderpass2)
     {
         ERR("KHR_create_renderpass2 is not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
+    if (!vulkan_info->KHR_sampler_mirror_clamp_to_edge)
+    {
+        ERR("KHR_sampler_mirror_clamp_to_edge is not supported by this implementation. This is required for correct operation.\n");
         return E_INVALIDARG;
     }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4253,7 +4253,8 @@ static VkSamplerAddressMode vk_address_mode_from_d3d12(D3D12_TEXTURE_ADDRESS_MOD
             return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
         case D3D12_TEXTURE_ADDRESS_MODE_BORDER:
             return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-            /* D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE requires VK_KHR_mirror_clamp_to_edge. */
+        case D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE:
+            return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
         default:
             FIXME("Unhandled address mode %#x.\n", mode);
             return VK_SAMPLER_ADDRESS_MODE_REPEAT;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -118,6 +118,7 @@ struct vkd3d_vulkan_info
     bool KHR_shader_float_controls;
     bool KHR_fragment_shading_rate;
     bool KHR_create_renderpass2;
+    bool KHR_sampler_mirror_clamp_to_edge;
     /* EXT device extensions */
     bool EXT_calibrated_timestamps;
     bool EXT_conditional_rendering;


### PR DESCRIPTION
CP77 requires it now.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>