### PR TITLE
renderdoc: Add global capture support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ pass `-Denable_renderdoc=true` to Meson.
  vkd3d-proton will automatically make a capture when a specific shader is encountered.
  - `VKD3D_AUTO_CAPTURE_COUNTS` - A comma-separated list of indices. This can be used to control which queue submissions to capture.
  E.g., use `VKD3D_AUTO_CAPTURE_COUNTS=0,4,10` to capture the 0th (first submission), 4th and 10th submissions which are candidates for capturing.
+ If `VKD3D_AUTO_CAPTURE_COUNTS` is `-1`, the entire app runtime can be turned into one big capture.
+ This is only intended to be used when capturing something like the test suite,
+ or tiny applications with a finite runtime to make it easier to debug cross submission work.
 
  If only `VKD3D_AUTO_CAPTURE_COUNTS` is set, any queue submission is considered for capturing.
  If only `VKD3D_AUTO_CAPTURE_SHADER` is set, `VKD3D_AUTO_CAPTURE_COUNTS` is considered to be equal to `"0"`, i.e. a capture is only

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2539,6 +2539,12 @@ static void d3d12_device_destroy(struct d3d12_device *device)
     vkd3d_memory_allocator_cleanup(&device->memory_allocator, device);
     /* Tear down descriptor global info late, so we catch last minute faults after we drain the queues. */
     vkd3d_descriptor_debug_free_global_info(device->descriptor_qa_global_info, device);
+
+#ifdef VKD3D_ENABLE_RENDERDOC
+    if (vkd3d_renderdoc_active() && vkd3d_renderdoc_global_capture_enabled())
+        vkd3d_renderdoc_end_capture(device->vkd3d_instance->vk_instance);
+#endif
+
     VK_CALL(vkDestroyDevice(device->vk_device, NULL));
     pthread_mutex_destroy(&device->mutex);
     if (device->parent)
@@ -5243,6 +5249,12 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
         IUnknown_AddRef(device->parent);
 
     d3d12_device_caps_init(device);
+
+#ifdef VKD3D_ENABLE_RENDERDOC
+    if (vkd3d_renderdoc_active() && vkd3d_renderdoc_global_capture_enabled())
+        vkd3d_renderdoc_begin_capture(device->vkd3d_instance->vk_instance);
+#endif
+
     return S_OK;
 
 out_cleanup_global_pipeline_cache:

--- a/libs/vkd3d/vkd3d_renderdoc.h
+++ b/libs/vkd3d/vkd3d_renderdoc.h
@@ -26,6 +26,7 @@
 bool vkd3d_renderdoc_active(void);
 bool vkd3d_renderdoc_loaded_api(void);
 bool vkd3d_renderdoc_should_capture_shader_hash(vkd3d_shader_hash_t hash);
+bool vkd3d_renderdoc_global_capture_enabled(void);
 
 bool vkd3d_renderdoc_begin_capture(void *instance);
 void vkd3d_renderdoc_end_capture(void *instance);


### PR DESCRIPTION
Useful for test suite since a test can be comprised of several smaller
submissions, and it's easier to debug if we have one trace.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>