### PR TITLE
vkd3d: Fix test suite regression on NV.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -6172,11 +6172,12 @@ HRESULT vkd3d_memory_info_init(struct vkd3d_memory_info *info,
     info->cpu_accessible_domain.sampled_type_mask = sampled_type_mask_cpu & host_visible_mask;
     info->cpu_accessible_domain.rt_ds_type_mask = rt_ds_type_mask_cpu & host_visible_mask;
 
-    if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_IGNORE_RTV_HOST_VISIBLE)
-    {
-        /* Ignore any requirements for color attachments since we're never going to use it. */
+    /* If we cannot support linear render targets, this is fine.
+     * If we don't fix this up here, we will fail to create a host visible TIER_2 heap.
+     * Ignore any requirements for color attachments since we're never going to use it anyways. */
+    if (info->cpu_accessible_domain.rt_ds_type_mask == 0 ||
+            (vkd3d_config_flags & VKD3D_CONFIG_FLAG_IGNORE_RTV_HOST_VISIBLE))
         info->cpu_accessible_domain.rt_ds_type_mask = info->cpu_accessible_domain.sampled_type_mask;
-    }
 
     TRACE("Device supports buffers on memory types 0x%#x.\n", buffer_type_mask);
     TRACE("Device supports textures on memory types 0x%#x.\n", sampled_type_mask);


### PR DESCRIPTION
Fix failure in test_create_heap where a TIER_2 host visible heap was
attempted, but failed due to recent DEATHLOOP fixes.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>