### PR TITLE
vkd3d: Remove VKD3D_MAX_DYNAMIC_STATE_COUNT

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1418,8 +1418,6 @@ HRESULT vkd3d_create_descriptor_set_layout(struct d3d12_device *device,
         VkDescriptorSetLayoutCreateFlags flags, unsigned int binding_count,
         const VkDescriptorSetLayoutBinding *bindings, VkDescriptorSetLayout *set_layout);
 
-#define VKD3D_MAX_DYNAMIC_STATE_COUNT (8)
-
 enum vkd3d_dynamic_state_flag
 {
     VKD3D_DYNAMIC_STATE_VIEWPORT              = (1 << 0),


### PR DESCRIPTION
This was off by one, at some point, which could cause a stack buffer overrun which is naughty.

Replace this with just an ARRAY_SIZE on the dynamic_state_list for the array size.

Signed-off-by: Joshua Ashton <joshua@froggi.es>