### PR TITLE
tests: Only check lower 24-bit when testing D24 copies.

### DIFF
--- a/tests/d3d12_copy.c
+++ b/tests/d3d12_copy.c
@@ -619,7 +619,7 @@ void test_copy_buffer_to_depth_stencil(void)
             for (x = 0; x < 2; x++)
             {
                 uint32_t v = get_readback_uint(&rb_depth, x, y, 0);
-                ok(v == tests[i].output_depth_24 || v == tests[i].input_depth, "Depth is 0x%x\n", v);
+                ok((v & 0xffffffu) == tests[i].output_depth_24 || v == tests[i].input_depth, "Depth is 0x%x\n", v);
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>

Fix #872.