### PR TITLE
Various PSO robustness fixes

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -212,6 +212,8 @@ struct vkd3d_shader_interface_info
     const struct vkd3d_shader_descriptor_binding *push_constant_ubo_binding;
     /* Ignored unless VKD3D_SHADER_INTERFACE_SSBO_OFFSET_BUFFER or TYPED_OFFSET_BUFFER is set */
     const struct vkd3d_shader_descriptor_binding *offset_buffer_binding;
+
+    VkShaderStageFlagBits stage;
 };
 
 struct vkd3d_shader_descriptor_table

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -523,7 +523,7 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
 
     if (dxil_spv_create_converter(blob, &converter) != DXIL_SPV_SUCCESS)
     {
-        ret = VKD3D_ERROR_INVALID_SHADER;
+        ret = VKD3D_ERROR_INVALID_ARGUMENT;
         goto end;
     }
 
@@ -747,13 +747,13 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
 
     if (dxil_spv_converter_run(converter) != DXIL_SPV_SUCCESS)
     {
-        ret = VKD3D_ERROR_INVALID_SHADER;
+        ret = VKD3D_ERROR_INVALID_ARGUMENT;
         goto end;
     }
 
     if (dxil_spv_converter_get_compiled_spirv(converter, &compiled) != DXIL_SPV_SUCCESS)
     {
-        ret = VKD3D_ERROR_INVALID_SHADER;
+        ret = VKD3D_ERROR_INVALID_ARGUMENT;
         goto end;
     }
 
@@ -828,7 +828,7 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
 
     if (dxil_spv_create_converter(blob, &converter) != DXIL_SPV_SUCCESS)
     {
-        ret = VKD3D_ERROR_INVALID_SHADER;
+        ret = VKD3D_ERROR_INVALID_ARGUMENT;
         goto end;
     }
 
@@ -1097,13 +1097,13 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
 
     if (dxil_spv_converter_run(converter) != DXIL_SPV_SUCCESS)
     {
-        ret = VKD3D_ERROR_INVALID_SHADER;
+        ret = VKD3D_ERROR_INVALID_ARGUMENT;
         goto end;
     }
 
     if (dxil_spv_converter_get_compiled_spirv(converter, &compiled) != DXIL_SPV_SUCCESS)
     {
-        ret = VKD3D_ERROR_INVALID_SHADER;
+        ret = VKD3D_ERROR_INVALID_ARGUMENT;
         goto end;
     }
 
@@ -1214,7 +1214,7 @@ int vkd3d_shader_dxil_append_library_entry_points(
             library_desc->DXILLibrary.BytecodeLength,
             &blob) != DXIL_SPV_SUCCESS)
     {
-        ret = VKD3D_ERROR_INVALID_SHADER;
+        ret = VKD3D_ERROR_INVALID_ARGUMENT;
         goto end;
     }
 
