### PR TITLE
Backport "vkd3d-shader: Read the SM5 resource type instruction modifier." from vkd3d

### DIFF
--- a/libs/vkd3d-shader/dxbc.c
+++ b/libs/vkd3d-shader/dxbc.c
@@ -23,7 +23,11 @@
 
 #define VKD3D_SM4_INSTRUCTION_MODIFIER        (0x1u << 31)
 
-#define VKD3D_SM4_MODIFIER_AOFFIMMI           0x1
+#define VKD3D_SM4_MODIFIER_MASK               0x3fu
+
+#define VKD3D_SM5_MODIFIER_RESOURCE_TYPE_SHIFT 6
+#define VKD3D_SM5_MODIFIER_RESOURCE_TYPE_MASK (0xfu << VKD3D_SM5_MODIFIER_RESOURCE_TYPE_SHIFT)
+
 #define VKD3D_SM4_AOFFIMMI_U_SHIFT            9
 #define VKD3D_SM4_AOFFIMMI_U_MASK             (0xfu << VKD3D_SM4_AOFFIMMI_U_SHIFT)
 #define VKD3D_SM4_AOFFIMMI_V_SHIFT            13
@@ -354,6 +358,12 @@ enum vkd3d_sm4_opcode
     VKD3D_SM5_OP_SAMPLE_D_CLAMP_FEEDBACK          = 0xe8,
     VKD3D_SM5_OP_SAMPLE_C_CLAMP_FEEDBACK          = 0xe9,
     VKD3D_SM5_OP_CHECK_ACCESS_FULLY_MAPPED        = 0xea,
+};
+
+enum vkd3d_sm4_instruction_modifier
+{
+    VKD3D_SM4_MODIFIER_AOFFIMMI         = 0x1,
+    VKD3D_SM5_MODIFIER_RESOURCE_TYPE    = 0x2,
 };
 
 enum vkd3d_sm4_register_type
