### PR TITLE
Hexadecimal floating constants require an exponent

### DIFF
--- a/vkd3d_build.h.in
+++ b/vkd3d_build.h.in
@@ -1,3 +1,3 @@
 #include <stdint.h>
 
-static const uint64_t vkd3d_build = 0x@VCS_TAG@p0;
+static const uint64_t vkd3d_build = @VCS_TAG@;


### PR DESCRIPTION
I build vkd3d yesterday without this change, but today I had to add this.