### PR TITLE
vkd3d: Optimize repeated null descriptor updates

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -961,6 +961,7 @@ enum vkd3d_descriptor_flag
     VKD3D_DESCRIPTOR_FLAG_RAW_VA_AUX_BUFFER = (1 << 1),
     VKD3D_DESCRIPTOR_FLAG_BUFFER_OFFSET     = (1 << 2),
     VKD3D_DESCRIPTOR_FLAG_OFFSET_RANGE      = (1 << 3),
+    VKD3D_DESCRIPTOR_FLAG_NON_NULL          = (1 << 4),
 };
 
 struct vkd3d_descriptor_binding
@@ -988,6 +989,7 @@ struct d3d12_desc
     DECLSPEC_ALIGN(D3D12_DESC_ALIGNMENT) struct vkd3d_descriptor_data metadata;
     struct d3d12_descriptor_heap *heap;
     uint32_t heap_offset;
+    VkDescriptorType current_null_type;
     union
     {
         VkDescriptorBufferInfo buffer;
@@ -1080,6 +1082,7 @@ struct d3d12_null_descriptor_template
     VkBufferView buffer_view;
     unsigned int num_writes;
     unsigned int set_info_mask;
+    bool has_mutable_descriptors;
 };
 
 struct d3d12_descriptor_heap


### PR DESCRIPTION
There are titles clearing the same descriptors constantly.
This leads to unnecessary updates that can become costly.

This commit introduces a new flag to track when D3D12 descriptors are not null, and skips clearing them if they are already null.
Descriptors are assumed to be null by default.

This fixes a performance regression introduced by 9983a1720f683b6366a9cf7a864a6efc94978e1d

Signed-off-by: Rodrigo Locatti <rlocatti@nvidia.com>