### PR TITLE
vkd3d: Handle multiple planes in d3d12_resource_get_subresource_count.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2315,6 +2315,8 @@ static void d3d12_command_list_discard_attachment_barrier(struct d3d12_command_l
         ERR("Unsupported resource flags %#x.\n", resource->desc.Flags);
         return;
     }
+
+    /* TODO: Separate depth-stencil layouts? Otherwise, we cannot discard single planes. */
     if (resource->format->vk_aspect_mask != subresource->aspectMask)
         return;
 
@@ -5324,7 +5326,7 @@ static void vk_image_copy_from_d3d12(VkImageCopy *image_copy,
 {
     vk_image_subresource_layers_from_d3d12(&image_copy->srcSubresource,
             src_format, src_sub_resource_idx, src_desc->MipLevels,
-            d3d12_resource_desc_get_sub_resource_count(src_desc), false);
+            d3d12_resource_desc_get_layer_count(src_desc), false);
     image_copy->srcOffset.x = src_box ? src_box->left : 0;
     image_copy->srcOffset.y = src_box ? src_box->top : 0;
     image_copy->srcOffset.z = src_box ? src_box->front : 0;
@@ -7884,7 +7886,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_DiscardResource(d3d12_command_l
     else
     {
         first_subresource = 0;
-        subresource_count = d3d12_resource_desc_get_sub_resource_count(&texture->desc);
+        subresource_count = d3d12_resource_get_sub_resource_count(texture);
     }
 
     /* We can't meaningfully discard sub-regions of an image. If rects

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -1165,7 +1165,7 @@ static void d3d12_resource_get_tiling(struct d3d12_device *device, struct d3d12_
         block_extent = vk_info->formatProperties.imageGranularity;
         tile_count = 0;
 
-        for (i = 0; i < d3d12_resource_desc_get_sub_resource_count(desc); i++)
+        for (i = 0; i < d3d12_resource_desc_get_sub_resource_count_per_plane(desc); i++)
         {
             unsigned int mip_level = i % desc->MipLevels;
             unsigned int tile_count_w = align(d3d12_resource_desc_get_width(desc, mip_level), block_extent.width) / block_extent.width;
@@ -1469,7 +1469,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_Map(d3d12_resource_iface *iface,
         return E_INVALIDARG;
     }
 
-    sub_resource_count = d3d12_resource_desc_get_sub_resource_count(&resource->desc);
+    sub_resource_count = d3d12_resource_get_sub_resource_count(resource);
     if (sub_resource >= sub_resource_count)
     {
         WARN("Sub-resource index %u is out of range (%u sub-resources).\n", sub_resource, sub_resource_count);
@@ -1508,7 +1508,7 @@ static void STDMETHODCALLTYPE d3d12_resource_Unmap(d3d12_resource_iface *iface, 
     TRACE("iface %p, sub_resource %u, written_range %p.\n",
             iface, sub_resource, written_range);
 
-    sub_resource_count = d3d12_resource_desc_get_sub_resource_count(&resource->desc);
+    sub_resource_count = d3d12_resource_get_sub_resource_count(resource);
     if (sub_resource >= sub_resource_count)
     {
         WARN("Sub-resource index %u is out of range (%u sub-resources).\n", sub_resource, sub_resource_count);
@@ -2210,7 +2210,7 @@ static HRESULT d3d12_resource_init_sparse_info(struct d3d12_resource *resource,
     if (!(resource->flags & VKD3D_RESOURCE_RESERVED))
         return S_OK;
 
-    sparse->tiling_count = d3d12_resource_desc_get_sub_resource_count(&resource->desc);
+    sparse->tiling_count = d3d12_resource_desc_get_sub_resource_count_per_plane(&resource->desc);
     sparse->tile_count = 0;
 
     if (!(sparse->tilings = vkd3d_malloc(sparse->tiling_count * sizeof(*sparse->tilings))))

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2900,9 +2900,15 @@ static inline unsigned int d3d12_resource_desc_get_layer_count(const D3D12_RESOU
     return desc->Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D ? desc->DepthOrArraySize : 1;
 }
 
-static inline unsigned int d3d12_resource_desc_get_sub_resource_count(const D3D12_RESOURCE_DESC *desc)
+static inline unsigned int d3d12_resource_desc_get_sub_resource_count_per_plane(const D3D12_RESOURCE_DESC *desc)
 {
     return d3d12_resource_desc_get_layer_count(desc) * desc->MipLevels;
+}
+
+static inline unsigned int d3d12_resource_get_sub_resource_count(const struct d3d12_resource *resource)
+{
+    return d3d12_resource_desc_get_sub_resource_count_per_plane(&resource->desc) *
+            (resource->format ? vkd3d_popcount(resource->format->vk_aspect_mask) : 1);
 }
 
 VkDeviceAddress vkd3d_get_buffer_device_address(struct d3d12_device *device, VkBuffer vk_buffer);


### PR DESCRIPTION
Separate out an explicit per_plane query for the cases where we need it.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>