### PR TITLE
Refactor pipeline library locking and ref-count strategy

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1651,6 +1651,10 @@ struct d3d12_pipeline_library
     struct d3d12_device *device;
 
     rwlock_t mutex;
+    /* driver_cache_map and spirv_cache_map can be touched in serialize_pipeline_state.
+     * Use the internal mutex when touching the internal caches
+     * so we don't need a big lock on the outside when serializing. */
+    rwlock_t internal_hashmap_mutex;
     struct hash_map pso_map;
     struct hash_map driver_cache_map;
     struct hash_map spirv_cache_map;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1647,6 +1647,7 @@ struct d3d12_pipeline_library
 {
     d3d12_pipeline_library_iface ID3D12PipelineLibrary_iface;
     LONG refcount;
+    LONG internal_refcount;
 
     struct d3d12_device *device;
 
@@ -1683,6 +1684,11 @@ HRESULT d3d12_cached_pipeline_state_validate(struct d3d12_device *device,
         const struct vkd3d_pipeline_cache_compatibility *compat);
 void vkd3d_pipeline_cache_compat_from_state_desc(struct vkd3d_pipeline_cache_compatibility *compat,
         const struct d3d12_pipeline_state_desc *desc);
+
+ULONG d3d12_pipeline_library_inc_public_ref(struct d3d12_pipeline_library *state);
+ULONG d3d12_pipeline_library_dec_public_ref(struct d3d12_pipeline_library *state);
+void d3d12_pipeline_library_inc_ref(struct d3d12_pipeline_library *state);
+void d3d12_pipeline_library_dec_ref(struct d3d12_pipeline_library *state);
 
 struct vkd3d_buffer
 {


### PR DESCRIPTION
To prepare for a world where we could have device-internal pipeline libraries, reshuffle some things around as a first step:

- Refactor out serialization call to a separate function so that an outer call could atomically GetSerializedSize + Serialize.
- Instead of taking a big write lock on StorePipeline, take locks as necessary when registering SPIR-V / PSO cache blobs. This allows us to use read-writer locks in StorePipeline and avoids contention when we have duplicate SPIR-V / PSO objects. This will be particularly useful for internal magic caches.
- Make use of internal reference counts in pipeline library as well. This allows us to hold pipeline libraries inside the device as needed without creating cycles.