### PR TITLE
Rewrite memory layout of d3d12_desc

### DIFF
--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -208,6 +208,14 @@ static inline unsigned int vkd3d_log2i(unsigned int x)
 #endif
 }
 
+static inline unsigned int vkd3d_log2i_ceil(unsigned int x)
+{
+    if (x == 1)
+        return 0;
+    else
+        return vkd3d_log2i(x - 1) + 1;
+}
+
 static inline int ascii_isupper(int c)
 {
     return 'A' <= c && c <= 'Z';

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4055,7 +4055,7 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple(d3d12_device_if
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
-    device = impl_from_ID3D12Device(iface);
+    device = unsafe_impl_from_ID3D12Device(iface);
 
     if (descriptor_heap_type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV ||
             descriptor_heap_type == D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -154,20 +154,22 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetCudaTextureObject(ID3
 {
     VkImageViewHandleInfoNVX imageViewHandleInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX };
     const struct vkd3d_vk_device_procs *vk_procs;
-    struct d3d12_desc *sampler_desc;
+    struct d3d12_desc_split sampler_desc;
+    struct d3d12_desc_split srv_desc;
     struct d3d12_device *device;
-    struct d3d12_desc *srv_desc;
-    
-    TRACE("iface %p, srv_handle %#x, sampler_handle %#x, cuda_texture_handle %p.\n", iface, srv_handle, sampler_handle, cuda_texture_handle);
+
+    TRACE("iface %p, srv_handle %zu, sampler_handle %zu, cuda_texture_handle %p.\n",
+            iface, srv_handle.ptr, sampler_handle.ptr, cuda_texture_handle);
+
     if (!cuda_texture_handle)
        return E_INVALIDARG;
 
     device = d3d12_device_from_ID3D12DeviceExt(iface);
-    srv_desc = d3d12_desc_from_cpu_handle(srv_handle);
-    sampler_desc = d3d12_desc_from_cpu_handle(sampler_handle);
+    srv_desc = d3d12_desc_decode_va(srv_handle.ptr);
+    sampler_desc = d3d12_desc_decode_va(sampler_handle.ptr);
 
-    imageViewHandleInfo.imageView = srv_desc->info.view->vk_image_view;
-    imageViewHandleInfo.sampler = sampler_desc->info.view->vk_sampler;
+    imageViewHandleInfo.imageView = srv_desc.view->info.view->vk_image_view;
+    imageViewHandleInfo.sampler = sampler_desc.view->info.view->vk_sampler;
     imageViewHandleInfo.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 
     vk_procs = &device->vk_procs;
@@ -180,17 +182,17 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetCudaSurfaceObject(ID3
 {
     VkImageViewHandleInfoNVX imageViewHandleInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX };
     const struct vkd3d_vk_device_procs *vk_procs;
+    struct d3d12_desc_split uav_desc;
     struct d3d12_device *device;
-    struct d3d12_desc *uav_desc;
-    
-    TRACE("iface %p, uav_handle %#x, cuda_surface_handle %p.\n", iface, uav_handle, cuda_surface_handle);
+
+    TRACE("iface %p, uav_handle %zu, cuda_surface_handle %p.\n", iface, uav_handle.ptr, cuda_surface_handle);
     if (!cuda_surface_handle)
        return E_INVALIDARG;
 
     device = d3d12_device_from_ID3D12DeviceExt(iface);
-    uav_desc = d3d12_desc_from_cpu_handle(uav_handle);
+    uav_desc = d3d12_desc_decode_va(uav_handle.ptr);
 
-    imageViewHandleInfo.imageView = uav_desc->info.view->vk_image_view;
+    imageViewHandleInfo.imageView = uav_desc.view->info.view->vk_image_view;
     imageViewHandleInfo.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
 
     vk_procs = &device->vk_procs;

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -1016,7 +1016,7 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
 #endif
     }
 
-    shader_interface_local_info.descriptor_size = sizeof(struct d3d12_desc);
+    shader_interface_local_info.descriptor_size = VKD3D_RESOURCE_DESC_INCREMENT;
 
     local_static_sampler_bindings = NULL;
     local_static_sampler_bindings_count = 0;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2930,6 +2930,11 @@ bool d3d12_device_is_uma(struct d3d12_device *device, bool *coherent);
 void d3d12_device_mark_as_removed(struct d3d12_device *device, HRESULT reason,
         const char *message, ...) VKD3D_PRINTF_FUNC(3, 4);
 
+static inline struct d3d12_device *unsafe_impl_from_ID3D12Device(d3d12_device_iface *iface)
+{
+    return CONTAINING_RECORD(iface, struct d3d12_device, ID3D12Device_iface);
+}
+
 static inline struct d3d12_device *impl_from_ID3D12Device(d3d12_device_iface *iface)
 {
     extern CONST_VTBL struct ID3D12Device9Vtbl d3d12_device_vtbl;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1045,12 +1045,13 @@ enum vkd3d_descriptor_flag
     VKD3D_DESCRIPTOR_FLAG_BUFFER_OFFSET     = (1 << 2),
     VKD3D_DESCRIPTOR_FLAG_OFFSET_RANGE      = (1 << 3),
     VKD3D_DESCRIPTOR_FLAG_NON_NULL          = (1 << 4),
+    VKD3D_DESCRIPTOR_FLAG_SINGLE_DESCRIPTOR = (1 << 5),
 };
 
 struct vkd3d_descriptor_binding
 {
-    uint16_t set;
-    uint16_t binding;
+    uint8_t set;
+    uint8_t binding;
 };
 
 #define VKD3D_RESOURCE_DESC_INCREMENT_LOG2 5
@@ -1063,10 +1064,15 @@ struct vkd3d_descriptor_binding
 struct vkd3d_descriptor_metadata_types
 {
     VkDescriptorType current_null_type;
-    uint16_t set_info_mask;
-    uint16_t flags;
+    uint8_t set_info_mask;
+    uint8_t flags;
+    /* If SINGLE_DESCRIPTOR is set, use the embedded write info instead
+     * to avoid missing caches. */
+    struct vkd3d_descriptor_binding single_binding;
 };
 STATIC_ASSERT(sizeof(struct vkd3d_descriptor_metadata_types) == 8);
+/* Our use of 8-bit mask relies on MAX_BINDLESS_DESCRIPTOR_SETS fitting. */
+STATIC_ASSERT(VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS <= 8);
 
 struct vkd3d_descriptor_metadata_view
 {


### PR DESCRIPTION
Optimize resource descriptors for cache access. From digging deep into how we implemented this stuff, the existing implementation is kinda horrible for cache. In this code, every nanosecond counts when games spam it 30k+ times per frame.

We have to remove the entire idea of a heap_offset / heap pointer being stored inside a d3d12_desc. This is almost a guaranteed miss and shows up clearly in perf.

Don't look at the destination descriptor metadata at all. Saves a cache miss. We don't need to be so conservative with eliding redundant copies. The older MUTABLE path never bothered with any of this, and it was fine.

Finally, optimize for single descriptor copies, since we don't have to look back into d3d12_device. If we can, just store things inline. When we have to copy many descriptors, we are kinda forced to poke at the device metadata since we need to know the binding layout.

Add a fairly esoteric CPU VA encoding scheme which allows us to deduce heap offset + descriptor heap + metadata pointers from a single VA. The details are elaborated in the code.

Rather than descriptor being 64 bytes full of padding, it is now tightly packed arrays of 32 bytes and 8 bytes.