### PR TITLE
build: Install dlls inside prefix without d3d12 dlls (only with Windows 10)

### DIFF
--- a/setup_vkd3d_proton.sh
+++ b/setup_vkd3d_proton.sh
@@ -70,8 +70,8 @@ fi
 
 # ensure wine placeholder dlls are recreated
 # if they are missing
-$wineboot -u && $wine wineserver --wait
-winver=$($wine winecfg -v)
+$wineboot -u && wineserver --wait
+winver=$($wine winecfg -v 2> /dev/null)
 
 win64_sys_path=$($wine64 winepath -u 'C:\windows\system32' 2> /dev/null)
 win64_sys_path="${win64_sys_path/$'\r'/}"

--- a/setup_vkd3d_proton.sh
+++ b/setup_vkd3d_proton.sh
@@ -71,7 +71,7 @@ fi
 # ensure wine placeholder dlls are recreated
 # if they are missing
 $wineboot -u && wineserver --wait
-winver=$($wine winecfg -v 2> /dev/null)
+winver=$($wine winecfg -v 2> /dev/null 1> /tmp/winver && cat /tmp/winver && rm /tmp/winver)
 
 win64_sys_path=$($wine64 winepath -u 'C:\windows\system32' 2> /dev/null)
 win64_sys_path="${win64_sys_path/$'\r'/}"


### PR DESCRIPTION
As I had reported on VKx (a while ago), if we use a Wine build without vkd3d, the prefixes generated with this build doesn't contain the d3d12 dlls and the script return an error (it is logical).

I have fixed this behavior but it contains some workarounds and it may be that the script is not very clear now. I would understand if you don't want this fix.