### PR TITLE
Narrow scope of pipeline cache workaround

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1180,14 +1180,21 @@ static void vkd3d_trace_physical_device_properties(const VkPhysicalDevicePropert
 {
     TRACE("Device name: %s.\n", properties->deviceName);
     TRACE("Vendor ID: %#x, Device ID: %#x.\n", properties->vendorID, properties->deviceID);
-    TRACE("Driver version: %#x (%u.%u.%u, %u.%u.%u.%u).\n", properties->driverVersion,
-            VK_VERSION_MAJOR(properties->driverVersion),
-            VK_VERSION_MINOR(properties->driverVersion),
-            VK_VERSION_PATCH(properties->driverVersion),
-            (properties->driverVersion >> 22),
-            (properties->driverVersion >> 14) & 0xff,
-            (properties->driverVersion >> 6)  & 0xff,
-            (properties->driverVersion >> 0)  & 0x3f);
+    if (properties->vendorID == VKD3D_VENDOR_ID_NVIDIA)
+    {
+        TRACE("Driver version: %#x (%u.%u.%u).\n", properties->driverVersion,
+                VKD3D_DRIVER_VERSION_MAJOR_NV(properties->driverVersion),
+                VKD3D_DRIVER_VERSION_MINOR_NV(properties->driverVersion),
+                VKD3D_DRIVER_VERSION_PATCH_NV(properties->driverVersion));
+    }
+    else
+    {
+        TRACE("Driver version: %#x (%u.%u.%u).\n", properties->driverVersion,
+                VK_VERSION_MAJOR(properties->driverVersion),
+                VK_VERSION_MINOR(properties->driverVersion),
+                VK_VERSION_PATCH(properties->driverVersion));
+    }
+
     TRACE("API version: %u.%u.%u.\n",
             VK_VERSION_MAJOR(properties->apiVersion),
             VK_VERSION_MINOR(properties->apiVersion),

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3094,4 +3094,9 @@ void vkd3d_acceleration_structure_copy(
 #define VKD3D_VENDOR_ID_AMD 0x1002
 #define VKD3D_VENDOR_ID_INTEL 0x8086
 
+#define VKD3D_DRIVER_VERSION_MAJOR_NV(v) ((v) >> 22)
+#define VKD3D_DRIVER_VERSION_MINOR_NV(v) (((v) >> 14) & 0xff)
+#define VKD3D_DRIVER_VERSION_PATCH_NV(v) (((v) >>  6) & 0xff)
+#define VKD3D_DRIVER_VERSION_MAKE_NV(major, minor, patch) (((major) << 22) | ((minor) << 14) | ((patch) << 6))
+
 #endif  /* __VKD3D_PRIVATE_H */


### PR DESCRIPTION
470.62.02 driver fixes the bug, but need to keep workaround for older 470 releases.