### PR TITLE
Planar copyable footprints

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3849,7 +3849,7 @@ static void STDMETHODCALLTYPE d3d12_device_GetCopyableFootprints(d3d12_device_if
             = {DXGI_FORMAT_UNKNOWN, VK_FORMAT_UNDEFINED, 1, 1, 1, 1, 0, 1};
 
     unsigned int i, sub_resource_idx, miplevel_idx, row_count, row_size, row_pitch;
-    unsigned int width, height, depth, array_size, num_planes, num_subresources;
+    unsigned int width, height, depth, num_planes, num_subresources;
     unsigned int num_subresources_per_plane, plane_idx;
     const struct vkd3d_format *plane_format;
     const struct vkd3d_format *format;
@@ -3886,9 +3886,8 @@ static void STDMETHODCALLTYPE d3d12_device_GetCopyableFootprints(d3d12_device_if
     }
 
     num_planes = format->plane_count;
-    array_size = d3d12_resource_desc_get_layer_count(desc);
     num_subresources_per_plane = d3d12_resource_desc_get_sub_resource_count_per_plane(desc);
-    num_subresources = num_subresources_per_plane * num_planes;
+    num_subresources = d3d12_resource_desc_get_sub_resource_count(device, desc);
 
     if (first_sub_resource >= num_subresources
             || sub_resource_count > num_subresources - first_sub_resource)

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -483,6 +483,25 @@ const struct vkd3d_format *vkd3d_get_format(const struct d3d12_device *device,
     return format->dxgi_format ? format : NULL;
 }
 
+const struct vkd3d_format *vkd3d_format_footprint_for_plane(const struct d3d12_device *device,
+        const struct vkd3d_format *format, unsigned int plane_idx)
+{
+    switch (format->dxgi_format)
+    {
+        case DXGI_FORMAT_R32G8X24_TYPELESS:
+        case DXGI_FORMAT_R24G8_TYPELESS:
+        case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+            if (plane_idx == 0)
+                return vkd3d_get_format(device, DXGI_FORMAT_R32_TYPELESS, false);
+            else
+                return vkd3d_get_format(device, DXGI_FORMAT_R8_TYPELESS, false);
+
+        default:
+            return format;
+    }
+}
+
 VkFormat vkd3d_internal_get_vk_format(const struct d3d12_device *device, DXGI_FORMAT dxgi_format)
 {
     const struct vkd3d_format *format;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2878,6 +2878,8 @@ DXGI_FORMAT vkd3d_get_typeless_format(const struct d3d12_device *device, DXGI_FO
 const struct vkd3d_format *vkd3d_find_uint_format(const struct d3d12_device *device,
         DXGI_FORMAT dxgi_format);
 VkFormat vkd3d_internal_get_vk_format(const struct d3d12_device *device, DXGI_FORMAT dxgi_format);
+const struct vkd3d_format *vkd3d_format_footprint_for_plane(const struct d3d12_device *device,
+        const struct vkd3d_format *format, unsigned int plane_idx);
 
 HRESULT vkd3d_init_format_info(struct d3d12_device *device);
 void vkd3d_cleanup_format_info(struct d3d12_device *device);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2962,6 +2962,13 @@ static inline unsigned int d3d12_resource_desc_get_sub_resource_count_per_plane(
     return d3d12_resource_desc_get_layer_count(desc) * desc->MipLevels;
 }
 
+static inline unsigned int d3d12_resource_desc_get_sub_resource_count(const struct d3d12_device *device,
+        const D3D12_RESOURCE_DESC *desc)
+{
+    const struct vkd3d_format *format = vkd3d_get_format(device, desc->Format, true);
+    return d3d12_resource_desc_get_sub_resource_count_per_plane(desc) * (format ? format->plane_count : 1);
+}
+
 static inline unsigned int d3d12_resource_get_sub_resource_count(const struct d3d12_resource *resource)
 {
     return d3d12_resource_desc_get_sub_resource_count_per_plane(&resource->desc) *

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2854,10 +2854,10 @@ struct vkd3d_format
 {
     DXGI_FORMAT dxgi_format;
     VkFormat vk_format;
-    size_t byte_count;
-    size_t block_width;
-    size_t block_height;
-    size_t block_byte_count;
+    uint32_t byte_count;
+    uint32_t block_width;
+    uint32_t block_height;
+    uint32_t block_byte_count;
     VkImageAspectFlags vk_aspect_mask;
     unsigned int plane_count;
     enum vkd3d_format_type type;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2840,6 +2840,16 @@ enum vkd3d_format_type
     VKD3D_FORMAT_TYPE_UINT,
 };
 
+struct vkd3d_format_footprint
+{
+    DXGI_FORMAT dxgi_format;
+    uint32_t block_width;
+    uint32_t block_height;
+    uint32_t block_byte_count;
+    uint32_t subsample_x_log2;
+    uint32_t subsample_y_log2;
+};
+
 struct vkd3d_format
 {
     DXGI_FORMAT dxgi_format;
@@ -2852,6 +2862,7 @@ struct vkd3d_format
     unsigned int plane_count;
     enum vkd3d_format_type type;
     bool is_emulated;
+    const struct vkd3d_format_footprint *plane_footprints;
 };
 
 static inline size_t vkd3d_format_get_data_offset(const struct vkd3d_format *format,
@@ -2878,8 +2889,7 @@ DXGI_FORMAT vkd3d_get_typeless_format(const struct d3d12_device *device, DXGI_FO
 const struct vkd3d_format *vkd3d_find_uint_format(const struct d3d12_device *device,
         DXGI_FORMAT dxgi_format);
 VkFormat vkd3d_internal_get_vk_format(const struct d3d12_device *device, DXGI_FORMAT dxgi_format);
-const struct vkd3d_format *vkd3d_format_footprint_for_plane(const struct d3d12_device *device,
-        const struct vkd3d_format *format, unsigned int plane_idx);
+struct vkd3d_format_footprint vkd3d_format_footprint_for_plane(const struct vkd3d_format *format, unsigned int plane_idx);
 
 HRESULT vkd3d_init_format_info(struct d3d12_device *device);
 void vkd3d_cleanup_format_info(struct d3d12_device *device);

--- a/tests/d3d12_test_utils.h
+++ b/tests/d3d12_test_utils.h
@@ -354,6 +354,51 @@ static inline unsigned int format_size(DXGI_FORMAT format)
     }
 }
 
+static inline unsigned int format_num_planes(DXGI_FORMAT format)
+{
+    switch (format)
+    {
+        case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        case DXGI_FORMAT_R24G8_TYPELESS:
+        case DXGI_FORMAT_R32G8X24_TYPELESS:
+            return 2;
+
+        default:
+            return 1;
+    }
+}
+
+static inline unsigned int format_size_planar(DXGI_FORMAT format, unsigned int plane)
+{
+    switch (format)
+    {
+        case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        case DXGI_FORMAT_R24G8_TYPELESS:
+        case DXGI_FORMAT_R32G8X24_TYPELESS:
+            return plane ? 1 : 4;
+
+        default:
+            return format_size(format);
+    }
+}
+
+static inline unsigned int format_to_footprint_format(DXGI_FORMAT format, unsigned int plane)
+{
+    switch (format)
+    {
+        case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        case DXGI_FORMAT_R24G8_TYPELESS:
+        case DXGI_FORMAT_R32G8X24_TYPELESS:
+            return plane ? DXGI_FORMAT_R8_TYPELESS : DXGI_FORMAT_R32_TYPELESS;
+
+        default:
+            return format;
+    }
+}
+
 static inline unsigned int format_block_width(DXGI_FORMAT format)
 {
     switch (format)

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -270,3 +270,4 @@ decl_test(test_shader_fp16);
 decl_test(test_shader_sm62_denorm);
 decl_test(test_shader_sm64_packed);
 decl_test(test_shader_sm65_wave_intrinsics);
+decl_test(test_get_copyable_footprints_planar);


### PR DESCRIPTION
Implement GetCopyableFootprints for depth-stencil, which fixes crashes when entering benchmark in F1 2021.