### PR TITLE
Disable primitive restart for list topologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ There are some hard requirements on drivers to be able to implement D3D12 in a r
 - `VK_KHR_copy_commands2`
 - `VK_KHR_dynamic_rendering`
 - `VK_EXT_extended_dynamic_state`
+- `VK_EXT_extended_dynamic_state2`
 
 Some notable extensions that **should** be supported for optimal or correct behavior.
 These extensions will likely become mandatory later.

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5254,6 +5254,15 @@ static void d3d12_command_list_update_dynamic_state(struct d3d12_command_list *l
                 dyn_state->vk_primitive_topology));
     }
 
+    if (dyn_state->dirty_flags & VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART)
+    {
+        /* The primitive restart dynamic state is only present if the PSO
+         * has a strip cut value, so we only need to check if the
+         * current primitive topology is a strip type. */
+        VK_CALL(vkCmdSetPrimitiveRestartEnableEXT(list->vk_command_buffer,
+                vk_primitive_topology_supports_restart(dyn_state->vk_primitive_topology)));
+    }
+
     if (dyn_state->dirty_flags & VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE)
     {
         update_vbos = (dyn_state->dirty_vbos | dyn_state->dirty_vbo_strides) & list->state->graphics.vertex_buffer_mask;
@@ -6791,7 +6800,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_IASetPrimitiveTopology(d3d12_co
     dyn_state->primitive_topology = topology;
     dyn_state->vk_primitive_topology = vk_topology_from_d3d12_topology(topology);
     d3d12_command_list_invalidate_current_pipeline(list, false);
-    dyn_state->dirty_flags |= VKD3D_DYNAMIC_STATE_TOPOLOGY;
+    dyn_state->dirty_flags |= VKD3D_DYNAMIC_STATE_TOPOLOGY | VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART;
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_RSSetViewports(d3d12_command_list_iface *iface,

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -102,6 +102,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_TRANSFORM_FEEDBACK, EXT_transform_feedback),
     VK_EXTENSION(EXT_VERTEX_ATTRIBUTE_DIVISOR, EXT_vertex_attribute_divisor),
     VK_EXTENSION(EXT_EXTENDED_DYNAMIC_STATE, EXT_extended_dynamic_state),
+    VK_EXTENSION(EXT_EXTENDED_DYNAMIC_STATE_2, EXT_extended_dynamic_state2),
     VK_EXTENSION(EXT_EXTERNAL_MEMORY_HOST, EXT_external_memory_host),
     VK_EXTENSION(EXT_4444_FORMATS, EXT_4444_formats),
     VK_EXTENSION(EXT_SHADER_IMAGE_ATOMIC_INT64, EXT_shader_image_atomic_int64),
@@ -1253,6 +1254,12 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->features2, &info->extended_dynamic_state_features);
     }
 
