### PR TITLE
vkd3d: Only disable raster based on SO stream if SO is used.

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3417,7 +3417,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     rs_desc_from_d3d12(&graphics->rs_desc, &desc->rasterizer_state);
     have_attachment = graphics->rt_count || graphics->dsv_format || is_dsv_format_unknown;
     if ((!have_attachment && !(desc->ps.pShaderBytecode && desc->ps.BytecodeLength))
-            || so_desc->RasterizedStream == D3D12_SO_NO_RASTERIZED_STREAM)
+            || (so_desc->NumEntries != 0 && so_desc->RasterizedStream == D3D12_SO_NO_RASTERIZED_STREAM))
         graphics->rs_desc.rasterizerDiscardEnable = VK_TRUE;
 
     rs_stream_info_from_d3d12(&graphics->rs_stream_info, &graphics->rs_desc, so_desc, vk_info);


### PR DESCRIPTION
Diablo 2 Resurrected creates all graphics pipeline with `RasterizedStream = D3D12_SO_NO_RASTERIZED_STREAM`.
This makes VKD3D-Proton disable rasterization, resulting in a black screen for that game.

Fixes #625

Props to DadSchoorse for pointing me at `rasterizerDiscardEnable`.

I've modified vkd3d gears to set `RasterizedStream = D3D12_SO_NO_RASTERIZED_STREAM` and it still rendered on Windows, so I assume it's ignored if the number of SO entries is 0. I don't know how stream output works (besides a super barebones understanding of it) so I'm not sure if that's the correct solution. As usual, the Microsoft docs aren't exactly in-depth about it.
It's certainly better than the current behavior though.