### PR TITLE
Fix unbound RTV rendering scenarios

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -325,6 +325,7 @@ enum vkd3d_render_pass_key_flag
 struct vkd3d_render_pass_key
 {
     uint32_t attachment_count;
+    uint32_t rtv_active_mask;
     uint32_t flags; /* vkd3d_render_pass_key_flag */
     uint32_t sample_count;
     VkFormat vk_formats[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT + 1];
@@ -1436,6 +1437,7 @@ struct d3d12_graphics_pipeline_state
     VkPipelineColorBlendAttachmentState blend_attachments[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
     unsigned int rt_count;
     unsigned int null_attachment_mask;
+    unsigned int rtv_active_mask;
     unsigned int patch_vertex_count;
     const struct vkd3d_format *dsv_format;
     VkFormat rtv_formats[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
@@ -1554,6 +1556,7 @@ struct vkd3d_pipeline_key
     D3D12_PRIMITIVE_TOPOLOGY topology;
     uint32_t viewport_count;
     uint32_t strides[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
+    uint32_t rtv_active_mask;
     VkFormat dsv_format;
 
     bool dynamic_stride;
@@ -1565,11 +1568,13 @@ bool d3d12_pipeline_state_has_replaced_shaders(struct d3d12_pipeline_state *stat
 HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindPoint bind_point,
         const struct d3d12_pipeline_state_desc *desc, struct d3d12_pipeline_state **state);
 VkPipeline d3d12_pipeline_state_get_or_create_pipeline(struct d3d12_pipeline_state *state,
-        const struct vkd3d_dynamic_state *dyn_state, const struct vkd3d_format *dsv_format,
+        const struct vkd3d_dynamic_state *dyn_state,
+        uint32_t rtv_nonnull_mask, const struct vkd3d_format *dsv_format,
         const struct vkd3d_render_pass_compatibility **render_pass_compat,
         uint32_t *dynamic_state_flags, uint32_t variant_flags);
 VkPipeline d3d12_pipeline_state_get_pipeline(struct d3d12_pipeline_state *state,
-        const struct vkd3d_dynamic_state *dyn_state, const struct vkd3d_format *dsv_format,
+        const struct vkd3d_dynamic_state *dyn_state,
+        uint32_t rtv_nonnull_mask, const struct vkd3d_format *dsv_format,
         const struct vkd3d_render_pass_compatibility **render_pass_compat,
         uint32_t *dynamic_state_flags, uint32_t variant_flags);
 VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_state *state,
@@ -1872,6 +1877,7 @@ struct d3d12_command_list
 
     struct d3d12_rtv_desc rtvs[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
     struct d3d12_rtv_desc dsv;
+    uint32_t rtv_nonnull_mask;
     uint32_t dsv_plane_optimal_mask;
     VkImageLayout dsv_layout;
     unsigned int fb_width;

--- a/tests/d3d12_descriptors.c
+++ b/tests/d3d12_descriptors.c
@@ -3400,6 +3400,7 @@ void test_null_rtv(void)
     /* Attempting to clear a NULL RTV crashes on native D3D12, so try to draw something instead */
     ID3D12GraphicsCommandList_SetGraphicsRootSignature(command_list, context.root_signature);
     ID3D12GraphicsCommandList_SetPipelineState(command_list, context.pipeline_state);
+    ID3D12GraphicsCommandList_IASetPrimitiveTopology(command_list, D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
     ID3D12GraphicsCommandList_DrawInstanced(command_list, 3, 1, 0, 0);
 
     transition_sub_resource_state(command_list, context.render_target, 0,

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -278,3 +278,4 @@ decl_test(test_read_write_subresource_2d);
 decl_test(test_read_subresource_rt);
 decl_test(test_integer_blending_pipeline_state);
 decl_test(test_discard_resource_uav);
+decl_test(test_unbound_rtv_rendering);


### PR DESCRIPTION
In DIRT5, the game attempts to rendering to RTV1, but RTV 1 is unbound. Based on testing on native drivers, this is supposed to work with no validation errors. The fix is to introduce fallback pipeline checks somewhat similar to DSV unknown tests, except this is in reverse. Rendering to NULL DSV is actually disallowed, but NULL RTV is allowed ... *shrug*