### PR TITLE
vkd3d: Clean up straggling getenv() calls.

### DIFF
--- a/libs/vkd3d/cache.c
+++ b/libs/vkd3d/cache.c
@@ -2941,6 +2941,7 @@ static void vkd3d_pipeline_library_disk_cache_initial_setup(struct vkd3d_pipelin
 HRESULT vkd3d_pipeline_library_init_disk_cache(struct vkd3d_pipeline_library_disk_cache *cache,
         struct d3d12_device *device)
 {
+    char path_buf[VKD3D_PATH_MAX];
     VKD3D_UNUSED size_t i, n;
     const char *separator;
     const char *path;
@@ -2955,9 +2956,8 @@ HRESULT vkd3d_pipeline_library_init_disk_cache(struct vkd3d_pipeline_library_dis
 
     /* Match DXVK style here. The environment variable is a directory.
      * If not set, it is in current working directory. */
-    path = getenv("VKD3D_SHADER_CACHE_PATH");
-    if (path && *path == '\0')
-        path = NULL;
+    vkd3d_get_env_var("VKD3D_SHADER_CACHE_PATH", path_buf, sizeof(path_buf));
+    path = *path_buf != '\0' ? path_buf : NULL;
 
     if (path)
     {

--- a/libs/vkd3d/descriptor_debug.c
+++ b/libs/vkd3d/descriptor_debug.c
@@ -76,10 +76,10 @@ static const char *debug_descriptor_type(vkd3d_descriptor_qa_flags type_flags)
 
 static void vkd3d_descriptor_debug_init_once(void)
 {
-    const char *env;
+    char env[VKD3D_PATH_MAX];
+    vkd3d_get_env_var("VKD3D_DESCRIPTOR_QA_LOG", env, sizeof(env));
 
-    env = getenv("VKD3D_DESCRIPTOR_QA_LOG");
-    if (env)
+    if (strlen(env) > 0)
     {
         INFO("Enabling VKD3D_DESCRIPTOR_QA_LOG\n");
         descriptor_debug_file = fopen(env, "w");

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -574,15 +574,17 @@ static void vkd3d_instance_apply_application_workarounds(void)
 
 static void vkd3d_instance_deduce_config_flags_from_environment(void)
 {
-    const char *env;
+    char env[VKD3D_PATH_MAX];
 
-    if (getenv("VKD3D_SHADER_OVERRIDE") || getenv("VKD3D_SHADER_DUMP_PATH"))
+    if (vkd3d_get_env_var("VKD3D_SHADER_OVERRIDE", env, sizeof(env)) ||
+            vkd3d_get_env_var("VKD3D_SHADER_DUMP_PATH", env, sizeof(env)))
     {
         INFO("VKD3D_SHADER_OVERRIDE or VKD3D_SHADER_DUMP_PATH is used, pipeline_library_ignore_spirv option is enforced.\n");
         vkd3d_config_flags |= VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_IGNORE_SPIRV;
     }
 
-    if ((env = getenv("VKD3D_SHADER_CACHE_PATH")) && strcmp(env, "0") == 0)
+    vkd3d_get_env_var("VKD3D_SHADER_CACHE_PATH", env, sizeof(env));
+    if (strcmp(env, "0") == 0)
     {
         INFO("Shader cache is explicitly disabled, relying solely on application caches.\n");
         vkd3d_config_flags |= VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_APP_CACHE_ONLY;

--- a/libs/vkd3d/renderdoc.c
+++ b/libs/vkd3d/renderdoc.c
@@ -100,9 +100,9 @@ static bool vkd3d_renderdoc_enable_submit_counter(uint32_t counter)
 
 static void vkd3d_renderdoc_init_once(void)
 {
+    char counts[VKD3D_PATH_MAX];
     pRENDERDOC_GetAPI get_api;
-    const char *counts;
-    const char *env;
+    char env[VKD3D_PATH_MAX];
 
 #ifdef _WIN32
     HMODULE renderdoc;
@@ -112,19 +112,19 @@ static void vkd3d_renderdoc_init_once(void)
     void *fn_ptr;
 #endif
 
-    env = getenv("VKD3D_AUTO_CAPTURE_SHADER");
-    counts = getenv("VKD3D_AUTO_CAPTURE_COUNTS");
+    vkd3d_get_env_var("VKD3D_AUTO_CAPTURE_SHADER", env, sizeof(env));
+    vkd3d_get_env_var("VKD3D_AUTO_CAPTURE_COUNTS", counts, sizeof(counts));
 
-    if (!env && !counts)
+    if (strlen(env) == 0 && strlen(counts) == 0)
     {
         WARN("VKD3D_AUTO_CAPTURE_SHADER or VKD3D_AUTO_CAPTURE_COUNTS is not set, RenderDoc auto capture will not be enabled.\n");
         return;
     }
 
-    if (!counts)
+    if (strlen(counts) == 0)
         WARN("VKD3D_AUTO_CAPTURE_COUNTS is not set, will assume that only the first submission is captured.\n");
 
-    if (env)
+    if (strlen(env) > 0)
         renderdoc_capture_shader_hash = strtoull(env, NULL, 16);
 
     if (renderdoc_capture_shader_hash)
@@ -132,7 +132,7 @@ static void vkd3d_renderdoc_init_once(void)
     else
         INFO("Enabling RenderDoc capture for all shaders.\n");
 
-    if (counts)
+    if (strlen(counts) > 0)
         vkd3d_renderdoc_init_capture_count_list(counts);
     else
     {

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -1409,9 +1409,9 @@ static HRESULT d3d12_swapchain_create_vulkan_swapchain(struct d3d12_swapchain *s
     unsigned int width, height, image_count;
     VkSurfaceCapabilitiesKHR surface_caps;
     unsigned int override_image_count;
+    char count_env[VKD3D_PATH_MAX];
     VkSwapchainKHR vk_swapchain;
     VkImageUsageFlags usage;
-    const char *count_env;
     VkResult vr;
     HRESULT hr;
 
@@ -1454,8 +1454,8 @@ static HRESULT d3d12_swapchain_create_vulkan_swapchain(struct d3d12_swapchain *s
     image_count = swapchain->desc.BufferCount + 1;
     image_count = max(image_count, surface_caps.minImageCount);
 
-    count_env = getenv("VKD3D_SWAPCHAIN_IMAGES");
-    if (count_env)
+    vkd3d_get_env_var("VKD3D_SWAPCHAIN_IMAGES", count_env, sizeof(count_env));
+    if (strlen(count_env) > 0)
     {
         override_image_count = strtoul(count_env, NULL, 0);
         image_count = max(image_count, override_image_count);


### PR DESCRIPTION
Replace with the new vkd3d_get_env wrapper.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>

Fix #1081.