### PR TITLE
vkd3d-shader: Fix multiple constant buffers with RAW_VA

### DIFF
--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -5575,7 +5575,7 @@ static const struct vkd3d_shader_buffer_reference_type *vkd3d_dxbc_compiler_get_
     {
         type = &compiler->buffer_ref_types[i];
 
-        if (type->data_type == data_type && type->flags == flags)
+        if (type->data_type == data_type && type->flags == flags && type->length == length)
             return type;
     }
 


### PR DESCRIPTION
Consider we have declarations of CB0 of size 36 and CB1 of size 153.
Previously we'd just return the struct of CB0 when accessing CB1 because it came first as we didn't consider the size.

Psychonauts 2 indexes into CB1 by constant values above 36.
There is no reason a compiler could not eliminate these reads as it is technically out of bounds for the underlying array type.

Signed-off-by: Joshua Ashton <joshua@froggi.es>