### PR TITLE
vkd3d: Fix RT local root signature interface flags

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -203,10 +203,12 @@ struct vkd3d_shader_interface_info
     /* Ignored unless VKD3D_SHADER_INTERFACE_SSBO_OFFSET_BUFFER or TYPED_OFFSET_BUFFER is set */
     const struct vkd3d_shader_descriptor_binding *offset_buffer_binding;
 
+#ifdef VKD3D_ENABLE_DESCRIPTOR_QA
     /* Ignored unless VKD3D_SHADER_INTERFACE_DESCRIPTOR_QA_BUFFER is set. */
     const struct vkd3d_shader_descriptor_binding *descriptor_qa_global_binding;
     /* Ignored unless VKD3D_SHADER_INTERFACE_DESCRIPTOR_QA_BUFFER is set. */
     const struct vkd3d_shader_descriptor_binding *descriptor_qa_heap_binding;
+#endif
 
     VkShaderStageFlagBits stage;
 

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -635,6 +635,7 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
         }
     }
 
+#ifdef VKD3D_ENABLE_DESCRIPTOR_QA
     if (shader_interface_info->flags & VKD3D_SHADER_INTERFACE_DESCRIPTOR_QA_BUFFER)
     {
         struct dxil_spv_option_descriptor_qa helper;
@@ -654,6 +655,7 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
             goto end;
         }
     }
+#endif
 
     {
         const struct dxil_spv_option_bindless_offset_buffer_layout helper =
@@ -1053,6 +1055,7 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
         }
     }
 
+#ifdef VKD3D_ENABLE_DESCRIPTOR_QA
     if (shader_interface_info->flags & VKD3D_SHADER_INTERFACE_DESCRIPTOR_QA_BUFFER)
     {
         struct dxil_spv_option_descriptor_qa helper;
@@ -1072,6 +1075,7 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
             goto end;
         }
     }
+#endif
 
     {
         const struct dxil_spv_option_sbt_descriptor_size_log2 helper =

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -913,7 +913,7 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
             shader_interface_local_info.binding_count = local_signature->binding_count;
 
             /* Promote state which might only be active in local root signature. */
-            shader_interface_info.flags |= local_signature->flags;
+            shader_interface_info.flags |= d3d12_root_signature_get_shader_interface_flags(local_signature);
             if (local_signature->flags & (VKD3D_ROOT_SIGNATURE_USE_SSBO_OFFSET_BUFFER | VKD3D_ROOT_SIGNATURE_USE_TYPED_OFFSET_BUFFER))
                 shader_interface_info.offset_buffer_binding = &local_signature->offset_buffer_binding;
         }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2653,7 +2653,9 @@ struct d3d12_device
     struct vkd3d_view_map sampler_map;
     struct vkd3d_sampler_state sampler_state;
     struct vkd3d_shader_debug_ring debug_ring;
+#ifdef VKD3D_ENABLE_DESCRIPTOR_QA
     struct vkd3d_descriptor_qa_global_info *descriptor_qa_global_info;
+#endif
 };
 
 HRESULT d3d12_device_create(struct vkd3d_instance *instance,


### PR DESCRIPTION
This was passing through flags of the root signature not the shader interface flags of it.

Need to get the shader interface flags of the root signature instead.

Signed-off-by: Joshua Ashton <joshua@froggi.es>