### PR TITLE
Fix Meson breakage on Windows CI

### DIFF
--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -34,26 +34,20 @@ jobs:
         Write-Output "VSDEVCMD=${installationPath}\Common7\Tools\VsDevCmd.bat" `
           | Out-File -FilePath "${Env:GITHUB_ENV}" -Append
 
-    - name: Prepare MSVC x86
-      shell: pwsh
-      run: |
-        & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x86 -host_arch=x64 -no_logo && set" `
-          | Out-File -FilePath "${Env:GITHUB_ENV}" -Append
-
     - name: Build MSVC x86
       shell: pwsh
       run: |
+        & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x86 -host_arch=x64 -no_logo && set" `
+          | % { , ($_ -Split '=', 2) } `
+          | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
         meson -Denable_tests=True -Denable_extras=True --buildtype release --backend vs2022 build-msvc-x86
         msbuild -m build-msvc-x86/vkd3d-proton.sln
-
-    - name: Prepare MSVC x64
-      shell: pwsh
-      run: |
-        & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x64 -host_arch=x64 -no_logo && set" `
-          | Out-File -FilePath "${Env:GITHUB_ENV}" -Append
 
     - name: Build MSVC x64
       shell: pwsh
       run: |
+        & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x64 -host_arch=x64 -no_logo && set" `
+          | % { , ($_ -Split '=', 2) } `
+          | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
         meson -Denable_tests=True -Denable_extras=True --buildtype release --backend vs2022 build-msvc-x64
         msbuild -m build-msvc-x64/vkd3d-proton.sln

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -21,9 +21,9 @@ jobs:
         Write-Output "$([System.Environment]::GetEnvironmentVariable('VULKAN_SDK', 'Machine'))\Bin" `
           | Out-File -FilePath "${Env:GITHUB_PATH}" -Append
 
-    - name: Setup Meson and Ninja
+    - name: Setup Meson
       shell: pwsh
-      run: pip install meson ninja
+      run: pip install meson
 
     - name: Find Visual Studio
       shell: pwsh
@@ -43,8 +43,8 @@ jobs:
     - name: Build MSVC x86
       shell: pwsh
       run: |
-        meson -Denable_tests=True -Denable_extras=True --buildtype release build-msvc-x86
-        ninja -C build-msvc-x86
+        meson -Denable_tests=True -Denable_extras=True --buildtype release --backend vs2022 build-msvc-x86
+        msbuild -m build-msvc-x86/vkd3d-proton.sln
 
     - name: Prepare MSVC x64
       shell: pwsh
@@ -55,5 +55,5 @@ jobs:
     - name: Build MSVC x64
       shell: pwsh
       run: |
-        meson -Denable_tests=True -Denable_extras=True --buildtype release build-msvc-x64
-        ninja -C build-msvc-x64
+        meson -Denable_tests=True -Denable_extras=True --buildtype release --backend vs2022 build-msvc-x64
+        msbuild -m build-msvc-x64/vkd3d-proton.sln


### PR DESCRIPTION
If you can't beat them, avoid the confrontation?

I still have no idea why that one Meson call fails but whatever Meson wants to do there, the `vs2022` backend handles on its own.

The second commit pulls the acquisition of environment variables into the build step itself so they don't leak between x86 and x64 builds, otherwise MSBuild complains about paths being too long.