### PR TITLE
Use Windows specific environment calls for better Windows compatibility

### DIFF
--- a/include/private/vkd3d_platform.h
+++ b/include/private/vkd3d_platform.h
@@ -37,6 +37,8 @@ int vkd3d_dlclose(vkd3d_module_t handle);
 
 const char *vkd3d_dlerror(void);
 
+bool vkd3d_get_env_var(const char *name, char *value, size_t value_size);
+
 bool vkd3d_get_program_name(char program_name[VKD3D_PATH_MAX]);
 
 #endif

--- a/libs/vkd3d-common/meson.build
+++ b/libs/vkd3d-common/meson.build
@@ -5,6 +5,7 @@ vkd3d_common_src = [
   'profiling.c',
   'string.c',
   'file_utils.c',
+  'platform.c',
 ]
 
 vkd3d_common_lib = static_library('vkd3d_common', vkd3d_common_src, vkd3d_header_files,

--- a/libs/vkd3d-common/platform.c
+++ b/libs/vkd3d-common/platform.c
@@ -18,6 +18,8 @@
 
 #include "vkd3d_platform.h"
 
+#include <assert.h>
+
 #if defined(__linux__)
 
 # include <dlfcn.h>
@@ -149,6 +151,46 @@ const char *vkd3d_dlerror(void)
 bool vkd3d_get_program_name(char program_name[VKD3D_PATH_MAX])
 {
     *program_name = '\0';
+    return false;
+}
+
+#endif
+
+#if defined(_WIN32)
+
+bool vkd3d_get_env_var(const char *name, char *value, size_t value_size)
+{
+    DWORD len;
+    
+    assert(value);
+    assert(value_size > 0);
+
+    len = GetEnvironmentVariableA(name, value, value_size);
+    if (len > 0 && len <= value_size)
+    {
+        return true;
+    }
+
+    value[0] = '\0';
+    return false;
+}
+
+#else
+
+bool vkd3d_get_env_var(const char *name, char *value, size_t value_size)
+{
+    const char *env_value;
+
+    assert(value);
+    assert(value_size > 0);
+
+    if ((env_value = getenv(name)))
+    {
+        snprintf(value, value_size, "%s", env_value);
+        return true;
+    }
+
+    value[0] = '\0';
     return false;
 }
 

--- a/libs/vkd3d-common/profiling.c
+++ b/libs/vkd3d-common/profiling.c
@@ -21,6 +21,7 @@
 #define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
 
 #include "vkd3d_profiling.h"
+#include "vkd3d_platform.h"
 #include "vkd3d_threads.h"
 #include "vkd3d_debug.h"
 #include <stdlib.h>
@@ -124,8 +125,10 @@ static void vkd3d_init_profiling_path(const char *path)
 
 static void vkd3d_init_profiling_once(void)
 {
-    const char *path = getenv("VKD3D_PROFILE_PATH");
-    if (path)
+    char path[VKD3D_PATH_MAX];
+
+    vkd3d_get_env_var("VKD3D_PROFILE_PATH", path, sizeof(path));
+    if (strlen(path) > 0)
         vkd3d_init_profiling_path(path);
 }
 

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -20,6 +20,8 @@
 
 #include "vkd3d_shader_private.h"
 
+#include "vkd3d_platform.h"
+
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -81,13 +83,13 @@ err:
 bool vkd3d_shader_replace(vkd3d_shader_hash_t hash, const void **data, size_t *size)
 {
     static bool enabled = true;
+    char path[VKD3D_PATH_MAX];
     char filename[1024];
-    const char *path;
 
     if (!enabled)
         return false;
 
-    if (!(path = getenv("VKD3D_SHADER_OVERRIDE")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_OVERRIDE", path, sizeof(path)))
     {
         enabled = false;
         return false;
@@ -100,13 +102,13 @@ bool vkd3d_shader_replace(vkd3d_shader_hash_t hash, const void **data, size_t *s
 bool vkd3d_shader_replace_export(vkd3d_shader_hash_t hash, const void **data, size_t *size, const char *export)
 {
     static bool enabled = true;
+    char path[VKD3D_PATH_MAX];
     char filename[1024];
-    const char *path;
 
     if (!enabled)
         return false;
 
-    if (!(path = getenv("VKD3D_SHADER_OVERRIDE")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_OVERRIDE", path, sizeof(path)))
     {
         enabled = false;
         return false;
@@ -119,12 +121,12 @@ bool vkd3d_shader_replace_export(vkd3d_shader_hash_t hash, const void **data, si
 void vkd3d_shader_dump_shader(vkd3d_shader_hash_t hash, const struct vkd3d_shader_code *shader, const char *ext)
 {
     static bool enabled = true;
-    const char *path;
+    char path[VKD3D_PATH_MAX];
 
     if (!enabled)
         return;
 
-    if (!(path = getenv("VKD3D_SHADER_DUMP_PATH")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_DUMP_PATH", path, sizeof(path)))
     {
         enabled = false;
         return;
@@ -136,12 +138,12 @@ void vkd3d_shader_dump_shader(vkd3d_shader_hash_t hash, const struct vkd3d_shade
 void vkd3d_shader_dump_spirv_shader(vkd3d_shader_hash_t hash, const struct vkd3d_shader_code *shader)
 {
     static bool enabled = true;
-    const char *path;
+    char path[VKD3D_PATH_MAX];
 
     if (!enabled)
         return;
 
-    if (!(path = getenv("VKD3D_SHADER_DUMP_PATH")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_DUMP_PATH", path, sizeof(path)))
     {
         enabled = false;
         return;
@@ -154,13 +156,13 @@ void vkd3d_shader_dump_spirv_shader_export(vkd3d_shader_hash_t hash, const struc
         const char *export)
 {
     static bool enabled = true;
-    const char *path;
+    char path[VKD3D_PATH_MAX];
     char tag[1024];
 
     if (!enabled)
         return;
 
-    if (!(path = getenv("VKD3D_SHADER_DUMP_PATH")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_DUMP_PATH", path, sizeof(path)))
     {
         enabled = false;
         return;

--- a/libs/vkd3d/debug_ring.c
+++ b/libs/vkd3d/debug_ring.c
@@ -21,6 +21,7 @@
 #include "vkd3d_private.h"
 #include "vkd3d_debug.h"
 #include "vkd3d_common.h"
+#include "vkd3d_platform.h"
 #include <stdio.h>
 
 void vkd3d_shader_debug_ring_init_spec_constant(struct d3d12_device *device,
@@ -259,10 +260,11 @@ HRESULT vkd3d_shader_debug_ring_init(struct vkd3d_shader_debug_ring *ring,
     D3D12_HEAP_PROPERTIES heap_properties;
     D3D12_RESOURCE_DESC1 resource_desc;
     VkMemoryPropertyFlags memory_props;
-    const char *env;
+    char env[VKD3D_PATH_MAX];
 
     memset(ring, 0, sizeof(*ring));
-    if (!(env = getenv("VKD3D_SHADER_DEBUG_RING_SIZE_LOG2")))
+
+    if (!vkd3d_get_env_var("VKD3D_SHADER_DEBUG_RING_SIZE_LOG2", env, sizeof(env)))
         return S_OK;
 
     ring->active = true;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -21,6 +21,7 @@
 #include "vkd3d_private.h"
 #include "vkd3d_sonames.h"
 #include "vkd3d_descriptor_debug.h"
+#include "vkd3d_platform.h"
 
 #ifdef VKD3D_ENABLE_RENDERDOC
 #include "vkd3d_renderdoc.h"
@@ -141,9 +142,9 @@ static unsigned int get_spec_version(const VkExtensionProperties *extensions,
 
 static bool is_extension_disabled(const char *extension_name)
 {
-    const char *disabled_extensions;
+    char disabled_extensions[VKD3D_PATH_MAX];
 
-    if (!(disabled_extensions = getenv("VKD3D_DISABLE_EXTENSIONS")))
+    if (!vkd3d_get_env_var("VKD3D_DISABLE_EXTENSIONS", disabled_extensions, sizeof(disabled_extensions)))
         return false;
 
     return vkd3d_debug_list_has_member(disabled_extensions, extension_name);
@@ -652,9 +653,9 @@ static const struct vkd3d_debug_option vkd3d_config_options[] =
 
 static void vkd3d_config_flags_init_once(void)
 {
-    const char *config;
+    char config[VKD3D_PATH_MAX];
 
-    config = getenv("VKD3D_CONFIG");
+    vkd3d_get_env_var("VKD3D_CONFIG", config, sizeof(config));
     vkd3d_config_flags = vkd3d_parse_debug_options(config, vkd3d_config_options, ARRAY_SIZE(vkd3d_config_options));
 
     if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_SKIP_APPLICATION_WORKAROUNDS))
@@ -674,7 +675,7 @@ static void vkd3d_config_flags_init_once(void)
         vkd3d_config_flags |= VKD3D_CONFIG_FLAG_DEBUG_UTILS;
 
     if (vkd3d_config_flags)
-        INFO("VKD3D_CONFIG='%s'.\n", config ? config : "");
+        INFO("VKD3D_CONFIG='%s'.\n", config);
 }
 
 static pthread_once_t vkd3d_config_flags_once = PTHREAD_ONCE_INIT;
@@ -2048,12 +2049,13 @@ static HRESULT vkd3d_select_physical_device(struct vkd3d_instance *instance,
     VkPhysicalDeviceProperties device_properties;
     VkPhysicalDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice *physical_devices;
-    const char *filter;
+    char filter[VKD3D_PATH_MAX];
+    bool has_filter;
     uint32_t count;
     unsigned int i;
     VkResult vr;
 
-    filter = getenv("VKD3D_FILTER_DEVICE_NAME");
+    has_filter = vkd3d_get_env_var("VKD3D_FILTER_DEVICE_NAME", filter, sizeof(filter));
 
     count = 0;
     if ((vr = VK_CALL(vkEnumeratePhysicalDevices(vk_instance, &count, NULL))) < 0)
@@ -2094,7 +2096,7 @@ static HRESULT vkd3d_select_physical_device(struct vkd3d_instance *instance,
         if (i == device_index)
             device = physical_devices[i];
 
-        if (filter && !strstr(device_properties.deviceName, filter))
+        if (has_filter && !strstr(device_properties.deviceName, filter))
         {
             INFO("Device %s doesn't match filter %s, skipping.\n", device_properties.deviceName, filter);
             continue;
@@ -5899,7 +5901,7 @@ static void d3d12_device_caps_override(struct d3d12_device *device)
 {
     D3D_FEATURE_LEVEL fl_override = (D3D_FEATURE_LEVEL)0;
     struct d3d12_caps *caps = &device->d3d12_caps;
-    const char* fl_string;
+    char fl_string[VKD3D_PATH_MAX];
     unsigned int i;
 
     static const struct
@@ -5916,7 +5918,7 @@ static void d3d12_device_caps_override(struct d3d12_device *device)
         { "12_2", D3D_FEATURE_LEVEL_12_2 },
     };
 
-    if (!(fl_string = getenv("VKD3D_FEATURE_LEVEL")))
+    if (!vkd3d_get_env_var("VKD3D_FEATURE_LEVEL", fl_string, sizeof(fl_string)))
         return;
 
     for (i = 0; i < ARRAY_SIZE(feature_levels); i++)

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -39,7 +39,6 @@ vkd3d_src = [
   'heap.c',
   'memory.c',
   'meta.c',
-  'platform.c',
   'resource.c',
   'state.c',
   'utils.c',


### PR DESCRIPTION
getenv is deprecated on windows due to security and threadsafe issues. It also (for our purposes) will not reflect environment variables set after the program/dll has started. This is exposed via vkd3d_platform already present in vkd3d.