### PR TITLE
Add a generic set of UE4 quirks

### DIFF
--- a/include/private/vkd3d_string.h
+++ b/include/private/vkd3d_string.h
@@ -47,4 +47,35 @@ static inline bool vkd3d_string_ends_with(const char *str, const char *ending)
     return vkd3d_string_ends_with_n(str, strlen(str), ending, strlen(ending));
 }
 
+enum vkd3d_string_compare_mode
+{
+    VKD3D_STRING_COMPARE_NEVER,
+    VKD3D_STRING_COMPARE_ALWAYS,
+    VKD3D_STRING_COMPARE_EXACT,
+    VKD3D_STRING_COMPARE_STARTS_WITH,
+    VKD3D_STRING_COMPARE_ENDS_WITH,
+    VKD3D_STRING_COMPARE_CONTAINS,
+};
+
+static inline bool vkd3d_string_compare(enum vkd3d_string_compare_mode mode, const char *string, const char *comparator)
+{
+    switch (mode)
+    {
+        default:
+        case VKD3D_STRING_COMPARE_NEVER:
+            return false;
+        case VKD3D_STRING_COMPARE_ALWAYS:
+            return true;
+        case VKD3D_STRING_COMPARE_EXACT:
+            return !strcmp(string, comparator);
+        case VKD3D_STRING_COMPARE_STARTS_WITH:
+            return !strncmp(string, comparator, strlen(comparator));
+        case VKD3D_STRING_COMPARE_ENDS_WITH:
+            return vkd3d_string_ends_with(string, comparator);
+        case VKD3D_STRING_COMPARE_CONTAINS:
+            return strstr(string, comparator) != NULL;
+    }
+}
+
+
 #endif /* __VKD3D_STRING_H */

--- a/include/private/vkd3d_string.h
+++ b/include/private/vkd3d_string.h
@@ -37,4 +37,14 @@ char *vkd3d_strdup_n(const char *str, size_t n);
 WCHAR *vkd3d_wstrdup(const WCHAR *str);
 WCHAR *vkd3d_wstrdup_n(const WCHAR *str, size_t n);
 
