### PR TITLE
cache: Unmap files before attempting to delete.

### DIFF
--- a/libs/vkd3d/cache.c
+++ b/libs/vkd3d/cache.c
@@ -2873,6 +2873,7 @@ static void vkd3d_pipeline_library_disk_cache_merge(struct vkd3d_pipeline_librar
 
 out:
     /* There shouldn't be any write cache left after merging. */
+    vkd3d_file_unmap(&mapped_write_cache);
     vkd3d_file_delete(write_path);
 
     /* If we have a stale merge file lying around, we might have been killed at some point
@@ -2884,9 +2885,9 @@ out:
     vkd3d_file_delete(merge_path);
 
 out_cancellation:
+    vkd3d_file_unmap(&mapped_write_cache);
     if (merge_file)
         fclose(merge_file);
-    vkd3d_file_unmap(&mapped_write_cache);
     hash_map_clear(&map);
     vkd3d_free(tmp_buffer);
 }


### PR DESCRIPTION
Native Win32 does not like it.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>

Works fine in Wine, but ran into this while testing a bit on Windows.