### PR TITLE
Use VK_KHR_dynamic_rendering

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4564,7 +4564,6 @@ static void d3d12_command_list_check_vbo_alignment(struct d3d12_command_list *li
 static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_list *list)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
-    const struct vkd3d_render_pass_compatibility *render_pass_compat;
     uint32_t dsv_plane_optimal_mask;
     uint32_t new_active_flags;
     VkImageLayout dsv_layout;
@@ -4580,13 +4579,11 @@ static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_lis
     }
 
     /* Try to grab the pipeline we compiled ahead of time. If we cannot do so, fall back. */
-    if (!(vk_pipeline = d3d12_pipeline_state_get_pipeline(list->state,
-            &list->dynamic_state, list->rtv_nonnull_mask, list->dsv.format,
-            &render_pass_compat, &new_active_flags)))
+    if (!(vk_pipeline = d3d12_pipeline_state_get_pipeline(list->state, &list->dynamic_state,
+            list->rtv_nonnull_mask, list->dsv.format, &new_active_flags)))
     {
-        if (!(vk_pipeline = d3d12_pipeline_state_get_or_create_pipeline(list->state,
-                &list->dynamic_state, list->rtv_nonnull_mask, list->dsv.format,
-                &render_pass_compat, &new_active_flags)))
+        if (!(vk_pipeline = d3d12_pipeline_state_get_or_create_pipeline(list->state, &list->dynamic_state,
+                list->rtv_nonnull_mask, list->dsv.format, &new_active_flags)))
             return false;
     }
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4561,16 +4561,6 @@ static void d3d12_command_list_check_vbo_alignment(struct d3d12_command_list *li
     }
 }
 
-static uint32_t d3d12_command_list_variant_flags(struct d3d12_command_list *list)
-{
-    uint32_t flags = 0;
-
-    if (list->vrs_image)
-        flags |= VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_VRS_ATTACHMENT;
-
-    return flags;
-}
-
 static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_list *list)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
@@ -4578,7 +4568,6 @@ static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_lis
     VkRenderPass vk_render_pass;
     uint32_t new_active_flags;
     VkPipeline vk_pipeline;
-    uint32_t variant_flags;
     uint32_t i;
 
     if (list->current_pipeline != VK_NULL_HANDLE)
@@ -4590,17 +4579,14 @@ static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_lis
         return false;
     }
 
-    variant_flags = d3d12_command_list_variant_flags(list);
-
     /* Try to grab the pipeline we compiled ahead of time. If we cannot do so, fall back. */
     if (!(vk_pipeline = d3d12_pipeline_state_get_pipeline(list->state,
             &list->dynamic_state, list->rtv_nonnull_mask, list->dsv.format,
-            &render_pass_compat, &new_active_flags,
-            variant_flags)))
+            &render_pass_compat, &new_active_flags)))
     {
         if (!(vk_pipeline = d3d12_pipeline_state_get_or_create_pipeline(list->state,
                 &list->dynamic_state, list->rtv_nonnull_mask, list->dsv.format,
-                &render_pass_compat, &new_active_flags, variant_flags)))
+                &render_pass_compat, &new_active_flags)))
             return false;
     }
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2762,7 +2762,6 @@ static void d3d12_device_destroy(struct d3d12_device *device)
     vkd3d_view_map_destroy(&device->sampler_map, device);
     vkd3d_meta_ops_cleanup(&device->meta_ops, device);
     vkd3d_bindless_state_cleanup(&device->bindless_state, device);
-    vkd3d_render_pass_cache_cleanup(&device->render_pass_cache, device);
     d3d12_device_destroy_vkd3d_queues(device);
     vkd3d_memory_allocator_cleanup(&device->memory_allocator, device);
     /* Tear down descriptor global info late, so we catch last minute faults after we drain the queues. */
@@ -6059,8 +6058,6 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
                 VKD3D_DESCRIPTOR_DEBUG_DEFAULT_NUM_COOKIES, device)))
             goto out_cleanup_global_pipeline_cache;
     }
-
-    vkd3d_render_pass_cache_init(&device->render_pass_cache);
 
     if ((device->parent = create_info->parent))
         IUnknown_AddRef(device->parent);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -80,6 +80,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_SHADER_ATOMIC_INT64, KHR_shader_atomic_int64),
     VK_EXTENSION(KHR_BIND_MEMORY_2, KHR_bind_memory2),
     VK_EXTENSION(KHR_COPY_COMMANDS_2, KHR_copy_commands2),
+    VK_EXTENSION(KHR_DYNAMIC_RENDERING, KHR_dynamic_rendering),
     /* EXT extensions */
     VK_EXTENSION(EXT_CALIBRATED_TIMESTAMPS, EXT_calibrated_timestamps),
     VK_EXTENSION(EXT_CONDITIONAL_RENDERING, EXT_conditional_rendering),
