### PR TITLE
tests: Fix Clear UAV test constant.

### DIFF
--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -5607,7 +5607,7 @@ static void test_clear_unordered_access_view_buffer(void)
         {DXGI_FORMAT_R10G10B10A2_UNORM, { 0, BUFFER_SIZE / sizeof(uint32_t), 0, 0, D3D12_BUFFER_UAV_FLAG_NONE},
                 {0x1010, 0x1020, 0x1030, 0x41}, (0x30u << 20) | (0x20u << 10) | (0x10u << 0) | (0x1u << 30)},
         {DXGI_FORMAT_R10G10B10A2_UNORM, { 0, BUFFER_SIZE / sizeof(uint32_t), 0, 0, D3D12_BUFFER_UAV_FLAG_NONE},
-                {0x3f000080 /* 0.5000762951f */, 0x3f800000 /* 1.0f */, 0, 0x3f800000 /* 1.0f */},
+                {0x3f002008 /* 0.5004887585532747f */, 0x3f800000 /* 1.0f */, 0, 0x3f800000 /* 1.0f */},
                 (0x3ffu << 10) | (0x200u << 0) | (0x3u << 30), true},
     };
 


### PR DESCRIPTION
Was using 0x8000 / 0xffff instead of 0x200 / 0x3ff, rounded differently
on NV.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>