### PR TITLE
vkd3d: Do not perform initial layout transition for placed RTV / DSV.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2947,6 +2947,15 @@ HRESULT d3d12_resource_create_placed(struct d3d12_device *device, const D3D12_RE
             goto fail;
     }
 
+    /* Placed RTV and DSV *must* be explicitly initialized after alias barriers and first use,
+     * so there is no need to do initial layout transition ourselves.
+     * It is extremely dangerous to do so since the initialization will clobber other
+     * aliased buffers when clearing DCC/HTILE state.
+     * For details, see:
+     * https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-createplacedresource#notes-on-the-required-resource-initialization. */
+    if (desc->Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL))
+        object->initial_layout_transition = 0;
+
     *resource = object;
     return S_OK;
 


### PR DESCRIPTION
Docs explicitly specify that placed RTV / DSV resource must be properly
initialized before use, either on first use or after aliasing barriers,
so there should be no need to perform initial layout transition.

Fixes spurious GPU hangs in Hitman III where application aliases
an indirect buffer and a DSV. The DSV is cleared after the indirect
buffer is consumed, but the initial_layout_transition is triggered and
HTILE init clobbered the buffer.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>