### PR TITLE
Integer blend validation

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -736,6 +736,8 @@ int vkd3d_shader_scan_dxbc(const struct vkd3d_shader_code *dxbc,
 
 int vkd3d_shader_parse_input_signature(const struct vkd3d_shader_code *dxbc,
         struct vkd3d_shader_signature *signature);
+int vkd3d_shader_parse_output_signature(const struct vkd3d_shader_code *dxbc,
+        struct vkd3d_shader_signature *signature);
 struct vkd3d_shader_signature_element *vkd3d_shader_find_signature_element(
         const struct vkd3d_shader_signature *signature, const char *semantic_name,
         unsigned int semantic_index, unsigned int stream_index);

--- a/libs/vkd3d-shader/dxbc.c
+++ b/libs/vkd3d-shader/dxbc.c
@@ -2249,6 +2249,21 @@ static int isgn_handler(const char *data, DWORD data_size, DWORD tag, void *ctx)
     return shader_parse_signature(tag, data, data_size, is);
 }
 
+static int osgn_handler(const char *data, DWORD data_size, DWORD tag, void *ctx)
+{
+    struct vkd3d_shader_signature *is = ctx;
+
+    if (tag != TAG_OSGN && tag != TAG_OSG1)
+        return VKD3D_OK;
+
+    if (is->elements)
+    {
+        FIXME("Multiple input signatures.\n");
+        vkd3d_shader_free_shader_signature(is);
+    }
+    return shader_parse_signature(tag, data, data_size, is);
+}
+
 int shader_parse_input_signature(const void *dxbc, size_t dxbc_length,
         struct vkd3d_shader_signature *signature)
 {
@@ -2257,6 +2272,17 @@ int shader_parse_input_signature(const void *dxbc, size_t dxbc_length,
     memset(signature, 0, sizeof(*signature));
     if ((ret = parse_dxbc(dxbc, dxbc_length, isgn_handler, signature)) < 0)
         ERR("Failed to parse input signature.\n");
+    return ret;
+}
+
+int shader_parse_output_signature(const void *dxbc, size_t dxbc_length,
+        struct vkd3d_shader_signature *signature)
+{
+    int ret;
+
+    memset(signature, 0, sizeof(*signature));
+    if ((ret = parse_dxbc(dxbc, dxbc_length, osgn_handler, signature)) < 0)
+        ERR("Failed to parse output signature.\n");
     return ret;
 }
 

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -672,6 +672,14 @@ int vkd3d_shader_parse_input_signature(const struct vkd3d_shader_code *dxbc,
     return shader_parse_input_signature(dxbc->code, dxbc->size, signature);
 }
 
+int vkd3d_shader_parse_output_signature(const struct vkd3d_shader_code *dxbc,
+        struct vkd3d_shader_signature *signature)
+{
+    TRACE("dxbc {%p, %zu}, signature %p.\n", dxbc->code, dxbc->size, signature);
+
+    return shader_parse_output_signature(dxbc->code, dxbc->size, signature);
+}
+
 struct vkd3d_shader_signature_element *vkd3d_shader_find_signature_element(
         const struct vkd3d_shader_signature *signature, const char *semantic_name,
         unsigned int semantic_index, unsigned int stream_index)

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -781,6 +781,8 @@ void free_shader_desc(struct vkd3d_shader_desc *desc);
 
 int shader_parse_input_signature(const void *dxbc, size_t dxbc_length,
         struct vkd3d_shader_signature *signature);
+int shader_parse_output_signature(const void *dxbc, size_t dxbc_length,
+        struct vkd3d_shader_signature *signature);
 
 struct vkd3d_dxbc_compiler;
 

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -276,3 +276,4 @@ decl_test(test_copy_buffer_to_depth_stencil);
 decl_test(test_map_texture_validation);
 decl_test(test_read_write_subresource_2d);
 decl_test(test_read_subresource_rt);
+decl_test(test_integer_blending_pipeline_state);


### PR DESCRIPTION
F1 2021 attempts to create pipelines with blending enabled on R32_UINT, but we're supposed to validate this or ignore it explicitly depending on the output signature.