### PR TITLE
vkd3d: Remove misleading FIXME.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3153,33 +3153,6 @@ void d3d12_desc_copy(struct d3d12_desc *dst, struct d3d12_desc *src,
     }
 }
 
-static VkDeviceSize vkd3d_get_required_texel_buffer_alignment(const struct d3d12_device *device,
-        const struct vkd3d_format *format)
-{
-    const VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT *properties;
-    const struct vkd3d_vulkan_info *vk_info = &device->vk_info;
-    VkDeviceSize alignment;
-
-    if (vk_info->EXT_texel_buffer_alignment)
-    {
-        properties = &vk_info->texel_buffer_alignment_properties;
-
-        alignment = max(properties->storageTexelBufferOffsetAlignmentBytes,
-                properties->uniformTexelBufferOffsetAlignmentBytes);
-
-        if (properties->storageTexelBufferOffsetSingleTexelAlignment
-                && properties->uniformTexelBufferOffsetSingleTexelAlignment)
-        {
-            assert(!vkd3d_format_is_compressed(format));
-            return min(format->byte_count, alignment);
-        }
-
-        return alignment;
-    }
-
-    return vk_info->device_limits.minTexelBufferOffsetAlignment;
-}
-
 bool vkd3d_create_raw_r32ui_vk_buffer_view(struct d3d12_device *device,
         VkBuffer vk_buffer, VkDeviceSize offset, VkDeviceSize range, VkBufferView *vk_view)
 {
@@ -3208,7 +3181,6 @@ static bool vkd3d_create_vk_buffer_view(struct d3d12_device *device,
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     struct VkBufferViewCreateInfo view_desc;
-    VkDeviceSize alignment;
     VkResult vr;
 
     if (vkd3d_format_is_compressed(format))
@@ -3216,10 +3188,6 @@ static bool vkd3d_create_vk_buffer_view(struct d3d12_device *device,
         WARN("Invalid format for buffer view %#x.\n", format->dxgi_format);
         return false;
     }
-
-    alignment = vkd3d_get_required_texel_buffer_alignment(device, format);
-    if (offset % alignment)
-        FIXME("Offset %#"PRIx64" violates the required alignment %#"PRIx64".\n", offset, alignment);
 
     view_desc.sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO;
     view_desc.pNext = NULL;


### PR DESCRIPTION
We can bind texel buffers at scalar alignment now.
The warning is misleading for placed resources, since 64k never aligns
with a float3.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>