@@ -1863,32 +1873,49 @@ static bool shader_sm4_read_dst_param(struct vkd3d_sm4_data *priv, const DWORD *
 
 static void shader_sm4_read_instruction_modifier(DWORD modifier, struct vkd3d_shader_instruction *ins)
 {
-    static const DWORD recognized_bits = VKD3D_SM4_INSTRUCTION_MODIFIER
-            | VKD3D_SM4_MODIFIER_AOFFIMMI
-            | VKD3D_SM4_AOFFIMMI_U_MASK
-            | VKD3D_SM4_AOFFIMMI_V_MASK
-            | VKD3D_SM4_AOFFIMMI_W_MASK;
+    enum vkd3d_sm4_instruction_modifier modifier_type = modifier & VKD3D_SM4_MODIFIER_MASK;
 
-    if (modifier & ~recognized_bits)
+    switch (modifier_type)
     {
-        WARN("Unhandled modifier 0x%08x.\n", modifier);
-    }
-    else
-    {
-        /* Bit fields are used for sign extension */
-        struct
+        case VKD3D_SM4_MODIFIER_AOFFIMMI:
         {
-            int u : 4;
-            int v : 4;
-            int w : 4;
+            static const DWORD recognized_bits = VKD3D_SM4_INSTRUCTION_MODIFIER
+                    | VKD3D_SM4_MODIFIER_MASK
+                    | VKD3D_SM4_AOFFIMMI_U_MASK
+                    | VKD3D_SM4_AOFFIMMI_V_MASK
+                    | VKD3D_SM4_AOFFIMMI_W_MASK;
+
+            /* Bit fields are used for sign extension. */
+            struct
+            {
+                int u : 4;
+                int v : 4;
+                int w : 4;
+            } aoffimmi;
+
+            if (modifier & ~recognized_bits)
+                FIXME("Unhandled instruction modifier %#x.\n", modifier);
+
+            aoffimmi.u = (modifier & VKD3D_SM4_AOFFIMMI_U_MASK) >> VKD3D_SM4_AOFFIMMI_U_SHIFT;
+            aoffimmi.v = (modifier & VKD3D_SM4_AOFFIMMI_V_MASK) >> VKD3D_SM4_AOFFIMMI_V_SHIFT;
+            aoffimmi.w = (modifier & VKD3D_SM4_AOFFIMMI_W_MASK) >> VKD3D_SM4_AOFFIMMI_W_SHIFT;
+            ins->texel_offset.u = aoffimmi.u;
+            ins->texel_offset.v = aoffimmi.v;
+            ins->texel_offset.w = aoffimmi.w;
+            break;
         }
-        aoffimmi;
-        aoffimmi.u = (modifier & VKD3D_SM4_AOFFIMMI_U_MASK) >> VKD3D_SM4_AOFFIMMI_U_SHIFT;
-        aoffimmi.v = (modifier & VKD3D_SM4_AOFFIMMI_V_MASK) >> VKD3D_SM4_AOFFIMMI_V_SHIFT;
-        aoffimmi.w = (modifier & VKD3D_SM4_AOFFIMMI_W_MASK) >> VKD3D_SM4_AOFFIMMI_W_SHIFT;
-        ins->texel_offset.u = aoffimmi.u;
-        ins->texel_offset.v = aoffimmi.v;
-        ins->texel_offset.w = aoffimmi.w;
+
+        case VKD3D_SM5_MODIFIER_RESOURCE_TYPE:
+        {
+            enum vkd3d_sm4_resource_type resource_type
+                    = (modifier & VKD3D_SM5_MODIFIER_RESOURCE_TYPE_MASK) >> VKD3D_SM5_MODIFIER_RESOURCE_TYPE_SHIFT;
+
+            ins->resource_type = resource_type_table[resource_type];
+            break;
+        }
+
+        default:
+            FIXME("Unhandled instruction modifier %#x.\n", modifier);
     }
 }
 
@@ -1947,6 +1974,7 @@ void shader_sm4_read_instruction(void *data, const DWORD **ptr, struct vkd3d_sha
     ins->dst = priv->dst_param;
     ins->src_count = strlen(opcode_info->src_info);
     ins->src = priv->src_param;
+    ins->resource_type = VKD3D_SHADER_RESOURCE_NONE;
     memset(&ins->texel_offset, 0, sizeof(ins->texel_offset));
 
     p = *ptr;

--- a/libs/vkd3d-shader/trace.c
+++ b/libs/vkd3d-shader/trace.c
@@ -511,6 +511,29 @@ static void shader_dump_shader_input_sysval_semantic(struct vkd3d_string_buffer 
     shader_addline(buffer, "unknown_shader_input_sysval_semantic(%#x)", semantic);
 }
 
+static void shader_dump_resource_type(struct vkd3d_string_buffer *buffer, enum vkd3d_shader_resource_type type)
+{
+    static const char *const resource_type_names[] =
+    {
+        /* VKD3D_SHADER_RESOURCE_NONE                 */ "none",
+        /* VKD3D_SHADER_RESOURCE_BUFFER               */ "buffer",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_1D           */ "texture1d",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_2D           */ "texture2d",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_2DMS         */ "texture2dms",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_3D           */ "texture3d",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_CUBE         */ "texturecube",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_1DARRAY      */ "texture1darray",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_2DARRAY      */ "texture2darray",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_2DMSARRAY    */ "texture2dmsarray",
+        /* VKD3D_SHADER_RESOURCE_TEXTURE_CUBEARRAY    */ "texturecubearray",
+    };
+
+    if (type <= ARRAY_SIZE(resource_type_names))
+        shader_addline(buffer, "%s", resource_type_names[type]);
+    else
+        shader_addline(buffer, "unknown");
+}
+
 static void shader_dump_decl_usage(struct vkd3d_string_buffer *buffer,
         const struct vkd3d_shader_semantic *semantic, unsigned int flags,
         const struct vkd3d_shader_version *shader_version)
@@ -544,52 +567,7 @@ static void shader_dump_decl_usage(struct vkd3d_string_buffer *buffer,
             shader_addline(buffer, "_resource_");
         else
             shader_addline(buffer, "_uav_");
-        switch (semantic->resource_type)
-        {
-            case VKD3D_SHADER_RESOURCE_BUFFER:
-                shader_addline(buffer, "buffer");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_1D:
-                shader_addline(buffer, "texture1d");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_2D:
-                shader_addline(buffer, "texture2d");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_2DMS:
-                shader_addline(buffer, "texture2dms");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_3D:
-                shader_addline(buffer, "texture3d");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_CUBE:
-                shader_addline(buffer, "texturecube");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_1DARRAY:
-                shader_addline(buffer, "texture1darray");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_2DARRAY:
-                shader_addline(buffer, "texture2darray");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_2DMSARRAY:
-                shader_addline(buffer, "texture2dmsarray");
-                break;
-
-            case VKD3D_SHADER_RESOURCE_TEXTURE_CUBEARRAY:
-                shader_addline(buffer, "texturecubearray");
-                break;
-
-            default:
-                shader_addline(buffer, "unknown");
-                break;
-        }
+        shader_dump_resource_type(buffer, semantic->resource_type);
         if (semantic->reg.reg.type == VKD3DSPR_UAV)
             shader_dump_uav_flags(buffer, flags);
         switch (semantic->resource_data_type)
@@ -1385,6 +1363,13 @@ static void shader_dump_instruction(struct vkd3d_string_buffer *buffer,
             {
                 shader_addline(buffer, "(%d,%d,%d)",
                         ins->texel_offset.u, ins->texel_offset.v, ins->texel_offset.w);
+            }
+
+            if (ins->resource_type != VKD3D_SHADER_RESOURCE_NONE)
+            {
+                shader_addline(buffer, "(");
+                shader_dump_resource_type(buffer, ins->resource_type);
+                shader_addline(buffer, ")");
             }
 
             for (i = 0; i < ins->dst_count; ++i)

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -718,6 +718,7 @@ struct vkd3d_shader_instruction
     const struct vkd3d_shader_dst_param *dst;
     const struct vkd3d_shader_src_param *src;
     struct vkd3d_shader_texel_offset texel_offset;
+    enum vkd3d_shader_resource_type resource_type;
     bool coissue;
     const struct vkd3d_shader_src_param *predicate;
     union


### PR DESCRIPTION
This is a hopefully-straightforward backport of @zfigura's commit from upstream vkd3d:
https://source.winehq.org/git/vkd3d.git/commit/c3a5df7375ba5d172fe6dd4d7987ed34777bc198

This doesn't actually fix the problem I was having (with Age of Empires IV), but it does get rid of a couple of the ``Unhandled modifier`` warnings which were cluttering up the log. Other than that, I've not tested it much, and know next-to-nothing about d3d12 (and only a little about Vulkan), so maybe it's broken…

Feel free to just close this if it's going to complicate a future bulk merge from vkd3d too much, but it's here if you want it. :-)