### PR TITLE
vkd3d: Enable F1 2020 quirks on 2019 as well.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -531,7 +531,7 @@ static const struct vkd3d_shader_quirk_info ue4_quirks = {
     ue4_hashes, ARRAY_SIZE(ue4_hashes), 0,
 };
 
-static const struct vkd3d_shader_quirk_info f1_2020_quirks = {
+static const struct vkd3d_shader_quirk_info f1_2019_2020_quirks = {
     NULL, 0, VKD3D_SHADER_QUIRK_FORCE_TGSM_BARRIERS,
 };
 
@@ -539,7 +539,9 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* F1 2020 (1080110) */
-    { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2020_quirks },
+    { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
+    /* F1 2019 (928600) */
+    { VKD3D_STRING_COMPARE_EXACT, "F1_2019_dx12.exe", &f1_2019_2020_quirks },
     /* MSVC fails to compile empty array. */
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };


### PR DESCRIPTION
Same game bug.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>