### PR TITLE
 vkd3d: Enable binary import and image view handle extensions

### DIFF
--- a/include/vkd3d_win32.h
+++ b/include/vkd3d_win32.h
@@ -42,8 +42,19 @@
 #define WIDL_C_INLINE_WRAPPERS
 #include <vkd3d_windows.h>
 
+/* Vulkan headers include static const declarations. Enable static keyword for
+ * them.
+ */
+#ifdef __MINGW32__
+# undef static
+#endif
+
 #define VK_USE_PLATFORM_WIN32_KHR
 #include <vulkan/vulkan.h>
+
+#ifdef __MINGW32__
+# define static
+#endif
 
 #include <dxgi1_6.h>
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -99,6 +99,8 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(AMD_SHADER_CORE_PROPERTIES_2, AMD_shader_core_properties2),
     /* NV extensions */
     VK_EXTENSION(NV_SHADER_SM_BUILTINS, NV_shader_sm_builtins),
+    VK_EXTENSION(NVX_BINARY_IMPORT, NVX_binary_import),
+    VK_EXTENSION(NVX_IMAGE_VIEW_HANDLE, NVX_image_view_handle),
     /* VALVE extensions */
     VK_EXTENSION(VALVE_MUTABLE_DESCRIPTOR_TYPE, VALVE_mutable_descriptor_type),
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -145,6 +145,8 @@ struct vkd3d_vulkan_info
     bool AMD_shader_core_properties2;
     /* NV device extensions */
     bool NV_shader_sm_builtins;
+    bool NVX_binary_import;
+    bool NVX_image_view_handle;
     /* VALVE extensions */
     bool VALVE_mutable_descriptor_type;
 


### PR DESCRIPTION
This also updates subprojects/Vulkan-Headers to 1.2.180

This is needed for VK_NVX_binary_import and VK_NVX_image_view_handle.

Signed-off-by: Roshan Chaudhari <rochaudhari@nvidia.com>

Reviewed-by: Liam Middlebrook <lmiddlebrook@nvidia.com>
