### PR TITLE
common: Fix _BitScanForward usage on MSVC.

### DIFF
--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -120,8 +120,7 @@ static inline unsigned int vkd3d_bitmask_tzcnt32(uint32_t mask)
 {
 #ifdef _MSC_VER
     unsigned long result;
-    _BitScanForward(&result, mask) ? result : 32;
-    return result;
+    return _BitScanForward(&result, mask) ? result : 32;
 #elif defined(__GNUC__) || defined(__clang__)
     return mask ? __builtin_ctz(mask) : 32;
 #else


### PR DESCRIPTION
Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>

Found in review of https://github.com/HansKristian-Work/vkd3d-proton/pull/1065#discussion_r852864906