### PR TITLE
vkd3d: Handle plane index when creating image descriptors.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -845,6 +845,8 @@ bool d3d12_resource_is_cpu_accessible(const struct d3d12_resource *resource);
 HRESULT d3d12_resource_validate_desc(const D3D12_RESOURCE_DESC *desc, struct d3d12_device *device);
 VkImageSubresource d3d12_resource_get_vk_subresource(const struct d3d12_resource *resource,
         uint32_t subresource_idx, bool all_aspects);
+VkImageAspectFlags vk_image_aspect_flags_from_d3d12(
+        const struct vkd3d_format *format, uint32_t plane_idx);
 VkImageSubresource vk_image_subresource_from_d3d12(
         const struct vkd3d_format *format, uint32_t subresource_idx,
         unsigned int miplevel_count, unsigned int layer_count,


### PR DESCRIPTION
This will be necessary to handle multi-plane images correctly, where the view format will be a color format (with `VK_IMAGE_ASPECT_COLOR_BIT`) while the image itself will have `VK_IMAGE_ASPECT_PLANE_{0,1}_BIT` set. Also removes some unnecessary warnings.

For depth-stencil images, this also behaves correctly: In order to sample the stencil aspect of a depth-stencil image, the plane index must be set to 1 in D3D12, and failing to do so crashes the AMD native driver.