### PR TITLE
tests: Add test for FirstWSlice/WSlice on 3D UAV.

### DIFF
--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -304,3 +304,4 @@ decl_test(test_mesh_shader_execute_indirect);
 decl_test(test_amplification_shader);
 decl_test(test_advanced_cbv_layout);
 decl_test(test_shader_waveop_maximal_convergence);
+decl_test(test_uav_3d_sliced_view);


### PR DESCRIPTION
Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>

This appears to be a fairly broken feature in D3D12 native ...

- NV: Works as expected.
- Intel: GetResourceDimensions does not respect WSize for MIP 1 for whatever reason.
- AMD: The descriptor seems to be created with depth = FirstWSlice + WSize, but base depth is kept at 0 (?!?!)