### PR TITLE
vkd3d: Support discarding single DS aspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ There are some hard requirements on drivers to be able to implement D3D12 in a r
 - `VK_KHR_create_renderpass2`
 - `VK_KHR_sampler_mirror_clamp_to_edge`
 - `VK_EXT_robustness2`
+- `VK_KHR_separate_depth_stencil_layouts`
 
 Some notable extensions that **should** be supported for optimal or correct behavior.
 These extensions will likely become mandatory later.

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2316,9 +2316,7 @@ static void d3d12_command_list_discard_attachment_barrier(struct d3d12_command_l
         return;
     }
 
-    /* TODO: Separate depth-stencil layouts? Otherwise, we cannot discard single planes. */
-    if (resource->format->vk_aspect_mask != subresource->aspectMask)
-        return;
+    /* With separate depth stencil layouts, we can only discard the aspect we care about. */
 
     barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     barrier.pNext = NULL;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -73,6 +73,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_FRAGMENT_SHADING_RATE, KHR_fragment_shading_rate),
     VK_EXTENSION(KHR_CREATE_RENDERPASS_2, KHR_create_renderpass2),
     VK_EXTENSION(KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE, KHR_sampler_mirror_clamp_to_edge),
+    VK_EXTENSION(KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS, KHR_separate_depth_stencil_layouts),
     /* EXT extensions */
     VK_EXTENSION(EXT_CALIBRATED_TIMESTAMPS, EXT_calibrated_timestamps),
     VK_EXTENSION(EXT_CONDITIONAL_RENDERING, EXT_conditional_rendering),
@@ -1158,6 +1159,13 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->features2, &info->fragment_shading_rate_features);
     }
 
+    if (vulkan_info->KHR_separate_depth_stencil_layouts)
+    {
+        info->separate_depth_stencil_layout_features.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES;
+        vk_prepend_struct(&info->features2, &info->separate_depth_stencil_layout_features);
+    }
+
     /* Core in Vulkan 1.1. */
     info->shader_draw_parameters_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES;
     vk_prepend_struct(&info->features2, &info->shader_draw_parameters_features);
@@ -1700,6 +1708,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     if (!vulkan_info->KHR_create_renderpass2)
     {
         ERR("KHR_create_renderpass2 is not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
+    if (!physical_device_info->separate_depth_stencil_layout_features.separateDepthStencilLayouts)
+    {
+        ERR("separateDepthStencilLayouts is not supported by this implementation. This is required for correct operation.\n");
         return E_INVALIDARG;
     }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -119,6 +119,7 @@ struct vkd3d_vulkan_info
     bool KHR_fragment_shading_rate;
     bool KHR_create_renderpass2;
     bool KHR_sampler_mirror_clamp_to_edge;
+    bool KHR_separate_depth_stencil_layouts;
     /* EXT device extensions */
     bool EXT_calibrated_timestamps;
     bool EXT_conditional_rendering;
@@ -2516,6 +2517,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragment_shading_rate_features;
     VkPhysicalDeviceShaderDrawParametersFeatures shader_draw_parameters_features;
     VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control_features;
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR separate_depth_stencil_layout_features;
 
     VkPhysicalDeviceFeatures2 features2;
 


### PR DESCRIPTION
We need separate depth stencil layouts to be able to use pipeline barrier with aspectMask != formatAspectMask. Without this, we cannot implement DiscardResource() correctly, so make it a required extension. It's widely supported and core Vulkan 1.2, so should be issue.