### PR TITLE
SPIR-V caching in pipeline libraries - Phase 1

### DIFF
--- a/include/private/hashmap.h
+++ b/include/private/hashmap.h
@@ -212,4 +212,27 @@ static inline uint32_t hash_uint64(uint64_t n)
     return hash_combine((uint32_t)n, (uint32_t)(n >> 32));
 }
 
+/* A somewhat stronger hash when we're meant to store the hash (pipeline caches, etc). Based on FNV-1a. */
+static inline uint64_t hash_fnv1_init()
+{
+    return 0xcbf29ce484222325ull;
+}
+
+static inline uint64_t hash_fnv1_iterate_u8(uint64_t h, uint8_t value)
+{
+    return (h * 0x100000001b3ull) ^ value;
+}
+
+static inline uint64_t hash_fnv1_iterate_u32(uint64_t h, uint32_t value)
+{
+    return (h * 0x100000001b3ull) ^ value;
+}
+
+static inline uint64_t hash_fnv1_iterate_u64(uint64_t h, uint64_t value)
+{
+    h = hash_fnv1_iterate_u32(h, value & UINT32_MAX);
+    h = hash_fnv1_iterate_u32(h, value >> 32);
+    return h;
+}
+
 #endif  /* __VKD3D_HASHMAP_H */

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -54,16 +54,20 @@ enum vkd3d_shader_visibility
 
 typedef uint64_t vkd3d_shader_hash_t;
 
+enum vkd3d_shader_meta_flags
+{
+    VKD3D_SHADER_META_FLAG_REPLACED = 1 << 0,
+    VKD3D_SHADER_META_FLAG_USES_SUBGROUP_SIZE = 1 << 1,
+    VKD3D_SHADER_META_FLAG_USES_NATIVE_16BIT_OPERATIONS = 1 << 2,
+};
+
 struct vkd3d_shader_meta
 {
     vkd3d_shader_hash_t hash;
     unsigned int cs_workgroup_size[3]; /* Only contains valid data if uses_subgroup_size is true. */
     unsigned int patch_vertex_count; /* Relevant for HS. May be 0, in which case the patch vertex count is not known. */
     unsigned int cs_required_wave_size; /* If non-zero, force a specific CS subgroup size. */
-    bool replaced;
-    bool uses_subgroup_size;
-    bool uses_native_16bit_operations;
-    bool padding;
+    uint32_t flags; /* vkd3d_shader_meta_flags */
 };
 STATIC_ASSERT(sizeof(struct vkd3d_shader_meta) == 32);
 

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -63,7 +63,9 @@ struct vkd3d_shader_meta
     bool replaced;
     bool uses_subgroup_size;
     bool uses_native_16bit_operations;
+    bool padding;
 };
+STATIC_ASSERT(sizeof(struct vkd3d_shader_meta) == 32);
 
 struct vkd3d_shader_code
 {
@@ -71,6 +73,8 @@ struct vkd3d_shader_code
     size_t size;
     struct vkd3d_shader_meta meta;
 };
+
+vkd3d_shader_hash_t vkd3d_shader_hash(const struct vkd3d_shader_code *shader);
 
 enum vkd3d_shader_descriptor_type
 {

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -799,6 +799,8 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
 uint32_t vkd3d_shader_compile_arguments_select_quirks(
         const struct vkd3d_shader_compile_arguments *args, vkd3d_shader_hash_t hash);
 
+uint64_t vkd3d_shader_get_revision(void);
+
 #endif  /* VKD3D_SHADER_NO_PROTOTYPES */
 
 /*

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -349,7 +349,7 @@ int vkd3d_shader_compile_dxbc(const struct vkd3d_shader_code *dxbc,
     spirv->meta.hash = hash;
     if (vkd3d_shader_replace(hash, &spirv->code, &spirv->size))
     {
-        spirv->meta.replaced = true;
+        spirv->meta.flags |= VKD3D_SHADER_META_FLAG_REPLACED;
         return VKD3D_OK;
     }
 

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -736,3 +736,12 @@ uint32_t vkd3d_shader_compile_arguments_select_quirks(
     else
         return 0;
 }
+
+uint64_t vkd3d_shader_get_revision(void)
+{
+    /* This is meant to be bumped every time a change is made to the shader compiler.
+     * Might get nuked later ...
+     * It's not immediately useful for invalidating pipeline caches, since that would mostly be covered
+     * by vkd3d-proton Git hash. */
+    return 1;
+}

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -712,12 +712,12 @@ void vkd3d_shader_free_shader_signature(struct vkd3d_shader_signature *signature
 
 vkd3d_shader_hash_t vkd3d_shader_hash(const struct vkd3d_shader_code *shader)
 {
-    vkd3d_shader_hash_t h = 0xcbf29ce484222325ull;
+    vkd3d_shader_hash_t h = hash_fnv1_init();
     const uint8_t *code = shader->code;
     size_t i, n;
 
     for (i = 0, n = shader->size; i < n; i++)
-        h = (h * 0x100000001b3ull) ^ code[i];
+        h = hash_fnv1_iterate_u8(h, code[i]);
 
     return h;
 }

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -919,6 +919,4 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
         const struct vkd3d_shader_interface_info *shader_interface_info,
         const struct vkd3d_shader_compile_arguments *compiler_args);
 
