### PR TITLE
Use VK_KHR_maintenance4.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -84,6 +84,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_DYNAMIC_RENDERING, KHR_dynamic_rendering),
     VK_EXTENSION(KHR_DRIVER_PROPERTIES, KHR_driver_properties),
     VK_EXTENSION(KHR_UNIFORM_BUFFER_STANDARD_LAYOUT, KHR_uniform_buffer_standard_layout),
+    VK_EXTENSION(KHR_MAINTENANCE_4, KHR_maintenance4),
     /* EXT extensions */
     VK_EXTENSION(EXT_CALIBRATED_TIMESTAMPS, EXT_calibrated_timestamps),
     VK_EXTENSION(EXT_CONDITIONAL_RENDERING, EXT_conditional_rendering),
@@ -1172,6 +1173,14 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->features2, &info->subgroup_extended_types_features);
     }
 
+    if (vulkan_info->KHR_maintenance4)
+    {
+        info->maintenance4_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES;
+        vk_prepend_struct(&info->properties2, &info->maintenance4_properties);
+        info->maintenance4_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES;
+        vk_prepend_struct(&info->features2, &info->maintenance4_features);
+    }
+
     if (vulkan_info->EXT_calibrated_timestamps)
         info->time_domains = vkd3d_physical_device_get_time_domains(device);
 
@@ -2033,6 +2042,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     if (!physical_device_info->extended_dynamic_state2_features.extendedDynamicState2)
     {
         ERR("EXT_extended_dynamic_state2 is not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
+    if (!physical_device_info->maintenance4_features.maintenance4)
+    {
+        ERR("KHR_maintenance4 is not supported by this implementation. This is required for correct operation.\n");
         return E_INVALIDARG;
     }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -132,6 +132,7 @@ struct vkd3d_vulkan_info
     bool KHR_dynamic_rendering;
     bool KHR_driver_properties;
     bool KHR_uniform_buffer_standard_layout;
+    bool KHR_maintenance4;
     /* EXT device extensions */
     bool EXT_calibrated_timestamps;
     bool EXT_conditional_rendering;
@@ -3029,6 +3030,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_properties;
     VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR shader_integer_dot_product_properties;
     VkPhysicalDeviceDriverPropertiesKHR driver_properties;
+    VkPhysicalDeviceMaintenance4PropertiesKHR maintenance4_properties;
 
     VkPhysicalDeviceProperties2KHR properties2;
 
@@ -3070,6 +3072,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE descriptor_set_host_mapping_features;
     VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features;
     VkPhysicalDeviceCoherentMemoryFeaturesAMD device_coherent_memory_features_amd;
+    VkPhysicalDeviceMaintenance4FeaturesKHR maintenance4_features;
 
     VkPhysicalDeviceFeatures2 features2;
 

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -218,6 +218,11 @@ VK_DEVICE_EXT_PFN(vkCmdCopyImage2KHR)
 VK_DEVICE_EXT_PFN(vkCmdCopyImageToBuffer2KHR)
 VK_DEVICE_EXT_PFN(vkCmdResolveImage2KHR)
 
+/* VK_KHR_maintenance4 */
+VK_DEVICE_EXT_PFN(vkGetDeviceBufferMemoryRequirementsKHR)
+VK_DEVICE_EXT_PFN(vkGetDeviceImageMemoryRequirementsKHR)
+VK_DEVICE_EXT_PFN(vkGetDeviceImageSparseMemoryRequirementsKHR)
+
 /* VK_EXT_calibrated_timestamps */
 VK_DEVICE_EXT_PFN(vkGetCalibratedTimestampsEXT)
 VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceCalibrateableTimeDomainsEXT)


### PR DESCRIPTION
And make it a hard requirement since driver support overlaps fairly well with KHR_dynamic_rendering. Removes the need to create a whole bunch of dummy resources.