### PR TITLE
vkd3d: Check for Int16 feature as well when exposing 16-bit ops.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4779,7 +4779,8 @@ static void d3d12_device_caps_init_feature_options4(struct d3d12_device *device)
     options4->MSAA64KBAlignedTextureSupported = FALSE;
     /* Shared resources not supported */
     options4->SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_0;
-    options4->Native16BitShaderOpsSupported = device->device_info.float16_int8_features.shaderFloat16;
+    options4->Native16BitShaderOpsSupported = device->device_info.float16_int8_features.shaderFloat16 &&
+            device->device_info.features2.features.shaderInt16;
 }
 
 static void d3d12_device_caps_init_feature_options5(struct d3d12_device *device)
@@ -4902,6 +4903,7 @@ static void d3d12_device_caps_init_shader_model(struct d3d12_device *device)
          * FP16, Denorm modes (float controls extension)
          */
         if (device->device_info.float16_int8_features.shaderFloat16 &&
+                device->device_info.features2.features.shaderInt16 &&
                 device->device_info.storage_16bit_features.storageBuffer16BitAccess &&
                 device->device_info.subgroup_extended_types_features.shaderSubgroupExtendedTypes)
         {


### PR DESCRIPTION
Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>