### PR TITLE
build: Support custom Wine versions

### DIFF
--- a/setup_vkd3d_proton.sh
+++ b/setup_vkd3d_proton.sh
@@ -48,36 +48,36 @@ export WINEDEBUG=-all
 # wine gecko and mono
 export WINEDLLOVERRIDES="mscoree,mshtml="
 
-wine="wine"
-wine64="wine64"
-wineboot="wineboot"
+# support custom Wine versions
+[ -z "$WINE" ] && WINE="$(command -v wine)"
+[ -z "$WINE64" ] && WINE64="${WINE}64"
 
 # $PATH is the way for user to control where wine is located (including custom Wine versions).
 # Pure 64-bit Wine (non Wow64) requries skipping 32-bit steps.
 # In such case, wine64 and winebooot will be present, but wine binary will be missing,
 # however it can be present in other PATHs, so it shouldn't be used, to avoid versions mixing.
-wine_path=$(dirname "$(which $wineboot)")
+wine_path=$(dirname "$WINE")
 wow64=true
-if ! [ -f "$wine_path/$wine" ]; then
-   wine=$wine64
+if ! [ -f "$wine_path/wine" ]; then
+   WINE="$WINE64"
    wow64=false
 fi
 
 # resolve 32-bit and 64-bit system32 path
-winever=$($wine --version | grep wine)
+winever=$("$WINE" --version | grep wine)
 if [ -z "$winever" ]; then
-    echo "$wine: Not a wine executable. Check your $wine." >&2
+    echo "$WINE: Not a wine executable. Check your $WINE." >&2
     exit 1
 fi
 
 # ensure wine placeholder dlls are recreated
 # if they are missing
-$wineboot -u
+"$WINE" wineboot -u
 
-win64_sys_path=$($wine64 winepath -u 'C:\windows\system32' 2> /dev/null)
+win64_sys_path=$("$WINE64" winepath -u 'C:\windows\system32' 2> /dev/null)
 win64_sys_path="${win64_sys_path/$'\r'/}"
 if $wow64; then
-  win32_sys_path=$($wine winepath -u 'C:\windows\system32' 2> /dev/null)
+  win32_sys_path=$("$WINE" winepath -u 'C:\windows\system32' 2> /dev/null)
   win32_sys_path="${win32_sys_path/$'\r'/}"
 fi
 
@@ -88,7 +88,7 @@ fi
 
 # create native dll override
 overrideDll() {
-  if ! $wine reg add 'HKEY_CURRENT_USER\Software\Wine\DllOverrides' /v "$1" /d native /f >/dev/null 2>&1
+  if ! "$WINE" reg add 'HKEY_CURRENT_USER\Software\Wine\DllOverrides' /v "$1" /d native /f >/dev/null 2>&1
   then
     echo -e "Failed to add override for $1"
     exit 1
@@ -97,7 +97,7 @@ overrideDll() {
 
 # remove dll override
 restoreDll() {
-  if ! $wine reg delete 'HKEY_CURRENT_USER\Software\Wine\DllOverrides' /v "$1" /f > /dev/null 2>&1
+  if ! "$WINE" reg delete 'HKEY_CURRENT_USER\Software\Wine\DllOverrides' /v "$1" /f > /dev/null 2>&1
   then
     echo "Failed to remove override for $1"
   fi


### PR DESCRIPTION
This allows people to use custom wine versions by exporting the WINE env variable.

If undefined, it uses the `$PATH`'s `wine` using `command -v` instead of `which`.
This is POSIX compliant while `which` isn't, Debian 11 deprecated which.

The changes are the same as https://github.com/doitsujin/dxvk/pull/2617