### PR TITLE
vkd3d: Add new interfaces: ID3D12DeviceExt, ID3D12GraphicsCommandListExt

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -10,6 +10,8 @@ vkd3d_idl = [
   'vkd3d_dxgiformat.idl',
   'vkd3d_dxgitype.idl',
   'vkd3d_swapchain_factory.idl',
+  'vkd3d_command_list_vkd3d_ext.idl',
+  'vkd3d_device_vkd3d_ext.idl'
 ]
 
 vkd3d_header_files = idl_generator.process(vkd3d_idl)

--- a/include/vkd3d_command_list_vkd3d_ext.idl
+++ b/include/vkd3d_command_list_vkd3d_ext.idl
@@ -1,0 +1,32 @@
+/*
+ * * Copyright 2021 NVIDIA Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+import "vkd3d_d3d12.idl";
+
+typedef struct VkCommandBuffer_T *VkCommandBuffer;
+
+[
+    uuid(77a86b09-2bea-4801-b89a-37648e104af1),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12GraphicsCommandListExt : IUnknown
+{
+   HRESULT GetVulkanHandle(VkCommandBuffer *pVkCommandBuffer);
+}
+

--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -1,0 +1,41 @@
+/*
+ * * Copyright 2021 NVIDIA Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+import "vkd3d_d3d12.idl";
+
+typedef struct VkInstance_T *VkInstance;
+typedef struct VkPhysicalDevice_T *VkPhysicalDevice;
+typedef struct VkDevice_T *VkDevice;
+
+typedef enum D3D12_VK_EXTENSION
+{
+    D3D12_VK_EXT_DRAW_INDIRECT_COUNT = 0x1
+} D3D12_VK_EXTENSION;
+
+[
+    uuid(11ea7a1a-0f6a-49bf-b612-3e30f8e201dd),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12DeviceExt : IUnknown
+{
+    HRESULT GetVulkanHandles(VkInstance *pVkInstance, VkPhysicalDevice *pVkPhysicalDevice, VkDevice *pVkDevice);
+
+    BOOL GetExtensionSupport(D3D12_VK_EXTENSION extension);
+}
+

--- a/include/vkd3d_win32.h
+++ b/include/vkd3d_win32.h
@@ -57,6 +57,8 @@
 #define __vkd3d_dxgi1_4_h__
 
 #include <vkd3d_swapchain_factory.h>
+#include <vkd3d_command_list_vkd3d_ext.h>
+#include <vkd3d_device_vkd3d_ext.h>
 #include <vkd3d_d3d12.h>
 #include <vkd3d_d3d12sdklayers.h>
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -36,6 +36,8 @@
 #include "vkd3d_threads.h"
 #include "vkd3d_platform.h"
 #include "vkd3d_swapchain_factory.h"
+#include "vkd3d_command_list_vkd3d_ext.h"
+#include "vkd3d_device_vkd3d_ext.h"
 #include "vkd3d_string.h"
 #include <assert.h>
 #include <inttypes.h>
@@ -1695,11 +1697,15 @@ struct vkd3d_query_range
     uint32_t flags;
 };
 
+/* ID3D12CommandListExt */
+typedef ID3D12GraphicsCommandListExt d3d12_command_list_vkd3d_ext_iface;
+
 struct d3d12_state_object;
 
 struct d3d12_command_list
 {
     d3d12_command_list_iface ID3D12GraphicsCommandList_iface;
+    d3d12_command_list_vkd3d_ext_iface ID3D12GraphicsCommandListExt_iface;
     LONG refcount;
 
     D3D12_COMMAND_LIST_TYPE type;
@@ -2544,9 +2550,13 @@ typedef ID3D12Device6 d3d12_device_iface;
 struct vkd3d_descriptor_qa_global_info;
 struct vkd3d_descriptor_qa_heap_buffer_data;
 
+/* ID3D12DeviceExt */
+typedef ID3D12DeviceExt d3d12_device_vkd3d_ext_iface;
+
 struct d3d12_device
 {
     d3d12_device_iface ID3D12Device_iface;
+    d3d12_device_vkd3d_ext_iface ID3D12DeviceExt_iface;
     LONG refcount;
 
     VkDevice vk_device;

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -24,7 +24,6 @@
 #endif
 
 #include "d3d12_crosstest.h"
-#include "d3d12_test_helper.h"
 
 static PFN_D3D12_CREATE_VERSIONED_ROOT_SIGNATURE_DESERIALIZER pfn_D3D12CreateVersionedRootSignatureDeserializer;
 static PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE pfn_D3D12SerializeVersionedRootSignature;
@@ -108,6 +107,27 @@ static bool compare_uint16(uint16_t a, uint16_t b, unsigned int max_diff)
 static bool compare_uint64(uint64_t a, uint64_t b, unsigned int max_diff)
 {
     return delta_uint64(a, b) <= max_diff;
+}
+
+static ULONG get_refcount(void *iface)
+{
+    IUnknown *unk = iface;
+    IUnknown_AddRef(unk);
+    return IUnknown_Release(unk);
+}
+
+#define check_interface(a, b, c) check_interface_(__LINE__, (IUnknown *)a, b, c)
+static void check_interface_(unsigned int line, IUnknown *iface, REFIID riid, bool supported)
+{
+    HRESULT hr, expected_hr;
+    IUnknown *unk;
+
+    expected_hr = supported ? S_OK : E_NOINTERFACE;
+
+    hr = IUnknown_QueryInterface(iface, riid, (void **)&unk);
+    ok_(line)(hr == expected_hr, "Got hr %#x, expected %#x.\n", hr, expected_hr);
+    if (SUCCEEDED(hr))
+        IUnknown_Release(unk);
 }
 
 #define check_heap_properties(a, b) check_heap_properties_(__LINE__, a, b)

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -24,6 +24,7 @@
 #endif
 
 #include "d3d12_crosstest.h"
+#include "d3d12_test_helper.h"
 
 static PFN_D3D12_CREATE_VERSIONED_ROOT_SIGNATURE_DESERIALIZER pfn_D3D12CreateVersionedRootSignatureDeserializer;
 static PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE pfn_D3D12SerializeVersionedRootSignature;
@@ -107,27 +108,6 @@ static bool compare_uint16(uint16_t a, uint16_t b, unsigned int max_diff)
 static bool compare_uint64(uint64_t a, uint64_t b, unsigned int max_diff)
 {
     return delta_uint64(a, b) <= max_diff;
-}
-
-static ULONG get_refcount(void *iface)
-{
-    IUnknown *unk = iface;
-    IUnknown_AddRef(unk);
-    return IUnknown_Release(unk);
-}
-
-#define check_interface(a, b, c) check_interface_(__LINE__, (IUnknown *)a, b, c)
-static void check_interface_(unsigned int line, IUnknown *iface, REFIID riid, bool supported)
-{
-    HRESULT hr, expected_hr;
-    IUnknown *unk;
-
-    expected_hr = supported ? S_OK : E_NOINTERFACE;
-
-    hr = IUnknown_QueryInterface(iface, riid, (void **)&unk);
-    ok_(line)(hr == expected_hr, "Got hr %#x, expected %#x.\n", hr, expected_hr);
-    if (SUCCEEDED(hr))
-        IUnknown_Release(unk);
 }
 
 #define check_heap_properties(a, b) check_heap_properties_(__LINE__, a, b)

--- a/tests/d3d12_ext_test.c
+++ b/tests/d3d12_ext_test.c
@@ -1,0 +1,119 @@
+#define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+
+#ifdef _MSC_VER
+/* Used for M_PI */
+#define _USE_MATH_DEFINES
+#endif
+
+#include "d3d12_crosstest.h"
+#include "d3d12_test_helper.h"
+#include "vkd3d_command_list_vkd3d_ext.h"
+#include "vkd3d_device_vkd3d_ext.h"
+
+static PFN_D3D12_CREATE_VERSIONED_ROOT_SIGNATURE_DESERIALIZER pfn_D3D12CreateVersionedRootSignatureDeserializer;
+static PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE pfn_D3D12SerializeVersionedRootSignature;
+PFN_D3D12_CREATE_DEVICE pfn_D3D12CreateDevice;
+PFN_D3D12_ENABLE_EXPERIMENTAL_FEATURES pfn_D3D12EnableExperimentalFeatures;
+PFN_D3D12_GET_DEBUG_INTERFACE pfn_D3D12GetDebugInterface;
+
+/* It will test ID3D12DeviceExt by querying from ID3D12Device. Also newly added API. */
+static void test_create_device_ext(void)
+{
+    VkPhysicalDevice physical_device = 0;
+    ID3D12DeviceExt *ext_device;
+    VkInstance instance = 0;
+    VkDevice vk_device = 0;
+    ID3D12Device *device;
+    ULONG refcount;
+    HRESULT hr;
+
+    if (!(device = create_device()))
+    {
+        skip("Failed to create device.\n");
+        return;
+    }
+      
+    check_interface(device, &IID_ID3D12Device, true);
+    check_interface(device, &IID_ID3D12DeviceExt, true);
+
+    hr = ID3D12Device_QueryInterface(device, &IID_ID3D12DeviceExt, (void**)&ext_device);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+
+    hr = ID3D12DeviceExt_GetVulkanHandles(ext_device, &instance, &physical_device, &vk_device);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(instance != 0 && physical_device != 0 && vk_device != 0, "Got invalid vulkan handles %#x, %#x, %#x \n", instance, physical_device, vk_device); 
+
+    refcount = ID3D12DeviceExt_Release(ext_device);
+    ok(refcount == 1, "Got unexpected refcount %#x.\n", refcount);
+
+    refcount = ID3D12Device_Release(device);
+    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+}
+
+/* It will test ID3D12GraphicsCommandListExt by querying it from ID3D12CommandList and also calling newly added API. */
+static void test_create_command_list_ext(void)
+{
+    ID3D12GraphicsCommandListExt *ext_command_list;
+    ID3D12CommandAllocator *command_allocator;
+    VkCommandBuffer vk_command_buffer = 0;
+    ID3D12CommandList *command_list;
+    ID3D12Device *device;
+    ULONG refcount;
+    HRESULT hr;
+    
+    if (!(device = create_device()))
+    {
+        skip("Failed to create device.\n");
+        return;
+    }
+    
+    hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
+            NULL, NULL, &IID_ID3D12CommandList, (void **)&command_list);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+
+    hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
+            &IID_ID3D12CommandAllocator, (void **)&command_allocator);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+
+    refcount = get_refcount(device);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+
+    hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
+            command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    
+    check_interface(command_list, &IID_ID3D12GraphicsCommandListExt, true);
+    ID3D12CommandList_QueryInterface(command_list, &IID_ID3D12GraphicsCommandListExt, (void **)&ext_command_list);
+
+    refcount = get_refcount(command_list);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+
+    hr = ID3D12GraphicsCommandListExt_GetVulkanHandle(ext_command_list, &vk_command_buffer);
+    ok(SUCCEEDED(hr), "Failed to get device from command list, hr %#x.\n", hr);
+    ok(vk_command_buffer != 0, "Got invalid vulkan handle %#x \n", vk_command_buffer); 
+
+    refcount = ID3D12GraphicsCommandListExt_Release(ext_command_list);
+    ok(refcount == 1, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+
+    refcount = ID3D12CommandList_Release(command_list);
+    ok(refcount == 0, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+}
+
+START_TEST(vkd3d_ext)
+{
+    pfn_D3D12CreateDevice = get_d3d12_pfn(D3D12CreateDevice);
+    pfn_D3D12EnableExperimentalFeatures = get_d3d12_pfn(D3D12EnableExperimentalFeatures);
+    pfn_D3D12GetDebugInterface = get_d3d12_pfn(D3D12GetDebugInterface);
+
+    parse_args(argc, argv);
+    enable_d3d12_debug_layer(argc, argv);
+    init_adapter_info();
+
+    pfn_D3D12CreateVersionedRootSignatureDeserializer = get_d3d12_pfn(D3D12CreateVersionedRootSignatureDeserializer);
+    pfn_D3D12SerializeVersionedRootSignature = get_d3d12_pfn(D3D12SerializeVersionedRootSignature);
+    /* Test newly added interface: ID3D12DeviceExt. */
+    run_test(test_create_device_ext);
+    /* Test newly added interface: ID3D12GraphicsCommandListExt. */
+    run_test(test_create_command_list_ext);
+}
+

--- a/tests/d3d12_test_helper.h
+++ b/tests/d3d12_test_helper.h
@@ -1,0 +1,26 @@
+#ifndef __VK3D12_TEST_HELPER_H__
+#define __VK3D12_TEST_HELPER_H__
+
+#define check_interface(a, b, c) check_interface_(__LINE__, (IUnknown *)a, b, c)
+static void check_interface_(unsigned int line, IUnknown *iface, REFIID riid, bool supported)
+{
+    HRESULT hr, expected_hr;
+    IUnknown *unk;
+
+    expected_hr = supported ? S_OK : E_NOINTERFACE;
+
+    hr = IUnknown_QueryInterface(iface, riid, (void **)&unk);
+    ok_(line)(hr == expected_hr, "Got hr %#x, expected %#x.\n", hr, expected_hr);
+    if (SUCCEEDED(hr))
+        IUnknown_Release(unk);
+}
+
+static ULONG get_refcount(void *iface)
+{
+    IUnknown *unk = iface;
+    IUnknown_AddRef(unk);
+    return IUnknown_Release(unk);
+}
+
+#endif  // __VK3D12_TEST_HELPER_H__
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -24,3 +24,11 @@ executable('descriptor-performance', 'descriptor_performance.c',
   install             : false,
   c_args              : vkd3d_test_flags,
   override_options    : [ 'c_std='+vkd3d_c_std ])
+
+executable('vkd3d_ext', 'd3d12_ext_test.c',
+  dependencies        : vkd3d_test_deps,
+  include_directories : vkd3d_private_includes,
+  install             : false,
+  c_args              : vkd3d_test_flags,
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+  


### PR DESCRIPTION
These interfaces are needed for d3d12 NvAPI support. Adds tests for new APIs.

Signed-off-by: Roshan Chaudhari <rochaudhari@nvidia.com>

Reviewed-by: Liam Middlebrook <lmiddlebrook@nvidia.com>