### PR TITLE
Promote and keep depth-stencil resources in OPTIMAL as long as possible

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2495,7 +2495,7 @@ static void d3d12_command_list_clear_attachment_pass(struct d3d12_command_list *
     dependencies[0].dstSubpass = 0;
     dependencies[0].srcStageMask = stages;
     dependencies[0].dstStageMask = stages;
-    dependencies[0].srcAccessMask = 0;
+    dependencies[0].srcAccessMask = clear_op ? access : 0;
     dependencies[0].dstAccessMask = access;
     dependencies[0].dependencyFlags = 0;
     dependencies[0].viewOffset = 0;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1291,6 +1291,12 @@ enum vkd3d_graphics_pipeline_static_variant_flag
     VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_LAST_BIT       = (1u << 1),
 };
 
+enum vkd3d_plane_optimal_flag
+{
+    VKD3D_DEPTH_PLANE_OPTIMAL = (1 << 0),
+    VKD3D_STENCIL_PLANE_OPTIMAL = (1 << 1),
+};
+
 #define VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_COUNT ((uint32_t)VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_LAST_BIT)
 
 struct d3d12_graphics_pipeline_state
@@ -1721,6 +1727,12 @@ struct vkd3d_query_range
 
 struct d3d12_state_object;
 
+struct d3d12_resource_tracking
+{
+    const struct d3d12_resource *resource;
+    uint32_t plane_optimal_mask;
+};
+
 struct d3d12_command_list
 {
     d3d12_command_list_iface ID3D12GraphicsCommandList_iface;
@@ -1801,6 +1813,10 @@ struct d3d12_command_list
     const struct d3d12_desc *cbv_srv_uav_descriptors;
 
     struct d3d12_resource *vrs_image;
+
+    struct d3d12_resource_tracking *dsv_resource_tracking;
+    size_t dsv_resource_tracking_count;
+    size_t dsv_resource_tracking_size;
 
     struct vkd3d_private_store private_store;
 };


### PR DESCRIPTION
Goal here is to avoid unnecessary image layout transitions when render
passes toggle depth-stencil PSO states. Since we cannot know which
states a resource is in, we have to be conservative, and assume that
shader reads *could* happen.

The best effort we can do is to detect when writes happen to a DSV
resource. In this scenario, we can deduce that the aspect cannot be
read, since DEPTH_WRITE | RESOURCE state is not allowed.

To make the tracking somewhat sane, we only promote to OPTIMAL if an
entire image's worth of subresources for a given aspect is transitioned.
The common case for depth-stencil images is 1 mip / 1 layer anyways.

Some other changes are required here:
- Instead of common_layout for the depth image, we need to consult the
  command list, which might promote the layout to optimal.
- We make use of render pass compatibility rules which state that we can
  change attachment reference layouts as well as initial/finalLayout.
  To make this change, a pipeline will fill in a
  vkd3d_render_pass_compat struct.
- A command list has a dsv_plane_optimal_mask which keeps track
  of the plane aspects we have promoted to OPTIMAL, and we know cannot
  be read by shaders.
  The desired optimal mask is (existing optimal | PSO write).
  The initial existing optimal is inherited from the command list's
  tracker.
- RTV/DSV/views no longer keep track of VkImageLayout. This is
  unnecessary since we always deduce image layout based on context.

Overall, this shows a massive gain in HZD benchmark (RADV, 1440p ultimate, ~16% FPS on RX 6800).