### PR TITLE
vkd3d: Enable and require shaderDrawParameters.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1118,6 +1118,10 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->features2, &info->fragment_shading_rate_features);
     }
 
+    /* Core in Vulkan 1.1. */
+    info->shader_draw_parameters_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES;
+    vk_prepend_struct(&info->features2, &info->shader_draw_parameters_features);
+
     VK_CALL(vkGetPhysicalDeviceFeatures2(device->vk_physical_device, &info->features2));
     VK_CALL(vkGetPhysicalDeviceProperties2(device->vk_physical_device, &info->properties2));
 }
@@ -1667,6 +1671,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
 
     if (vulkan_info->KHR_fragment_shading_rate)
         physical_device_info->additional_shading_rates_supported = d3d12_device_determine_additional_shading_rates_supported(device);
+
+    if (!physical_device_info->shader_draw_parameters_features.shaderDrawParameters)
+    {
+        ERR("shaderDrawParameters is not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
 
     return S_OK;
 }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2499,6 +2499,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline_features;
     VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure_features;
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragment_shading_rate_features;
+    VkPhysicalDeviceShaderDrawParametersFeatures shader_draw_parameters_features;
 
     VkPhysicalDeviceFeatures2 features2;
 


### PR DESCRIPTION
Unless I miss something in the spec, `shaderDrawParameters` is an optional feature in 1.1 and should be enabled with `VkPhysicalDeviceShaderDrawParametersFeatures` before use. It seems like this was missed while porting from 1.0 to 1.1 because the original extension doesn't have a feature struct.