### PR TITLE
Do not attempt to place linear host visible textures on heaps.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -5539,16 +5539,14 @@ static D3D12_RESOURCE_HEAP_TIER d3d12_device_determine_heap_tier(struct d3d12_de
     const VkPhysicalDeviceLimits *limits = &device->device_info.properties2.properties.limits;
     const struct vkd3d_memory_info *mem_info = &device->memory_info;
     const struct vkd3d_memory_info_domain *non_cpu_domain;
-    const struct vkd3d_memory_info_domain *cpu_domain;
 
     non_cpu_domain = &mem_info->non_cpu_accessible_domain;
-    cpu_domain = &mem_info->cpu_accessible_domain;
 
-    // Heap Tier 2 requires us to be able to create a heap that supports all resource
-    // categories at the same time, except RT/DS textures on UPLOAD/READBACK heaps.
+    /* Heap Tier 2 requires us to be able to create a heap that supports all resource
+     * categories at the same time, except RT/DS textures on UPLOAD/READBACK heaps.
+     * Ignore CPU visible heaps since we only place buffers there. Textures are promoted to committed always. */
     if (limits->bufferImageGranularity > D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT ||
-            !(non_cpu_domain->buffer_type_mask & non_cpu_domain->sampled_type_mask & non_cpu_domain->rt_ds_type_mask) ||
-            !(cpu_domain->buffer_type_mask & cpu_domain->sampled_type_mask))
+            !(non_cpu_domain->buffer_type_mask & non_cpu_domain->sampled_type_mask & non_cpu_domain->rt_ds_type_mask))
         return D3D12_RESOURCE_HEAP_TIER_1;
 
     return D3D12_RESOURCE_HEAP_TIER_2;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2863,15 +2863,25 @@ HRESULT d3d12_resource_create_placed(struct d3d12_device *device, const D3D12_RE
     VkMemoryRequirements memory_requirements;
     VkBindImageMemoryInfo bind_info;
     struct d3d12_resource *object;
+    bool force_committed;
     VkResult vr;
     HRESULT hr;
 
     if (FAILED(hr = d3d12_resource_validate_heap(desc, heap)))
         return hr;
 
-    if (heap->allocation.device_allocation.vk_memory == VK_NULL_HANDLE)
+    /* Placed linear textures are ... problematic
+     * since we have no way of signalling that they have different alignment and size requirements
+     * than optimal textures. GetResourceAllocationInfo() does not take heap property information
+     * and assumes that we are not modifying the tiling mode. */
+    force_committed = desc->Dimension != D3D12_RESOURCE_DIMENSION_BUFFER &&
+            is_cpu_accessible_heap(&heap->desc.Properties);
+
+    if (force_committed || heap->allocation.device_allocation.vk_memory == VK_NULL_HANDLE)
     {
-        WARN("Placing resource on heap with no memory backing it. Falling back to committed resource.\n");
+        if (!force_committed)
+            WARN("Placing resource on heap with no memory backing it. Falling back to committed resource.\n");
+
         if (FAILED(hr = d3d12_resource_create_committed(device, desc, &heap->desc.Properties,
                 heap->desc.Flags & ~(D3D12_HEAP_FLAG_DENY_BUFFERS |
                         D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES |


### PR DESCRIPTION
Alignment and size requirements cannot be returned to application. Fall back to committed resources here instead.

Fixes weird GI flicker in Guardians of the Galaxy, since it ended up placing 3x 16x16x80 R32_UINT textures close to each other. In OPTIMAL tiling, the size was < 128 KiB, but ~300 KiB in linear tiling due to 256 byte aligned rows on AMD.