### PR TITLE
Support RelaxedPrecision in DXBC

### DIFF
--- a/libs/vkd3d-shader/dxbc.c
+++ b/libs/vkd3d-shader/dxbc.c
@@ -1616,9 +1616,11 @@ static bool shader_sm4_read_param(struct vkd3d_sm4_data *priv, const DWORD **ptr
         }
 
         if (m & 0x20000)
-            param->modifier = VKD3DSPRM_NONUNIFORM;
+            param->modifier |= VKD3DSPRM_NONUNIFORM;
+        if (m & 0x4000)
+            param->modifier |= VKD3DSPRM_RELAXED_PRECISION;
 
-        if ((m &= ~(0x200c1)))
+        if ((m &= ~(0x240c1)))
             FIXME("Skipping modifier 0x%08x.\n", m);
     }
     else

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -3515,7 +3515,7 @@ static uint32_t vkd3d_dxbc_compiler_emit_load_constant_buffer(struct vkd3d_dxbc_
         ptr_id = vkd3d_spirv_build_op_access_chain(builder, ptr_type_id,
                 base_id, indexes, last_index + 1);
 
-        if (reg->modifier == VKD3DSPRM_NONUNIFORM)
+        if (reg->modifier & VKD3DSPRM_NONUNIFORM)
             vkd3d_dxbc_compiler_decorate_nonuniform(compiler, ptr_id);
 
         component_ids[j++] = vkd3d_spirv_build_op_loadv(builder, type_id, ptr_id,
@@ -8939,7 +8939,7 @@ static uint32_t vkd3d_dxbc_compiler_get_resource_index(struct vkd3d_dxbc_compile
 #endif
 
     /* AMD drivers rely on the index being marked as nonuniform */
-    if (reg->modifier == VKD3DSPRM_NONUNIFORM)
+    if (reg->modifier & VKD3DSPRM_NONUNIFORM)
         vkd3d_dxbc_compiler_decorate_nonuniform(compiler, index_id);
 
     return index_id;
@@ -9027,7 +9027,7 @@ static void vkd3d_dxbc_compiler_prepare_image(struct vkd3d_dxbc_compiler *compil
         image->image_id = 0;
     }
 
-    if (image->image_id && resource_reg->modifier == VKD3DSPRM_NONUNIFORM)
+    if (image->image_id && (resource_reg->modifier & VKD3DSPRM_NONUNIFORM))
         vkd3d_dxbc_compiler_decorate_nonuniform(compiler, image->image_id);
 
     if (sampled)
@@ -9043,12 +9043,12 @@ static void vkd3d_dxbc_compiler_prepare_image(struct vkd3d_dxbc_compiler *compil
         image->sampled_image_id = vkd3d_spirv_build_op_sampled_image(builder,
                 sampled_image_type_id, image->image_id, sampler_id);
 
-        if (sampler_reg->modifier == VKD3DSPRM_NONUNIFORM)
+        if (sampler_reg->modifier & VKD3DSPRM_NONUNIFORM)
             vkd3d_dxbc_compiler_decorate_nonuniform(compiler, sampler_id);
 
         /* To be strict against Vulkan spec, the sampled image itself needs to be marked as NonUniform. */
-        if ((image->image_id && resource_reg->modifier == VKD3DSPRM_NONUNIFORM) ||
-            sampler_reg->modifier == VKD3DSPRM_NONUNIFORM)
+        if ((image->image_id && (resource_reg->modifier & VKD3DSPRM_NONUNIFORM)) ||
+                (sampler_reg->modifier & VKD3DSPRM_NONUNIFORM))
         {
             vkd3d_dxbc_compiler_decorate_nonuniform(compiler, image->sampled_image_id);
         }
@@ -9681,7 +9681,7 @@ static void vkd3d_dxbc_compiler_emit_ld_raw_structured_srv_uav(struct vkd3d_dxbc
             ptr_id = vkd3d_spirv_build_op_access_chain(builder, ptr_type_id, image.id, indices, ARRAY_SIZE(indices));
             constituents[j++] = vkd3d_spirv_build_op_loadv(builder, type_id, ptr_id, access_mask, &alignment, 1);
 
-            if (resource->reg.modifier == VKD3DSPRM_NONUNIFORM)
+            if (resource->reg.modifier & VKD3DSPRM_NONUNIFORM)
                 vkd3d_dxbc_compiler_decorate_nonuniform(compiler, ptr_id);
         }
         else
@@ -9821,7 +9821,7 @@ static void vkd3d_dxbc_compiler_emit_store_uav_raw_structured(struct vkd3d_dxbc_
             ptr_id = vkd3d_spirv_build_op_access_chain(builder, ptr_type_id, image.id, indices, ARRAY_SIZE(indices));
             vkd3d_spirv_build_op_storev(builder, ptr_id, texel_id, access_mask, &alignment, 1);
 
-            if (dst->reg.modifier == VKD3DSPRM_NONUNIFORM)
+            if (dst->reg.modifier & VKD3DSPRM_NONUNIFORM)
                 vkd3d_dxbc_compiler_decorate_nonuniform(compiler, ptr_id);
         }
         else
@@ -10032,7 +10032,7 @@ static void vkd3d_dxbc_compiler_emit_uav_counter_instruction(struct vkd3d_dxbc_c
                 ctr_ptr_type_id, image_ptr, zero_id, zero_id);
 
         /* Need to mark the pointer argument itself as non-uniform. */
-        if (src->reg.modifier == VKD3DSPRM_NONUNIFORM)
+        if (src->reg.modifier & VKD3DSPRM_NONUNIFORM)
             vkd3d_dxbc_compiler_decorate_nonuniform(compiler, pointer_id);
     }
     else
@@ -10195,7 +10195,7 @@ static void vkd3d_dxbc_compiler_emit_atomic_instruction(struct vkd3d_dxbc_compil
         ptr_type_id = vkd3d_spirv_get_op_type_pointer(builder, image.storage_class, type_id);
         pointer_id = vkd3d_spirv_build_op_access_chain(builder, ptr_type_id, image.id, indices, ARRAY_SIZE(indices));
 
-        if (resource->reg.modifier == VKD3DSPRM_NONUNIFORM)
+        if (resource->reg.modifier & VKD3DSPRM_NONUNIFORM)
             vkd3d_dxbc_compiler_decorate_nonuniform(compiler, pointer_id);
     }
     else
@@ -10207,7 +10207,7 @@ static void vkd3d_dxbc_compiler_emit_atomic_instruction(struct vkd3d_dxbc_compil
         pointer_id = vkd3d_spirv_build_op_image_texel_pointer(builder,
                 ptr_type_id, image.id, coordinate_id, sample_id);
 
-        if (resource->reg.modifier == VKD3DSPRM_NONUNIFORM)
+        if (resource->reg.modifier & VKD3DSPRM_NONUNIFORM)
             vkd3d_dxbc_compiler_decorate_nonuniform(compiler, pointer_id);
     }
 
@@ -10258,7 +10258,7 @@ static void vkd3d_dxbc_compiler_emit_bufinfo(struct vkd3d_dxbc_compiler *compile
         }
         else
         {
-            if (src->reg.modifier == VKD3DSPRM_NONUNIFORM)
+            if (src->reg.modifier & VKD3DSPRM_NONUNIFORM)
                 vkd3d_dxbc_compiler_decorate_nonuniform(compiler, image.id);
 
             val_id = vkd3d_spirv_build_op_array_length(builder, type_id, image.id, 0);

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -5823,7 +5823,7 @@ static void vkd3d_dxbc_compiler_emit_dcl_global_flags(struct vkd3d_dxbc_compiler
         flags &= ~(VKD3DSGF_ENABLE_DOUBLE_PRECISION_FLOAT_OPS | VKD3DSGF_ENABLE_11_1_DOUBLE_EXTENSIONS);
     }
 
-    if (flags & ~(VKD3DSGF_REFACTORING_ALLOWED | VKD3DSGF_ENABLE_RAW_AND_STRUCTURED_BUFFERS))
+    if (flags & ~(VKD3DSGF_REFACTORING_ALLOWED | VKD3DSGF_ENABLE_MINIMUM_PRECISION | VKD3DSGF_ENABLE_RAW_AND_STRUCTURED_BUFFERS))
         FIXME("Unhandled global flags %#x.\n", flags);
     else
         WARN("Unhandled global flags %#x.\n", flags);

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -386,7 +386,8 @@ enum vkd3d_immconst_type
 enum vkd3d_shader_register_modifier
 {
     VKD3DSPRM_NONE = 0,
-    VKD3DSPRM_NONUNIFORM = 1,
+    VKD3DSPRM_NONUNIFORM = 0x1,
+    VKD3DSPRM_RELAXED_PRECISION = 0x2,
 };
 
 enum vkd3d_shader_src_modifier
@@ -534,7 +535,7 @@ struct vkd3d_shader_register_index
 struct vkd3d_shader_register
 {
     enum vkd3d_shader_register_type type;
-    enum vkd3d_shader_register_modifier modifier;
+    uint32_t modifier; /* enum vkd3d_shader_register_modifier */
     enum vkd3d_data_type data_type;
     struct vkd3d_shader_register_index idx[3];
     enum vkd3d_immconst_type immconst_type;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -5563,8 +5563,7 @@ static void d3d12_device_caps_init_feature_options(struct d3d12_device *device)
 
     options->DoublePrecisionFloatShaderOps = features->shaderFloat64;
     options->OutputMergerLogicOp = features->logicOp;
-    /* Currently not supported */
-    options->MinPrecisionSupport = D3D12_SHADER_MIN_PRECISION_SUPPORT_NONE;
+    options->MinPrecisionSupport = D3D12_SHADER_MIN_PRECISION_SUPPORT_16_BIT;
     options->TiledResourcesTier = d3d12_device_determine_tiled_resources_tier(device);
     options->ResourceBindingTier = d3d12_device_determine_resource_binding_tier(device);
     options->PSSpecifiedStencilRefSupported = vk_info->EXT_shader_stencil_export;

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -304,3 +304,4 @@ decl_test(test_mesh_shader_execute_indirect);
 decl_test(test_amplification_shader);
 decl_test(test_advanced_cbv_layout);
 decl_test(test_shader_waveop_maximal_convergence);
+decl_test(test_minprecision_dxbc);


### PR DESCRIPTION
Emits tons of RelaxedPrecision now in Hellblade FSR implementation. Untested if it helps performance in any meaningful way.