### PR TITLE
Remove TODO for MinLOD test.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3505,6 +3505,8 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
     VkImageView vk_view = VK_NULL_HANDLE;
     VkImageViewCreateInfo view_desc;
     struct vkd3d_view *object;
+    uint32_t clamp_base_level;
+    uint32_t end_level;
     VkResult vr;
 
     view_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -3527,26 +3529,24 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
      * The clamp is absolute, and not affected by the baseMipLevel. */
     if (desc->miplevel_clamp <= (float)(desc->miplevel_idx + desc->miplevel_count - 1))
     {
-        if (device->device_info.image_view_min_lod_features.minLod)
+        if (desc->miplevel_clamp > (float)desc->miplevel_idx)
         {
-            min_lod_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT;
-            min_lod_desc.pNext = NULL;
-            min_lod_desc.minLod = desc->miplevel_clamp;
-            vk_prepend_struct(&view_desc, &min_lod_desc);
-        }
-        else
-        {
-            if (desc->miplevel_clamp != 0.0f)
-                FIXME_ONCE("Cannot handle MinResourceLOD clamp of %f correctly.\n", desc->miplevel_clamp);
-            /* This is not correct, but it's the best we can do without VK_EXT_image_view_min_lod.
-            * It should at least avoid a scenario where implicit LOD fetches from invalid levels. */
-            if (desc->miplevel_clamp >= 1.0f)
+            if (device->device_info.image_view_min_lod_features.minLod)
             {
-                uint32_t clamp_base_level = max((uint32_t)desc->miplevel_clamp, view_desc.subresourceRange.baseMipLevel);
-                uint32_t end_level = view_desc.subresourceRange.baseMipLevel + view_desc.subresourceRange.levelCount;
-                uint32_t new_base_level = min(end_level - 1, clamp_base_level);
-                view_desc.subresourceRange.levelCount = end_level - new_base_level;
-                view_desc.subresourceRange.baseMipLevel = new_base_level;
+                min_lod_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT;
+                min_lod_desc.pNext = NULL;
+                min_lod_desc.minLod = desc->miplevel_clamp;
+                vk_prepend_struct(&view_desc, &min_lod_desc);
+            }
+            else
+            {
+                FIXME_ONCE("Cannot handle MinResourceLOD clamp of %f correctly.\n", desc->miplevel_clamp);
+                /* This is not correct, but it's the best we can do without VK_EXT_image_view_min_lod.
+                 * It should at least avoid a scenario where implicit LOD fetches from invalid levels. */
+                clamp_base_level = (uint32_t)desc->miplevel_clamp;
+                end_level = view_desc.subresourceRange.baseMipLevel + view_desc.subresourceRange.levelCount;
+                view_desc.subresourceRange.levelCount = end_level - clamp_base_level;
+                view_desc.subresourceRange.baseMipLevel = clamp_base_level;
             }
         }
 

--- a/tests/d3d12_descriptors.c
+++ b/tests/d3d12_descriptors.c
@@ -4336,10 +4336,10 @@ void test_view_min_lod(void)
         {&ps_view_min_lod_load, 0,  3.0f, 0.0f, 0xffffffff},
 
         {&ps_view_min_lod_load, 0, -1.0f, 1.0f, 0x00000000},
-        {&ps_view_min_lod_load, 0,  0.0f, 1.0f, 0x00000000, true},
-        {&ps_view_min_lod_load, 0,  1.0f, 1.0f, 0xffffffff, true},
-        {&ps_view_min_lod_load, 0,  2.0f, 1.0f, 0x0f0f0f0f, true},
-        {&ps_view_min_lod_load, 0,  3.0f, 1.0f, 0xffffffff, true},
+        {&ps_view_min_lod_load, 0,  0.0f, 1.0f, 0x00000000},
+        {&ps_view_min_lod_load, 0,  1.0f, 1.0f, 0xffffffff},
+        {&ps_view_min_lod_load, 0,  2.0f, 1.0f, 0x0f0f0f0f},
+        {&ps_view_min_lod_load, 0,  3.0f, 1.0f, 0xffffffff},
 
         {&ps_view_min_lod_load, 1, -1.0f, 1.0f, 0x00000000},
         {&ps_view_min_lod_load, 1,  0.0f, 1.0f, 0xffffffff},
@@ -4348,7 +4348,7 @@ void test_view_min_lod(void)
         {&ps_view_min_lod_load, 1,  3.0f, 1.0f, 0x00000000},
 
         {&ps_view_min_lod_load, 1, -1.0f, 9.0f, 0x00000000},
-        {&ps_view_min_lod_load, 1,  0.0f, 9.0f, 0x00000000, true},
+        {&ps_view_min_lod_load, 1,  0.0f, 9.0f, 0x00000000},
         {&ps_view_min_lod_load, 1,  1.0f, 9.0f, 0x00000000},
         {&ps_view_min_lod_load, 1,  2.0f, 9.0f, 0x00000000},
         {&ps_view_min_lod_load, 1,  3.0f, 9.0f, 0x00000000},
@@ -4361,8 +4361,8 @@ void test_view_min_lod(void)
 
         {&ps_view_min_lod_sample, 0, -1.0f, 1.0f, 0xffffffff},
         {&ps_view_min_lod_sample, 0,  0.0f, 1.0f, 0xffffffff},
-        {&ps_view_min_lod_sample, 0,  1.0f, 1.0f, 0xffffffff, true},
-        {&ps_view_min_lod_sample, 0,  2.0f, 1.0f, 0x0f0f0f0f, true},
+        {&ps_view_min_lod_sample, 0,  1.0f, 1.0f, 0xffffffff},
+        {&ps_view_min_lod_sample, 0,  2.0f, 1.0f, 0x0f0f0f0f},
         {&ps_view_min_lod_sample, 0,  3.0f, 1.0f, 0xffffffff},
 
         {&ps_view_min_lod_sample, 1, -1.0f, 1.0f, 0xffffffff},
@@ -4372,11 +4372,11 @@ void test_view_min_lod(void)
         {&ps_view_min_lod_sample, 1,  3.0f, 1.0f, 0xffffffff},
         {&ps_view_min_lod_sample, 1,  4.0f, 1.0f, 0xffffffff},
 
-        {&ps_view_min_lod_sample, 1, -1.0f, 9.0f, 0x00000000, true},
-        {&ps_view_min_lod_sample, 1,  0.0f, 9.0f, 0x00000000, true},
-        {&ps_view_min_lod_sample, 1,  1.0f, 9.0f, 0x00000000, true},
-        {&ps_view_min_lod_sample, 1,  2.0f, 9.0f, 0x00000000, true},
-        {&ps_view_min_lod_sample, 1,  3.0f, 9.0f, 0x00000000, true},
+        {&ps_view_min_lod_sample, 1, -1.0f, 9.0f, 0x00000000},
+        {&ps_view_min_lod_sample, 1,  0.0f, 9.0f, 0x00000000},
+        {&ps_view_min_lod_sample, 1,  1.0f, 9.0f, 0x00000000},
+        {&ps_view_min_lod_sample, 1,  2.0f, 9.0f, 0x00000000},
+        {&ps_view_min_lod_sample, 1,  3.0f, 9.0f, 0x00000000},
     };
 
     /* Alternate mip colors */


### PR DESCRIPTION
Also, only emit MinLOD struct where actually needed. Simplifies some logic and shuts validation layers up for time being.