### PR TITLE
vkd3d: Remove the global VkPipelineCache.

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2302,7 +2302,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     shader_interface.descriptor_qa_heap_binding = &root_signature->descriptor_qa_heap_binding;
 #endif
 
-    if (!device->global_pipeline_cache)
+    if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE))
     {
         if ((hr = vkd3d_create_pipeline_cache_from_d3d12_desc(device, cached_pso, &state->vk_pso_cache)) < 0)
         {
@@ -2317,7 +2317,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     hr = vkd3d_create_compute_pipeline(device,
             &desc->cs, &shader_interface,
             root_signature->compute.vk_pipeline_layout,
-            state->vk_pso_cache ? state->vk_pso_cache : device->global_pipeline_cache,
+            state->vk_pso_cache,
             &state->compute.vk_pipeline,
             &state->compute.code);
 
@@ -3584,7 +3584,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
 
     if (can_compile_pipeline_early)
     {
-        if (!device->global_pipeline_cache)
+        if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE))
         {
             if ((hr = vkd3d_create_pipeline_cache_from_d3d12_desc(device, cached_pso, &state->vk_pso_cache)) < 0)
             {
@@ -3594,7 +3594,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         }
 
         if (!(graphics->pipeline = d3d12_pipeline_state_create_pipeline_variant(state, NULL, graphics->dsv_format,
-                state->vk_pso_cache ? state->vk_pso_cache : device->global_pipeline_cache, &graphics->dynamic_state_flags)))
+                state->vk_pso_cache, &graphics->dynamic_state_flags)))
             goto fail;
     }
     else

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3237,7 +3237,6 @@ struct d3d12_device
 #ifdef VKD3D_ENABLE_DESCRIPTOR_QA
     struct vkd3d_descriptor_qa_global_info *descriptor_qa_global_info;
 #endif
-    VkPipelineCache global_pipeline_cache;
     uint64_t shader_interface_key;
 };
 


### PR DESCRIPTION
Just use VK_NULL_HANDLE. We rely on the disk cache to exist anyways
here. We never serialize the global pipeline cache, so it might just
confuse drivers into disable disk cache if anything.

Also reduce memory bloat.

Also gets rid of very old NV driver workaround where we forced global
pipeline cache.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>