### PR TITLE
impl_from overhead refactor

### DIFF
--- a/libs/vkd3d/cache.c
+++ b/libs/vkd3d/cache.c
@@ -334,7 +334,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_pipeline_library_StorePipeline(d3d12_pipe
         LPCWSTR name, ID3D12PipelineState *pipeline)
 {
     struct d3d12_pipeline_library *pipeline_library = impl_from_ID3D12PipelineLibrary(iface);
-    struct d3d12_pipeline_state *pipeline_state = unsafe_impl_from_ID3D12PipelineState(pipeline);
+    struct d3d12_pipeline_state *pipeline_state = impl_from_ID3D12PipelineState(pipeline);
     struct vkd3d_cached_pipeline_entry entry;
     void *new_name, *new_blob;
     VkResult vr;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8758,7 +8758,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ExecuteIndirect(d3d12_command_l
         ID3D12CommandSignature *command_signature, UINT max_command_count, ID3D12Resource *arg_buffer,
         UINT64 arg_buffer_offset, ID3D12Resource *count_buffer, UINT64 count_buffer_offset)
 {
-    struct d3d12_command_signature *sig_impl = unsafe_impl_from_ID3D12CommandSignature(command_signature);
+    struct d3d12_command_signature *sig_impl = impl_from_ID3D12CommandSignature(command_signature);
     struct d3d12_resource *count_impl = impl_from_ID3D12Resource(count_buffer);
     struct d3d12_resource *arg_impl = impl_from_ID3D12Resource(arg_buffer);
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
@@ -11340,11 +11340,6 @@ VKD3D_EXPORT void vkd3d_enqueue_initial_transition(ID3D12CommandQueue *queue, ID
 }
 
 /* ID3D12CommandSignature */
-static inline struct d3d12_command_signature *impl_from_ID3D12CommandSignature(ID3D12CommandSignature *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_command_signature, ID3D12CommandSignature_iface);
-}
-
 static HRESULT STDMETHODCALLTYPE d3d12_command_signature_QueryInterface(ID3D12CommandSignature *iface,
         REFIID iid, void **out)
 {
@@ -11440,7 +11435,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_signature_GetDevice(ID3D12Command
     return d3d12_device_query_interface(signature->device, iid, device);
 }
 
-static CONST_VTBL struct ID3D12CommandSignatureVtbl d3d12_command_signature_vtbl =
+CONST_VTBL struct ID3D12CommandSignatureVtbl d3d12_command_signature_vtbl =
 {
     /* IUnknown methods */
     d3d12_command_signature_QueryInterface,
@@ -11454,14 +11449,6 @@ static CONST_VTBL struct ID3D12CommandSignatureVtbl d3d12_command_signature_vtbl
     /* ID3D12DeviceChild methods */
     d3d12_command_signature_GetDevice,
 };
-
-struct d3d12_command_signature *unsafe_impl_from_ID3D12CommandSignature(ID3D12CommandSignature *iface)
-{
-    if (!iface)
-        return NULL;
-    assert(iface->lpVtbl == &d3d12_command_signature_vtbl);
-    return CONTAINING_RECORD(iface, struct d3d12_command_signature, ID3D12CommandSignature_iface);
-}
 
 HRESULT d3d12_command_signature_create(struct d3d12_device *device, const D3D12_COMMAND_SIGNATURE_DESC *desc,
         struct d3d12_command_signature **signature)

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8492,6 +8492,11 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResolveQueryData(d3d12_command_
             iface, heap, type, start_index, query_count,
             dst_buffer, aligned_dst_buffer_offset);
 
+    /* Some games call this with a query_count of 0.
+     * Avoid ending the render pass and doing worthless tracking. */
+    if (!query_count)
+        return;
+
     if (!d3d12_resource_is_buffer(buffer))
     {
         WARN("Destination resource is not a buffer.\n");

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5531,9 +5531,9 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyBufferRegion(d3d12_command_
 
     vk_procs = &list->device->vk_procs;
 
-    dst_resource = unsafe_impl_from_ID3D12Resource(dst);
+    dst_resource = impl_from_ID3D12Resource(dst);
     assert(d3d12_resource_is_buffer(dst_resource));
-    src_resource = unsafe_impl_from_ID3D12Resource(src);
+    src_resource = impl_from_ID3D12Resource(src);
     assert(d3d12_resource_is_buffer(src_resource));
 
     d3d12_command_list_track_resource_usage(list, dst_resource, true);
@@ -6026,8 +6026,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyTextureRegion(d3d12_command
 
     vk_procs = &list->device->vk_procs;
 
-    dst_resource = unsafe_impl_from_ID3D12Resource(dst->pResource);
-    src_resource = unsafe_impl_from_ID3D12Resource(src->pResource);
+    dst_resource = impl_from_ID3D12Resource(dst->pResource);
+    src_resource = impl_from_ID3D12Resource(src->pResource);
 
     d3d12_command_list_track_resource_usage(list, src_resource, true);
 
@@ -6155,8 +6155,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyResource(d3d12_command_list
 
     vk_procs = &list->device->vk_procs;
 
-    dst_resource = unsafe_impl_from_ID3D12Resource(dst);
-    src_resource = unsafe_impl_from_ID3D12Resource(src);
+    dst_resource = impl_from_ID3D12Resource(dst);
+    src_resource = impl_from_ID3D12Resource(src);
 
     d3d12_command_list_track_resource_usage(list, dst_resource, false);
     d3d12_command_list_track_resource_usage(list, src_resource, true);
@@ -6225,8 +6225,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyTiles(d3d12_command_list_if
 
     d3d12_command_list_end_current_render_pass(list, true);
 
-    tiled_res = unsafe_impl_from_ID3D12Resource(tiled_resource);
-    linear_res = unsafe_impl_from_ID3D12Resource(buffer);
+    tiled_res = impl_from_ID3D12Resource(tiled_resource);
+    linear_res = impl_from_ID3D12Resource(buffer);
 
     d3d12_command_list_track_resource_usage(list, tiled_res, true);
 
@@ -6442,8 +6442,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResolveSubresource(d3d12_comman
     TRACE("iface %p, dst_resource %p, dst_sub_resource_idx %u, src_resource %p, src_sub_resource_idx %u, "
             "format %#x.\n", iface, dst, dst_sub_resource_idx, src, src_sub_resource_idx, format);
 
-    dst_resource = unsafe_impl_from_ID3D12Resource(dst);
-    src_resource = unsafe_impl_from_ID3D12Resource(src);
+    dst_resource = impl_from_ID3D12Resource(dst);
+    src_resource = impl_from_ID3D12Resource(src);
 
     assert(d3d12_resource_is_texture(dst_resource));
     assert(d3d12_resource_is_texture(src_resource));
@@ -6904,7 +6904,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResourceBarrier(d3d12_command_l
                     continue;
                 }
 
-                if (!(preserve_resource = unsafe_impl_from_ID3D12Resource(transition->pResource)))
+                if (!(preserve_resource = impl_from_ID3D12Resource(transition->pResource)))
                 {
                     d3d12_command_list_mark_as_invalid(list, "A resource pointer is NULL.");
                     continue;
@@ -6959,7 +6959,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResourceBarrier(d3d12_command_l
                 const D3D12_RESOURCE_UAV_BARRIER *uav = &current->UAV;
                 uint32_t state_mask;
 
-                preserve_resource = unsafe_impl_from_ID3D12Resource(uav->pResource);
+                preserve_resource = impl_from_ID3D12Resource(uav->pResource);
 
                 /* The only way to synchronize an RTAS is UAV barriers,
                  * as their resource state must be frozen.
@@ -6993,8 +6993,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResourceBarrier(d3d12_command_l
 
                 alias = &current->Aliasing;
                 TRACE("Aliasing barrier (before %p, after %p).\n", alias->pResourceBefore, alias->pResourceAfter);
-                before = unsafe_impl_from_ID3D12Resource(alias->pResourceBefore);
-                after = unsafe_impl_from_ID3D12Resource(alias->pResourceAfter);
+                before = impl_from_ID3D12Resource(alias->pResourceBefore);
+                after = impl_from_ID3D12Resource(alias->pResourceAfter);
 
                 discard_resource = after;
 
@@ -8108,7 +8108,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
 
     memcpy(color.uint32, values, sizeof(color.uint32));
 
-    resource_impl = unsafe_impl_from_ID3D12Resource(resource);
+    resource_impl = impl_from_ID3D12Resource(resource);
 
     if (!vkd3d_clear_uav_info_from_desc(&args, desc))
         return;
@@ -8196,7 +8196,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewFloat(d
 
     memcpy(color.float32, values, sizeof(color.float32));
 
-    resource_impl = unsafe_impl_from_ID3D12Resource(resource);
+    resource_impl = impl_from_ID3D12Resource(resource);
 
     if (!vkd3d_clear_uav_info_from_desc(&args, desc))
         return;
@@ -8207,7 +8207,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_DiscardResource(d3d12_command_l
         ID3D12Resource *resource, const D3D12_DISCARD_REGION *region)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    struct d3d12_resource *texture = unsafe_impl_from_ID3D12Resource(resource);
+    struct d3d12_resource *texture = impl_from_ID3D12Resource(resource);
     unsigned int i, first_subresource, subresource_count;
     VkImageSubresourceLayers vk_subresource_layers;
     unsigned int resource_subresource_count;
@@ -8464,7 +8464,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResolveQueryData(d3d12_command_
 {
     struct d3d12_query_heap *query_heap = unsafe_impl_from_ID3D12QueryHeap(heap);
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    struct d3d12_resource *buffer = unsafe_impl_from_ID3D12Resource(dst_buffer);
+    struct d3d12_resource *buffer = impl_from_ID3D12Resource(dst_buffer);
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     size_t stride = d3d12_query_heap_type_get_data_size(query_heap->desc.Type);
     VkBufferCopy copy_region;
@@ -8529,7 +8529,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPredication(d3d12_command_li
         ID3D12Resource *buffer, UINT64 aligned_buffer_offset, D3D12_PREDICATION_OP operation)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    struct d3d12_resource *resource = unsafe_impl_from_ID3D12Resource(buffer);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource(buffer);
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     const struct vkd3d_predicate_ops *predicate_ops = &list->device->meta_ops.predicate;
     struct vkd3d_predicate_resolve_args resolve_args;
@@ -8759,8 +8759,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_ExecuteIndirect(d3d12_command_l
         UINT64 arg_buffer_offset, ID3D12Resource *count_buffer, UINT64 count_buffer_offset)
 {
     struct d3d12_command_signature *sig_impl = unsafe_impl_from_ID3D12CommandSignature(command_signature);
-    struct d3d12_resource *count_impl = unsafe_impl_from_ID3D12Resource(count_buffer);
-    struct d3d12_resource *arg_impl = unsafe_impl_from_ID3D12Resource(arg_buffer);
+    struct d3d12_resource *count_impl = impl_from_ID3D12Resource(count_buffer);
+    struct d3d12_resource *arg_impl = impl_from_ID3D12Resource(arg_buffer);
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     const D3D12_COMMAND_SIGNATURE_DESC *signature_desc = &sig_impl->desc;
@@ -8968,8 +8968,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResolveSubresourceRegion(d3d12_
             iface, dst, dst_sub_resource_idx, dst_x, dst_y,
             src, src_sub_resource_idx, src_rect, format, mode);
 
-    dst_resource = unsafe_impl_from_ID3D12Resource(dst);
-    src_resource = unsafe_impl_from_ID3D12Resource(src);
+    dst_resource = impl_from_ID3D12Resource(dst);
+    src_resource = impl_from_ID3D12Resource(src);
 
     assert(d3d12_resource_is_texture(dst_resource));
     assert(d3d12_resource_is_texture(src_resource));
@@ -9396,7 +9396,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_RSSetShadingRateImage(d3d12_com
         ID3D12Resource *image)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    struct d3d12_resource *vrs_image = unsafe_impl_from_ID3D12Resource(image);
+    struct d3d12_resource *vrs_image = impl_from_ID3D12Resource(image);
 
     TRACE("iface %p, image %p.\n", iface, image);
 
@@ -9768,7 +9768,7 @@ static void STDMETHODCALLTYPE d3d12_command_queue_UpdateTileMappings(ID3D12Comma
 {
     struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
     unsigned int region_tile = 0, region_idx = 0, range_tile = 0, range_idx = 0;
-    struct d3d12_resource *res = unsafe_impl_from_ID3D12Resource(resource);
+    struct d3d12_resource *res = impl_from_ID3D12Resource(resource);
     struct d3d12_heap *memory_heap = impl_from_ID3D12Heap(heap);
     struct vkd3d_sparse_memory_bind *bind, **bound_tiles;
     struct d3d12_sparse_info *sparse = &res->sparse;
@@ -9912,8 +9912,8 @@ static void STDMETHODCALLTYPE d3d12_command_queue_CopyTileMappings(ID3D12Command
         const D3D12_TILE_REGION_SIZE *region_size, D3D12_TILE_MAPPING_FLAGS flags)
 {
     struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
-    struct d3d12_resource *dst_res = unsafe_impl_from_ID3D12Resource(dst_resource);
-    struct d3d12_resource *src_res = unsafe_impl_from_ID3D12Resource(src_resource);
+    struct d3d12_resource *dst_res = impl_from_ID3D12Resource(dst_resource);
+    struct d3d12_resource *src_res = impl_from_ID3D12Resource(src_resource);
     struct d3d12_command_queue_submission sub;
     struct vkd3d_sparse_memory_bind *bind;
     unsigned int i;
@@ -11327,7 +11327,7 @@ VKD3D_EXPORT void vkd3d_enqueue_initial_transition(ID3D12CommandQueue *queue, ID
 {
     struct d3d12_command_queue_submission sub;
     struct d3d12_command_queue *d3d12_queue = impl_from_ID3D12CommandQueue(queue);
-    struct d3d12_resource *d3d12_resource = unsafe_impl_from_ID3D12Resource(resource);
+    struct d3d12_resource *d3d12_resource = impl_from_ID3D12Resource(resource);
 
     memset(&sub, 0, sizeof(sub));
     sub.type = VKD3D_SUBMISSION_EXECUTE;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -7112,7 +7112,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetDescriptorHeaps(d3d12_comman
 
     for (i = 0; i < heap_count; i++)
     {
-        struct d3d12_descriptor_heap *heap = unsafe_impl_from_ID3D12DescriptorHeap(heaps[i]);
+        struct d3d12_descriptor_heap *heap = impl_from_ID3D12DescriptorHeap(heaps[i]);
         unsigned int set_index = 0;
 
         if (!heap)

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6587,7 +6587,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_OMSetStencilRef(d3d12_command_l
 static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_list_iface *iface,
         ID3D12PipelineState *pipeline_state)
 {
-    struct d3d12_pipeline_state *state = unsafe_impl_from_ID3D12PipelineState(pipeline_state);
+    struct d3d12_pipeline_state *state = impl_from_ID3D12PipelineState(pipeline_state);
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
     struct vkd3d_pipeline_bindings *bindings;
     unsigned int i;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -7180,7 +7180,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootSignature(d3d12_c
     TRACE("iface %p, root_signature %p.\n", iface, root_signature);
 
     d3d12_command_list_set_root_signature(list, VK_PIPELINE_BIND_POINT_COMPUTE,
-            unsafe_impl_from_ID3D12RootSignature(root_signature));
+            impl_from_ID3D12RootSignature(root_signature));
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootSignature(d3d12_command_list_iface *iface,
@@ -7191,7 +7191,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootSignature(d3d12_
     TRACE("iface %p, root_signature %p.\n", iface, root_signature);
 
     d3d12_command_list_set_root_signature(list, VK_PIPELINE_BIND_POINT_GRAPHICS,
-            unsafe_impl_from_ID3D12RootSignature(root_signature));
+            impl_from_ID3D12RootSignature(root_signature));
 }
 
 static void d3d12_command_list_set_descriptor_table(struct d3d12_command_list *list,

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -9769,7 +9769,7 @@ static void STDMETHODCALLTYPE d3d12_command_queue_UpdateTileMappings(ID3D12Comma
     struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
     unsigned int region_tile = 0, region_idx = 0, range_tile = 0, range_idx = 0;
     struct d3d12_resource *res = unsafe_impl_from_ID3D12Resource(resource);
-    struct d3d12_heap *memory_heap = unsafe_impl_from_ID3D12Heap(heap);
+    struct d3d12_heap *memory_heap = impl_from_ID3D12Heap(heap);
     struct vkd3d_sparse_memory_bind *bind, **bound_tiles;
     struct d3d12_sparse_info *sparse = &res->sparse;
     D3D12_TILED_RESOURCE_COORDINATE region_coord;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -519,11 +519,6 @@ static const struct vkd3d_shader_root_parameter *root_signature_get_root_descrip
 }
 
 /* ID3D12Fence */
-static struct d3d12_fence *impl_from_ID3D12Fence(d3d12_fence_iface *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_fence, ID3D12Fence_iface);
-}
-
 static void d3d12_fence_destroy_vk_objects(struct d3d12_fence *fence)
 {
     const struct vkd3d_vk_device_procs *vk_procs;
@@ -803,7 +798,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_QueryInterface(d3d12_fence_iface *i
 
 static ULONG STDMETHODCALLTYPE d3d12_fence_AddRef(d3d12_fence_iface *iface)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
     ULONG refcount = InterlockedIncrement(&fence->refcount);
 
     TRACE("%p increasing refcount to %u.\n", fence, refcount);
@@ -813,7 +808,7 @@ static ULONG STDMETHODCALLTYPE d3d12_fence_AddRef(d3d12_fence_iface *iface)
 
 static ULONG STDMETHODCALLTYPE d3d12_fence_Release(d3d12_fence_iface *iface)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
     ULONG refcount = InterlockedDecrement(&fence->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", fence, refcount);
@@ -831,7 +826,7 @@ static ULONG STDMETHODCALLTYPE d3d12_fence_Release(d3d12_fence_iface *iface)
 static HRESULT STDMETHODCALLTYPE d3d12_fence_GetPrivateData(d3d12_fence_iface *iface,
         REFGUID guid, UINT *data_size, void *data)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
 
     TRACE("iface %p, guid %s, data_size %p, data %p.\n",
             iface, debugstr_guid(guid), data_size, data);
@@ -842,7 +837,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_GetPrivateData(d3d12_fence_iface *i
 static HRESULT STDMETHODCALLTYPE d3d12_fence_SetPrivateData(d3d12_fence_iface *iface,
         REFGUID guid, UINT data_size, const void *data)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
 
     TRACE("iface %p, guid %s, data_size %u, data %p.\n",
             iface, debugstr_guid(guid), data_size, data);
@@ -854,7 +849,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_SetPrivateData(d3d12_fence_iface *i
 static HRESULT STDMETHODCALLTYPE d3d12_fence_SetPrivateDataInterface(d3d12_fence_iface *iface,
         REFGUID guid, const IUnknown *data)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
 
     TRACE("iface %p, guid %s, data %p.\n", iface, debugstr_guid(guid), data);
 
@@ -864,7 +859,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_SetPrivateDataInterface(d3d12_fence
 
 static HRESULT STDMETHODCALLTYPE d3d12_fence_GetDevice(d3d12_fence_iface *iface, REFIID iid, void **device)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
 
     TRACE("iface %p, iid %s, device %p.\n", iface, debugstr_guid(iid), device);
 
@@ -873,7 +868,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_GetDevice(d3d12_fence_iface *iface,
 
 static UINT64 STDMETHODCALLTYPE d3d12_fence_GetCompletedValue(d3d12_fence_iface *iface)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
     uint64_t completed_value;
     int rc;
 
@@ -963,7 +958,7 @@ HRESULT d3d12_fence_set_event_on_completion(struct d3d12_fence *fence,
 static HRESULT STDMETHODCALLTYPE d3d12_fence_SetEventOnCompletion(d3d12_fence_iface *iface,
         UINT64 value, HANDLE event)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
 
     TRACE("iface %p, value %#"PRIx64", event %p.\n", iface, value, event);
 
@@ -972,7 +967,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_SetEventOnCompletion(d3d12_fence_if
 
 static HRESULT STDMETHODCALLTYPE d3d12_fence_Signal(d3d12_fence_iface *iface, UINT64 value)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
 
     TRACE("iface %p, value %#"PRIx64".\n", iface, value);
 
@@ -981,14 +976,14 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_Signal(d3d12_fence_iface *iface, UI
 
 static D3D12_FENCE_FLAGS STDMETHODCALLTYPE d3d12_fence_GetCreationFlags(d3d12_fence_iface *iface)
 {
-    struct d3d12_fence *fence = impl_from_ID3D12Fence(iface);
+    struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
 
     TRACE("iface %p.\n", iface);
 
     return fence->d3d12_flags;
 }
 
-static CONST_VTBL struct ID3D12Fence1Vtbl d3d12_fence_vtbl =
+CONST_VTBL struct ID3D12Fence1Vtbl d3d12_fence_vtbl =
 {
     /* IUnknown methods */
     d3d12_fence_QueryInterface,
@@ -1008,19 +1003,6 @@ static CONST_VTBL struct ID3D12Fence1Vtbl d3d12_fence_vtbl =
     /* ID3D12Fence1 methods */
     d3d12_fence_GetCreationFlags,
 };
-
-struct d3d12_fence *unsafe_impl_from_ID3D12Fence1(ID3D12Fence1 *iface)
-{
-    if (!iface)
-        return NULL;
-    assert(iface->lpVtbl == &d3d12_fence_vtbl);
-    return impl_from_ID3D12Fence(iface);
-}
-
-struct d3d12_fence *unsafe_impl_from_ID3D12Fence(ID3D12Fence *iface)
-{
-    return unsafe_impl_from_ID3D12Fence1((ID3D12Fence1 *)iface);
-}
 
 static HRESULT d3d12_fence_init_timeline(struct d3d12_fence *fence, struct d3d12_device *device,
         UINT64 initial_value)
@@ -10119,7 +10101,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_queue_Signal(ID3D12CommandQueue *
 
     TRACE("iface %p, fence %p, value %#"PRIx64".\n", iface, fence_iface, value);
 
-    fence = unsafe_impl_from_ID3D12Fence(fence_iface);
+    fence = impl_from_ID3D12Fence(fence_iface);
     d3d12_fence_inc_ref(fence);
 
     sub.type = VKD3D_SUBMISSION_SIGNAL;
@@ -10138,7 +10120,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_queue_Wait(ID3D12CommandQueue *if
 
     TRACE("iface %p, fence %p, value %#"PRIx64".\n", iface, fence_iface, value);
 
-    fence = unsafe_impl_from_ID3D12Fence(fence_iface);
+    fence = impl_from_ID3D12Fence(fence_iface);
     d3d12_fence_inc_ref(fence);
 
     sub.type = VKD3D_SUBMISSION_WAIT;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8297,7 +8297,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_BeginQuery(d3d12_command_list_i
         ID3D12QueryHeap *heap, D3D12_QUERY_TYPE type, UINT index)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    struct d3d12_query_heap *query_heap = unsafe_impl_from_ID3D12QueryHeap(heap);
+    struct d3d12_query_heap *query_heap = impl_from_ID3D12QueryHeap(heap);
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkQueryControlFlags flags = d3d12_query_type_get_vk_flags(type);
 
@@ -8338,7 +8338,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_EndQuery(d3d12_command_list_ifa
         ID3D12QueryHeap *heap, D3D12_QUERY_TYPE type, UINT index)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    struct d3d12_query_heap *query_heap = unsafe_impl_from_ID3D12QueryHeap(heap);
+    struct d3d12_query_heap *query_heap = impl_from_ID3D12QueryHeap(heap);
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
 
     TRACE("iface %p, heap %p, type %#x, index %u.\n", iface, heap, type, index);
@@ -8462,7 +8462,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResolveQueryData(d3d12_command_
         ID3D12QueryHeap *heap, D3D12_QUERY_TYPE type, UINT start_index, UINT query_count,
         ID3D12Resource *dst_buffer, UINT64 aligned_dst_buffer_offset)
 {
-    struct d3d12_query_heap *query_heap = unsafe_impl_from_ID3D12QueryHeap(heap);
+    struct d3d12_query_heap *query_heap = impl_from_ID3D12QueryHeap(heap);
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
     struct d3d12_resource *buffer = impl_from_ID3D12Resource(dst_buffer);
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3509,7 +3509,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateShaderResourceView(d3d12_device
             iface, resource, desc, descriptor.ptr);
 
     d3d12_desc_create_srv(d3d12_desc_from_cpu_handle(descriptor),
-            device, unsafe_impl_from_ID3D12Resource(resource), desc);
+            device, impl_from_ID3D12Resource(resource), desc);
 }
 
 VKD3D_THREAD_LOCAL struct D3D12_UAV_INFO *d3d12_uav_info = NULL;
@@ -3522,7 +3522,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateUnorderedAccessView(d3d12_devic
     VkImageViewHandleInfoNVX imageViewHandleInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX };
     const struct vkd3d_vk_device_procs *vk_procs;
     VkResult vr;
-    struct d3d12_resource *d3d12_resource_ = unsafe_impl_from_ID3D12Resource(resource);
+    struct d3d12_resource *d3d12_resource_ = impl_from_ID3D12Resource(resource);
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     struct d3d12_desc *d3d12_desc_cpu = d3d12_desc_from_cpu_handle(descriptor);
     TRACE("iface %p, resource %p, counter_resource %p, desc %p, descriptor %#lx.\n",
@@ -3530,7 +3530,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateUnorderedAccessView(d3d12_devic
 
     d3d12_desc_create_uav(d3d12_desc_cpu,
             device, d3d12_resource_,
-            unsafe_impl_from_ID3D12Resource(counter_resource), desc);
+            impl_from_ID3D12Resource(counter_resource), desc);
     
     /* d3d12_uav_info stores the pointer to data from previous call to d3d12_device_vkd3d_ext_CaptureUAVInfo(). Below code will update the data. */
     if (d3d12_uav_info)
@@ -3562,7 +3562,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateRenderTargetView(d3d12_device_i
             iface, resource, desc, descriptor.ptr);
 
     d3d12_rtv_desc_create_rtv(d3d12_rtv_desc_from_cpu_handle(descriptor),
-            impl_from_ID3D12Device(iface), unsafe_impl_from_ID3D12Resource(resource), desc);
+            impl_from_ID3D12Device(iface), impl_from_ID3D12Resource(resource), desc);
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CreateDepthStencilView(d3d12_device_iface *iface,
@@ -3573,7 +3573,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateDepthStencilView(d3d12_device_i
             iface, resource, desc, descriptor.ptr);
 
     d3d12_rtv_desc_create_dsv(d3d12_rtv_desc_from_cpu_handle(descriptor),
-            impl_from_ID3D12Device(iface), unsafe_impl_from_ID3D12Resource(resource), desc);
+            impl_from_ID3D12Device(iface), impl_from_ID3D12Resource(resource), desc);
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CreateSampler(d3d12_device_iface *iface,
@@ -4042,7 +4042,7 @@ static void STDMETHODCALLTYPE d3d12_device_GetResourceTiling(d3d12_device_iface 
         D3D12_TILE_SHAPE *tile_shape, UINT *tiling_count, UINT first_tiling,
         D3D12_SUBRESOURCE_TILING *tilings)
 {
-    struct d3d12_sparse_info *sparse = &unsafe_impl_from_ID3D12Resource(resource)->sparse;
+    struct d3d12_sparse_info *sparse = &impl_from_ID3D12Resource(resource)->sparse;
     unsigned int max_tiling_count, i;
 
     TRACE("iface %p, resource %p, tile_count %p, packed_mip_info %p, "

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2430,11 +2430,6 @@ void d3d12_device_return_query_pool(struct d3d12_device *device, const struct vk
 }
 
 /* ID3D12Device */
-static inline struct d3d12_device *impl_from_ID3D12Device(d3d12_device_iface *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_device, ID3D12Device_iface);
-}
-
 extern ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_AddRef(ID3D12DeviceExt *iface);
 
 HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
@@ -4545,7 +4540,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_SetBackgroundProcessingMode(d3d12_
     return E_NOTIMPL;
 }
 
-static CONST_VTBL struct ID3D12Device6Vtbl d3d12_device_vtbl =
+CONST_VTBL struct ID3D12Device6Vtbl d3d12_device_vtbl =
 {
     /* IUnknown methods */
     d3d12_device_QueryInterface,
@@ -5161,21 +5156,6 @@ static void d3d12_device_caps_init(struct d3d12_device *device)
 static bool d3d12_device_supports_feature_level(struct d3d12_device *device, D3D_FEATURE_LEVEL feature_level)
 {
     return feature_level <= device->d3d12_caps.max_feature_level;
-}
-
-struct d3d12_device *unsafe_impl_from_ID3D12Device(d3d12_device_iface *iface)
-{
-    if (!iface)
-        return NULL;
-
-#ifdef VKD3D_ENABLE_PROFILING
-    assert(iface->lpVtbl == &d3d12_device_vtbl ||
-           iface->lpVtbl == &d3d12_device_vtbl_profiled);
-#else
-    assert(iface->lpVtbl == &d3d12_device_vtbl);
-#endif
-
-    return impl_from_ID3D12Device(iface);
 }
 
 extern CONST_VTBL struct ID3D12DeviceExtVtbl d3d12_device_vkd3d_ext_vtbl;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3791,7 +3791,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreatePlacedResource(d3d12_device_
         const D3D12_RESOURCE_DESC *desc, D3D12_RESOURCE_STATES initial_state,
         const D3D12_CLEAR_VALUE *optimized_clear_value, REFIID iid, void **resource)
 {
-    struct d3d12_heap *heap_object = unsafe_impl_from_ID3D12Heap(heap);
+    struct d3d12_heap *heap_object = impl_from_ID3D12Heap(heap);
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     struct d3d12_resource *object;
     HRESULT hr;

--- a/libs/vkd3d/device_profiled.h
+++ b/libs/vkd3d/device_profiled.h
@@ -215,7 +215,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreatePipelineState_profiled(d3d12
     DEVICE_PROFILED_CALL_HRESULT(CreatePipelineState, iface, desc, riid, pipeline_state);
 }
 
-static CONST_VTBL struct ID3D12Device6Vtbl d3d12_device_vtbl_profiled =
+CONST_VTBL struct ID3D12Device6Vtbl d3d12_device_vtbl_profiled =
 {
     /* IUnknown methods */
     d3d12_device_QueryInterface,

--- a/libs/vkd3d/heap.c
+++ b/libs/vkd3d/heap.c
@@ -23,11 +23,6 @@
 #include "vkd3d_private.h"
 
 /* ID3D12Heap */
-static inline struct d3d12_heap *impl_from_ID3D12Heap(d3d12_heap_iface *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_heap, ID3D12Heap_iface);
-}
-
 static HRESULT STDMETHODCALLTYPE d3d12_heap_QueryInterface(d3d12_heap_iface *iface,
         REFIID iid, void **object)
 {
@@ -53,7 +48,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_QueryInterface(d3d12_heap_iface *ifa
 
 static ULONG STDMETHODCALLTYPE d3d12_heap_AddRef(d3d12_heap_iface *iface)
 {
-    struct d3d12_heap *heap = impl_from_ID3D12Heap(iface);
+    struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
     ULONG refcount = InterlockedIncrement(&heap->refcount);
 
     TRACE("%p increasing refcount to %u.\n", heap, refcount);
@@ -79,7 +74,7 @@ static void d3d12_heap_set_name(struct d3d12_heap *heap, const char *name)
 
 static ULONG STDMETHODCALLTYPE d3d12_heap_Release(d3d12_heap_iface *iface)
 {
-    struct d3d12_heap *heap = impl_from_ID3D12Heap(iface);
+    struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
     ULONG refcount = InterlockedDecrement(&heap->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", heap, refcount);
@@ -93,7 +88,7 @@ static ULONG STDMETHODCALLTYPE d3d12_heap_Release(d3d12_heap_iface *iface)
 static HRESULT STDMETHODCALLTYPE d3d12_heap_GetPrivateData(d3d12_heap_iface *iface,
         REFGUID guid, UINT *data_size, void *data)
 {
-    struct d3d12_heap *heap = impl_from_ID3D12Heap(iface);
+    struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
 
     TRACE("iface %p, guid %s, data_size %p, data %p.\n", iface, debugstr_guid(guid), data_size, data);
 
@@ -103,7 +98,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_GetPrivateData(d3d12_heap_iface *ifa
 static HRESULT STDMETHODCALLTYPE d3d12_heap_SetPrivateData(d3d12_heap_iface *iface,
         REFGUID guid, UINT data_size, const void *data)
 {
-    struct d3d12_heap *heap = impl_from_ID3D12Heap(iface);
+    struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
 
     TRACE("iface %p, guid %s, data_size %u, data %p.\n", iface, debugstr_guid(guid), data_size, data);
 
@@ -114,7 +109,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_SetPrivateData(d3d12_heap_iface *ifa
 static HRESULT STDMETHODCALLTYPE d3d12_heap_SetPrivateDataInterface(d3d12_heap_iface *iface,
         REFGUID guid, const IUnknown *data)
 {
-    struct d3d12_heap *heap = impl_from_ID3D12Heap(iface);
+    struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
 
     TRACE("iface %p, guid %s, data %p.\n", iface, debugstr_guid(guid), data);
 
@@ -124,7 +119,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_SetPrivateDataInterface(d3d12_heap_i
 
 static HRESULT STDMETHODCALLTYPE d3d12_heap_GetDevice(d3d12_heap_iface *iface, REFIID iid, void **device)
 {
-    struct d3d12_heap *heap = impl_from_ID3D12Heap(iface);
+    struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
 
     TRACE("iface %p, iid %s, device %p.\n", iface, debugstr_guid(iid), device);
 
@@ -134,7 +129,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_GetDevice(d3d12_heap_iface *iface, R
 static D3D12_HEAP_DESC * STDMETHODCALLTYPE d3d12_heap_GetDesc(d3d12_heap_iface *iface,
         D3D12_HEAP_DESC *desc)
 {
-    struct d3d12_heap *heap = impl_from_ID3D12Heap(iface);
+    struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
 
     TRACE("iface %p, desc %p.\n", iface, desc);
 
@@ -150,7 +145,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_GetProtectedResourceSession(d3d12_he
     return E_NOTIMPL;
 }
 
-static CONST_VTBL struct ID3D12Heap1Vtbl d3d12_heap_vtbl =
+CONST_VTBL struct ID3D12Heap1Vtbl d3d12_heap_vtbl =
 {
     /* IUnknown methods */
     d3d12_heap_QueryInterface,
@@ -168,19 +163,6 @@ static CONST_VTBL struct ID3D12Heap1Vtbl d3d12_heap_vtbl =
     /* ID3D12Heap1 methods */
     d3d12_heap_GetProtectedResourceSession,
 };
-
-static struct d3d12_heap *unsafe_impl_from_ID3D12Heap1(ID3D12Heap1 *iface)
-{
-    if (!iface)
-        return NULL;
-    assert(iface->lpVtbl == &d3d12_heap_vtbl);
-    return impl_from_ID3D12Heap(iface);
-}
-
-struct d3d12_heap *unsafe_impl_from_ID3D12Heap(ID3D12Heap *iface)
-{
-    return unsafe_impl_from_ID3D12Heap1((ID3D12Heap1 *)iface);
-}
 
 static HRESULT validate_heap_desc(const D3D12_HEAP_DESC *desc)
 {

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -20,11 +20,6 @@
 #include "vkd3d_private.h"
 #include "vkd3d_string.h"
 
-struct d3d12_state_object *impl_from_ID3D12StateObject(ID3D12StateObject *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_state_object, ID3D12StateObject_iface);
-}
-
 static inline struct d3d12_state_object *impl_from_ID3D12StateObjectProperties(ID3D12StateObjectProperties *iface)
 {
     return CONTAINING_RECORD(iface, struct d3d12_state_object, ID3D12StateObjectProperties_iface);

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -530,7 +530,7 @@ static HRESULT d3d12_state_object_parse_subobjects(struct d3d12_state_object *ob
                             {
                                 data->associations[data->associations_count].export = association->pExports[j];
                                 data->associations[data->associations_count].root_signature =
-                                        unsafe_impl_from_ID3D12RootSignature(local_rs->pLocalRootSignature);
+                                        impl_from_ID3D12RootSignature(local_rs->pLocalRootSignature);
                                 data->associations_count++;
                             }
                         }
@@ -766,9 +766,9 @@ static struct d3d12_root_signature *d3d12_state_object_pipeline_data_get_local_r
     }
 
     if (data->high_priority_local_root_signature)
-        return unsafe_impl_from_ID3D12RootSignature(data->high_priority_local_root_signature);
+        return impl_from_ID3D12RootSignature(data->high_priority_local_root_signature);
     else if (data->low_priority_local_root_signature)
-        return unsafe_impl_from_ID3D12RootSignature(data->low_priority_local_root_signature);
+        return impl_from_ID3D12RootSignature(data->low_priority_local_root_signature);
     else
         return NULL;
 }
@@ -877,7 +877,7 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
     shader_interface_info.stage = VK_SHADER_STAGE_ALL;
     shader_interface_info.xfb_info = NULL;
 
-    global_signature = unsafe_impl_from_ID3D12RootSignature(data->global_root_signature);
+    global_signature = impl_from_ID3D12RootSignature(data->global_root_signature);
 
     if (global_signature)
     {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2737,7 +2737,7 @@ fail:
 VKD3D_EXPORT HRESULT vkd3d_create_image_resource(ID3D12Device *device,
         const struct vkd3d_image_resource_create_info *create_info, ID3D12Resource **resource)
 {
-    struct d3d12_device *d3d12_device = unsafe_impl_from_ID3D12Device((d3d12_device_iface *)device);
+    struct d3d12_device *d3d12_device = impl_from_ID3D12Device((d3d12_device_iface *)device);
     struct d3d12_resource *object;
     HRESULT hr;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5595,11 +5595,6 @@ static void d3d12_query_heap_set_name(struct d3d12_query_heap *heap, const char 
 }
 
 /* ID3D12QueryHeap */
-static inline struct d3d12_query_heap *impl_from_ID3D12QueryHeap(ID3D12QueryHeap *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_query_heap, ID3D12QueryHeap_iface);
-}
-
 static HRESULT STDMETHODCALLTYPE d3d12_query_heap_QueryInterface(ID3D12QueryHeap *iface,
         REFIID iid, void **out)
 {
@@ -5699,7 +5694,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_query_heap_GetDevice(ID3D12QueryHeap *ifa
     return d3d12_device_query_interface(heap->device, iid, device);
 }
 
-static CONST_VTBL struct ID3D12QueryHeapVtbl d3d12_query_heap_vtbl =
+CONST_VTBL struct ID3D12QueryHeapVtbl d3d12_query_heap_vtbl =
 {
     /* IUnknown methods */
     d3d12_query_heap_QueryInterface,
@@ -5713,14 +5708,6 @@ static CONST_VTBL struct ID3D12QueryHeapVtbl d3d12_query_heap_vtbl =
     /* ID3D12DeviceChild methods */
     d3d12_query_heap_GetDevice,
 };
-
-struct d3d12_query_heap *unsafe_impl_from_ID3D12QueryHeap(ID3D12QueryHeap *iface)
-{
-    if (!iface)
-        return NULL;
-    assert(iface->lpVtbl == &d3d12_query_heap_vtbl);
-    return impl_from_ID3D12QueryHeap(iface);
-}
 
 HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_HEAP_DESC *desc,
         struct d3d12_query_heap **heap)

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5753,24 +5753,6 @@ struct d3d12_query_heap *unsafe_impl_from_ID3D12QueryHeap(ID3D12QueryHeap *iface
     return impl_from_ID3D12QueryHeap(iface);
 }
 
-size_t d3d12_query_heap_type_get_data_size(D3D12_QUERY_HEAP_TYPE heap_type)
-{
-    switch (heap_type)
-    {
-        case D3D12_QUERY_HEAP_TYPE_OCCLUSION:
-        case D3D12_QUERY_HEAP_TYPE_TIMESTAMP:
-        case D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP:
-            return sizeof(uint64_t);
-        case D3D12_QUERY_HEAP_TYPE_PIPELINE_STATISTICS:
-            return sizeof(D3D12_QUERY_DATA_PIPELINE_STATISTICS);
-        case D3D12_QUERY_HEAP_TYPE_SO_STATISTICS:
-            return sizeof(D3D12_QUERY_DATA_SO_STATISTICS);
-        default:
-            ERR("Unhandled query pool type %u.\n", heap_type);
-            return 0;
-    }
-}
-
 HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_HEAP_DESC *desc,
         struct d3d12_query_heap **heap)
 {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -1302,11 +1302,6 @@ static void d3d12_resource_set_name(struct d3d12_resource *resource, const char 
 }
 
 /* ID3D12Resource */
-static inline struct d3d12_resource *impl_from_ID3D12Resource(d3d12_resource_iface *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_resource, ID3D12Resource_iface);
-}
-
 static HRESULT STDMETHODCALLTYPE d3d12_resource_QueryInterface(d3d12_resource_iface *iface,
         REFIID riid, void **object)
 {
@@ -1332,7 +1327,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_QueryInterface(d3d12_resource_if
 
 static ULONG STDMETHODCALLTYPE d3d12_resource_AddRef(d3d12_resource_iface *iface)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
     ULONG refcount = InterlockedIncrement(&resource->refcount);
 
     TRACE("%p increasing refcount to %u.\n", resource, refcount);
@@ -1350,7 +1345,7 @@ static ULONG STDMETHODCALLTYPE d3d12_resource_AddRef(d3d12_resource_iface *iface
 
 static ULONG STDMETHODCALLTYPE d3d12_resource_Release(d3d12_resource_iface *iface)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
     ULONG refcount = InterlockedDecrement(&resource->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", resource, refcount);
@@ -1364,7 +1359,7 @@ static ULONG STDMETHODCALLTYPE d3d12_resource_Release(d3d12_resource_iface *ifac
 static HRESULT STDMETHODCALLTYPE d3d12_resource_GetPrivateData(d3d12_resource_iface *iface,
         REFGUID guid, UINT *data_size, void *data)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
 
     TRACE("iface %p, guid %s, data_size %p, data %p.\n", iface, debugstr_guid(guid), data_size, data);
 
@@ -1374,7 +1369,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_GetPrivateData(d3d12_resource_if
 static HRESULT STDMETHODCALLTYPE d3d12_resource_SetPrivateData(d3d12_resource_iface *iface,
         REFGUID guid, UINT data_size, const void *data)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
 
     TRACE("iface %p, guid %s, data_size %u, data %p.\n", iface, debugstr_guid(guid), data_size, data);
 
@@ -1385,7 +1380,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_SetPrivateData(d3d12_resource_if
 static HRESULT STDMETHODCALLTYPE d3d12_resource_SetPrivateDataInterface(d3d12_resource_iface *iface,
         REFGUID guid, const IUnknown *data)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
 
     TRACE("iface %p, guid %s, data %p.\n", iface, debugstr_guid(guid), data);
 
@@ -1395,7 +1390,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_SetPrivateDataInterface(d3d12_re
 
 static HRESULT STDMETHODCALLTYPE d3d12_resource_GetDevice(d3d12_resource_iface *iface, REFIID iid, void **device)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
 
     TRACE("iface %p, iid %s, device %p.\n", iface, debugstr_guid(iid), device);
 
@@ -1479,7 +1474,7 @@ static bool d3d12_resource_texture_validate_map(struct d3d12_resource *resource)
 static HRESULT STDMETHODCALLTYPE d3d12_resource_Map(d3d12_resource_iface *iface, UINT sub_resource,
         const D3D12_RANGE *read_range, void **data)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
     unsigned int sub_resource_count;
 
     TRACE("iface %p, sub_resource %u, read_range %p, data %p.\n",
@@ -1525,7 +1520,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_Map(d3d12_resource_iface *iface,
 static void STDMETHODCALLTYPE d3d12_resource_Unmap(d3d12_resource_iface *iface, UINT sub_resource,
         const D3D12_RANGE *written_range)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
     unsigned int sub_resource_count;
 
     TRACE("iface %p, sub_resource %u, written_range %p.\n",
@@ -1544,7 +1539,7 @@ static void STDMETHODCALLTYPE d3d12_resource_Unmap(d3d12_resource_iface *iface, 
 static D3D12_RESOURCE_DESC * STDMETHODCALLTYPE d3d12_resource_GetDesc(d3d12_resource_iface *iface,
         D3D12_RESOURCE_DESC *resource_desc)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
 
     TRACE("iface %p, resource_desc %p.\n", iface, resource_desc);
 
@@ -1554,7 +1549,7 @@ static D3D12_RESOURCE_DESC * STDMETHODCALLTYPE d3d12_resource_GetDesc(d3d12_reso
 
 static D3D12_GPU_VIRTUAL_ADDRESS STDMETHODCALLTYPE d3d12_resource_GetGPUVirtualAddress(d3d12_resource_iface *iface)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
 
     TRACE("iface %p.\n", iface);
 
@@ -1565,7 +1560,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_WriteToSubresource(d3d12_resourc
         UINT dst_sub_resource, const D3D12_BOX *dst_box, const void *src_data,
         UINT src_row_pitch, UINT src_slice_pitch)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
     const struct vkd3d_vk_device_procs *vk_procs;
     VkImageSubresource vk_sub_resource;
     VkSubresourceLayout vk_layout;
@@ -1644,7 +1639,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_ReadFromSubresource(d3d12_resour
         void *dst_data, UINT dst_row_pitch, UINT dst_slice_pitch,
         UINT src_sub_resource, const D3D12_BOX *src_box)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
     const struct vkd3d_vk_device_procs *vk_procs;
     VkImageSubresource vk_sub_resource;
     VkSubresourceLayout vk_layout;
@@ -1722,7 +1717,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_ReadFromSubresource(d3d12_resour
 static HRESULT STDMETHODCALLTYPE d3d12_resource_GetHeapProperties(d3d12_resource_iface *iface,
         D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS *flags)
 {
-    struct d3d12_resource *resource = impl_from_ID3D12Resource(iface);
+    struct d3d12_resource *resource = impl_from_ID3D12Resource1(iface);
 
     TRACE("iface %p, heap_properties %p, flags %p.\n",
             iface, heap_properties, flags);
@@ -1763,7 +1758,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_GetProtectedResourceSession(d3d1
     return E_NOTIMPL;
 }
 
-static CONST_VTBL struct ID3D12Resource1Vtbl d3d12_resource_vtbl =
+CONST_VTBL struct ID3D12Resource1Vtbl d3d12_resource_vtbl =
 {
     /* IUnknown methods */
     d3d12_resource_QueryInterface,
@@ -1787,19 +1782,6 @@ static CONST_VTBL struct ID3D12Resource1Vtbl d3d12_resource_vtbl =
     /* ID3D12Resource1 methods */
     d3d12_resource_GetProtectedResourceSession,
 };
-
-static struct d3d12_resource *unsafe_impl_from_ID3D12Resource1(ID3D12Resource1 *iface)
-{
-    if (!iface)
-        return NULL;
-    assert(iface->lpVtbl == &d3d12_resource_vtbl);
-    return impl_from_ID3D12Resource(iface);
-}
-
-struct d3d12_resource *unsafe_impl_from_ID3D12Resource(ID3D12Resource *iface)
-{
-    return unsafe_impl_from_ID3D12Resource1((ID3D12Resource1 *)iface);
-}
 
 VkImageAspectFlags vk_image_aspect_flags_from_d3d12(
         const struct vkd3d_format *format, uint32_t plane_idx)
@@ -2807,13 +2789,13 @@ VKD3D_EXPORT HRESULT vkd3d_create_image_resource(ID3D12Device *device,
 VKD3D_EXPORT ULONG vkd3d_resource_incref(ID3D12Resource *resource)
 {
     TRACE("resource %p.\n", resource);
-    return d3d12_resource_incref(unsafe_impl_from_ID3D12Resource(resource));
+    return d3d12_resource_incref(impl_from_ID3D12Resource(resource));
 }
 
 VKD3D_EXPORT ULONG vkd3d_resource_decref(ID3D12Resource *resource)
 {
     TRACE("resource %p.\n", resource);
-    return d3d12_resource_decref(unsafe_impl_from_ID3D12Resource(resource));
+    return d3d12_resource_decref(impl_from_ID3D12Resource(resource));
 }
 
 /* CBVs, SRVs, UAVs */

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4869,11 +4869,6 @@ void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_dev
 }
 
 /* ID3D12DescriptorHeap */
-static inline struct d3d12_descriptor_heap *impl_from_ID3D12DescriptorHeap(ID3D12DescriptorHeap *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_descriptor_heap, ID3D12DescriptorHeap_iface);
-}
-
 static HRESULT STDMETHODCALLTYPE d3d12_descriptor_heap_QueryInterface(ID3D12DescriptorHeap *iface,
         REFIID riid, void **object)
 {
@@ -5003,7 +4998,7 @@ static D3D12_GPU_DESCRIPTOR_HANDLE * STDMETHODCALLTYPE d3d12_descriptor_heap_Get
     return descriptor;
 }
 
-static CONST_VTBL struct ID3D12DescriptorHeapVtbl d3d12_descriptor_heap_vtbl =
+CONST_VTBL struct ID3D12DescriptorHeapVtbl d3d12_descriptor_heap_vtbl =
 {
     /* IUnknown methods */
     d3d12_descriptor_heap_QueryInterface,
@@ -5021,14 +5016,6 @@ static CONST_VTBL struct ID3D12DescriptorHeapVtbl d3d12_descriptor_heap_vtbl =
     d3d12_descriptor_heap_GetCPUDescriptorHandleForHeapStart,
     d3d12_descriptor_heap_GetGPUDescriptorHandleForHeapStart,
 };
-
-struct d3d12_descriptor_heap *unsafe_impl_from_ID3D12DescriptorHeap(ID3D12DescriptorHeap *iface)
-{
-    if (!iface)
-        return NULL;
-    assert(iface->lpVtbl == &d3d12_descriptor_heap_vtbl);
-    return impl_from_ID3D12DescriptorHeap(iface);
-}
 
 static HRESULT d3d12_descriptor_heap_create_descriptor_pool(struct d3d12_descriptor_heap *descriptor_heap,
         VkDescriptorPool *vk_descriptor_pool)

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1843,11 +1843,6 @@ struct vkd3d_compiled_pipeline
 };
 
 /* ID3D12PipelineState */
-static inline struct d3d12_pipeline_state *impl_from_ID3D12PipelineState(ID3D12PipelineState *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_pipeline_state, ID3D12PipelineState_iface);
-}
-
 static HRESULT STDMETHODCALLTYPE d3d12_pipeline_state_QueryInterface(ID3D12PipelineState *iface,
         REFIID riid, void **object)
 {
@@ -2021,7 +2016,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_pipeline_state_GetCachedBlob(ID3D12Pipeli
     return S_OK;
 }
 
-static CONST_VTBL struct ID3D12PipelineStateVtbl d3d12_pipeline_state_vtbl =
+CONST_VTBL struct ID3D12PipelineStateVtbl d3d12_pipeline_state_vtbl =
 {
     /* IUnknown methods */
     d3d12_pipeline_state_QueryInterface,
@@ -2037,14 +2032,6 @@ static CONST_VTBL struct ID3D12PipelineStateVtbl d3d12_pipeline_state_vtbl =
     /* ID3D12PipelineState methods */
     d3d12_pipeline_state_GetCachedBlob,
 };
-
-struct d3d12_pipeline_state *unsafe_impl_from_ID3D12PipelineState(ID3D12PipelineState *iface)
-{
-    if (!iface)
-        return NULL;
-    assert(iface->lpVtbl == &d3d12_pipeline_state_vtbl);
-    return impl_from_ID3D12PipelineState(iface);
-}
 
 static HRESULT create_shader_stage(struct d3d12_device *device,
         VkPipelineShaderStageCreateInfo *stage_desc, VkShaderStageFlagBits stage,

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -25,11 +25,6 @@
 #include <stdio.h>
 
 /* ID3D12RootSignature */
-static inline struct d3d12_root_signature *impl_from_ID3D12RootSignature(ID3D12RootSignature *iface)
-{
-    return CONTAINING_RECORD(iface, struct d3d12_root_signature, ID3D12RootSignature_iface);
-}
-
 static HRESULT STDMETHODCALLTYPE d3d12_root_signature_QueryInterface(ID3D12RootSignature *iface,
         REFIID riid, void **object)
 {
@@ -142,7 +137,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_root_signature_GetDevice(ID3D12RootSignat
     return d3d12_device_query_interface(root_signature->device, iid, device);
 }
 
-static CONST_VTBL struct ID3D12RootSignatureVtbl d3d12_root_signature_vtbl =
+CONST_VTBL struct ID3D12RootSignatureVtbl d3d12_root_signature_vtbl =
 {
     /* IUnknown methods */
     d3d12_root_signature_QueryInterface,
@@ -156,14 +151,6 @@ static CONST_VTBL struct ID3D12RootSignatureVtbl d3d12_root_signature_vtbl =
     /* ID3D12DeviceChild methods */
     d3d12_root_signature_GetDevice,
 };
-
-struct d3d12_root_signature *unsafe_impl_from_ID3D12RootSignature(ID3D12RootSignature *iface)
-{
-    if (!iface)
-        return NULL;
-    assert(iface->lpVtbl == &d3d12_root_signature_vtbl);
-    return impl_from_ID3D12RootSignature(iface);
-}
 
 static VkShaderStageFlags stage_flags_from_visibility(D3D12_SHADER_VISIBILITY visibility)
 {
@@ -2206,9 +2193,9 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     state->refcount = 1;
 
     if (desc->root_signature)
-        root_signature = unsafe_impl_from_ID3D12RootSignature(desc->root_signature);
+        root_signature = impl_from_ID3D12RootSignature(desc->root_signature);
     else
-        root_signature = unsafe_impl_from_ID3D12RootSignature(state->private_root_signature);
+        root_signature = impl_from_ID3D12RootSignature(state->private_root_signature);
 
     shader_interface.flags = d3d12_root_signature_get_shader_interface_flags(root_signature);
     shader_interface.min_ssbo_alignment = d3d12_device_get_ssbo_alignment(device);
@@ -3034,9 +3021,9 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     }
 
     if (desc->root_signature)
-        root_signature = unsafe_impl_from_ID3D12RootSignature(desc->root_signature);
+        root_signature = impl_from_ID3D12RootSignature(desc->root_signature);
     else
-        root_signature = unsafe_impl_from_ID3D12RootSignature(state->private_root_signature);
+        root_signature = impl_from_ID3D12RootSignature(state->private_root_signature);
 
     sample_count = vk_samples_from_dxgi_sample_desc(&desc->sample_desc);
     if (desc->sample_desc.Count != 1 && desc->sample_desc.Quality)

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -1967,7 +1967,7 @@ static HRESULT d3d12_swapchain_present(struct d3d12_swapchain *swapchain,
         return hr;
     }
 
-    if (FAILED(hr = d3d12_fence_set_event_on_completion(unsafe_impl_from_ID3D12Fence(swapchain->frame_latency_fence),
+    if (FAILED(hr = d3d12_fence_set_event_on_completion(impl_from_ID3D12Fence(swapchain->frame_latency_fence),
             swapchain->frame_number, swapchain->frame_latency_event, VKD3D_WAITING_EVENT_TYPE_SEMAPHORE)))
     {
         ERR("Failed to enqueue frame latency event, hr %#x.\n", hr);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1344,7 +1344,16 @@ struct d3d12_root_signature
 
 HRESULT d3d12_root_signature_create(struct d3d12_device *device, const void *bytecode,
         size_t bytecode_length, struct d3d12_root_signature **root_signature);
-struct d3d12_root_signature *unsafe_impl_from_ID3D12RootSignature(ID3D12RootSignature *iface);
+
+static inline struct d3d12_root_signature *impl_from_ID3D12RootSignature(ID3D12RootSignature *iface)
+{
+    extern CONST_VTBL struct ID3D12RootSignatureVtbl d3d12_root_signature_vtbl;
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_root_signature_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_root_signature, ID3D12RootSignature_iface);
+}
+
 unsigned int d3d12_root_signature_get_shader_interface_flags(const struct d3d12_root_signature *root_signature);
 
 int vkd3d_parse_root_signature_v_1_0(const struct vkd3d_shader_code *dxbc,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2169,7 +2169,15 @@ struct d3d12_command_signature
 
 HRESULT d3d12_command_signature_create(struct d3d12_device *device, const D3D12_COMMAND_SIGNATURE_DESC *desc,
         struct d3d12_command_signature **signature);
-struct d3d12_command_signature *unsafe_impl_from_ID3D12CommandSignature(ID3D12CommandSignature *iface);
+
+static inline struct d3d12_command_signature *impl_from_ID3D12CommandSignature(ID3D12CommandSignature *iface)
+{
+    extern CONST_VTBL struct ID3D12CommandSignatureVtbl d3d12_command_signature_vtbl;
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_command_signature_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_command_signature, ID3D12CommandSignature_iface);
+}
 
 /* Static samplers */
 struct vkd3d_sampler_state

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -572,8 +572,20 @@ struct d3d12_fence
     struct vkd3d_private_store private_store;
 };
 
-struct d3d12_fence *unsafe_impl_from_ID3D12Fence1(ID3D12Fence1 *iface);
-struct d3d12_fence *unsafe_impl_from_ID3D12Fence(ID3D12Fence *iface);
+static inline struct d3d12_fence *impl_from_ID3D12Fence1(ID3D12Fence1 *iface)
+{
+    extern CONST_VTBL struct ID3D12Fence1Vtbl d3d12_fence_vtbl;
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_fence_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_fence, ID3D12Fence_iface);
+}
+
+static inline struct d3d12_fence *impl_from_ID3D12Fence(ID3D12Fence *iface)
+{
+    return impl_from_ID3D12Fence1((ID3D12Fence1 *)iface);
+}
+
 HRESULT d3d12_fence_create(struct d3d12_device *device,
         uint64_t initial_value, D3D12_FENCE_FLAGS flags, struct d3d12_fence **fence);
 HRESULT d3d12_fence_set_event_on_completion(struct d3d12_fence *fence,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2993,7 +2993,11 @@ struct d3d12_state_object
 
 HRESULT d3d12_state_object_create(struct d3d12_device *device, const D3D12_STATE_OBJECT_DESC *desc,
         struct d3d12_state_object **object);
-struct d3d12_state_object *impl_from_ID3D12StateObject(ID3D12StateObject *iface);
+
+static inline struct d3d12_state_object *impl_from_ID3D12StateObject(ID3D12StateObject *iface)
+{
+    return CONTAINING_RECORD(iface, struct d3d12_state_object, ID3D12StateObject_iface);
+}
 
 /* utils */
 enum vkd3d_format_type

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -914,7 +914,20 @@ HRESULT d3d12_resource_create_placed(struct d3d12_device *device, const D3D12_RE
 HRESULT d3d12_resource_create_reserved(struct d3d12_device *device,
         const D3D12_RESOURCE_DESC *desc, D3D12_RESOURCE_STATES initial_state,
         const D3D12_CLEAR_VALUE *optimized_clear_value, struct d3d12_resource **resource);
-struct d3d12_resource *unsafe_impl_from_ID3D12Resource(ID3D12Resource *iface);
+
+static inline struct d3d12_resource *impl_from_ID3D12Resource1(ID3D12Resource1 *iface)
+{
+    extern CONST_VTBL struct ID3D12Resource1Vtbl d3d12_resource_vtbl;
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_resource_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_resource, ID3D12Resource_iface);
+}
+
+static inline struct d3d12_resource *impl_from_ID3D12Resource(ID3D12Resource *iface)
+{
+    return impl_from_ID3D12Resource1((ID3D12Resource1 *)iface);
+}
 
 HRESULT vkd3d_allocate_device_memory(struct d3d12_device *device,
         VkDeviceSize size, VkMemoryPropertyFlags type_flags, uint32_t type_mask,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1576,7 +1576,15 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
         const struct vkd3d_pipeline_key *key, const struct vkd3d_format *dsv_format, VkPipelineCache vk_cache,
         struct vkd3d_render_pass_compatibility *render_pass_compat,
         uint32_t *dynamic_state_flags, uint32_t variant_flags);
-struct d3d12_pipeline_state *unsafe_impl_from_ID3D12PipelineState(ID3D12PipelineState *iface);
+
+static inline struct d3d12_pipeline_state *impl_from_ID3D12PipelineState(ID3D12PipelineState *iface)
+{
+    extern CONST_VTBL struct ID3D12PipelineStateVtbl d3d12_pipeline_state_vtbl;
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_pipeline_state_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_pipeline_state, ID3D12PipelineState_iface);
+}
 
 /* ID3D12PipelineLibrary */
 typedef ID3D12PipelineLibrary1 d3d12_pipeline_library_iface;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -760,7 +760,20 @@ struct d3d12_heap
 
 HRESULT d3d12_heap_create(struct d3d12_device *device, const D3D12_HEAP_DESC *desc,
         void *host_address, struct d3d12_heap **heap);
-struct d3d12_heap *unsafe_impl_from_ID3D12Heap(ID3D12Heap *iface);
+
+static inline struct d3d12_heap *impl_from_ID3D12Heap1(ID3D12Heap1 *iface)
+{
+    extern CONST_VTBL struct ID3D12Heap1Vtbl d3d12_heap_vtbl;
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_heap_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_heap, ID3D12Heap_iface);
+}
+
+static inline struct d3d12_heap *impl_from_ID3D12Heap(ID3D12Heap *iface)
+{
+    return impl_from_ID3D12Heap1((ID3D12Heap1 *)iface);
+}
 
 enum vkd3d_resource_flag
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1223,7 +1223,15 @@ struct d3d12_query_heap
 
 HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_HEAP_DESC *desc,
         struct d3d12_query_heap **heap);
-struct d3d12_query_heap *unsafe_impl_from_ID3D12QueryHeap(ID3D12QueryHeap *iface);
+
+static inline struct d3d12_query_heap *impl_from_ID3D12QueryHeap(ID3D12QueryHeap *iface)
+{
+    extern CONST_VTBL struct ID3D12QueryHeapVtbl d3d12_query_heap_vtbl;
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_query_heap_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_query_heap, ID3D12QueryHeap_iface);
+}
 
 static inline size_t d3d12_query_heap_type_get_data_size(D3D12_QUERY_HEAP_TYPE heap_type)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1184,7 +1184,15 @@ struct d3d12_descriptor_heap
 HRESULT d3d12_descriptor_heap_create(struct d3d12_device *device,
         const D3D12_DESCRIPTOR_HEAP_DESC *desc, struct d3d12_descriptor_heap **descriptor_heap);
 void d3d12_descriptor_heap_cleanup(struct d3d12_descriptor_heap *descriptor_heap);
-struct d3d12_descriptor_heap *unsafe_impl_from_ID3D12DescriptorHeap(ID3D12DescriptorHeap *iface);
+
+static inline struct d3d12_descriptor_heap *impl_from_ID3D12DescriptorHeap(ID3D12DescriptorHeap *iface)
+{
+    extern CONST_VTBL struct ID3D12DescriptorHeapVtbl d3d12_descriptor_heap_vtbl;
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_descriptor_heap_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_descriptor_heap, ID3D12DescriptorHeap_iface);
+}
 
 static inline uint32_t d3d12_desc_heap_offset(const struct d3d12_desc *dst)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1178,7 +1178,24 @@ struct d3d12_query_heap
 HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_HEAP_DESC *desc,
         struct d3d12_query_heap **heap);
 struct d3d12_query_heap *unsafe_impl_from_ID3D12QueryHeap(ID3D12QueryHeap *iface);
-size_t d3d12_query_heap_type_get_data_size(D3D12_QUERY_HEAP_TYPE heap_type);
+
+static inline size_t d3d12_query_heap_type_get_data_size(D3D12_QUERY_HEAP_TYPE heap_type)
+{
+    switch (heap_type)
+    {
+        case D3D12_QUERY_HEAP_TYPE_OCCLUSION:
+        case D3D12_QUERY_HEAP_TYPE_TIMESTAMP:
+        case D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP:
+            return sizeof(uint64_t);
+        case D3D12_QUERY_HEAP_TYPE_PIPELINE_STATISTICS:
+            return sizeof(D3D12_QUERY_DATA_PIPELINE_STATISTICS);
+        case D3D12_QUERY_HEAP_TYPE_SO_STATISTICS:
+            return sizeof(D3D12_QUERY_DATA_SO_STATISTICS);
+        default:
+            ERR("Unhandled query pool type %u.\n", heap_type);
+            return 0;
+    }
+}
 
 static inline bool d3d12_query_heap_type_is_inline(D3D12_QUERY_HEAP_TYPE heap_type)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2813,7 +2813,26 @@ void d3d12_device_unmap_vkd3d_queue(struct d3d12_device *device,
 bool d3d12_device_is_uma(struct d3d12_device *device, bool *coherent);
 void d3d12_device_mark_as_removed(struct d3d12_device *device, HRESULT reason,
         const char *message, ...) VKD3D_PRINTF_FUNC(3, 4);
-struct d3d12_device *unsafe_impl_from_ID3D12Device(d3d12_device_iface *iface);
+
+static inline struct d3d12_device *impl_from_ID3D12Device(d3d12_device_iface *iface)
+{
+    extern CONST_VTBL struct ID3D12Device6Vtbl d3d12_device_vtbl;
+#ifdef VKD3D_ENABLE_PROFILING
+    extern CONST_VTBL struct ID3D12Device6Vtbl d3d12_device_vtbl_profiled;
+#endif
+    if (!iface)
+        return NULL;
+
+#ifdef VKD3D_ENABLE_PROFILING
+    assert(iface->lpVtbl == &d3d12_device_vtbl ||
+           iface->lpVtbl == &d3d12_device_vtbl_profiled);
+#else
+    assert(iface->lpVtbl == &d3d12_device_vtbl);
+#endif
+
+    return CONTAINING_RECORD(iface, struct d3d12_device, ID3D12Device_iface);
+}
+
 bool d3d12_device_validate_shader_meta(struct d3d12_device *device, const struct vkd3d_shader_meta *meta);
 
 HRESULT d3d12_device_get_scratch_buffer(struct d3d12_device *device, VkDeviceSize min_size, struct vkd3d_scratch_buffer *scratch);


### PR DESCRIPTION
 - Move `impl_from`s into the header.
   - Previously we were doing function calls for every single object cast from another compilation unit which is... no.
   - Initial thoughts are that it's gross to require vtable exposed everywhere for the asserts, but C++ requires that for dynamic_cast so, meh.
 - Remove `unsafe_impl_from`s. These can just be the normal one and the checks get optimized away now. (yay)
 - Optimization for calling ResolveQueryData with zero queries.
 - Moved `d3d12_query_heap_type_get_data_size` to header.