### PR TITLE
Fix validation of dual source blending rules in PSO creation

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3935,7 +3935,7 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
     rendering_info.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO_KHR;
     rendering_info.pNext = NULL;
     rendering_info.viewMask = 0;
-    rendering_info.colorAttachmentCount = vkd3d_get_color_attachment_count(graphics->rtv_active_mask);
+    rendering_info.colorAttachmentCount = graphics->rt_count;
     rendering_info.pColorAttachmentFormats = rtv_formats;
     rendering_info.depthAttachmentFormat = dsv_format ? dsv_format->vk_format : VK_FORMAT_UNDEFINED;
     rendering_info.stencilAttachmentFormat = dsv_format ? dsv_format->vk_format : VK_FORMAT_UNDEFINED;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3173,6 +3173,9 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
          * Be defensive about programs which do not do this for us. */
         memset(graphics->blend_attachments + 1, 0,
                 sizeof(graphics->blend_attachments[0]) * (ARRAY_SIZE(graphics->blend_attachments) - 1));
+
+        /* Only allow RT 0 to be active for dual source blending. */
+        graphics->rtv_active_mask &= 1u << 0;
     }
 
     graphics->xfb_enabled = false;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3401,16 +3401,6 @@ static inline const struct vkd3d_format *vkd3d_format_from_d3d12_resource_desc(
             desc->Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 }
 
-static inline unsigned int vkd3d_get_color_attachment_count(unsigned int attachment_mask)
-{
-    unsigned int count = 0;
-
-    while (attachment_mask >> count)
-        count++;
-
-    return count;
-}
-
 static inline VkImageSubresourceRange vk_subresource_range_from_layers(const VkImageSubresourceLayers *layers)
 {
     VkImageSubresourceRange range;


### PR DESCRIPTION
Also fixes some validation errors related to rtv_active_mask vs rt_count.

The old code was buggy in two ways:
- The check was too conservative
- The check was never hit because it checked compile_args instead of ps_compile_args <_<