@@ -1230,7 +1230,7 @@ int vkd3d_shader_dxil_append_library_entry_points(
             stage = dxil_spv_parsed_blob_get_shader_stage_for_entry(blob, ascii_entry);
             if (stage == DXIL_SPV_STAGE_UNKNOWN)
             {
-                ret = VKD3D_ERROR_INVALID_SHADER;
+                ret = VKD3D_ERROR_INVALID_ARGUMENT;
                 goto end;
             }
 
@@ -1251,7 +1251,7 @@ int vkd3d_shader_dxil_append_library_entry_points(
     {
         if (dxil_spv_parsed_blob_get_num_entry_points(blob, &count) != DXIL_SPV_SUCCESS)
         {
-            ret = VKD3D_ERROR_INVALID_SHADER;
+            ret = VKD3D_ERROR_INVALID_ARGUMENT;
             goto end;
         }
 
@@ -1262,13 +1262,13 @@ int vkd3d_shader_dxil_append_library_entry_points(
             if (stage == DXIL_SPV_STAGE_UNKNOWN)
             {
                 ERR("Invalid shader stage for %s.\n", mangled_entry);
-                ret = VKD3D_ERROR_INVALID_SHADER;
+                ret = VKD3D_ERROR_INVALID_ARGUMENT;
                 goto end;
             }
 
             if (!vkd3d_dxil_build_entry(&new_entry, identifier, mangled_entry, stage))
             {
-                ret = VKD3D_ERROR_INVALID_SHADER;
+                ret = VKD3D_ERROR_INVALID_ARGUMENT;
                 goto end;
             }
 

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -30,6 +30,8 @@ static void vkd3d_shader_dump_blob(const char *path, vkd3d_shader_hash_t hash, c
 
     snprintf(filename, ARRAY_SIZE(filename), "%s/%016"PRIx64".%s", path, hash, ext);
 
+    INFO("Dumping blob to %s.\n", filename);
+
     /* Exclusive open to avoid multiple threads spamming out the same shader module, and avoids race condition. */
     if ((f = fopen(filename, "wbx")))
     {

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -875,6 +875,9 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
     shader_interface_info.type = VKD3D_SHADER_STRUCTURE_TYPE_SHADER_INTERFACE_INFO;
     shader_interface_info.min_ssbo_alignment = d3d12_device_get_ssbo_alignment(object->device);
 
+    /* Effectively ignored. */
+    shader_interface_info.stage = VK_SHADER_STAGE_ALL;
+
     global_signature = unsafe_impl_from_ID3D12RootSignature(data->global_root_signature);
 
     if (global_signature)

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2021,7 +2021,7 @@ struct d3d12_pipeline_state *unsafe_impl_from_ID3D12PipelineState(ID3D12Pipeline
 }
 
 static HRESULT create_shader_stage(struct d3d12_device *device,
-        struct VkPipelineShaderStageCreateInfo *stage_desc, enum VkShaderStageFlagBits stage,
+        struct VkPipelineShaderStageCreateInfo *stage_desc, VkShaderStageFlagBits stage,
         const D3D12_SHADER_BYTECODE *code, const struct vkd3d_shader_interface_info *shader_interface,
         const struct vkd3d_shader_compile_arguments *compile_args, struct vkd3d_shader_meta *meta)
 {
@@ -2143,6 +2143,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
     shader_interface.push_constant_ubo_binding = &root_signature->push_constant_ubo_binding;
     shader_interface.offset_buffer_binding = &root_signature->offset_buffer_binding;
+    shader_interface.stage = VK_SHADER_STAGE_COMPUTE_BIT;
 
     if ((hr = vkd3d_create_pipeline_cache_from_d3d12_desc(device, &desc->cached_pso, &state->vk_pso_cache)) < 0)
     {
@@ -3073,7 +3074,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         }
 
         shader_interface.next = shader_stages[i].stage == xfb_stage ? &xfb_info : NULL;
-
+        shader_interface.stage = shader_stages[i].stage;
         if (FAILED(hr = create_shader_stage(device, &graphics->stages[graphics->stage_count],
                 shader_stages[i].stage, b, &shader_interface,
                 shader_stages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT ? &ps_compile_args : &compile_args,

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2044,11 +2044,13 @@ static HRESULT create_shader_stage(struct d3d12_device *device,
     shader_desc.pNext = NULL;
     shader_desc.flags = 0;
 
+    TRACE("Calling vkd3d_shader_compile_dxbc.\n");
     if ((ret = vkd3d_shader_compile_dxbc(&dxbc, &spirv, 0, shader_interface, compile_args)) < 0)
     {
         WARN("Failed to compile shader, vkd3d result %d.\n", ret);
         return hresult_from_vkd3d_result(ret);
     }
+    TRACE("Called vkd3d_shader_compile_dxbc.\n");
     shader_desc.codeSize = spirv.size;
     shader_desc.pCode = spirv.code;
     *meta = spirv.meta;
@@ -2103,8 +2105,10 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_device *device,
         pipeline_info.stage.pSpecializationInfo = &spec_info.spec_info;
     }
 
+    TRACE("Calling vkCreateComputePipelines.\n");
     vr = VK_CALL(vkCreateComputePipelines(device->vk_device,
             vk_cache, 1, &pipeline_info, NULL, vk_pipeline));
+    TRACE("Called vkCreateComputePipelines.\n");
     VK_CALL(vkDestroyShaderModule(device->vk_device, pipeline_info.stage.module, NULL));
     if (vr < 0)
     {
@@ -3709,12 +3713,14 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
 
     *vk_render_pass = pipeline_desc.renderPass;
 
+    TRACE("Calling vkCreateGraphicsPipelines.\n");
     if ((vr = VK_CALL(vkCreateGraphicsPipelines(device->vk_device,
             vk_cache, 1, &pipeline_desc, NULL, &vk_pipeline))) < 0)
     {
         WARN("Failed to create Vulkan graphics pipeline, vr %d.\n", vr);
         return VK_NULL_HANDLE;
     }
+    TRACE("Completed vkCreateGraphicsPipelines.\n");
 
     return vk_pipeline;
 }

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3382,6 +3382,7 @@ static HRESULT d3d12_pipeline_create_private_root_signature(struct d3d12_device 
 HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindPoint bind_point,
         const struct d3d12_pipeline_state_desc *desc, struct d3d12_pipeline_state **state)
 {
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     struct d3d12_pipeline_state *object;
     HRESULT hr;
 
@@ -3420,6 +3421,7 @@ HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindP
     {
         if (object->private_root_signature)
             ID3D12RootSignature_Release(object->private_root_signature);
+        VK_CALL(vkDestroyPipelineCache(device->vk_device, object->vk_pso_cache, NULL));
 
         vkd3d_free(object);
         return hr;


### PR DESCRIPTION
Works around a lot of broken code in FH4.

The D3D12 runtime is verified to be robust against these bugs, so we also need to be.

Fix #618.