### PR TITLE
vkd3d: Don't do layout transition in aliasing barrier.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6716,32 +6716,6 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_
     }
 }
 
-static void vk_image_memory_barrier_for_after_aliasing_barrier(struct d3d12_device *device,
-        VkQueueFlags vk_queue_flags, struct d3d12_resource *after, VkImageMemoryBarrier *vk_barrier)
-{
-    vk_barrier->sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    vk_barrier->pNext = NULL;
-    vk_barrier->srcAccessMask = 0;
-    vk_barrier->dstAccessMask = vk_access_flags_all_possible_for_image(device, after->desc.Flags, vk_queue_flags, true);
-    vk_barrier->oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-    /* We currently do not know the resource state.
-     * There are two scenarios here:
-     * - The image is in render target state. In this case, we must have a following Discard / Clear / Copy,
-     * which will transition away from UNDEFINED either way.
-     * - Otherwise, we have to initialize the image in some way anyways which will trigger oldLayout = UNDEFINED.
-     * Just discarding to common_layout is a sensible option. */
-    vk_barrier->newLayout = after->common_layout;
-    vk_barrier->srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    vk_barrier->dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    vk_barrier->image = after->res.vk_image;
-    vk_barrier->subresourceRange.aspectMask = after->format->vk_aspect_mask;
-    vk_barrier->subresourceRange.baseMipLevel = 0;
-    vk_barrier->subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
-    vk_barrier->subresourceRange.baseArrayLayer = 0;
-    vk_barrier->subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
-}
-
 static bool d3d12_resource_may_alias_other_resources(struct d3d12_resource *resource)
 {
     /* Treat a NULL resource as "all" resources. */
@@ -7081,33 +7055,27 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResourceBarrier(d3d12_command_l
 
                     if (after && d3d12_resource_is_texture(after))
                     {
-                        VkImageMemoryBarrier vk_alias_barrier;
-
                         /* An aliasing barrier discards to common layout.
-                         * We'll see a DiscardResource later anyways which should make the resource optimal. */
+                         * We'll see a DiscardResource/CopyResource/Clear later anyways which should make the resource optimal.
+                         * We can rely on that to handle the actual image layout transition. */
                         if (after->desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)
                             d3d12_command_list_notify_decay_dsv_resource(list, after);
 
-                        vk_image_memory_barrier_for_after_aliasing_barrier(list->device, list->vk_queue_flags,
-                                after, &vk_alias_barrier);
-                        d3d12_command_list_barrier_batch_add_layout_transition(list, &batch, &vk_alias_barrier);
-                        /* If this alias triggers a flush, make sure we add global barriers after that happens. */
-                        batch.vk_memory_barrier.srcAccessMask |= alias_src_access;
-                        batch.src_stage_mask |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-                        batch.dst_stage_mask |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+                        alias_dst_access = vk_access_flags_all_possible_for_image(list->device, after->desc.Flags, list->vk_queue_flags, true);
                     }
                     else
                     {
                         if (!after)
                             FIXME_ONCE("NULL resource for pResourceAfter. Won't be able to transition images away from UNDEFINED.\n");
+
                         alias_dst_access = vk_access_flags_all_possible_for_buffer(list->device,
                                 list->vk_queue_flags, true);
-
-                        batch.src_stage_mask |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-                        batch.dst_stage_mask |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-                        batch.vk_memory_barrier.srcAccessMask |= alias_src_access;
-                        batch.vk_memory_barrier.dstAccessMask |= alias_dst_access;
                     }
+
+                    batch.src_stage_mask |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+                    batch.dst_stage_mask |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+                    batch.vk_memory_barrier.srcAccessMask |= alias_src_access;
+                    batch.vk_memory_barrier.dstAccessMask |= alias_dst_access;
                 }
                 break;
             }


### PR DESCRIPTION
See #945

I'm not sure if this is correct so I'm looking forward to feedback.

Fixes black screen in HZD when enabling FSR on Nvidia Pascal. Might be broken in different ways on other HW.