### PR TITLE
vkd3d: Require VK_EXT_extended_dynamic_state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ There are some hard requirements on drivers to be able to implement D3D12 in a r
 - `VK_KHR_bind_memory2`
 - `VK_KHR_copy_commands2`
 - `VK_KHR_dynamic_rendering`
+- `VK_EXT_extended_dynamic_state`
 
 Some notable extensions that **should** be supported for optimal or correct behavior.
 These extensions will likely become mandatory later.
 
 - `VK_KHR_buffer_device_address`
-- `VK_EXT_extended_dynamic_state`
 - `VK_EXT_image_view_min_lod`
 
 `VK_VALVE_mutable_descriptor_type` is also highly recommended, but not mandatory.

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1985,6 +1985,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
         return E_INVALIDARG;
     }
 
+    if (!physical_device_info->extended_dynamic_state_features.extendedDynamicState)
+    {
+        ERR("EXT_extended_dynamic_state is not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
     return S_OK;
 }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1426,10 +1426,8 @@ enum vkd3d_dynamic_state_flag
     VKD3D_DYNAMIC_STATE_DEPTH_BOUNDS          = (1 << 4),
     VKD3D_DYNAMIC_STATE_TOPOLOGY              = (1 << 5),
     VKD3D_DYNAMIC_STATE_VERTEX_BUFFER         = (1 << 6),
-    VKD3D_DYNAMIC_STATE_VIEWPORT_COUNT        = (1 << 7),
-    VKD3D_DYNAMIC_STATE_SCISSOR_COUNT         = (1 << 8),
-    VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE  = (1 << 9),
-    VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE = (1 << 10),
+    VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE  = (1 << 7),
+    VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE = (1 << 8),
 };
 
 struct vkd3d_shader_debug_ring_spec_constants
@@ -1616,7 +1614,6 @@ struct vkd3d_pipeline_key
     VkFormat dsv_format;
 
     bool dynamic_stride;
-    bool dynamic_viewport;
     bool dynamic_topology;
 };
 


### PR DESCRIPTION
This is basically required for not horrible stutter and performance and
is widely supported.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>