### PR TITLE
Release VKD3D-Proton version 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 2.3.1
+
+This is a minor bugfix release to address some issues solved shortly after the last release.
+
+### Fixes
+
+- Improved support for older Wine and Vulkan Loader versions.
+- Fix blocky shadows in Horizon Zero Dawn.
+- Fix the install script failing on Wine installs not built with upstream vkd3d.
+- Fix minor dxil translation issues.
+
 ## 2.3
 
 This release adds support for more D3D12 features and greatly improves GPU bound performance

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('vkd3d-proton', ['c'], version : '2.3', meson_version : '>= 0.49', default_options : [
+project('vkd3d-proton', ['c'], version : '2.3.1', meson_version : '>= 0.49', default_options : [
   'warning_level=2',
 ])
 


### PR DESCRIPTION
Adds the changelog for this release and bumps the Meson version.