### PR TITLE
vkd3d: Pad reserved resources to 64k alignment.

### DIFF
--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -42,6 +42,11 @@
 
 #define MEMBER_SIZE(t, m) sizeof(((t *)0)->m)
 
+static inline uint64_t align64(uint64_t addr, uint64_t alignment)
+{
+    return (addr + (alignment - 1)) & ~(alignment - 1);
+}
+
 static inline size_t align(size_t addr, size_t alignment)
 {
     return (addr + (alignment - 1)) & ~(alignment - 1);


### PR DESCRIPTION
Fix GPU crashes when attempting to bind non-aligned reserved resource.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>