@@ -1368,6 +1369,13 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->features2, &info->scalar_block_layout_features);
     }
 
+    if (vulkan_info->KHR_dynamic_rendering)
+    {
+        info->dynamic_rendering_features.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR;
+        vk_prepend_struct(&info->features2, &info->dynamic_rendering_features);
+    }
+
     if (vulkan_info->VALVE_descriptor_set_host_mapping)
     {
         info->descriptor_set_host_mapping_features.sType =
@@ -1949,6 +1957,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     if (!vulkan_info->KHR_copy_commands2)
     {
         ERR("KHR_copy_commands2 is not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
+    if (!physical_device_info->dynamic_rendering_features.dynamicRendering)
+    {
+        ERR("KHR_dynamic_rendering is not supported by this implementation. This is required for correct operation.\n");
         return E_INVALIDARG;
     }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -128,6 +128,7 @@ struct vkd3d_vulkan_info
     bool KHR_shader_atomic_int64;
     bool KHR_bind_memory2;
     bool KHR_copy_commands2;
+    bool KHR_dynamic_rendering;
     /* EXT device extensions */
     bool EXT_calibrated_timestamps;
     bool EXT_conditional_rendering;
@@ -2855,6 +2856,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceScalarBlockLayoutFeaturesEXT scalar_block_layout_features;
     VkPhysicalDeviceImageViewMinLodFeaturesEXT image_view_min_lod_features;
     VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE descriptor_set_host_mapping_features;
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features;
 
     VkPhysicalDeviceFeatures2 features2;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2559,7 +2559,6 @@ struct vkd3d_copy_image_info
 {
     VkDescriptorSetLayout vk_set_layout;
     VkPipelineLayout vk_pipeline_layout;
-    VkRenderPass vk_render_pass;
     VkPipeline vk_pipeline;
 };
 
@@ -2568,7 +2567,6 @@ struct vkd3d_copy_image_pipeline_key
     const struct vkd3d_format *format;
     VkImageViewType view_type;
     VkSampleCountFlagBits sample_count;
-    VkImageLayout layout;
     VkImageAspectFlags dst_aspect_mask;
 };
 
@@ -2576,7 +2574,6 @@ struct vkd3d_copy_image_pipeline
 {
     struct vkd3d_copy_image_pipeline_key key;
 
-    VkRenderPass vk_render_pass;
     VkPipeline vk_pipeline;
 };
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3104,6 +3104,7 @@ static inline bool d3d12_device_use_ssbo_root_descriptors(struct d3d12_device *d
 }
 
 bool d3d12_device_supports_variable_shading_rate_tier_1(struct d3d12_device *device);
+bool d3d12_device_supports_variable_shading_rate_tier_2(struct d3d12_device *device);
 bool d3d12_device_supports_ray_tracing_tier_1_0(const struct d3d12_device *device);
 
 /* ID3DBlob */
@@ -3269,6 +3270,16 @@ static inline const struct vkd3d_format *vkd3d_format_from_d3d12_resource_desc(
 {
     return vkd3d_get_format(device, view_format ? view_format : desc->Format,
             desc->Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
+}
+
+static inline unsigned int vkd3d_get_color_attachment_count(unsigned int attachment_mask)
+{
+    unsigned int count = 0;
+
+    while (attachment_mask >> count)
+        count++;
+
+    return count;
 }
 
 static inline VkImageSubresourceRange vk_subresource_range_from_layers(const VkImageSubresourceLayers *layers)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1795,10 +1795,6 @@ struct d3d12_command_allocator
 
     struct d3d12_descriptor_pool_cache descriptor_pool_caches[VKD3D_DESCRIPTOR_POOL_TYPE_COUNT];
 
-    VkFramebuffer *framebuffers;
-    size_t framebuffers_size;
-    size_t framebuffer_count;
-
     struct vkd3d_view **views;
     size_t views_size;
     size_t view_count;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2600,7 +2600,6 @@ void vkd3d_copy_image_ops_cleanup(struct vkd3d_copy_image_ops *meta_copy_image_o
 struct vkd3d_swapchain_pipeline_key
 {
     VkPipelineBindPoint bind_point;
-    VkAttachmentLoadOp load_op;
     VkFormat format;
     VkFilter filter;
 };
@@ -2609,13 +2608,11 @@ struct vkd3d_swapchain_info
 {
     VkDescriptorSetLayout vk_set_layout;
     VkPipelineLayout vk_pipeline_layout;
-    VkRenderPass vk_render_pass;
     VkPipeline vk_pipeline;
 };
 
 struct vkd3d_swapchain_pipeline
 {
-    VkRenderPass vk_render_pass;
     VkPipeline vk_pipeline;
     struct vkd3d_swapchain_pipeline_key key;
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1958,6 +1958,22 @@ struct vkd3d_query_range
     uint32_t flags;
 };
 
+enum vkd3d_rendering_flags
+{
+    VKD3D_RENDERING_ACTIVE    = (1u << 0),
+    VKD3D_RENDERING_SUSPENDED = (1u << 1),
+    VKD3D_RENDERING_CURRENT   = (1u << 2),
+};
+
+struct vkd3d_rendering_info
+{
+    VkRenderingInfoKHR info;
+    VkRenderingAttachmentInfoKHR rtv[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
+    VkRenderingAttachmentInfoKHR dsv;
+    VkRenderingFragmentShadingRateAttachmentInfoKHR vrs;
+    uint32_t state_flags;
+};
+
 /* ID3D12CommandListExt */
 typedef ID3D12GraphicsCommandListExt d3d12_command_list_vkd3d_ext_iface;
 
@@ -2007,12 +2023,9 @@ struct d3d12_command_list
     unsigned int fb_layer_count;
 
     bool xfb_enabled;
-    bool render_pass_suspended;
 
     bool predicate_enabled;
     VkDeviceAddress predicate_va;
-
-    VkFramebuffer current_framebuffer;
 
     /* This is VK_NULL_HANDLE when we are no longer sure which pipeline to bind,
      * if this is NULL, we might need to lookup a pipeline key in order to bind the correct pipeline. */
@@ -2023,7 +2036,7 @@ struct d3d12_command_list
     VkPipeline command_buffer_pipeline;
 
     VkRenderPass pso_render_pass;
-    VkRenderPass current_render_pass;
+    struct vkd3d_rendering_info rendering_info;
     struct vkd3d_dynamic_state dynamic_state;
     struct vkd3d_pipeline_bindings pipeline_bindings[VKD3D_PIPELINE_BIND_POINT_COUNT];
     VkPipelineBindPoint active_bind_point;
@@ -3106,6 +3119,7 @@ static inline bool d3d12_device_use_ssbo_root_descriptors(struct d3d12_device *d
 bool d3d12_device_supports_variable_shading_rate_tier_1(struct d3d12_device *device);
 bool d3d12_device_supports_variable_shading_rate_tier_2(struct d3d12_device *device);
 bool d3d12_device_supports_ray_tracing_tier_1_0(const struct d3d12_device *device);
+UINT d3d12_determine_shading_rate_image_tile_size(struct d3d12_device *device);
 
 /* ID3DBlob */
 struct d3d_blob

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -331,7 +331,6 @@ enum vkd3d_render_pass_key_flag
     VKD3D_RENDER_PASS_KEY_STENCIL_ENABLE = (1u << 1),
     VKD3D_RENDER_PASS_KEY_DEPTH_WRITE    = (1u << 2),
     VKD3D_RENDER_PASS_KEY_STENCIL_WRITE  = (1u << 3),
-    VKD3D_RENDER_PASS_KEY_VRS_ATTACHMENT = (1u << 4),
 
     VKD3D_RENDER_PASS_KEY_DEPTH_STENCIL_ENABLE = (VKD3D_RENDER_PASS_KEY_DEPTH_ENABLE | VKD3D_RENDER_PASS_KEY_STENCIL_ENABLE),
     VKD3D_RENDER_PASS_KEY_DEPTH_STENCIL_WRITE  = (VKD3D_RENDER_PASS_KEY_DEPTH_WRITE  | VKD3D_RENDER_PASS_KEY_STENCIL_WRITE),
@@ -1482,12 +1481,6 @@ struct vkd3d_shader_debug_ring_spec_info
     VkSpecializationInfo spec_info;
 };
 
-enum vkd3d_graphics_pipeline_static_variant_flag
-{
-    VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_VRS_ATTACHMENT = (1u << 0),
-    VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_LAST_BIT       = (1u << 1),
-};
-
 /* One render pass for each plane optimal mask. */
 #define VKD3D_RENDER_PASS_COMPATIBILITY_VARIANT_COUNT 4
 struct vkd3d_render_pass_compatibility
@@ -1500,8 +1493,6 @@ enum vkd3d_plane_optimal_flag
     VKD3D_DEPTH_PLANE_OPTIMAL = (1 << 0),
     VKD3D_STENCIL_PLANE_OPTIMAL = (1 << 1),
 };
-
-#define VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_COUNT ((uint32_t)VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_LAST_BIT)
 
 struct d3d12_graphics_pipeline_state
 {
@@ -1530,7 +1521,7 @@ struct d3d12_graphics_pipeline_state
     const struct vkd3d_format *dsv_format;
     VkFormat rtv_formats[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
     uint32_t dsv_plane_optimal_mask;
-    struct vkd3d_render_pass_compatibility render_pass[VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_COUNT];
+    struct vkd3d_render_pass_compatibility render_pass;
 
     D3D12_INDEX_BUFFER_STRIP_CUT_VALUE index_buffer_strip_cut_value;
     VkPipelineRasterizationStateCreateInfo rs_desc;
@@ -1546,7 +1537,7 @@ struct d3d12_graphics_pipeline_state
     uint32_t dynamic_state_flags; /* vkd3d_dynamic_state_flag */
 
     VkPipelineLayout pipeline_layout;
-    VkPipeline pipeline[VKD3D_GRAPHICS_PIPELINE_STATIC_VARIANT_COUNT];
+    VkPipeline pipeline;
     struct list compiled_fallback_pipelines;
 
     bool xfb_enabled;
@@ -1657,7 +1648,6 @@ struct vkd3d_pipeline_key
     uint32_t viewport_count;
     uint32_t strides[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
     uint32_t rtv_active_mask;
-    uint32_t variant_flags;
     VkFormat dsv_format;
 
     bool dynamic_stride;
@@ -1672,16 +1662,16 @@ VkPipeline d3d12_pipeline_state_get_or_create_pipeline(struct d3d12_pipeline_sta
         const struct vkd3d_dynamic_state *dyn_state,
         uint32_t rtv_nonnull_mask, const struct vkd3d_format *dsv_format,
         const struct vkd3d_render_pass_compatibility **render_pass_compat,
-        uint32_t *dynamic_state_flags, uint32_t variant_flags);
+        uint32_t *dynamic_state_flags);
 VkPipeline d3d12_pipeline_state_get_pipeline(struct d3d12_pipeline_state *state,
         const struct vkd3d_dynamic_state *dyn_state,
         uint32_t rtv_nonnull_mask, const struct vkd3d_format *dsv_format,
         const struct vkd3d_render_pass_compatibility **render_pass_compat,
-        uint32_t *dynamic_state_flags, uint32_t variant_flags);
+        uint32_t *dynamic_state_flags);
 VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_state *state,
         const struct vkd3d_pipeline_key *key, const struct vkd3d_format *dsv_format, VkPipelineCache vk_cache,
         struct vkd3d_render_pass_compatibility *render_pass_compat,
-        uint32_t *dynamic_state_flags, uint32_t variant_flags);
+        uint32_t *dynamic_state_flags);
 
 static inline struct d3d12_pipeline_state *impl_from_ID3D12PipelineState(ID3D12PipelineState *iface)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1795,10 +1795,6 @@ struct d3d12_command_allocator
 
     struct d3d12_descriptor_pool_cache descriptor_pool_caches[VKD3D_DESCRIPTOR_POOL_TYPE_COUNT];
 
-    VkRenderPass *passes;
-    size_t passes_size;
-    size_t pass_count;
-
     VkFramebuffer *framebuffers;
     size_t framebuffers_size;
     size_t framebuffer_count;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1958,6 +1958,7 @@ struct vkd3d_rendering_info
     VkRenderingAttachmentInfoKHR dsv;
     VkRenderingFragmentShadingRateAttachmentInfoKHR vrs;
     uint32_t state_flags;
+    uint32_t rtv_mask;
 };
 
 /* ID3D12CommandListExt */
@@ -2021,7 +2022,6 @@ struct d3d12_command_list
      * possible calls to vkCmdBindPipeline and avoids invalidating dynamic state. */
     VkPipeline command_buffer_pipeline;
 
-    VkRenderPass pso_render_pass;
     struct vkd3d_rendering_info rendering_info;
     struct vkd3d_dynamic_state dynamic_state;
     struct vkd3d_pipeline_bindings pipeline_bindings[VKD3D_PIPELINE_BIND_POINT_COUNT];

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -279,6 +279,10 @@ VK_DEVICE_EXT_PFN(vkGetSwapchainImagesKHR)
 VK_DEVICE_EXT_PFN(vkAcquireNextImageKHR)
 VK_DEVICE_EXT_PFN(vkQueuePresentKHR)
 
+/* VK_KHR_dynamic_rendering */
+VK_DEVICE_EXT_PFN(vkCmdBeginRenderingKHR)
+VK_DEVICE_EXT_PFN(vkCmdEndRenderingKHR)
+
 /* VK_AMD_buffer_marker */
 VK_DEVICE_EXT_PFN(vkCmdWriteBufferMarkerAMD)
 


### PR DESCRIPTION
Keeping this as a draft for now since merging without support from stable drivers is not an option.

Tests pass on Nvidia, requires Vulkan beta driver 470.62.12 or later.

Needs more testing on RADV as its implementation of the extension comes along, and testing in actual games, although for that we'll need some sort of working Proton build with winevulkan support for this extension. I haven't checked if this is provided by proton-experimental bleeding edge yet.