### PR TITLE
SPIR-V caching - Phase 2 - Rewrite pipeline library implementation

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6934,15 +6934,15 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_
 
         if (state->vk_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE)
         {
-            TRACE("Binding compute module with hash: %016"PRIx64".\n", state->compute.meta.hash);
+            TRACE("Binding compute module with hash: %016"PRIx64".\n", state->compute.code.meta.hash);
         }
         else if (state->vk_bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS)
         {
             for (i = 0; i < state->graphics.stage_count; i++)
             {
                 TRACE("Binding graphics module with hash: %016"PRIx64" (replaced: %s).\n",
-                        state->graphics.stage_meta[i].hash,
-                        (state->graphics.stage_meta[i].flags & VKD3D_SHADER_META_FLAG_REPLACED) ? "yes" : "no");
+                        state->graphics.code[i].meta.hash,
+                        (state->graphics.code[i].meta.flags & VKD3D_SHADER_META_FLAG_REPLACED) ? "yes" : "no");
             }
         }
     }

--- a/libs/vkd3d/renderdoc.c
+++ b/libs/vkd3d/renderdoc.c
@@ -238,7 +238,7 @@ void vkd3d_renderdoc_command_list_check_capture(struct d3d12_command_list *list,
     {
         if (state->vk_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE)
         {
-            if (vkd3d_renderdoc_should_capture_shader_hash(state->compute.meta.hash))
+            if (vkd3d_renderdoc_should_capture_shader_hash(state->compute.code.meta.hash))
             {
                 WARN("Triggering RenderDoc capture for this command list.\n");
                 list->debug_capture = true;
@@ -248,7 +248,7 @@ void vkd3d_renderdoc_command_list_check_capture(struct d3d12_command_list *list,
         {
             for (i = 0; i < state->graphics.stage_count; i++)
             {
-                if (vkd3d_renderdoc_should_capture_shader_hash(state->graphics.stage_meta[i].hash))
+                if (vkd3d_renderdoc_should_capture_shader_hash(state->graphics.code[i].meta.hash))
                 {
                     WARN("Triggering RenderDoc capture for this command list.\n");
                     list->debug_capture = true;

--- a/tests/d3d12_pso_blob.c
+++ b/tests/d3d12_pso_blob.c
@@ -254,7 +254,7 @@ void test_pipeline_library(void)
 
     hr = ID3D12PipelineLibrary_LoadComputePipeline(pipeline_library,
             graphics_name, &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    todo ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
 
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(state);

--- a/tests/d3d12_pso_blob.c
+++ b/tests/d3d12_pso_blob.c
@@ -259,6 +259,13 @@ void test_pipeline_library(void)
     ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", hr);
     ID3D12PipelineState_Release(state);
 
+    /* Verify that modifying a PSO description must be invalidated by runtime. */
+    graphics_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE;
+    hr = ID3D12PipelineLibrary_LoadGraphicsPipeline(pipeline_library,
+            graphics_name, &graphics_desc, &IID_ID3D12PipelineState, (void**)&state);
+    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", hr);
+    graphics_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+
     serialized_size = ID3D12PipelineLibrary_GetSerializedSize(pipeline_library);
     ok(serialized_size > 0, "Serialized size for pipeline library is 0.\n");
 


### PR DESCRIPTION
Builds on https://github.com/HansKristian-Work/vkd3d-proton/pull/980.

This became basically a rewrite in the end, and it got too awkward to
split these commits in any meaningful way.

The goals here were primarily to:

- Support serializing SPIR-V and load SPIR-V.
  To do this robustly requires a lot more validation and checks to make
  sure end up compiling the same SPIR-V that we load from cache.
  This is critical for performance when games have primed their pipeline
  libraries and expect that loading a PSO should be fast. Without this,
  we will hit vkd3d-shader for every PSO, causing very long load times.
- Implement the required validation for mismatched PSO descriptions.
- Rewrite the binary layout of the pipeline library for flexibility
  concerns and performance.
  If the pipeline library is mmap-ed from disk - which appears to be
  the intended use - we only need to scan through the TOC to fully parse
  the library contents.
  From a flexibility concern, a blob needs to support inlined data,
  but a library can use referential links. We introduce separate
  hashmaps which store deduplicated SPIR-V and pipeline cache blobs,
  which significantly drop memory and storage requirements.
  For future improvements, it should be fairly easy to add information
  which lets us avoid SPIR-V or pipeline cache data altogether if
  relevant changes to Vulkan/drivers are made.