### PR TITLE
vkd3d: Rewrite image layout transition handling

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4204,7 +4204,6 @@ static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_lis
     uint32_t new_active_flags;
     VkPipeline vk_pipeline;
     uint32_t variant_flags;
-    VkFormat dsv_format;
 
     if (list->current_pipeline != VK_NULL_HANDLE)
         return true;
@@ -4215,17 +4214,15 @@ static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_lis
         return false;
     }
 
-    dsv_format = list->dsv.format ? list->dsv.format->vk_format : VK_FORMAT_UNDEFINED;
-
     variant_flags = d3d12_command_list_variant_flags(list);
 
     /* Try to grab the pipeline we compiled ahead of time. If we cannot do so, fall back. */
     if (!(vk_pipeline = d3d12_pipeline_state_get_pipeline(list->state,
-            &list->dynamic_state, dsv_format, &vk_render_pass, &new_active_flags,
+            &list->dynamic_state, list->dsv.format, &vk_render_pass, &new_active_flags,
             variant_flags)))
     {
         if (!(vk_pipeline = d3d12_pipeline_state_get_or_create_pipeline(list->state,
-                &list->dynamic_state, dsv_format,
+                &list->dynamic_state, list->dsv.format,
                 &vk_render_pass, &new_active_flags, variant_flags)))
             return false;
     }

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -565,6 +565,9 @@ static HRESULT vkd3d_create_image(struct d3d12_device *device,
         }
         else
             resource->common_layout = vk_common_image_layout_from_d3d12_desc(desc);
+
+        if (desc->Flags & D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS)
+            resource->flags |= VKD3D_RESOURCE_SIMULTANEOUS_ACCESS;
     }
 
     if ((vr = VK_CALL(vkCreateImage(device->vk_device, &image_info, NULL, vk_image))) < 0)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -806,6 +806,7 @@ struct d3d12_resource
 
     /* To keep track of initial layout. */
     VkImageLayout common_layout;
+    D3D12_RESOURCE_STATES initial_state;
     uint32_t initial_layout_transition;
 
     struct d3d12_sparse_info sparse;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1310,7 +1310,7 @@ struct d3d12_graphics_pipeline_state
     unsigned int rt_count;
     unsigned int null_attachment_mask;
     unsigned int patch_vertex_count;
-    VkFormat dsv_format;
+    const struct vkd3d_format *dsv_format;
     VkFormat rtv_formats[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
     VkImageLayout dsv_layout;
     VkRenderPass render_pass[VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_COUNT];
@@ -1437,13 +1437,13 @@ bool d3d12_pipeline_state_has_replaced_shaders(struct d3d12_pipeline_state *stat
 HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindPoint bind_point,
         const struct d3d12_pipeline_state_desc *desc, struct d3d12_pipeline_state **state);
 VkPipeline d3d12_pipeline_state_get_or_create_pipeline(struct d3d12_pipeline_state *state,
-        const struct vkd3d_dynamic_state *dyn_state, VkFormat dsv_format,
+        const struct vkd3d_dynamic_state *dyn_state, const struct vkd3d_format *dsv_format,
         VkRenderPass *vk_render_pass, uint32_t *dynamic_state_flags, uint32_t variant_flags);
 VkPipeline d3d12_pipeline_state_get_pipeline(struct d3d12_pipeline_state *state,
-        const struct vkd3d_dynamic_state *dyn_state, VkFormat dsv_format,
+        const struct vkd3d_dynamic_state *dyn_state, const struct vkd3d_format *dsv_format,
         VkRenderPass *vk_render_pass, uint32_t *dynamic_state_flags, uint32_t variant_flags);
 VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_state *state,
-        const struct vkd3d_pipeline_key *key, VkFormat dsv_format, VkPipelineCache vk_cache,
+        const struct vkd3d_pipeline_key *key, const struct vkd3d_format *dsv_format, VkPipelineCache vk_cache,
         VkRenderPass *vk_render_pass, uint32_t *dynamic_state_flags, uint32_t variant_flags);
 struct d3d12_pipeline_state *unsafe_impl_from_ID3D12PipelineState(ID3D12PipelineState *iface);
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -734,6 +734,7 @@ enum vkd3d_resource_flag
     VKD3D_RESOURCE_LINEAR_TILING          = (1u << 4),
     VKD3D_RESOURCE_EXTERNAL               = (1u << 5),
     VKD3D_RESOURCE_ACCELERATION_STRUCTURE = (1u << 6),
+    VKD3D_RESOURCE_SIMULTANEOUS_ACCESS    = (1u << 7),
 };
 
 struct d3d12_sparse_image_region
@@ -836,7 +837,8 @@ static inline bool d3d12_resource_is_texture(const struct d3d12_resource *resour
 
 static inline VkImageLayout d3d12_resource_pick_layout(const struct d3d12_resource *resource, VkImageLayout layout)
 {
-    return resource->flags & VKD3D_RESOURCE_LINEAR_TILING ? VK_IMAGE_LAYOUT_GENERAL : layout;
+    return resource->flags & (VKD3D_RESOURCE_LINEAR_TILING | VKD3D_RESOURCE_SIMULTANEOUS_ACCESS) ?
+            resource->common_layout : layout;
 }
 
 LONG64 vkd3d_allocate_cookie();


### PR DESCRIPTION
Yet another iteration of this.

- Honor resource barriers for resource states which cannot automatically
  decay or promote. This includes COLOR_ATTACHMENT, UNORDERED_ACCESS and
  VRS image. If SIMULTANEOUS_ACCESS is used, we can still promote, and
  we handle that by setting common layout to GENERAL for these resources.

- Avoid redundant barriers in render passes since normal resource
  barriers will always make sure we are already in
  COLOR_ATTACHMENT_OPTIMAL.

- Do not force GENERAL layout if resource has UNORDERED_ACCESS flag set.
  As this is not a promotable state, we have to explicitly transition
  into it. I tested this on validation layers, where even COMMON state
  refuses to promote to UAV state. The exception here of course is
  SIMULTANOUS_ACCESS, but we handle that properly now.

- Verify that UAV or SIMULTANEOUS access is not used together with DSV
  state. This is explicitly banned in the API docs.

- Actually emit image barriers. Batch the image transitions as that's
  what D3D12 docs encourage app developers to do, and it also expects
  that drivers can optimize this. Ensure that we respect the in-order
  resource barrier rules by splitting batches if there are overlaps in
  the transitions.

- Ensure that correct image layout is used when clearing a suspended
  render pass attachment.

I also cleaned up a ton of validation errors. There are some benign ones left, but it runs 100% clean w.r.t. image layout validation.