### PR TITLE
Implement COLOR -> STENCIL copies if stencil export is supported.

### DIFF
--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -19,6 +19,7 @@ vkd3d_shaders =[
 
   'shaders/fs_copy_image_float.frag',
   'shaders/fs_copy_image_uint.frag',
+  'shaders/fs_copy_image_stencil.frag',
 
   'shaders/gs_fullscreen.geom',
   'shaders/vs_fullscreen.vert',

--- a/libs/vkd3d/shaders/fs_copy_image_stencil.frag
+++ b/libs/vkd3d/shaders/fs_copy_image_stencil.frag
@@ -1,0 +1,28 @@
+#version 450
+
+#extension GL_EXT_samplerless_texture_functions : enable
+#extension GL_ARB_shader_stencil_export : enable
+
+#define MODE_1D 0
+#define MODE_2D 1
+#define MODE_MS 2
+
+layout(constant_id = 0) const uint c_mode = MODE_2D;
+
+layout(binding = 0) uniform utexture1DArray tex_1d;
+layout(binding = 0) uniform utexture2DArray tex_2d;
+layout(binding = 0) uniform utexture2DMSArray tex_ms;
+
+layout(push_constant)
+uniform u_info_t {
+  ivec2 offset;
+} u_info;
+
+void main() {
+  ivec3 coord = ivec3(u_info.offset + ivec2(gl_FragCoord.xy), gl_Layer);
+  uint value;
+  if (c_mode == MODE_1D) value = texelFetch(tex_1d, coord.xz, 0).r;
+  if (c_mode == MODE_2D) value = texelFetch(tex_2d, coord, 0).r;
+  if (c_mode == MODE_MS) value = texelFetch(tex_ms, coord, gl_SampleID).r;
+  gl_FragStencilRefARB = int(value);
+}

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2481,6 +2481,7 @@ struct vkd3d_copy_image_pipeline_key
     VkImageViewType view_type;
     VkSampleCountFlagBits sample_count;
     VkImageLayout layout;
+    VkImageAspectFlags dst_aspect_mask;
 };
 
 struct vkd3d_copy_image_pipeline
@@ -2497,6 +2498,7 @@ struct vkd3d_copy_image_ops
     VkPipelineLayout vk_pipeline_layout;
     VkShaderModule vk_fs_float_module;
     VkShaderModule vk_fs_uint_module;
+    VkShaderModule vk_fs_stencil_module;
 
     pthread_mutex_t mutex;
 

--- a/libs/vkd3d/vkd3d_shaders.h
+++ b/libs/vkd3d/vkd3d_shaders.h
@@ -50,6 +50,7 @@ enum vkd3d_meta_copy_mode
 #include <gs_fullscreen.h>
 #include <fs_copy_image_float.h>
 #include <fs_copy_image_uint.h>
+#include <fs_copy_image_stencil.h>
 #include <vs_swapchain_fullscreen.h>
 #include <fs_swapchain_fullscreen.h>
 

--- a/tests/d3d12_copy.c
+++ b/tests/d3d12_copy.c
@@ -137,6 +137,10 @@ void test_copy_texture(void)
         { 0.7f, 41, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R32G8X24_TYPELESS, true, false },
         { 0.2f, 42, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R32G8X24_TYPELESS, false, true },
         { 0.5f, 43, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R32G8X24_TYPELESS, true, true },
+
+        /* Test color <-> stencil copies. */
+        { 1.0f, 44, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R8_UINT, true, false },
+        { 1.0f, 45, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R8_UINT, true, true },
     };
 
     static const D3D12_RESOURCE_STATES resource_states[] =
@@ -309,7 +313,7 @@ void test_copy_texture(void)
 
         if (depth_copy_tests[i].roundtrip)
         {
-            /* Test color to depth copy. */
+            /* Test color to depth/stencil copy. */
             D3D12_TEXTURE_COPY_LOCATION tmp_src_location = dst_location;
             D3D12_TEXTURE_COPY_LOCATION tmp_dst_location = src_location;
             transition_sub_resource_state(command_list, dst_texture, srv.Texture2D.PlaneSlice,

--- a/tests/d3d12_copy.c
+++ b/tests/d3d12_copy.c
@@ -119,6 +119,7 @@ void test_copy_texture(void)
         DXGI_FORMAT readback_format;
         bool stencil;
         bool roundtrip;
+        bool requires_stencil_export;
     };
     static const struct depth_copy_test depth_copy_tests[] = {
         { 0.0f, 0, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_R32_FLOAT, false, false },
@@ -140,7 +141,7 @@ void test_copy_texture(void)
 
         /* Test color <-> stencil copies. */
         { 1.0f, 44, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R8_UINT, true, false },
-        { 1.0f, 45, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R8_UINT, true, true },
+        { 1.0f, 45, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R8_UINT, true, true, true },
     };
 
     static const D3D12_RESOURCE_STATES resource_states[] =
@@ -352,6 +353,8 @@ void test_copy_texture(void)
 
         if (depth_copy_tests[i].stencil)
         {
+            /* Supported on AMD, but not NV. Need buffer copy roundtrip workaround for that to work. */
+            todo_if(depth_copy_tests[i].requires_stencil_export)
             check_sub_resource_float(context.render_target, 0, queue, command_list, (float)depth_copy_tests[i].stencil_value, 0);
         }
         else

--- a/tests/d3d12_copy.c
+++ b/tests/d3d12_copy.c
@@ -207,7 +207,7 @@ void test_copy_texture(void)
 
     for (i = 0; i < ARRAY_SIZE(resource_states); ++i)
     {
-        src_texture = create_default_texture(device, 16, 16, DXGI_FORMAT_R8G8B8A8_UNORM,
+        src_texture = create_default_texture(device, 4, 4, DXGI_FORMAT_R8G8B8A8_UNORM,
                 0, D3D12_RESOURCE_STATE_COPY_DEST);
         texture_data.pData = bitmap_data;
         texture_data.RowPitch = 4 * sizeof(*bitmap_data);


### PR DESCRIPTION
Also cleans up a benign fixme that was misreporting in at least BF2042.

Also adds some additional tests for DS <-> DS copies and stencil <-> color copy.