### PR TITLE
Avoid implicit DSV layout transitions with GENERAL layout when feasible

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -82,6 +82,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_BIND_MEMORY_2, KHR_bind_memory2),
     VK_EXTENSION(KHR_COPY_COMMANDS_2, KHR_copy_commands2),
     VK_EXTENSION(KHR_DYNAMIC_RENDERING, KHR_dynamic_rendering),
+    VK_EXTENSION(KHR_DRIVER_PROPERTIES, KHR_driver_properties),
     /* EXT extensions */
     VK_EXTENSION(EXT_CALIBRATED_TIMESTAMPS, EXT_calibrated_timestamps),
     VK_EXTENSION(EXT_CONDITIONAL_RENDERING, EXT_conditional_rendering),
@@ -1388,6 +1389,13 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         info->descriptor_set_host_mapping_features.sType =
                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE;
         vk_prepend_struct(&info->features2, &info->descriptor_set_host_mapping_features);
+    }
+
+    if (vulkan_info->KHR_driver_properties)
+    {
+        info->driver_properties.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR;
+        vk_prepend_struct(&info->properties2, &info->driver_properties);
     }
 
     /* Core in Vulkan 1.1. */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -129,6 +129,7 @@ struct vkd3d_vulkan_info
     bool KHR_bind_memory2;
     bool KHR_copy_commands2;
     bool KHR_dynamic_rendering;
+    bool KHR_driver_properties;
     /* EXT device extensions */
     bool EXT_calibrated_timestamps;
     bool EXT_conditional_rendering;
@@ -2765,6 +2766,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_properties;
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_properties;
     VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR shader_integer_dot_product_properties;
+    VkPhysicalDeviceDriverPropertiesKHR driver_properties;
 
     VkPhysicalDeviceProperties2KHR properties2;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1445,11 +1445,11 @@ struct vkd3d_shader_debug_ring_spec_info
     VkSpecializationInfo spec_info;
 };
 
-/* One render pass for each plane optimal mask. */
 enum vkd3d_plane_optimal_flag
 {
     VKD3D_DEPTH_PLANE_OPTIMAL = (1 << 0),
     VKD3D_STENCIL_PLANE_OPTIMAL = (1 << 1),
+    VKD3D_DEPTH_STENCIL_PLANE_GENERAL = (1 << 2),
 };
 
 struct d3d12_graphics_pipeline_state


### PR DESCRIPTION
The idea behind this change is that some implementations don't really care if we use GENERAL layout, so might as well just use it to avoid having to carefully transition to correct image DSV layouts everywhere.

The key improvement here is in rendering passes which split depth-rendering over many parallel command lists. This is a very common pattern which we ideally want to avoid.

Also, since we're no longer doing transitions for DSV images, drop the somewhat redundant UNDEFINED transition in Clear*View() if we don't need to handle aliasing rules.