### PR TITLE
vkd3d: Do not create pipeline variants for NULL RTVs.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1610,7 +1610,6 @@ struct vkd3d_pipeline_key
     D3D12_PRIMITIVE_TOPOLOGY topology;
     uint32_t viewport_count;
     uint32_t strides[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
-    uint32_t rtv_active_mask;
     VkFormat dsv_format;
 
     bool dynamic_stride;
@@ -1621,11 +1620,11 @@ bool d3d12_pipeline_state_has_replaced_shaders(struct d3d12_pipeline_state *stat
 HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindPoint bind_point,
         const struct d3d12_pipeline_state_desc *desc, struct d3d12_pipeline_state **state);
 VkPipeline d3d12_pipeline_state_get_or_create_pipeline(struct d3d12_pipeline_state *state,
-        const struct vkd3d_dynamic_state *dyn_state, uint32_t rtv_nonnull_mask,
-        const struct vkd3d_format *dsv_format, uint32_t *dynamic_state_flags);
+        const struct vkd3d_dynamic_state *dyn_state, const struct vkd3d_format *dsv_format,
+        uint32_t *dynamic_state_flags);
 VkPipeline d3d12_pipeline_state_get_pipeline(struct d3d12_pipeline_state *state,
-        const struct vkd3d_dynamic_state *dyn_state, uint32_t rtv_nonnull_mask,
-        const struct vkd3d_format *dsv_format, uint32_t *dynamic_state_flags);
+        const struct vkd3d_dynamic_state *dyn_state, const struct vkd3d_format *dsv_format,
+        uint32_t *dynamic_state_flags);
 VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_state *state,
         const struct vkd3d_pipeline_key *key, const struct vkd3d_format *dsv_format,
         VkPipelineCache vk_cache, uint32_t *dynamic_state_flags);
@@ -1975,7 +1974,6 @@ struct d3d12_command_list
 
     struct d3d12_rtv_desc rtvs[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
     struct d3d12_rtv_desc dsv;
-    uint32_t rtv_nonnull_mask;
     uint32_t dsv_plane_optimal_mask;
     VkImageLayout dsv_layout;
     unsigned int fb_width;


### PR DESCRIPTION
Not sure if this is doing the right thing since this seemed a bit *too* simple, but it passes our tests on RADV.