### PR TITLE
vkd3d-shader: Emit NoContraction for MAD/DFMA.

### DIFF
--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -7633,6 +7633,9 @@ static void vkd3d_dxbc_compiler_emit_ext_glsl_instruction(struct vkd3d_dxbc_comp
                 vkd3d_dxbc_compiler_get_constant_uint(compiler, 31), val_id);
     }
 
+    if (glsl_inst == GLSLstd450Fma && (instruction->flags & VKD3DSI_PRECISE_XYZW))
+        vkd3d_spirv_build_op_decorate(builder, val_id, SpvDecorationNoContraction, NULL, 0);
+
     vkd3d_dxbc_compiler_emit_store_dst(compiler, dst, val_id);
 }
 


### PR DESCRIPTION
Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>