-vkd3d_shader_hash_t vkd3d_shader_hash(const struct vkd3d_shader_code *shader);
-
 #endif  /* __VKD3D_SHADER_PRIVATE_H */

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6930,8 +6930,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_
             for (i = 0; i < state->graphics.stage_count; i++)
             {
                 TRACE("Binding graphics module with hash: %016"PRIx64" (replaced: %s).\n",
-                      state->graphics.stage_meta[i].hash,
-                      state->graphics.stage_meta[i].replaced ? "yes" : "no");
+                        state->graphics.stage_meta[i].hash,
+                        (state->graphics.stage_meta[i].flags & VKD3D_SHADER_META_FLAG_REPLACED) ? "yes" : "no");
             }
         }
     }

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -5987,7 +5987,8 @@ out_free_mutex:
 bool d3d12_device_validate_shader_meta(struct d3d12_device *device, const struct vkd3d_shader_meta *meta)
 {
     /* TODO: Add more as required. */
-    if (meta->uses_native_16bit_operations && !device->d3d12_caps.options4.Native16BitShaderOpsSupported)
+    if ((meta->flags & VKD3D_SHADER_META_FLAG_USES_NATIVE_16BIT_OPERATIONS) &&
+            !device->d3d12_caps.options4.Native16BitShaderOpsSupported)
     {
         WARN("Attempting to use 16-bit operations in shader %016"PRIx64", but this is not supported.", meta->hash);
         return false;

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -1130,7 +1130,7 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
 
         stage->module = create_shader_module(object->device, spirv.code, spirv.size);
 
-        if (spirv.meta.uses_subgroup_size &&
+        if ((spirv.meta.flags & VKD3D_SHADER_META_FLAG_USES_SUBGROUP_SIZE) &&
                 object->device->device_info.subgroup_size_control_features.subgroupSizeControl)
         {
             stage->flags |= VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1877,7 +1877,8 @@ HRESULT vkd3d_pipeline_state_desc_from_d3d12_graphics_desc(struct d3d12_pipeline
     desc->dsv_format = d3d12_desc->DSVFormat;
     desc->sample_desc = d3d12_desc->SampleDesc;
     desc->node_mask = d3d12_desc->NodeMask;
-    desc->cached_pso = d3d12_desc->CachedPSO;
+    desc->cached_pso.blob = d3d12_desc->CachedPSO;
+    desc->cached_pso.library = NULL;
     desc->flags = d3d12_desc->Flags;
     return S_OK;
 }
@@ -1889,7 +1890,8 @@ HRESULT vkd3d_pipeline_state_desc_from_d3d12_compute_desc(struct d3d12_pipeline_
     desc->root_signature = d3d12_desc->pRootSignature;
     desc->cs = d3d12_desc->CS;
     desc->node_mask = d3d12_desc->NodeMask;
-    desc->cached_pso = d3d12_desc->CachedPSO;
+    desc->cached_pso.blob = d3d12_desc->CachedPSO;
+    desc->cached_pso.library = NULL;
     desc->flags = d3d12_desc->Flags;
     return S_OK;
 }
@@ -1972,7 +1974,7 @@ HRESULT vkd3d_pipeline_state_desc_from_d3d12_stream_desc(struct d3d12_pipeline_s
             VKD3D_HANDLE_SUBOBJECT(DEPTH_STENCIL_FORMAT, DXGI_FORMAT, desc->dsv_format);
             VKD3D_HANDLE_SUBOBJECT(SAMPLE_DESC, DXGI_SAMPLE_DESC, desc->sample_desc);
             VKD3D_HANDLE_SUBOBJECT(NODE_MASK, UINT, desc->node_mask);
-            VKD3D_HANDLE_SUBOBJECT(CACHED_PSO, D3D12_CACHED_PIPELINE_STATE, desc->cached_pso);
+            VKD3D_HANDLE_SUBOBJECT(CACHED_PSO, D3D12_CACHED_PIPELINE_STATE, desc->cached_pso.blob);
             VKD3D_HANDLE_SUBOBJECT(FLAGS, D3D12_PIPELINE_STATE_FLAGS, desc->flags);
             VKD3D_HANDLE_SUBOBJECT(DEPTH_STENCIL1, D3D12_DEPTH_STENCIL_DESC1, desc->depth_stencil_state);
             VKD3D_HANDLE_SUBOBJECT(VIEW_INSTANCING, D3D12_VIEW_INSTANCING_DESC, desc->view_instancing_desc);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2881,6 +2881,7 @@ struct d3d12_device
     struct vkd3d_descriptor_qa_global_info *descriptor_qa_global_info;
 #endif
     VkPipelineCache global_pipeline_cache;
+    uint64_t shader_interface_key;
 };
 
 HRESULT d3d12_device_create(struct vkd3d_instance *instance,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1633,7 +1633,7 @@ struct d3d12_pipeline_library
 
     struct d3d12_device *device;
 
-    pthread_mutex_t mutex;
+    rwlock_t mutex;
     struct hash_map map;
 
     struct vkd3d_private_store private_store;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1549,6 +1549,14 @@ static inline bool d3d12_pipeline_state_has_unknown_dsv_format(struct d3d12_pipe
     return false;
 }
 
+struct d3d12_cached_pipeline_state
+{
+    D3D12_CACHED_PIPELINE_STATE blob;
+    /* For cached PSO if that blob comes from a library.
+     * Might need it to resolve references. */
+    struct d3d12_pipeline_library *library;
+};
+
 struct d3d12_pipeline_state_desc
 {
     ID3D12RootSignature *root_signature;
@@ -1571,7 +1579,7 @@ struct d3d12_pipeline_state_desc
     DXGI_SAMPLE_DESC sample_desc;
     D3D12_VIEW_INSTANCING_DESC view_instancing_desc;
     UINT node_mask;
-    D3D12_CACHED_PIPELINE_STATE cached_pso;
+    struct d3d12_cached_pipeline_state cached_pso;
     D3D12_PIPELINE_STATE_FLAGS flags;
 };
 
@@ -1645,7 +1653,7 @@ HRESULT d3d12_pipeline_library_create(struct d3d12_device *device, const void *b
 VkResult vkd3d_create_pipeline_cache(struct d3d12_device *device,
         size_t size, const void *data, VkPipelineCache *cache);
 HRESULT vkd3d_create_pipeline_cache_from_d3d12_desc(struct d3d12_device *device,
-        const D3D12_CACHED_PIPELINE_STATE *state, VkPipelineCache *cache);
+        const struct d3d12_cached_pipeline_state *state, VkPipelineCache *cache);
 VkResult vkd3d_serialize_pipeline_state(const struct d3d12_pipeline_state *state, size_t *size, void *data);
 
 struct vkd3d_buffer


### PR DESCRIPTION
This PR focuses on slight refactors which will be required for saving any SPIR-V in cache.

- First, move over to RW locks for pipeline libraries. It was supposed to be a big optimization, but then I realized that the lock was unlocked before create_pipeline_state(), so it's not as useful as initially thought. Still nice to have though.
- Then, add a hash which should be used for storing SPIR-V and deduplicated blobs. It's the same one as used for DXBC shader blobs, just make it more reusable.
- Finally, add concept of shader interface key. Given equivalent DXBC + root signature + device UUID + shader interface key, we should guarantee a 1:1 match with SPIR-V.
- Store the shader interface key in pipeline library as well and validate it.