### PR TITLE
vkd3d: Remove warning for setting NULL index buffer.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -7754,7 +7754,6 @@ static void STDMETHODCALLTYPE d3d12_command_list_IASetIndexBuffer(d3d12_command_
 
     if (!view)
     {
-        WARN("Got NULL index buffer view, indexed draw calls will be dropped.\n");
         list->has_valid_index_buffer = false;
         return;
     }


### PR DESCRIPTION
This is benign and easily gets spammed a TON.
We will warn if an indexed draw is actually made like this.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>