### PR TITLE
vkd3d: Add workaround for MinLODClamp.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -943,6 +943,7 @@ struct vkd3d_texture_view_desc
     unsigned int miplevel_count;
     unsigned int layer_idx;
     unsigned int layer_count;
+    float miplevel_clamp;
     VkComponentMapping components;
     bool allowed_swizzle;
 };


### PR DESCRIPTION
Not correct, will need spec additions to handle it properly.
Fixes ground rendering in DIRT 5.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>