### PR TITLE
vkd3d-shader: Fix vkd3d-compiler crash

### DIFF
--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -369,10 +369,13 @@ int vkd3d_shader_compile_dxbc(const struct vkd3d_shader_code *dxbc,
         return ret;
     }
 
-    if ((ret = vkd3d_shader_validate_shader_type(parser.shader_version.type, shader_interface_info->stage)) < 0)
+    if (shader_interface_info)
     {
-        vkd3d_shader_scan_destroy(&scan_info);
-        return ret;
+        if ((ret = vkd3d_shader_validate_shader_type(parser.shader_version.type, shader_interface_info->stage)) < 0)
+        {
+            vkd3d_shader_scan_destroy(&scan_info);
+            return ret;
+        }
     }
 
     vkd3d_shader_dump_shader(hash, dxbc, "dxbc");


### PR DESCRIPTION
Since we added validation here for FH4, this crashes now as vkd3d-compiler passes a NULL shader_interface_info.

Signed-off-by: Joshua Ashton <joshua@froggi.es>