### PR TITLE
Require robustness2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ There are some hard requirements on drivers to be able to implement D3D12 in a r
 - `VK_KHR_timeline_semaphore`
 - `VK_KHR_create_renderpass2`
 - `VK_KHR_sampler_mirror_clamp_to_edge`
+- `VK_EXT_robustness2`
 
 Some notable extensions that **should** be supported for optimal or correct behavior.
 These extensions will likely become mandatory later.
 
-- `VK_EXT_robustness2`
 - `VK_KHR_buffer_device_address`
 - `VK_EXT_extended_dynamic_state`
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2415,7 +2415,6 @@ static void d3d12_device_destroy(struct d3d12_device *device)
     vkd3d_view_map_destroy(&device->sampler_map, device);
     vkd3d_meta_ops_cleanup(&device->meta_ops, device);
     vkd3d_bindless_state_cleanup(&device->bindless_state, device);
-    vkd3d_destroy_null_resources(&device->null_resources, device);
     vkd3d_render_pass_cache_cleanup(&device->render_pass_cache, device);
     d3d12_device_destroy_vkd3d_queues(device);
     vkd3d_memory_allocator_cleanup(&device->memory_allocator, device);
@@ -5037,11 +5036,8 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     if (FAILED(hr = vkd3d_memory_info_init(&device->memory_info, device)))
         goto out_cleanup_format_info;
 
-    if (FAILED(hr = vkd3d_init_null_resources(&device->null_resources, device)))
-        goto out_cleanup_format_info;
-
     if (FAILED(hr = vkd3d_bindless_state_init(&device->bindless_state, device)))
-        goto out_destroy_null_resources;
+        goto out_cleanup_format_info;
 
     if (FAILED(hr = vkd3d_view_map_init(&device->sampler_map)))
         goto out_cleanup_bindless_state;
@@ -5080,8 +5076,6 @@ out_cleanup_view_map:
     vkd3d_view_map_destroy(&device->sampler_map, device);
 out_cleanup_bindless_state:
     vkd3d_bindless_state_cleanup(&device->bindless_state, device);
-out_destroy_null_resources:
-    vkd3d_destroy_null_resources(&device->null_resources, device);
 out_cleanup_format_info:
     vkd3d_cleanup_format_info(device);
 out_free_memory_allocator:

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1667,6 +1667,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
         return E_INVALIDARG;
     }
 
+    if (!physical_device_info->robustness2_features.nullDescriptor)
+    {
+        ERR("Null descriptor in VK_EXT_robustness2 is not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
     if (vulkan_info->KHR_fragment_shading_rate)
         physical_device_info->additional_shading_rates_supported = d3d12_device_determine_additional_shading_rates_supported(device);
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2064,31 +2064,6 @@ void vkd3d_shader_debug_ring_init_spec_constant(struct d3d12_device *device,
         struct vkd3d_shader_debug_ring_spec_info *info, vkd3d_shader_hash_t hash);
 void vkd3d_shader_debug_ring_end_command_buffer(struct d3d12_command_list *list);
 
-/* NULL resources */
-struct vkd3d_null_resources
-{
-    VkBuffer vk_buffer;
-    VkBufferView vk_buffer_view;
-    VkDeviceMemory vk_buffer_memory;
-
-    VkBuffer vk_storage_buffer;
-    VkBufferView vk_storage_buffer_view;
-    VkDeviceMemory vk_storage_buffer_memory;
-
-    VkImage vk_2d_image;
-    VkDeviceMemory vk_2d_image_memory;
-
-    VkImage vk_2d_storage_image;
-    VkDeviceMemory vk_2d_storage_image_memory;
-
-    struct vkd3d_view_map view_map;
-};
-
-HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
-        struct d3d12_device *device);
-void vkd3d_destroy_null_resources(struct vkd3d_null_resources *null_resources,
-        struct d3d12_device *device);
-
 /* Bindless */
 enum vkd3d_bindless_flags
 {
@@ -2619,7 +2594,6 @@ struct d3d12_device
     const struct vkd3d_format *depth_stencil_formats;
     unsigned int format_compatibility_list_count;
     const struct vkd3d_format_compatibility_list *format_compatibility_lists;
-    struct vkd3d_null_resources null_resources;
     struct vkd3d_bindless_state bindless_state;
     struct vkd3d_memory_info memory_info;
     struct vkd3d_meta_ops meta_ops;


### PR DESCRIPTION
This is widely supported on desktop, and the non-robustness path is essentially completely untested at this point. For upcoming workarounds, having non-robustness2 in the picture is going to get more and more annoying, so it's time to flip it to required.

The non-robustness2 path is also broken for any robust UAV either way, since stores are not masked.