### PR TITLE
Draft: vkd3d: Add descriptor_only_hvv for non-reBAR performance improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ commas or semicolons.
       May free up vital VRAM in certain critical situations, at cost of lower GPU performance.
       A fraction of VRAM is reserved for resizable BAR allocations either way,
       so it should not be a real issue even on lower VRAM cards.
+    - `descriptor_only_hvv` - Same as `no_upload_hvv`, except it allows vkd3d's internal descriptors heaps to be placed
+      on HVV. Useful for small BAR systems (systems without resizable BAR) to prevent UPLOAD heaps from evicting the
+      frequently read descriptor heap.
     - `force_host_cached` - Forces all host visible allocations to be CACHED, which greatly accelerates captures.
     - `no_invariant_position` - Avoids workarounds for invariant position. The workaround is enabled by default.
  - `VKD3D_DEBUG` - controls the debug level for log messages produced by

--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -87,6 +87,7 @@ extern "C" {
 #define VKD3D_CONFIG_FLAG_BREADCRUMBS (1ull << 25)
 #define VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_APP_CACHE_ONLY (1ull << 26)
 #define VKD3D_CONFIG_FLAG_SHADER_CACHE_SYNC (1ull << 27)
+#define VKD3D_CONFIG_FLAG_DESCRIPTOR_ONLY_HVV (1ull << 28)
 
 typedef HRESULT (*PFN_vkd3d_signal_event)(HANDLE event);
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -652,6 +652,7 @@ static const struct vkd3d_debug_option vkd3d_config_options[] =
     {"breadcrumbs", VKD3D_CONFIG_FLAG_BREADCRUMBS},
     {"pipeline_library_app_cache", VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_APP_CACHE_ONLY},
     {"shader_cache_sync", VKD3D_CONFIG_FLAG_SHADER_CACHE_SYNC},
+    {"descriptor_only_hvv", VKD3D_CONFIG_FLAG_DESCRIPTOR_ONLY_HVV},
 };
 
 static void vkd3d_config_flags_init_once(void)

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -77,7 +77,7 @@ static HRESULT vkd3d_select_memory_flags(struct d3d12_device *device, const D3D1
             *type_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
             if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_FORCE_HOST_CACHED)
                 *type_flags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-            else if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV))
+            else if (!(vkd3d_config_flags & (VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV | VKD3D_CONFIG_FLAG_DESCRIPTOR_ONLY_HVV)))
                 *type_flags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
             break;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -6342,7 +6342,7 @@ static uint32_t vkd3d_memory_info_find_global_mask(const struct vkd3d_memory_top
     uint32_t heap_index;
     uint32_t i, mask;
 
-    if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV))
+    if (!(vkd3d_config_flags & (VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV | VKD3D_CONFIG_FLAG_DESCRIPTOR_ONLY_HVV)))
         return UINT32_MAX;
 
     /* If we only have one device local heap, or no host-only heaps, there is nothing to do. */


### PR DESCRIPTION
(Copied from updated README)

This option is the same as `no_upload_hvv`, except it allows vkd3d's internal descriptors heaps to be placed
on HVV. Useful for small BAR systems (systems without resizable BAR) to prevent UPLOAD heaps from evicting the
frequently read descriptor heap.