### PR TITLE
vkd3d: Fix potential deadlock in descriptor QA checks.

### DIFF
--- a/libs/vkd3d/debug_ring.c
+++ b/libs/vkd3d/debug_ring.c
@@ -76,7 +76,8 @@ void *vkd3d_shader_debug_ring_thread_main(void *arg)
     while (is_active)
     {
         pthread_mutex_lock(&ring->ring_lock);
-        pthread_cond_wait(&ring->ring_cond, &ring->ring_lock);
+        if (ring->active)
+            pthread_cond_wait(&ring->ring_cond, &ring->ring_lock);
         is_active = ring->active;
         pthread_mutex_unlock(&ring->ring_lock);
 

--- a/libs/vkd3d/descriptor_debug.c
+++ b/libs/vkd3d/descriptor_debug.c
@@ -157,7 +157,8 @@ static void *vkd3d_descriptor_debug_qa_check_entry(void *userdata)
     {
         /* Don't spin endlessly, this thread is kicked after a successful fence wait. */
         pthread_mutex_lock(&global_info->ring_lock);
-        pthread_cond_wait(&global_info->ring_cond, &global_info->ring_lock);
+        if (global_info->active)
+            pthread_cond_wait(&global_info->ring_cond, &global_info->ring_lock);
         active = global_info->active;
         pthread_mutex_unlock(&global_info->ring_lock);
 


### PR DESCRIPTION
If we destroy device right after creating it, we risk a deadlock.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>