### PR TITLE
d3d12: export fixes

### DIFF
--- a/libs/d3d12/d3d12.def
+++ b/libs/d3d12/d3d12.def
@@ -3,9 +3,9 @@ LIBRARY d3d12.dll
 EXPORTS
     D3D12CreateDevice @101
     D3D12GetDebugInterface @102
-    D3D12CreateRootSignatureDeserializer @107
-    D3D12CreateVersionedRootSignatureDeserializer @108
+    D3D12CreateRootSignatureDeserializer
+    D3D12CreateVersionedRootSignatureDeserializer
 
-    D3D12EnableExperimentalFeatures @110
-    D3D12SerializeRootSignature @115
-    D3D12SerializeVersionedRootSignature @116
+    D3D12EnableExperimentalFeatures
+    D3D12SerializeRootSignature
+    D3D12SerializeVersionedRootSignature

--- a/libs/vkd3d-utils/vkd3d-proton-utils.def
+++ b/libs/vkd3d-utils/vkd3d-proton-utils.def
@@ -3,12 +3,12 @@ LIBRARY vkd3d-proton-utils-3.dll
 EXPORTS
     D3D12CreateDevice @101
     D3D12GetDebugInterface @102
-    D3D12CreateRootSignatureDeserializer @107
-    D3D12CreateVersionedRootSignatureDeserializer @108
+    D3D12CreateRootSignatureDeserializer
+    D3D12CreateVersionedRootSignatureDeserializer
 
-    D3D12EnableExperimentalFeatures @110
-    D3D12SerializeRootSignature @115
-    D3D12SerializeVersionedRootSignature @116
+    D3D12EnableExperimentalFeatures
+    D3D12SerializeRootSignature
+    D3D12SerializeVersionedRootSignature
 
     vkd3d_create_event
     vkd3d_wait_event


### PR DESCRIPTION
Fix some crashes when test suite and demo apps link against our d3d12.dll, which is then tested on native d3d12.dll. Many crashes occur since we export ordinals where we're not supposed to, and there was an ABI break at some point apparently ...

Based on an attempt to link against MSVC d3d12, objdump gives us this PE header:
```
        DLL Name: d3d12.dll
        vma:  Hint/Ord Member-Name Bound-To
        16ae6e      4  D3D12CreateRootSignatureDeserializer
        16ae96     14  D3D12SerializeVersionedRootSignature
        8000000000000065            000000065  <none> (GetDebugInterface)
        16aeee      7  D3D12EnableExperimentalFeatures
        8000000000000066            000000066  <none> (CreateDevice)
        16aebe      5  D3D12CreateVersionedRootSignatureDeserializer
        16ae50     13  D3D12SerializeRootSignature
```
