### PR TITLE
Allow DiscardResource on UAVs

### DIFF
--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -277,3 +277,4 @@ decl_test(test_map_texture_validation);
 decl_test(test_read_write_subresource_2d);
 decl_test(test_read_subresource_rt);
 decl_test(test_integer_blending_pipeline_state);
+decl_test(test_discard_resource_uav);


### PR DESCRIPTION
Also refactor discards so that a complete discard does one barrier instead of one per subresource.