+    if (vulkan_info->EXT_extended_dynamic_state2)
+    {
+        info->extended_dynamic_state2_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT;
+        vk_prepend_struct(&info->features2, &info->extended_dynamic_state2_features);
+    }
+
     if (vulkan_info->EXT_external_memory_host)
     {
         info->external_memory_host_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT;
@@ -1920,6 +1927,10 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     acceleration_structure = &physical_device_info->acceleration_structure_features;
     acceleration_structure->accelerationStructureCaptureReplay = VK_FALSE;
 
+    /* Don't need or require these. */
+    physical_device_info->extended_dynamic_state2_features.extendedDynamicState2LogicOp = VK_FALSE;
+    physical_device_info->extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints = VK_FALSE;
+
     if (!physical_device_info->descriptor_indexing_properties.robustBufferAccessUpdateAfterBind)
     {
         /* Generally, we cannot enable robustness if this is not supported,
@@ -1988,6 +1999,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     if (!physical_device_info->extended_dynamic_state_features.extendedDynamicState)
     {
         ERR("EXT_extended_dynamic_state is not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
+    if (!physical_device_info->extended_dynamic_state2_features.extendedDynamicState2)
+    {
+        ERR("EXT_extended_dynamic_state2 is not supported by this implementation. This is required for correct operation.\n");
         return E_INVALIDARG;
     }
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2822,6 +2822,7 @@ static uint32_t d3d12_graphics_pipeline_state_init_dynamic_state(struct d3d12_pi
         { VKD3D_DYNAMIC_STATE_TOPOLOGY,              VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT },
         { VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE,  VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT },
         { VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE, VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR },
+        { VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART,     VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT },
     };
 
     dynamic_state_flags = 0;
@@ -2865,6 +2866,9 @@ static uint32_t d3d12_graphics_pipeline_state_init_dynamic_state(struct d3d12_pi
      * so we don't need to worry about side effects when there are no render targets. */
     if (d3d12_device_supports_variable_shading_rate_tier_1(state->device) && graphics->rt_count)
         dynamic_state_flags |= VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE;
+
+    if (graphics->index_buffer_strip_cut_value)
+        dynamic_state_flags |= VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART;
 
     /* Build dynamic state create info */
     for (i = 0, count = 0; i < ARRAY_SIZE(dynamic_state_list); i++)
@@ -4163,7 +4167,7 @@ VkPipeline d3d12_pipeline_state_get_or_create_pipeline(struct d3d12_pipeline_sta
     /* Try to keep as much dynamic state as possible so we don't have to rebind state unnecessarily. */
 
     if (graphics->primitive_topology_type != D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH &&
-        graphics->primitive_topology_type != D3D12_PRIMITIVE_TOPOLOGY_TYPE_UNDEFINED)
+            graphics->primitive_topology_type != D3D12_PRIMITIVE_TOPOLOGY_TYPE_UNDEFINED)
         pipeline_key.dynamic_topology = true;
     else
         pipeline_key.topology = dyn_state->primitive_topology;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -149,6 +149,7 @@ struct vkd3d_vulkan_info
     bool EXT_transform_feedback;
     bool EXT_vertex_attribute_divisor;
     bool EXT_extended_dynamic_state;
+    bool EXT_extended_dynamic_state2;
     bool EXT_external_memory_host;
     bool EXT_4444_formats;
     bool EXT_shader_image_atomic_int64;
@@ -1415,7 +1416,7 @@ HRESULT vkd3d_create_descriptor_set_layout(struct d3d12_device *device,
         VkDescriptorSetLayoutCreateFlags flags, unsigned int binding_count,
         const VkDescriptorSetLayoutBinding *bindings, VkDescriptorSetLayout *set_layout);
 
-#define VKD3D_MAX_DYNAMIC_STATE_COUNT (7)
+#define VKD3D_MAX_DYNAMIC_STATE_COUNT (8)
 
 enum vkd3d_dynamic_state_flag
 {
@@ -1428,6 +1429,7 @@ enum vkd3d_dynamic_state_flag
     VKD3D_DYNAMIC_STATE_VERTEX_BUFFER         = (1 << 6),
     VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE  = (1 << 7),
     VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE = (1 << 8),
+    VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART     = (1 << 9),
 };
 
 struct vkd3d_shader_debug_ring_spec_constants
@@ -1604,6 +1606,21 @@ HRESULT vkd3d_pipeline_state_desc_from_d3d12_compute_desc(struct d3d12_pipeline_
         const D3D12_COMPUTE_PIPELINE_STATE_DESC *d3d12_desc);
 HRESULT vkd3d_pipeline_state_desc_from_d3d12_stream_desc(struct d3d12_pipeline_state_desc *desc,
         const D3D12_PIPELINE_STATE_STREAM_DESC *d3d12_desc, VkPipelineBindPoint *vk_bind_point);
+
+static inline bool vk_primitive_topology_supports_restart(VkPrimitiveTopology topology)
+{
+    switch (topology)
+    {
+        case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP:
+        case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY:
+        case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP:
+        case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY:
+            return true;
+
+        default:
+            return false;
+    }
+}
 
 struct vkd3d_pipeline_key
 {
@@ -2957,6 +2974,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR subgroup_extended_types_features;
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features;
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features;
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features;
     VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE mutable_descriptor_features;
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline_features;
     VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure_features;

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -245,6 +245,9 @@ VK_DEVICE_EXT_PFN(vkCmdSetPrimitiveTopologyEXT)
 VK_DEVICE_EXT_PFN(vkCmdSetScissorWithCountEXT)
 VK_DEVICE_EXT_PFN(vkCmdSetViewportWithCountEXT)
 
+/* VK_EXT_extended_dynamic_state2 */
+VK_DEVICE_EXT_PFN(vkCmdSetPrimitiveRestartEnableEXT)
+
 /* VK_EXT_external_memory_host */
 VK_DEVICE_EXT_PFN(vkGetMemoryHostPointerPropertiesEXT)
 

--- a/tests/d3d12_streamout.c
+++ b/tests/d3d12_streamout.c
@@ -22,6 +22,159 @@
 #define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
 #include "d3d12_crosstest.h"
 
+void test_primitive_restart_list_topology_stream_output(void)
+{
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC pso_desc;
+    ID3D12Resource *counter_buffer, *so_buffer;
+    ID3D12GraphicsCommandList *command_list;
+    D3D12_STREAM_OUTPUT_BUFFER_VIEW sobv;
+    struct test_context_desc desc;
+    ID3D12Resource *index_buffer;
+    struct resource_readback rb;
+    struct test_context context;
+    D3D12_INDEX_BUFFER_VIEW ibv;
+    ID3D12CommandQueue *queue;
+    const struct vec4 *data;
+    ID3D12Device *device;
+    uint32_t counter;
+    unsigned int i;
+    HRESULT hr;
+
+    static const D3D12_SO_DECLARATION_ENTRY so_declaration[] =
+    {
+        {0, "SV_Position", 0, 0, 4, 0},
+    };
+    static const struct vec4 expected_output[] =
+    {
+        /* Strip */
+        { 2000.0f, 2000.0f, 2000.0f, 2000.0f },
+        { 3000.0f, 3000.0f, 3000.0f, 3000.0f },
+        { 4000.0f, 4000.0f, 4000.0f, 4000.0f },
+
+        /* List */
+        { 0.0f, 0.0f, 0.0f, 0.0f },
+        { 1.0f, 1.0f, 1.0f, 1.0f },
+        { -1.0f, -1.0f, -1.0f, -1.0f },
+        { 9.0f, 9.0f, 9.0f, 9.0f },
+        { -1.0f, -1.0f, -1.0f, -1.0f },
+        { -1.0f, -1.0f, -1.0f, -1.0f },
+        { 2000.0f, 2000.0f, 2000.0f, 2000.0f },
+        { 3000.0f, 3000.0f, 3000.0f, 3000.0f },
+        { 4000.0f, 4000.0f, 4000.0f, 4000.0f },
+
+        /* Strip */
+        { 2000.0f, 2000.0f, 2000.0f, 2000.0f },
+        { 3000.0f, 3000.0f, 3000.0f, 3000.0f },
+        { 4000.0f, 4000.0f, 4000.0f, 4000.0f },
+    };
+    static const uint32_t index_data[] = { 0, 1, UINT32_MAX, 9, UINT32_MAX, UINT32_MAX, 2000, 3000, 4000 };
+    static const UINT strides[] = { 16 };
+
+    static const DWORD vs_code[] =
+    {
+#if 0
+        float4 main(uint vid : SV_VertexID) : SV_Position
+        {
+            if (vid == ~0u)
+                return float4(-1, -1, -1, -1);
+            else
+                return float4(vid, vid, vid, vid);
+        }
+#endif
+        0x43425844, 0x59eaaf80, 0xf7ab5160, 0xf0ce6da4, 0x82ce289b, 0x00000001, 0x00000140, 0x00000003,
+        0x0000002c, 0x00000060, 0x00000094, 0x4e475349, 0x0000002c, 0x00000001, 0x00000008, 0x00000020,
+        0x00000000, 0x00000006, 0x00000001, 0x00000000, 0x00000101, 0x565f5653, 0x65747265, 0x00444978,
+        0x4e47534f, 0x0000002c, 0x00000001, 0x00000008, 0x00000020, 0x00000000, 0x00000001, 0x00000003,
+        0x00000000, 0x0000000f, 0x505f5653, 0x7469736f, 0x006e6f69, 0x58454853, 0x000000a4, 0x00010050,
+        0x00000029, 0x0100086a, 0x04000060, 0x00101012, 0x00000000, 0x00000006, 0x04000067, 0x001020f2,
+        0x00000000, 0x00000001, 0x02000068, 0x00000001, 0x07000020, 0x00100012, 0x00000000, 0x0010100a,
+        0x00000000, 0x00004001, 0xffffffff, 0x0304001f, 0x0010000a, 0x00000000, 0x08000036, 0x001020f2,
+        0x00000000, 0x00004002, 0xbf800000, 0xbf800000, 0xbf800000, 0xbf800000, 0x0100003e, 0x01000012,
+        0x05000056, 0x001020f2, 0x00000000, 0x00101006, 0x00000000, 0x0100003e, 0x01000015, 0x0100003e,
+    };
+
+    static const D3D12_SHADER_BYTECODE vs = SHADER_BYTECODE(vs_code);
+
+    memset(&desc, 0, sizeof(desc));
+    desc.root_signature_flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT;
+    desc.no_pipeline = true;
+    if (!init_test_context(&context, &desc))
+        return;
+
+    device = context.device;
+    command_list = context.list;
+    queue = context.queue;
+
+    init_pipeline_state_desc(&pso_desc, context.root_signature, 0, &vs, NULL, NULL);
+    pso_desc.StreamOutput.NumEntries = ARRAY_SIZE(so_declaration);
+    pso_desc.StreamOutput.pSODeclaration = so_declaration;
+    pso_desc.StreamOutput.pBufferStrides = strides;
+    pso_desc.StreamOutput.NumStrides = ARRAY_SIZE(strides);
+    pso_desc.StreamOutput.RasterizedStream = D3D12_SO_NO_RASTERIZED_STREAM;
+    pso_desc.IBStripCutValue = D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFFFFFF;
+    hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
+            &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+
+    counter_buffer = create_default_buffer(device, 32,
+            D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_STREAM_OUT);
+    so_buffer = create_default_buffer(device, 4096,
+            D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_STREAM_OUT);
+    index_buffer = create_upload_buffer(device, sizeof(index_data), index_data);
+    sobv.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(so_buffer);
+    sobv.SizeInBytes = 4096;
+    sobv.BufferFilledSizeLocation = ID3D12Resource_GetGPUVirtualAddress(counter_buffer);
+
+    ibv.Format = DXGI_FORMAT_R32_UINT;
+    ibv.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(index_buffer);
+    ibv.SizeInBytes = sizeof(index_data);
+
+    ID3D12GraphicsCommandList_RSSetScissorRects(command_list, 1, &context.scissor_rect);
+    ID3D12GraphicsCommandList_RSSetViewports(command_list, 1, &context.viewport);
+    ID3D12GraphicsCommandList_SetGraphicsRootSignature(command_list, context.root_signature);
+    ID3D12GraphicsCommandList_SetPipelineState(command_list, context.pipeline_state);
+    ID3D12GraphicsCommandList_SOSetTargets(command_list, 0, 1, &sobv);
+    ID3D12GraphicsCommandList_IASetIndexBuffer(command_list, &ibv);
+
+    /* Primitive restart state only applies to strip primitives. */
+    ID3D12GraphicsCommandList_IASetPrimitiveTopology(command_list, D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+    ID3D12GraphicsCommandList_DrawIndexedInstanced(command_list, ARRAY_SIZE(index_data), 1,
+              0, 0, 0);
+    ID3D12GraphicsCommandList_IASetPrimitiveTopology(command_list, D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ID3D12GraphicsCommandList_DrawIndexedInstanced(command_list, ARRAY_SIZE(index_data), 1,
+                                                   0, 0, 0);
+    ID3D12GraphicsCommandList_IASetPrimitiveTopology(command_list, D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+    ID3D12GraphicsCommandList_DrawIndexedInstanced(command_list, ARRAY_SIZE(index_data), 1,
+                                                   0, 0, 0);
+
+    transition_resource_state(command_list, counter_buffer,
+              D3D12_RESOURCE_STATE_STREAM_OUT, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    transition_resource_state(command_list, so_buffer,
+              D3D12_RESOURCE_STATE_STREAM_OUT, D3D12_RESOURCE_STATE_COPY_SOURCE);
+
+    get_buffer_readback_with_command_list(counter_buffer, DXGI_FORMAT_R32_UINT, &rb, queue, command_list);
+    counter = get_readback_uint(&rb, 0, 0, 0);
+    ok(counter == sizeof(expected_output), "Got unexpected counter %u, expected %u.\n",
+            counter, (unsigned int)sizeof(expected_output));
+    release_resource_readback(&rb);
+    reset_command_list(command_list, context.allocator);
+    get_buffer_readback_with_command_list(so_buffer, DXGI_FORMAT_UNKNOWN, &rb, queue, command_list);
+    for (i = 0; i < ARRAY_SIZE(expected_output); ++i)
+    {
+        const struct vec4 *expected = &expected_output[i];
+        data = get_readback_vec4(&rb, i, 0);
+        ok(compare_vec4(data, expected, 1),
+                "Got {%.8e, %.8e, %.8e, %.8e}, expected {%.8e, %.8e, %.8e, %.8e}.\n",
+                data->x, data->y, data->z, data->w, expected->x, expected->y, expected->z, expected->w);
+    }
+    release_resource_readback(&rb);
+
+    ID3D12Resource_Release(index_buffer);
+    ID3D12Resource_Release(counter_buffer);
+    ID3D12Resource_Release(so_buffer);
+    destroy_test_context(&context);
+}
+
 static void test_vertex_shader_stream_output(bool use_dxil)
 {
     D3D12_GRAPHICS_PIPELINE_STATE_DESC pso_desc;

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -199,6 +199,7 @@ decl_test(test_primitive_restart);
 decl_test(test_index_buffer_edge_case_stream_output);
 decl_test(test_vertex_shader_stream_output_dxbc);
 decl_test(test_vertex_shader_stream_output_dxil);
+decl_test(test_primitive_restart_list_topology_stream_output);
 decl_test(test_read_write_subresource);
 decl_test(test_queue_wait);
 decl_test(test_graphics_compute_queue_synchronization);


### PR DESCRIPTION
IBStripCut only applies to strip primitive types. Use extended_dynamic_state2 when we can and fallback pipeline when we can't.

Builds on #1038.