### PR TITLE
Reflect HS patch count in DXIL

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -57,7 +57,7 @@ typedef uint64_t vkd3d_shader_hash_t;
 struct vkd3d_shader_meta
 {
     vkd3d_shader_hash_t hash;
-    uint32_t cs_workgroup_size[3]; /* Only contains valid data if uses_subgroup_size is true. */
+    unsigned int cs_workgroup_size[3]; /* Only contains valid data if uses_subgroup_size is true. */
     bool replaced;
     bool uses_subgroup_size;
 };

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -58,6 +58,7 @@ struct vkd3d_shader_meta
 {
     vkd3d_shader_hash_t hash;
     unsigned int cs_workgroup_size[3]; /* Only contains valid data if uses_subgroup_size is true. */
+    unsigned int patch_vertex_count; /* Relevant for HS. May be 0, in which case the patch vertex count is not known. */
     bool replaced;
     bool uses_subgroup_size;
 };
@@ -624,6 +625,7 @@ struct vkd3d_shader_scan_info
     bool has_side_effects;
     bool needs_late_zs;
     bool discards;
+    unsigned int patch_vertex_count;
 };
 
 enum vkd3d_component_type
@@ -729,10 +731,6 @@ int vkd3d_shader_convert_root_signature(struct vkd3d_versioned_root_signature_de
 int vkd3d_shader_scan_dxbc(const struct vkd3d_shader_code *dxbc,
         struct vkd3d_shader_scan_info *scan_info);
 
-/* If value cannot be determined, *patch_vertex_count returns 0. */
-int vkd3d_shader_scan_patch_vertex_count(const struct vkd3d_shader_code *dxbc,
-        unsigned int *patch_vertex_count);
-
 int vkd3d_shader_parse_input_signature(const struct vkd3d_shader_code *dxbc,
         struct vkd3d_shader_signature *signature);
 struct vkd3d_shader_signature_element *vkd3d_shader_find_signature_element(
@@ -788,8 +786,6 @@ typedef int (*PFN_vkd3d_shader_convert_root_signature)(struct vkd3d_versioned_ro
 
 typedef int (*PFN_vkd3d_shader_scan_dxbc)(const struct vkd3d_shader_code *dxbc,
         struct vkd3d_shader_scan_info *scan_info);
-typedef int (*PFN_vkd3d_shader_scan_patch_vertex_count)(const struct vkd3d_shader_code *dxbc,
-        unsigned int *patch_vertex_count);
 
 typedef int (*PFN_vkd3d_shader_parse_input_signature)(const struct vkd3d_shader_code *dxbc,
         struct vkd3d_shader_signature *signature);

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -494,11 +494,9 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
 
     dxil_spv_set_thread_log_callback(vkd3d_dxil_log_callback, NULL);
 
+    memset(&spirv->meta, 0, sizeof(spirv->meta));
     hash = vkd3d_shader_hash(dxbc);
-    spirv->meta.replaced = false;
     spirv->meta.hash = hash;
-    spirv->meta.uses_subgroup_size = false;
-    memset(spirv->meta.cs_workgroup_size, 0, sizeof(spirv->meta.cs_workgroup_size));
     if (vkd3d_shader_replace(hash, &spirv->code, &spirv->size))
     {
         spirv->meta.replaced = true;
@@ -827,11 +825,9 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
 
     dxil_spv_set_thread_log_callback(vkd3d_dxil_log_callback, NULL);
 
+    memset(&spirv->meta, 0, sizeof(spirv->meta));
     hash = vkd3d_shader_hash(dxil);
-    spirv->meta.replaced = false;
-    spirv->meta.uses_subgroup_size = false;
     spirv->meta.hash = hash;
-    memset(spirv->meta.cs_workgroup_size, 0, sizeof(spirv->meta.cs_workgroup_size));
     demangled_export = vkd3d_dup_demangled_entry_point_ascii(export);
     if (demangled_export)
     {

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -789,6 +789,7 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
             &spirv->meta.cs_workgroup_size[0],
             &spirv->meta.cs_workgroup_size[1],
             &spirv->meta.cs_workgroup_size[2]);
+    dxil_spv_converter_get_patch_vertex_count(converter, &spirv->meta.patch_vertex_count);
 
     vkd3d_shader_dump_spirv_shader(hash, spirv);
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3210,12 +3210,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
                 break;
 
             case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
-                if ((ret = vkd3d_shader_scan_patch_vertex_count(&dxbc, &graphics->patch_vertex_count)) < 0)
-                {
-                    hr = hresult_from_vkd3d_result(ret);
-                    goto fail;
-                }
-                /* fallthrough */
             case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
                 if (desc->primitive_topology_type != D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH)
                 {
@@ -3241,6 +3235,9 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
                 shader_stages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT ? &ps_compile_args : &compile_args,
                 &graphics->stage_meta[graphics->stage_count])))
             goto fail;
+
+        if (shader_stages[i].stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
+            graphics->patch_vertex_count = graphics->stage_meta[graphics->stage_count].patch_vertex_count;
 
         if (graphics->stage_meta[graphics->stage_count].replaced && device->debug_ring.active)
         {


### PR DESCRIPTION
Avoids late pipeline compile in DIRT5. Use the meta struct instead of random scan entry point.