### PR TITLE
Swapchain semaphore

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1009,7 +1009,7 @@ static CONST_VTBL struct ID3D12Fence1Vtbl d3d12_fence_vtbl =
     d3d12_fence_GetCreationFlags,
 };
 
-static struct d3d12_fence *unsafe_impl_from_ID3D12Fence1(ID3D12Fence1 *iface)
+struct d3d12_fence *unsafe_impl_from_ID3D12Fence1(ID3D12Fence1 *iface)
 {
     if (!iface)
         return NULL;
@@ -1017,7 +1017,7 @@ static struct d3d12_fence *unsafe_impl_from_ID3D12Fence1(ID3D12Fence1 *iface)
     return impl_from_ID3D12Fence(iface);
 }
 
-static struct d3d12_fence *unsafe_impl_from_ID3D12Fence(ID3D12Fence *iface)
+struct d3d12_fence *unsafe_impl_from_ID3D12Fence(ID3D12Fence *iface)
 {
     return unsafe_impl_from_ID3D12Fence1((ID3D12Fence1 *)iface);
 }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -570,6 +570,8 @@ struct d3d12_fence
     struct vkd3d_private_store private_store;
 };
 
+struct d3d12_fence *unsafe_impl_from_ID3D12Fence1(ID3D12Fence1 *iface);
+struct d3d12_fence *unsafe_impl_from_ID3D12Fence(ID3D12Fence *iface);
 HRESULT d3d12_fence_create(struct d3d12_device *device,
         uint64_t initial_value, D3D12_FENCE_FLAGS flags, struct d3d12_fence **fence);
 HRESULT d3d12_fence_set_event_on_completion(struct d3d12_fence *fence,


### PR DESCRIPTION
Similar to the implementation used in DXVK. Passes `test_frame_latency_event` in wine's DXGI tests.