### PR TITLE
Add exploratory test for sparse mapping behavior.

### DIFF
--- a/include/vkd3d_d3d12.idl
+++ b/include/vkd3d_d3d12.idl
@@ -3644,8 +3644,8 @@ interface ID3D12CommandQueue : ID3D12Pageable
             ID3D12Heap *heap,
             UINT range_count,
             const D3D12_TILE_RANGE_FLAGS *range_flags,
-            UINT *heap_range_offsets,
-            UINT *range_tile_counts,
+            const UINT *heap_range_offsets,
+            const UINT *range_tile_counts,
             D3D12_TILE_MAPPING_FLAGS flags);
 
     void CopyTileMappings(ID3D12Resource *dst_resource,

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -11587,7 +11587,8 @@ static unsigned int vkd3d_get_tile_index_from_region(const struct d3d12_sparse_i
 static void STDMETHODCALLTYPE d3d12_command_queue_UpdateTileMappings(ID3D12CommandQueue *iface,
         ID3D12Resource *resource, UINT region_count, const D3D12_TILED_RESOURCE_COORDINATE *region_coords,
         const D3D12_TILE_REGION_SIZE *region_sizes, ID3D12Heap *heap, UINT range_count,
-        const D3D12_TILE_RANGE_FLAGS *range_flags, UINT *heap_range_offsets, UINT *range_tile_counts,
+        const D3D12_TILE_RANGE_FLAGS *range_flags,
+        const UINT *heap_range_offsets, const UINT *range_tile_counts,
         D3D12_TILE_MAPPING_FLAGS flags)
 {
     struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -320,3 +320,4 @@ decl_test(test_raytracing_collection_identifiers);
 decl_test(test_fence_wait_robustness);
 decl_test(test_fence_wait_robustness_shared);
 decl_test(test_root_signature_empty_blob);
+decl_test(test_sparse_buffer_memory_lifetime);


### PR DESCRIPTION
In this test we attempt to bind a page to memory which is subsequently freed. We don't access the freed page in the normal path, and this passes on all drivers. (RADV with a tiny workaround).

With the exploratory path, we aim to figure out how the freed memory behaves, both with respect to values we read, and how sparse feedback behaves (is the page considered fully mapped or not).

## Native D3D12 behavior

### EXPLORATORY == 0

NV / AMD / Intel all pass test. No D3D12 validation errors.

### EXPLORATORY == 1

- NV: Faults. Device lost.
- AMD: Sparse feedback suggests the freed page is valid. Reads garbage value. Does not fault.
- Intel: Sparse feedback suggests the freed page is valid. Reads zero (instead of expected 42). Does not fault.

## Vulkan Windows behavior

### EXPLORATORY == 0

NV / AMD pass. Intel cannot run due to lack of dynamic rendering.

### EXPLORATORY == 1

NV and AMD behave exactly the same as D3D12 counterpart.

## Linux

### EXPLORATORY == 0

- NV passes
- RADV passes with tiny workaround applied to avoid error in kernel due to stale BO reference.
- AMDVLK. Passes, (but had to nop out the compute shader creation since it segfaults driver ...).
- Intel: N/A. Does not support sparse.

### EXPLORATORY == 1

- NV: Does not fault. Sparse feedback suggests freed page is not mapped (!?). Reads 0.
- RADV: Faults. Device lost.
- AMDVLK: N/A. cannot compile compute shader.
- Intel: N/A