+static inline bool vkd3d_string_ends_with_n(const char *str, size_t str_len, const char *ending, size_t ending_len)
+{
+    return str_len >= ending_len && !strncmp(str + (str_len - ending_len), ending, ending_len);
+}
+
+static inline bool vkd3d_string_ends_with(const char *str, const char *ending)
+{
+    return vkd3d_string_ends_with_n(str, strlen(str), ending, strlen(ending));
+}
+
 #endif /* __VKD3D_STRING_H */

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -427,6 +427,7 @@ static const struct vkd3d_instance_application_meta application_override[] = {
 
 struct vkd3d_shader_quirk_meta
 {
+    enum vkd3d_string_compare_mode mode;
     const char *name;
     const struct vkd3d_shader_quirk_info *info;
 };
@@ -453,11 +454,11 @@ static const struct vkd3d_shader_quirk_info f1_2020_quirks = {
 
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* Psychonauts 2 (607080) */
-    { "Psychonauts2-Win64-Shipping.exe", &psychonauts2_quirks },
+    { VKD3D_STRING_COMPARE_EXACT, "Psychonauts2-Win64-Shipping.exe", &psychonauts2_quirks },
     /* Necromunda: Hired Gun (1222370) */
-    { "Necromunda-Win64-Shipping.exe", &necromunda_quirks },
+    { VKD3D_STRING_COMPARE_EXACT, "Necromunda-Win64-Shipping.exe", &necromunda_quirks },
     /* F1 2020 (1080110) */
-    { "F1_2020_dx12.exe", &f1_2020_quirks },
+    { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2020_quirks },
 };
 
 static void vkd3d_instance_apply_application_workarounds(void)
@@ -481,7 +482,7 @@ static void vkd3d_instance_apply_application_workarounds(void)
 
     for (i = 0; i < ARRAY_SIZE(application_shader_quirks); i++)
     {
-        if (application_shader_quirks[i].name && !strcmp(app, application_shader_quirks[i].name))
+        if (vkd3d_string_compare(application_shader_quirks[i].mode, app, application_shader_quirks[i].name))
         {
             vkd3d_shader_quirk_info = application_shader_quirks[i].info;
             INFO("Detected game %s, adding shader quirks for specific shaders.\n", app);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -459,6 +459,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "Necromunda-Win64-Shipping.exe", &necromunda_quirks },
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2020_quirks },
+    /* MSVC fails to compile empty array. */
+    { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };
 
 static void vkd3d_instance_apply_application_workarounds(void)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -413,15 +413,16 @@ const struct vkd3d_shader_quirk_info *vkd3d_shader_quirk_info;
 
 struct vkd3d_instance_application_meta
 {
+    enum vkd3d_string_compare_mode mode;
     const char *name;
     uint64_t global_flags_add;
     uint64_t global_flags_remove;
 };
 static const struct vkd3d_instance_application_meta application_override[] = {
     /* MSVC fails to compile empty array. */
-    { "GravityMark.exe", VKD3D_CONFIG_FLAG_FORCE_MINIMUM_SUBGROUP_SIZE, 0 },
-    { "Deathloop.exe", VKD3D_CONFIG_FLAG_IGNORE_RTV_HOST_VISIBLE, 0 },
-    { NULL, 0, 0 }
+    { VKD3D_STRING_COMPARE_EXACT, "GravityMark.exe", VKD3D_CONFIG_FLAG_FORCE_MINIMUM_SUBGROUP_SIZE, 0 },
+    { VKD3D_STRING_COMPARE_EXACT, "Deathloop.exe", VKD3D_CONFIG_FLAG_IGNORE_RTV_HOST_VISIBLE, 0 },
+    { VKD3D_STRING_COMPARE_NEVER, NULL, 0, 0 }
 };
 
 struct vkd3d_shader_quirk_meta
@@ -468,7 +469,7 @@ static void vkd3d_instance_apply_application_workarounds(void)
 
     for (i = 0; i < ARRAY_SIZE(application_override); i++)
     {
-        if (application_override[i].name && !strcmp(app, application_override[i].name))
+        if (vkd3d_string_compare(application_override[i].mode, app, application_override[i].name))
         {
             vkd3d_config_flags |= application_override[i].global_flags_add;
             vkd3d_config_flags &= ~application_override[i].global_flags_remove;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -432,20 +432,13 @@ struct vkd3d_shader_quirk_meta
     const struct vkd3d_shader_quirk_info *info;
 };
 
-static const struct vkd3d_shader_quirk_hash psychonauts2_hashes[] = {
+static const struct vkd3d_shader_quirk_hash ue4_hashes[] = {
     { 0x08a323ee81c1e393ull, VKD3D_SHADER_QUIRK_FORCE_EXPLICIT_LOD_IN_CONTROL_FLOW },
-};
-
-static const struct vkd3d_shader_quirk_info psychonauts2_quirks = {
-    psychonauts2_hashes, ARRAY_SIZE(psychonauts2_hashes), 0,
-};
-
-static const struct vkd3d_shader_quirk_hash necromunda_hashes[] = {
     { 0x75dcbd76ee898815ull, VKD3D_SHADER_QUIRK_FORCE_EXPLICIT_LOD_IN_CONTROL_FLOW },
 };
 
-static const struct vkd3d_shader_quirk_info necromunda_quirks = {
-    necromunda_hashes, ARRAY_SIZE(necromunda_hashes), 0,
+static const struct vkd3d_shader_quirk_info ue4_quirks = {
+    ue4_hashes, ARRAY_SIZE(ue4_hashes), 0,
 };
 
 static const struct vkd3d_shader_quirk_info f1_2020_quirks = {
@@ -453,10 +446,8 @@ static const struct vkd3d_shader_quirk_info f1_2020_quirks = {
 };
 
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
-    /* Psychonauts 2 (607080) */
-    { VKD3D_STRING_COMPARE_EXACT, "Psychonauts2-Win64-Shipping.exe", &psychonauts2_quirks },
-    /* Necromunda: Hired Gun (1222370) */
-    { VKD3D_STRING_COMPARE_EXACT, "Necromunda-Win64-Shipping.exe", &necromunda_quirks },
+    /* Unreal Engine 4 */
+    { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2020_quirks },
     /* MSVC fails to compile empty array. */


### PR DESCRIPTION
I encountered another game, Bus Simulator 22, which has the same broken shader as Necromunda, including the same hash.

Looks like a bunch of UE4 games are affected, so check if the exe name ends in `-Shipping.exe` and apply these quirks for these shader hashes going forward.

I reeeeally would have liked to have done a regex here, but it looks like there's nothing nice and portable in the std and pulling in some external dependency is kinda gross, there is this which was licensed nice and is small however https://github.com/kokke/tiny-regex-c if we want to consider it.

Fixes Bus Simulator 22