### PR TITLE
Fix clearing attachments that are not currently active

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -3343,13 +3343,15 @@ static void d3d12_command_list_discard_attachment_barrier(struct d3d12_command_l
     VkImageLayout layout;
 
     /* Ignore read access bits since reads will be undefined anyway */
-    if (resource->desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET)
+    if ((list->type == D3D12_COMMAND_LIST_TYPE_DIRECT) &&
+            (resource->desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET))
     {
         stages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
         access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         layout = d3d12_resource_pick_layout(resource, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     }
-    else if (resource->desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)
+    else if ((list->type == D3D12_COMMAND_LIST_TYPE_DIRECT) &&
+            (resource->desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL))
     {
         stages = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
         access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3765,6 +3765,17 @@ static inline const struct vkd3d_format *vkd3d_format_from_d3d12_resource_desc(
             desc->Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 }
 
+static inline VkImageSubresourceRange vk_subresource_range_from_subresource(const VkImageSubresource *subresource)
+{
+    VkImageSubresourceRange range;
+    range.aspectMask = subresource->aspectMask;
+    range.baseMipLevel = subresource->mipLevel;
+    range.levelCount = 1;
+    range.baseArrayLayer = subresource->arrayLayer;
+    range.layerCount = 1;
+    return range;
+}
+
 static inline VkImageSubresourceRange vk_subresource_range_from_layers(const VkImageSubresourceLayers *layers)
 {
     VkImageSubresourceRange range;


### PR DESCRIPTION
Apparently we hit a bug in Saint's Row where we clear an RTV that's bound to the D3D command list but wasn't used by any Vulkan pipeline, so it's not bound to the Vulkan command buffer.