### PR TITLE
vkd3d: Add static pipeline variant flag to pipeline key.

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -4157,6 +4157,7 @@ VkPipeline d3d12_pipeline_state_get_or_create_pipeline(struct d3d12_pipeline_sta
 
     pipeline_key.dsv_format = dsv_format ? dsv_format->vk_format : VK_FORMAT_UNDEFINED;
     pipeline_key.rtv_active_mask = state->graphics.rtv_active_mask & rtv_nonnull_mask;
+    pipeline_key.variant_flags = variant_flags;
 
     if ((vk_pipeline = d3d12_pipeline_state_find_compiled_pipeline(state, &pipeline_key, render_pass_compat,
             dynamic_state_flags)))

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1578,6 +1578,7 @@ struct vkd3d_pipeline_key
     uint32_t viewport_count;
     uint32_t strides[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
     uint32_t rtv_active_mask;
+    uint32_t variant_flags;
     VkFormat dsv_format;
 
     bool dynamic_stride;


### PR DESCRIPTION
If we need to fallback in both VRS and non-VRS scenarios, we need to key
on it. Fixes segfault in DIRT5 when toggling VRS.

Fix #837.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>