### PR TITLE
Adding the dxil-spirv shader conversion to the d3d12 pipeline creation cached blob

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -722,6 +722,8 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
         const struct vkd3d_shader_interface_local_info *shader_interface_local_info,
         const struct vkd3d_shader_compile_arguments *compiler_args);
 
+vkd3d_shader_hash_t vkd3d_shader_hash(const struct vkd3d_shader_code* shader);
+
 #endif  /* VKD3D_SHADER_NO_PROTOTYPES */
 
 /*

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -916,6 +916,4 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
         const struct vkd3d_shader_interface_info *shader_interface_info,
         const struct vkd3d_shader_compile_arguments *compiler_args);
 
-vkd3d_shader_hash_t vkd3d_shader_hash(const struct vkd3d_shader_code *shader);
-
 #endif  /* __VKD3D_SHADER_PRIVATE_H */

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6186,15 +6186,15 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_
 
         if (state->vk_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE)
         {
-            TRACE("Binding compute module with hash: %016"PRIx64".\n", state->compute.meta.hash);
+            TRACE("Binding compute module with hash: %016"PRIx64".\n", state->compute.spirv.meta.hash);
         }
         else if (state->vk_bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS)
         {
             for (i = 0; i < state->graphics.stage_count; i++)
             {
                 TRACE("Binding graphics module with hash: %016"PRIx64" (replaced: %s).\n",
-                      state->graphics.stage_meta[i].hash,
-                      state->graphics.stage_meta[i].replaced ? "yes" : "no");
+                      state->graphics.stage_spirv[i].meta.hash,
+                      state->graphics.stage_spirv[i].meta.replaced ? "yes" : "no");
             }
         }
     }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1258,7 +1258,7 @@ struct d3d12_graphics_pipeline_state
 {
     struct vkd3d_shader_debug_ring_spec_info spec_info[VKD3D_MAX_SHADER_STAGES];
     VkPipelineShaderStageCreateInfo stages[VKD3D_MAX_SHADER_STAGES];
-    struct vkd3d_shader_meta stage_meta[VKD3D_MAX_SHADER_STAGES];
+    struct vkd3d_shader_code stage_spirv[VKD3D_MAX_SHADER_STAGES];
     size_t stage_count;
 
     VkVertexInputAttributeDescription attributes[D3D12_VS_INPUT_REGISTER_COUNT];
@@ -1310,7 +1310,7 @@ static inline unsigned int dsv_attachment_mask(const struct d3d12_graphics_pipel
 struct d3d12_compute_pipeline_state
 {
     VkPipeline vk_pipeline;
-    struct vkd3d_shader_meta meta;
+    struct vkd3d_shader_code spirv;
 };
 
 /* ID3D12PipelineState */
@@ -1433,9 +1433,21 @@ struct d3d12_pipeline_library
 HRESULT d3d12_pipeline_library_create(struct d3d12_device *device, const void *blob,
         size_t blob_length, struct d3d12_pipeline_library **pipeline_library);
 
-HRESULT vkd3d_create_pipeline_cache_from_d3d12_desc(struct d3d12_device *device,
-        const D3D12_CACHED_PIPELINE_STATE *state, VkPipelineCache *cache);
-VkResult vkd3d_serialize_pipeline_state(const struct d3d12_pipeline_state *state, size_t *size, void *data);
+struct d3d12_pipeline_cache_serializer
+{
+    const uint8_t* pBegin;
+    const uint8_t* pEnd;
+    const uint8_t* pCurrent;
+};
+
+HRESULT d3d12_create_serializer_from_cached_pipeline_state(struct d3d12_device* device,
+    const D3D12_CACHED_PIPELINE_STATE* state,
+    struct d3d12_pipeline_cache_serializer* serializer);
+HRESULT vkd3d_create_pipeline_cache_from_d3d12_serializer(struct d3d12_device * device,
+    struct d3d12_pipeline_cache_serializer* serializer, VkPipelineCache* cache);
+HRESULT vkd3d_serialize_pipeline_state(const struct d3d12_pipeline_state* state, size_t* size, void* data);
+
+HRESULT serialize_shader_stage(struct vkd3d_shader_code* spirv, size_t* size, void* data);
 
 struct vkd3d_buffer
 {


### PR DESCRIPTION
Massive speed up in AAA game creation of thousands of pipelines that utilize caching of the blobs but not ID3D12PipelineLibrary.

Putting this here for feedback, NOT direct integration as there is surely some work still to do.