### PR TITLE
[WIP] Add VKD3D profiles to express vulkan requirements 

### DIFF
--- a/VP_VKD3D_requirements.json
+++ b/VP_VKD3D_requirements.json
@@ -1,0 +1,778 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.0-224.json#",
+    "capabilities": {
+        "vulkan10requirements": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "robustBufferAccess": true
+                }
+            }
+        },
+        "vulkan11requirements": {
+            "features": {
+                "VkPhysicalDeviceVulkan11Features": {
+                    "multiview": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceVulkan11Properties": {
+                    "maxMultiviewViewCount": 6,
+                    "maxMultiviewInstanceIndex": 134217727
+                }
+            }
+        },
+        "d3d12_level_11_0": {
+            "extensions": {
+                "VK_KHR_surface": 1,
+                "VK_KHR_swapchain": 1,
+                "VK_KHR_timeline_semaphore": 1,
+                "VK_KHR_separate_depth_stencil_layouts": 1,
+                "VK_KHR_sampler_mirror_clamp_to_edge": 1,
+                "VK_EXT_robustness2": 1,
+                "VK_KHR_bind_memory2": 1,
+                "VK_KHR_copy_commands2": 1,
+                "VK_KHR_dynamic_rendering": 1,
+                "VK_EXT_extended_dynamic_state": 1,
+                "VK_EXT_extended_dynamic_state2": 1,
+                "VK_KHR_maintenance4": 1,
+                "VK_EXT_descriptor_indexing": 1
+            },
+            "features": {
+                "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                    "separateDepthStencilLayouts": true
+                },
+                "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                    "nullDescriptor": true
+                },
+                "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                    "shaderDrawParameters": true
+                },
+                "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
+                    "dynamicRendering": true
+                },
+                "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                    "extendedDynamicState": true
+                },
+                "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                    "extendedDynamicState2": true
+                },
+                "VkPhysicalDeviceMaintenance4FeaturesKHR": {
+                    "maintenance4": true
+                },
+                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                    "runtimeDescriptorArray": true,
+                    "descriptorBindingPartiallyBound": true,
+                    "descriptorBindingUpdateUnusedWhilePending": true,
+                    "descriptorBindingVariableDescriptorCount": true,
+                    "descriptorBindingSampledImageUpdateAfterBind": true,
+                    "descriptorBindingUniformTexelBufferUpdateAfterBind": true,
+                    "shaderSampledImageArrayNonUniformIndexing": true,
+                    "shaderUniformTexelBufferArrayNonUniformIndexing": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                    "maxPerStageDescriptorUpdateAfterBindSampledImages": 1000000,
+                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000
+                }
+            }
+        },
+        "d3d12_level_11_0_bindless_uniform": {
+            "extensions": {
+                "VK_EXT_descriptor_indexing": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                    "maxPerStageDescriptorUpdateAfterBindUniformBuffers": 1000000
+                }
+            }      
+        },
+        "d3d12_level_11_0_bindless_storage": {
+            "extensions": {
+                "VK_EXT_descriptor_indexing": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                    "maxPerStageDescriptorUpdateAfterBindStorageBuffers": 1000000
+                }
+            }
+        },
+        "d3d12_level_11_0_optimal": {
+            "extensions": {
+                "VK_EXT_descriptor_indexing": 1,
+                "VK_EXT_shader_stencil_export": 1,
+                "VK_EXT_shader_viewport_index_layer": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                    "robustBufferAccessUpdateAfterBind": true
+                }
+            }
+        },
+        "d3d12_level_11_1": {
+            "extensions": {
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "logicOp": true,
+                    "vertexPipelineStoresAndAtomics": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorStorageBuffers": 64,
+                        "maxPerStageDescriptorStorageImages": 64
+                    }
+                }
+            }
+        },
+        "d3d12_level_12_0": {
+            "extensions": {
+                "VK_EXT_sampler_filter_minmax": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "sparseBinding": true,
+                    "sparseResidencyAliased": true,
+                    "sparseResidencyBuffer": true,
+                    "sparseResidencyImage2D": true,
+                    "shaderResourceResidency": true,
+                    "shaderResourceMinLod": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "sparseProperties": {
+                        "residencyStandard2DBlockShape": true,
+                        "residencyNonResidentStrict": true
+                    }
+                },
+                "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                    "filterMinmaxSingleComponentFormats": false
+                }
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [ "VK_QUEUE_SPARSE_BINDING_BIT" ],
+                        "queueCount": 1
+                    }
+                }
+            ]
+        },
+        "d3d12_level_12_0_properties3_read_without_format": {
+            "extensions": {
+                "VK_KHR_format_feature_flags2": 1
+            },
+            "formats": {
+                "VK_FORMAT_R32_SFLOAT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R32_UINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R32_SINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_UINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UNORM": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R16_SFLOAT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R16_UINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R16_SINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R8_UNORM": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R8_UINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                },
+                "VK_FORMAT_R8_SINT": {
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
+                        ]
+                    }
+                }
+            }
+        },
+        "d3d12_level_12_0_global_read_without_format": {
+            "extensions": {
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "shaderStorageImageReadWithoutFormat": true
+                }
+            }
+        },
+        "d3d12_level_12_1": {
+            "extensions": {
+                "VK_EXT_conservative_rasterization": 1
+            }
+        },
+        "d3d12_level_12_2": {
+            "extensions": {
+                "VK_EXT_descriptor_indexing": 1,
+                "VK_EXT_shader_viewport_index_layer": 1,
+                "VK_KHR_ray_tracing_pipeline": 1,
+                "VK_KHR_acceleration_structure": 1,
+                "VK_KHR_ray_query": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "shaderInt64": true,
+                    "depthBounds": true,
+                    "sparseResidencyImage3D": true
+                },
+                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                    "descriptorBindingStorageImageUpdateAfterBind": true,
+                    "descriptorBindingStorageTexelBufferUpdateAfterBind": true,
+                    "shaderStorageImageArrayNonUniformIndexing": true,
+                    "shaderStorageTexelBufferArrayNonUniformIndexing": true
+                },
+                "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                    "rayTracingPipeline": true,
+                    "rayTraversalPrimitiveCulling": true
+                },
+                "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                    "accelerationStructure": true
+                },
+                "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                    "rayQuery": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "sparseProperties": {
+                        "residencyStandard3DBlockShape": true
+                    }
+                },
+                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000
+                },
+                "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                    "degenerateTrianglesRasterized": true
+                },
+                "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                    "maxRayHitAttributeSize": 0,
+                    "shaderGroupHandleSize": 0,
+                    "shaderGroupBaseAlignment": 0,
+                    "shaderGroupHandleAlignment": 0
+                }
+            },
+            "formats": {
+                "VK_FORMAT_R32G32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R32G32B32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R16G16_SFLOAT": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R16G16_SNORM": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SNORM": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UNORM": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R16G16_UNORM": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UNORM": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R8G8_UNORM": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SNORM": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
+                "VK_FORMAT_R8G8_SNORM": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                }
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [ "VK_QUEUE_TRANSFER_BIT" ],
+                        "timestampValidBits": 1
+                    }
+                }
+            ]
+        },
+        "d3d12_level_12_2_update_after_uniform": {
+            "extensions": {
+                "VK_EXT_descriptor_indexing": 1
+            },
+            "features": {
+                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                    "descriptorBindingUniformBufferUpdateAfterBind": true,
+                    "shaderUniformBufferArrayNonUniformIndexing": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000
+                }
+            },
+        },
+        "d3d12_level_12_2_update_after_storage": {
+            "extensions": {
+                "VK_EXT_descriptor_indexing": 1
+            },
+            "features": {
+                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                    "descriptorBindingStorageBufferUpdateAfterBind": true,
+                    "shaderStorageBufferArrayNonUniformIndexing": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000
+                }
+            },
+        },
+        "d3d12_level_12_2_sm6_0": {
+            "extensions": {
+                "VK_KHR_shader_float_controls": 1,
+                "VK_KHR_uniform_buffer_standard_layout": 1,
+                "VK_EXT_scalar_block_layout": 1
+            },
+            "features": {
+                "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                    "uniformBufferStandardLayout": true
+                },
+                "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                    "scalarBlockLayout": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                    "shaderDenormFlushToZeroFloat32": true,
+                    "shaderDenormPreserveFloat32": true
+                },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "subgroupSize": 4,
+                    "supportedStages": ["VK_SHADER_STAGE_COMPUTE_BIT", "VK_SHADER_STAGE_FRAGMENT_BIT"],
+                    "supportedOperations": ["VK_SUBGROUP_FEATURE_ARITHMETIC_BIT", "VK_SUBGROUP_FEATURE_BASIC_BIT", "VK_SUBGROUP_FEATURE_BALLOT_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_BIT", "VK_SUBGROUP_FEATURE_QUAD_BIT", "VK_SUBGROUP_FEATURE_VOTE_BIT"]
+
+                }
+            }
+        },
+        "d3d12_level_12_2_sm6_2_32_bit_only": {
+            "extensions": {
+                "VK_KHR_shader_float_controls": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                    "denormBehaviorIndependence": "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                    "shaderDenormFlushToZeroFloat32": true,
+                    "shaderDenormPreserveFloat32": true
+                }
+            }
+        },
+        "d3d12_level_12_2_sm6_2_32_all": {
+            "extensions": {
+                "VK_KHR_shader_float_controls": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                    "denormBehaviorIndependence": "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                    "shaderDenormFlushToZeroFloat32": true,
+                    "shaderDenormPreserveFloat32": true
+                }
+            }
+        },
+        "d3d12_level_12_2_sm6_2_32_bit_only_nv": {
+            "extensions": {
+                "VK_KHR_shader_float_controls": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "vendorID": 4318
+                },
+                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                    "denormBehaviorIndependence": "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY"
+                }
+            }
+        },
+        "d3d12_level_12_2_sm6_2_32_all_nv": {
+            "extensions": {
+                "VK_KHR_shader_float_controls": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "vendorID": 4318
+                },
+                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                    "denormBehaviorIndependence": "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL"
+                }
+            }
+        },
+        "d3d12_level_12_2_sm6_3": {
+            "extensions": {
+                "VK_KHR_spirv_1_4": 1
+            }
+        },
+        "d3d12_level_12_2_sm6_6": {
+            "extensions": {
+                "VK_NV_compute_shader_derivatives": 1,
+                "VK_KHR_shader_atomic_int64": 1,
+                "VK_EXT_shader_demote_to_helper_invocation": 1,
+                "VK_KHR_shader_float16_int8": 1,
+                "VK_EXT_subgroup_size_control": 1
+            },
+            "features": {
+                "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                    "computeDerivativeGroupLinear": true
+                },
+                "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                    "shaderBufferInt64Atomics": true
+                },
+                "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                    "shaderDemoteToHelperInvocation": true
+                },
+                "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                    "shaderInt8": true
+                },
+                "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                    "subgroupSizeControl": true,
+                    "computeFullSubgroups": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                    "requiredSubgroupSizeStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
+                }
+            }
+        },
+    },
+    "profiles": {
+        "VP_VKD3D_d3d12_level_11_0_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "VKD3D D3D12 Level 11.0 Baseline profile",
+            "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
+            "contributors": {
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-09-01",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "d3d12_level_11_0",
+                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"]
+            ]
+        },
+        "VP_VKD3D_d3d12_level_11_1_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "VKD3D D3D12 Level 11.1 Baseline profile",
+            "description": "VKD3D for D3D12 Feature Level 11.1 minimum requirements",
+            "contributors": {
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-09-01",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "d3d12_level_11_0",
+                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"],
+                "d3d12_level_11_1",
+            ]
+        },
+        "VP_VKD3D_d3d12_level_12_0_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "VKD3D D3D12 Level 12.0 Baseline profile",
+            "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
+            "contributors": {
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-09-01",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "d3d12_level_11_0",
+                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"],
+                "d3d12_level_11_1",
+                "d3d12_level_12_0"
+            ]
+        },
+        "VP_VKD3D_d3d12_level_12_1_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "VKD3D D3D12 Level 12.0 Baseline profile",
+            "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
+            "contributors": {
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-09-01",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "d3d12_level_11_0",
+                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"],
+                "d3d12_level_11_1",
+                "d3d12_level_12_0",
+                "d3d12_level_12_1"
+            ]
+        },
+        "VP_VKD3D_d3d12_level_12_2_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "VKD3D D3D12 Level 12.2 Baseline profile",
+            "description": "VKD3D for D3D12 Feature Level 12.2 minimum requirements",
+            "contributors": {
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-09-01",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "d3d12_level_11_0",
+                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"],
+                "d3d12_level_11_1",
+                "d3d12_level_12_0",
+                ["d3d12_level_12_0_properties3_read_without_format", "d3d12_level_12_0_global_read_without_format"],
+                "d3d12_level_12_1",
+                "d3d12_level_12_2",
+                ["d3d12_level_12_2_update_after_uniform", "d3d12_level_12_2_update_after_storage"],
+                "d3d12_level_12_2_sm6_0",
+                ["d3d12_level_12_2_sm6_2_32_bit_only", "d3d12_level_12_2_sm6_2_32_all", "d3d12_level_12_2_sm6_2_32_bit_only_nv", "d3d12_level_12_2_sm6_2_32_all_nv", ],
+                "d3d12_level_12_2_sm6_3"
+            ]
+        }
+    }
+}

--- a/VP_VKD3D_requirements.json
+++ b/VP_VKD3D_requirements.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.0-224.json#",
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.1-197.json#",
     "capabilities": {
         "vulkan10requirements": {
             "features": {
@@ -621,25 +621,9 @@
     "profiles": {
         "VP_VKD3D_d3d12_level_11_0_baseline": {
             "version": 1,
-            "api-version": "1.3.204",
+            "api-version": "1.2.197",
             "label": "VKD3D D3D12 Level 11.0 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
-            "contributors": {
-                "Pierre-Loup A. Griffais": {
-                    "company": "Valve"
-                },
-                "Christophe Riccio": {
-                    "company": "LunarG"
-                }
-            },
-            "history": [
-                {
-                    "revision": 1,
-                    "date": "2022-09-01",
-                    "author": "Christophe Riccio",
-                    "comment": "Initial revision"
-                }
-            ],
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -649,25 +633,9 @@
         },
         "VP_VKD3D_d3d12_level_11_1_baseline": {
             "version": 1,
-            "api-version": "1.3.204",
+            "api-version": "1.2.197",
             "label": "VKD3D D3D12 Level 11.1 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 11.1 minimum requirements",
-            "contributors": {
-                "Pierre-Loup A. Griffais": {
-                    "company": "Valve"
-                },
-                "Christophe Riccio": {
-                    "company": "LunarG"
-                }
-            },
-            "history": [
-                {
-                    "revision": 1,
-                    "date": "2022-09-01",
-                    "author": "Christophe Riccio",
-                    "comment": "Initial revision"
-                }
-            ],
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -678,25 +646,9 @@
         },
         "VP_VKD3D_d3d12_level_12_0_baseline": {
             "version": 1,
-            "api-version": "1.3.204",
+            "api-version": "1.2.197",
             "label": "VKD3D D3D12 Level 12.0 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
-            "contributors": {
-                "Pierre-Loup A. Griffais": {
-                    "company": "Valve"
-                },
-                "Christophe Riccio": {
-                    "company": "LunarG"
-                }
-            },
-            "history": [
-                {
-                    "revision": 1,
-                    "date": "2022-09-01",
-                    "author": "Christophe Riccio",
-                    "comment": "Initial revision"
-                }
-            ],
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -708,25 +660,9 @@
         },
         "VP_VKD3D_d3d12_level_12_1_baseline": {
             "version": 1,
-            "api-version": "1.3.204",
+            "api-version": "1.2.197",
             "label": "VKD3D D3D12 Level 12.0 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
-            "contributors": {
-                "Pierre-Loup A. Griffais": {
-                    "company": "Valve"
-                },
-                "Christophe Riccio": {
-                    "company": "LunarG"
-                }
-            },
-            "history": [
-                {
-                    "revision": 1,
-                    "date": "2022-09-01",
-                    "author": "Christophe Riccio",
-                    "comment": "Initial revision"
-                }
-            ],
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -739,40 +675,40 @@
         },
         "VP_VKD3D_d3d12_level_12_2_baseline": {
             "version": 1,
-            "api-version": "1.3.204",
+            "api-version": "1.2.197",
             "label": "VKD3D D3D12 Level 12.2 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 12.2 minimum requirements",
-            "contributors": {
-                "Pierre-Loup A. Griffais": {
-                    "company": "Valve"
-                },
-                "Christophe Riccio": {
-                    "company": "LunarG"
-                }
-            },
-            "history": [
-                {
-                    "revision": 1,
-                    "date": "2022-09-01",
-                    "author": "Christophe Riccio",
-                    "comment": "Initial revision"
-                }
-            ],
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
                 "d3d12_level_11_0",
-                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"],
+                [ "d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage" ],
                 "d3d12_level_11_1",
                 "d3d12_level_12_0",
-                ["d3d12_level_12_0_properties3_read_without_format", "d3d12_level_12_0_global_read_without_format"],
+                [ "d3d12_level_12_0_properties3_read_without_format", "d3d12_level_12_0_global_read_without_format" ],
                 "d3d12_level_12_1",
                 "d3d12_level_12_2",
-                ["d3d12_level_12_2_update_after_uniform", "d3d12_level_12_2_update_after_storage"],
+                [ "d3d12_level_12_2_update_after_uniform", "d3d12_level_12_2_update_after_storage" ],
                 "d3d12_level_12_2_sm6_0",
-                ["d3d12_level_12_2_sm6_2_32_bit_only", "d3d12_level_12_2_sm6_2_32_all", "d3d12_level_12_2_sm6_2_32_bit_only_nv", "d3d12_level_12_2_sm6_2_32_all_nv", ],
+                [ "d3d12_level_12_2_sm6_2_32_bit_only", "d3d12_level_12_2_sm6_2_32_all", "d3d12_level_12_2_sm6_2_32_bit_only_nv", "d3d12_level_12_2_sm6_2_32_all_nv" ],
                 "d3d12_level_12_2_sm6_3"
             ]
         }
-    }
+    },
+    "contributors": {
+        "Pierre-Loup A. Griffais": {
+            "company": "Valve"
+        },
+        "Christophe Riccio": {
+            "company": "LunarG"
+        }
+    },
+    "history": [
+        {
+            "revision": 1,
+            "date": "2022-09-01",
+            "author": "Christophe Riccio",
+            "comment": "Initial revision"
+        }
+    ]
 }

--- a/VP_VKD3D_requirements.json
+++ b/VP_VKD3D_requirements.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.1-197.json#",
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.1-235.json#",
     "capabilities": {
         "vulkan10requirements": {
             "features": {
@@ -21,91 +21,203 @@
                 }
             }
         },
+        "vulkan12requirements": {
+            "features": {
+                "VkPhysicalDeviceVulkan12Features": {
+                    "uniformBufferStandardLayout": true,
+                    "subgroupBroadcastDynamicId": true,
+                    "imagelessFramebuffer": true,
+                    "separateDepthStencilLayouts": true,
+                    "hostQueryReset": true,
+                    "timelineSemaphore": true,
+                    "shaderSubgroupExtendedTypes": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceVulkan12Properties": {
+                    "maxTimelineSemaphoreValueDifference": 2147483647
+                }
+            }
+        },
+        "vulkan13requirements": {
+            "features": {
+                "VkPhysicalDeviceVulkan12Features": {
+                    "vulkanMemoryModel": true,
+                    "vulkanMemoryModelDeviceScope": true,
+                    "bufferDeviceAddress": true
+                },
+                "VkPhysicalDeviceVulkan13Features": {
+                    "robustImageAccess": true,
+                    "shaderTerminateInvocation": true,
+                    "shaderZeroInitializeWorkgroupMemory": true,
+                    "synchronization2": true,
+                    "shaderIntegerDotProduct": true,
+                    "maintenance4": true,
+                    "pipelineCreationCacheControl": true,
+                    "subgroupSizeControl": true,
+                    "computeFullSubgroups": true,
+                    "shaderDemoteToHelperInvocation": true,
+                    "inlineUniformBlock": true,
+                    "dynamicRendering": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceVulkan13Properties": {
+                    "maxBufferSize": 1073741824,
+                    "maxInlineUniformBlockSize": 256,
+                    "maxPerStageDescriptorInlineUniformBlocks": 4,
+                    "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": 4,
+                    "maxDescriptorSetInlineUniformBlocks": 4,
+                    "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": 4,
+                    "maxInlineUniformTotalSize": 256
+                }
+            }
+        },
+        "vulkan_min_requirements": {
+            "extensions": {
+                "VK_KHR_push_descriptor": 1,
+                "VK_EXT_robustness2": 1,
+                "VK_EXT_extended_dynamic_state2": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "shaderTessellationAndGeometryPointSize": false
+                },
+                "VkPhysicalDeviceVulkan11Features": {
+                    "protectedMemory": false,
+                    "samplerYcbcrConversion": false,
+                    "shaderDrawParameters": true
+                },
+                "VkPhysicalDeviceVulkan12Features": {
+                    "samplerMirrorClampToEdge": true,
+                    "storageBuffer8BitAccess": false,
+                    "uniformAndStorageBuffer8BitAccess": false,
+                    "storagePushConstant8": false,
+                    "bufferDeviceAddressCaptureReplay": false,
+                    "bufferDeviceAddressMultiDevice": false,
+                    "imagelessFramebuffer": false,
+                    "hostQueryReset": false,
+                    "vulkanMemoryModel": false,
+                    "vulkanMemoryModelDeviceScope": false,
+                    "vulkanMemoryModelAvailabilityVisibilityChains": false,
+                    "separateDepthStencilLayouts": true,
+                    "shaderInputAttachmentArrayDynamicIndexing": false,
+                    "shaderUniformTexelBufferArrayDynamicIndexing": true,
+                    "shaderStorageTexelBufferArrayDynamicIndexing": true,
+                    "shaderUniformBufferArrayNonUniformIndexing": true,
+                    "shaderSampledImageArrayNonUniformIndexing": true,
+                    "shaderStorageBufferArrayNonUniformIndexing": true,
+                    "shaderStorageImageArrayNonUniformIndexing": true,
+                    "shaderInputAttachmentArrayNonUniformIndexing": false,
+                    "shaderUniformTexelBufferArrayNonUniformIndexing": true,
+                    "shaderStorageTexelBufferArrayNonUniformIndexing": true,
+                    "descriptorBindingUniformBufferUpdateAfterBind": true,
+                    "descriptorBindingSampledImageUpdateAfterBind": true,
+                    "descriptorBindingStorageImageUpdateAfterBind": true,
+                    "descriptorBindingStorageBufferUpdateAfterBind": true,
+                    "descriptorBindingUniformTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingStorageTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingUpdateUnusedWhilePending": true,
+                    "descriptorBindingPartiallyBound": true,
+                    "descriptorBindingVariableDescriptorCount": true,
+                    "runtimeDescriptorArray": true
+                },
+                "VkPhysicalDeviceVulkan13Features": {
+                    "robustImageAccess": false,
+                    "inlineUniformBlock": false,
+                    "descriptorBindingInlineUniformBlockUpdateAfterBind": false,
+                    "privateData": false,
+                    "textureCompressionASTC_HDR": false,
+                    "dynamicRendering": true,
+                    "maintenance4": true
+                },
+                "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                    "extendedDynamicState2LogicOp": false
+                },
+                "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                    "nullDescriptor": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceVulkan12Properties": {
+                    "maxPerStageDescriptorUpdateAfterBindSampledImages": 1000000,
+                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000,
+                    "maxPerStageDescriptorUpdateAfterBindStorageBuffers": 1000000
+                }
+            }
+        },
         "d3d12_level_11_0": {
             "extensions": {
                 "VK_KHR_surface": 1,
                 "VK_KHR_swapchain": 1,
-                "VK_KHR_timeline_semaphore": 1,
-                "VK_KHR_separate_depth_stencil_layouts": 1,
-                "VK_KHR_sampler_mirror_clamp_to_edge": 1,
                 "VK_EXT_robustness2": 1,
-                "VK_KHR_bind_memory2": 1,
-                "VK_KHR_copy_commands2": 1,
-                "VK_KHR_dynamic_rendering": 1,
                 "VK_EXT_extended_dynamic_state": 1,
-                "VK_EXT_extended_dynamic_state2": 1,
-                "VK_KHR_maintenance4": 1,
-                "VK_EXT_descriptor_indexing": 1
+                "VK_EXT_extended_dynamic_state2": 1
             },
             "features": {
-                "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
-                    "separateDepthStencilLayouts": true
+                "VkPhysicalDeviceVulkan11Features": {
+                    "shaderDrawParameters": true
+                },
+                "VkPhysicalDeviceVulkan13Features": {
+
                 },
                 "VkPhysicalDeviceRobustness2FeaturesEXT": {
                     "nullDescriptor": true
-                },
-                "VkPhysicalDeviceShaderDrawParametersFeatures": {
-                    "shaderDrawParameters": true
-                },
-                "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                    "dynamicRendering": true
                 },
                 "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
                     "extendedDynamicState": true
                 },
                 "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
                     "extendedDynamicState2": true
-                },
-                "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                    "maintenance4": true
-                },
-                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
-                    "runtimeDescriptorArray": true,
-                    "descriptorBindingPartiallyBound": true,
-                    "descriptorBindingUpdateUnusedWhilePending": true,
-                    "descriptorBindingVariableDescriptorCount": true,
-                    "descriptorBindingSampledImageUpdateAfterBind": true,
-                    "descriptorBindingUniformTexelBufferUpdateAfterBind": true,
-                    "shaderSampledImageArrayNonUniformIndexing": true,
-                    "shaderUniformTexelBufferArrayNonUniformIndexing": true
-                }
-            },
-            "properties": {
-                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
-                    "maxPerStageDescriptorUpdateAfterBindSampledImages": 1000000,
-                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000
                 }
             }
         },
-        "d3d12_level_11_0_bindless_uniform": {
-            "extensions": {
-                "VK_EXT_descriptor_indexing": 1
-            },
+        "d3d12_level_11_0_descriptor_sets": {
             "properties": {
-                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
-                    "maxPerStageDescriptorUpdateAfterBindUniformBuffers": 1000000
-                }
-            }      
-        },
-        "d3d12_level_11_0_bindless_storage": {
-            "extensions": {
-                "VK_EXT_descriptor_indexing": 1
-            },
-            "properties": {
-                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                "VkPhysicalDeviceVulkan12Properties": {
+                    "maxPerStageDescriptorUpdateAfterBindSampledImages": 1000000,
+                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000,
                     "maxPerStageDescriptorUpdateAfterBindStorageBuffers": 1000000
                 }
             }
         },
-        "d3d12_level_11_0_optimal": {
+        "d3d12_level_11_0_descriptor_buffers": {
             "extensions": {
-                "VK_EXT_descriptor_indexing": 1,
-                "VK_EXT_shader_stencil_export": 1,
-                "VK_EXT_shader_viewport_index_layer": 1
+                "VK_EXT_descriptor_buffer": 1
+            },
+            "features": {
+                "VkPhysicalDeviceDescriptorBufferFeaturesEXT": {
+                    "descriptorBuffer": true,
+                    "descriptorBufferPushDescriptors": true
+                }
             },
             "properties": {
-                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
-                    "robustBufferAccessUpdateAfterBind": true
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorStorageBuffers": 64,
+                        "maxPerStageDescriptorStorageImages": 64,
+                        "minStorageBufferOffsetAlignment": 4
+                    }
+                }
+            }
+        },
+        "d3d12_level_11_0_mutable_descriptor_type_ext": {
+            "extensions": {
+                "VK_EXT_mutable_descriptor_type": 1
+            },
+            "features": {
+                "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
+                    "mutableDescriptorType": true
+                }
+            }
+        },
+        "d3d12_level_11_0_mutable_descriptor_type_valve": {
+            "extensions": {
+                "VK_VALVE_mutable_descriptor_type": 1
+            },
+            "features": {
+                "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                    "mutableDescriptorType": true   
                 }
             }
         },
@@ -145,11 +257,17 @@
                 "VkPhysicalDeviceProperties": {
                     "sparseProperties": {
                         "residencyStandard2DBlockShape": true,
-                        "residencyNonResidentStrict": true
+                        "residencyNonResidentStrict": true,
+                        "residencyAlignedMipSize": false
                     }
                 },
-                "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
-                    "filterMinmaxSingleComponentFormats": false
+                "VkPhysicalDeviceVulkan11Properties": {
+                    "subgroupSize": 4,
+                    "subgroupSupportedOperations": [ "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT", "VK_SUBGROUP_FEATURE_BASIC_BIT", "VK_SUBGROUP_FEATURE_BALLOT_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_BIT", "VK_SUBGROUP_FEATURE_QUAD_BIT", "VK_SUBGROUP_FEATURE_VOTE_BIT" ],
+                    "subgroupSupportedStages": [ "VK_SHADER_STAGE_COMPUTE_BIT", "VK_SHADER_STAGE_FRAGMENT_BIT" ]
+                },
+                "VkPhysicalDeviceVulkan12Properties": {
+                    "filterMinmaxSingleComponentFormats": true
                 }
             },
             "queueFamiliesProperties": [
@@ -161,214 +279,78 @@
                 }
             ]
         },
-        "d3d12_level_12_0_properties3_read_without_format": {
-            "extensions": {
-                "VK_KHR_format_feature_flags2": 1
-            },
-            "formats": {
-                "VK_FORMAT_R32_SFLOAT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R32_UINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R32_SINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_SFLOAT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_UINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_SINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_SFLOAT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_UINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_SINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_UNORM": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_UINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_SINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R16_SFLOAT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R16_UINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R16_SINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R8_UNORM": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R8_UINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                },
-                "VK_FORMAT_R8_SINT": {
-                    "VkFormatProperties3KHR": {
-                        "linearTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ],
-                        "optimalTilingFeatures": [
-                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR", "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR"
-                        ]
-                    }
-                }
-            }
-        },
-        "d3d12_level_12_0_global_read_without_format": {
-            "extensions": {
-            },
-            "features": {
-                "VkPhysicalDeviceFeatures": {
-                    "shaderStorageImageReadWithoutFormat": true
-                }
-            }
-        },
         "d3d12_level_12_1": {
             "extensions": {
                 "VK_EXT_conservative_rasterization": 1
             }
         },
+        "d3d12_level_12_2_min_shading_rate_8": {
+            "properties": {
+                "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                    "minFragmentShadingRateAttachmentTexelSize": {
+                        "width": 8,
+                        "height": 8,
+                    }
+                } 
+            }
+        },
+        "d3d12_level_12_2_min_shading_rate_16": {
+            "properties": {
+                "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                    "minFragmentShadingRateAttachmentTexelSize": {
+                        "width": 16,
+                        "height": 16,
+                    }
+                } 
+            }
+        },
+        "d3d12_level_12_2_min_shading_rate_32": {
+            "properties": {
+                "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                    "minFragmentShadingRateAttachmentTexelSize":  {
+                        "width": 32,
+                        "height": 32,
+                    }
+                } 
+            }
+        },
+        "d3d12_level_12_2_max_shading_rate_8": {
+            "properties": {
+                "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                    "maxFragmentShadingRateAttachmentTexelSize":  {
+                        "width": 8,
+                        "height": 8,
+                    }
+                } 
+            }
+        },
+        "d3d12_level_12_2_max_shading_rate_16": {
+            "properties": {
+                "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                    "maxFragmentShadingRateAttachmentTexelSize": {
+                        "width": 16,
+                        "height": 16,
+                    }
+                } 
+            }
+        },
+        "d3d12_level_12_2_max_shading_rate_32": {
+            "properties": {
+                "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                    "maxFragmentShadingRateAttachmentTexelSize": {
+                        "width": 32,
+                        "height": 32,
+                    }
+                } 
+            }
+        },
         "d3d12_level_12_2": {
             "extensions": {
-                "VK_EXT_descriptor_indexing": 1,
                 "VK_EXT_shader_viewport_index_layer": 1,
                 "VK_KHR_ray_tracing_pipeline": 1,
                 "VK_KHR_acceleration_structure": 1,
-                "VK_KHR_ray_query": 1
+                "VK_KHR_ray_query": 1,
+                "VK_EXT_mesh_shader": 1
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
@@ -376,7 +358,7 @@
                     "depthBounds": true,
                     "sparseResidencyImage3D": true
                 },
-                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                "VkPhysicalDeviceVulkan12Features": {
                     "descriptorBindingStorageImageUpdateAfterBind": true,
                     "descriptorBindingStorageTexelBufferUpdateAfterBind": true,
                     "shaderStorageImageArrayNonUniformIndexing": true,
@@ -391,25 +373,40 @@
                 },
                 "VkPhysicalDeviceRayQueryFeaturesKHR": {
                     "rayQuery": true
+                },
+                "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                    "attachmentFragmentShadingRate": true,
+                    "pipelineFragmentShadingRate": true
+                },
+                "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+                    "meshShader": true,
+                    "taskShader": true
                 }
             },
             "properties": {
                 "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "framebufferColorSampleCounts": [ "VK_SAMPLE_COUNT_2_BIT" ]
+                    },
                     "sparseProperties": {
                         "residencyStandard3DBlockShape": true
                     }
                 },
-                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                "VkPhysicalDeviceVulkan12Properties": {
                     "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000
                 },
                 "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
-                    "degenerateTrianglesRasterized": true
+                    "degenerateTrianglesRasterized": true,
+                    "fullyCoveredFragmentShaderInputVariable": true
                 },
                 "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                    "maxRayHitAttributeSize": 0,
-                    "shaderGroupHandleSize": 0,
-                    "shaderGroupBaseAlignment": 0,
-                    "shaderGroupHandleAlignment": 0
+                    "maxRayHitAttributeSize": 32,
+                    "shaderGroupHandleSize": 32,
+                    "shaderGroupBaseAlignment": 64,
+                    "shaderGroupHandleAlignment": 32
+                },
+                "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                    "fragmentShadingRateNonTrivialCombinerOps": true
                 }
             },
             "formats": {
@@ -445,6 +442,10 @@
                     "VkFormatProperties": {
                         "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
                 },
+                "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                    "VkFormatProperties": {
+                        "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
+                },
                 "VK_FORMAT_R8G8B8A8_UNORM": {
                     "VkFormatProperties": {
                         "bufferFeatures": [ "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR" ]                    }
@@ -471,42 +472,8 @@
                 }
             ]
         },
-        "d3d12_level_12_2_update_after_uniform": {
-            "extensions": {
-                "VK_EXT_descriptor_indexing": 1
-            },
-            "features": {
-                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
-                    "descriptorBindingUniformBufferUpdateAfterBind": true,
-                    "shaderUniformBufferArrayNonUniformIndexing": true
-                }
-            },
-            "properties": {
-                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
-                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000
-                }
-            },
-        },
-        "d3d12_level_12_2_update_after_storage": {
-            "extensions": {
-                "VK_EXT_descriptor_indexing": 1
-            },
-            "features": {
-                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
-                    "descriptorBindingStorageBufferUpdateAfterBind": true,
-                    "shaderStorageBufferArrayNonUniformIndexing": true
-                }
-            },
-            "properties": {
-                "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
-                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 1000000
-                }
-            },
-        },
         "d3d12_level_12_2_sm6_0": {
             "extensions": {
-                "VK_KHR_shader_float_controls": 1,
-                "VK_KHR_uniform_buffer_standard_layout": 1,
                 "VK_EXT_scalar_block_layout": 1
             },
             "features": {
@@ -518,7 +485,7 @@
                 }
             },
             "properties": {
-                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                "VkPhysicalDeviceVulkan12Properties": {
                     "shaderDenormFlushToZeroFloat32": true,
                     "shaderDenormPreserveFloat32": true
                 },
@@ -531,11 +498,8 @@
             }
         },
         "d3d12_level_12_2_sm6_2_32_bit_only": {
-            "extensions": {
-                "VK_KHR_shader_float_controls": 1
-            },
             "properties": {
-                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                "VkPhysicalDeviceVulkan12Properties": {
                     "denormBehaviorIndependence": "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
                     "shaderDenormFlushToZeroFloat32": true,
                     "shaderDenormPreserveFloat32": true
@@ -543,11 +507,8 @@
             }
         },
         "d3d12_level_12_2_sm6_2_32_all": {
-            "extensions": {
-                "VK_KHR_shader_float_controls": 1
-            },
             "properties": {
-                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                "VkPhysicalDeviceVulkan12Properties": {
                     "denormBehaviorIndependence": "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
                     "shaderDenormFlushToZeroFloat32": true,
                     "shaderDenormPreserveFloat32": true
@@ -555,119 +516,177 @@
             }
         },
         "d3d12_level_12_2_sm6_2_32_bit_only_nv": {
-            "extensions": {
-                "VK_KHR_shader_float_controls": 1
-            },
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "vendorID": 4318
                 },
-                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                "VkPhysicalDeviceVulkan12Properties": {
                     "denormBehaviorIndependence": "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY"
                 }
             }
         },
         "d3d12_level_12_2_sm6_2_32_all_nv": {
-            "extensions": {
-                "VK_KHR_shader_float_controls": 1
-            },
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "vendorID": 4318
                 },
-                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                "VkPhysicalDeviceVulkan12Properties": {
                     "denormBehaviorIndependence": "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL"
                 }
             }
         },
-        "d3d12_level_12_2_sm6_3": {
-            "extensions": {
-                "VK_KHR_spirv_1_4": 1
-            }
-        },
         "d3d12_level_12_2_sm6_6": {
             "extensions": {
-                "VK_NV_compute_shader_derivatives": 1,
-                "VK_KHR_shader_atomic_int64": 1,
-                "VK_EXT_shader_demote_to_helper_invocation": 1,
-                "VK_KHR_shader_float16_int8": 1,
-                "VK_EXT_subgroup_size_control": 1
+                "VK_NV_compute_shader_derivatives": 1
             },
             "features": {
-                "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
-                    "computeDerivativeGroupLinear": true
-                },
-                "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                "VkPhysicalDeviceVulkan12Features": {
+                    "shaderInt8": true,
                     "shaderBufferInt64Atomics": true
                 },
-                "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                    "shaderDemoteToHelperInvocation": true
-                },
-                "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
-                    "shaderInt8": true
-                },
-                "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                    "subgroupSizeControl": true,
-                    "computeFullSubgroups": true
+                "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                    "computeDerivativeGroupLinear": true
                 }
             },
             "properties": {
-                "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                "VkPhysicalDeviceVulkan13Properties": {
                     "requiredSubgroupSizeStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
                 }
             }
-        },
+        }
     },
     "profiles": {
         "VP_VKD3D_d3d12_level_11_0_baseline": {
             "version": 1,
-            "api-version": "1.2.197",
+            "api-version": "1.3.204",
             "label": "VKD3D D3D12 Level 11.0 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
                 "d3d12_level_11_0",
-                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"]
+                "d3d12_level_11_0_descriptor_sets"
+            ]
+        },
+        "VP_VKD3D_d3d12_level_11_0_optimal": {
+            "version": 1,
+            "api-version": "1.3.235",
+            "label": "VKD3D D3D12 Level 11.0 Optimal profile",
+            "description": "VKD3D for D3D12 Feature Level 11.0 requirements for optimal performance",
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
+                "d3d12_level_11_0",
+                "d3d12_level_11_0_descriptor_buffers",
+                ["d3d12_level_11_0_mutable_descriptor_type_valve", "d3d12_level_11_0_mutable_descriptor_type_ext"]
             ]
         },
         "VP_VKD3D_d3d12_level_11_1_baseline": {
             "version": 1,
-            "api-version": "1.2.197",
+            "api-version": "1.3.204",
             "label": "VKD3D D3D12 Level 11.1 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 11.1 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
                 "d3d12_level_11_0",
-                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"],
+                "d3d12_level_11_0_descriptor_sets",
+                "d3d12_level_11_1",
+            ]
+        },
+        "VP_VKD3D_d3d12_level_11_1_optimal": {
+            "version": 1,
+            "api-version": "1.3.235",
+            "label": "VKD3D D3D12 Level 11.1 Optimal profile",
+            "description": "VKD3D for D3D12 Feature Level 11.1 requirements for optimal performance",
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
+                "d3d12_level_11_0",
+                "d3d12_level_11_0_descriptor_buffers",
+                ["d3d12_level_11_0_mutable_descriptor_type_valve", "d3d12_level_11_0_mutable_descriptor_type_ext"],
                 "d3d12_level_11_1",
             ]
         },
         "VP_VKD3D_d3d12_level_12_0_baseline": {
             "version": 1,
-            "api-version": "1.2.197",
+            "api-version": "1.3.204",
             "label": "VKD3D D3D12 Level 12.0 Baseline profile",
-            "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
+            "description": "VKD3D for D3D12 Feature Level 12.0 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
                 "d3d12_level_11_0",
-                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"],
+                "d3d12_level_11_0_descriptor_sets",
+                "d3d12_level_11_1",
+                "d3d12_level_12_0"
+            ]
+        },
+        "VP_VKD3D_d3d12_level_12_0_optimal": {
+            "version": 1,
+            "api-version": "1.3.235",
+            "label": "VKD3D D3D12 Level 12.0 Optimal profile",
+            "description": "VKD3D for D3D12 Feature Level 12.0 requirements for optimal performance",
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
+                "d3d12_level_11_0",
+                "d3d12_level_11_0_descriptor_buffers",
+                ["d3d12_level_11_0_mutable_descriptor_type_valve", "d3d12_level_11_0_mutable_descriptor_type_ext"],
                 "d3d12_level_11_1",
                 "d3d12_level_12_0"
             ]
         },
         "VP_VKD3D_d3d12_level_12_1_baseline": {
             "version": 1,
-            "api-version": "1.2.197",
-            "label": "VKD3D D3D12 Level 12.0 Baseline profile",
-            "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
+            "api-version": "1.3.204",
+            "label": "VKD3D D3D12 Level 12.1 Baseline profile",
+            "description": "VKD3D for D3D12 Feature Level 12.1 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
                 "d3d12_level_11_0",
-                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"],
+                "d3d12_level_11_0_descriptor_sets",
+                "d3d12_level_11_1",
+                "d3d12_level_12_0",
+                "d3d12_level_12_1"
+            ]
+        },
+        "VP_VKD3D_d3d12_level_12_1_optimal": {
+            "version": 1,
+            "api-version": "1.3.235",
+            "label": "VKD3D D3D12 Level 12.1 Optimal profile",
+            "description": "VKD3D for D3D12 Feature Level 12.1 requirements for optimal performance",
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
+                "d3d12_level_11_0",
+                "d3d12_level_11_0_descriptor_buffers",
+                ["d3d12_level_11_0_mutable_descriptor_type_valve", "d3d12_level_11_0_mutable_descriptor_type_ext"],
                 "d3d12_level_11_1",
                 "d3d12_level_12_0",
                 "d3d12_level_12_1"
@@ -675,23 +694,49 @@
         },
         "VP_VKD3D_d3d12_level_12_2_baseline": {
             "version": 1,
-            "api-version": "1.2.197",
+            "api-version": "1.3.204",
             "label": "VKD3D D3D12 Level 12.2 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 12.2 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
                 "d3d12_level_11_0",
-                [ "d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage" ],
+                "d3d12_level_11_0_descriptor_sets",
                 "d3d12_level_11_1",
                 "d3d12_level_12_0",
-                [ "d3d12_level_12_0_properties3_read_without_format", "d3d12_level_12_0_global_read_without_format" ],
                 "d3d12_level_12_1",
                 "d3d12_level_12_2",
-                [ "d3d12_level_12_2_update_after_uniform", "d3d12_level_12_2_update_after_storage" ],
                 "d3d12_level_12_2_sm6_0",
                 [ "d3d12_level_12_2_sm6_2_32_bit_only", "d3d12_level_12_2_sm6_2_32_all", "d3d12_level_12_2_sm6_2_32_bit_only_nv", "d3d12_level_12_2_sm6_2_32_all_nv" ],
-                "d3d12_level_12_2_sm6_3"
+                [ "d3d12_level_12_2_min_shading_rate_8", "d3d12_level_12_2_min_shading_rate_16", "d3d12_level_12_2_min_shading_rate_32" ],
+                [ "d3d12_level_12_2_max_shading_rate_8", "d3d12_level_12_2_max_shading_rate_16", "d3d12_level_12_2_max_shading_rate_32" ]
+            ]
+        },
+        "VP_VKD3D_d3d12_level_12_2_optimal": {
+            "version": 1,
+            "api-version": "1.3.235",
+            "label": "VKD3D D3D12 Level 12.2 Optimal profile",
+            "description": "VKD3D for D3D12 Feature Level 12.2 requirements for optimal performance",
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "vulkan_min_requirements",
+                "d3d12_level_11_0",
+                "d3d12_level_11_0_descriptor_buffers",
+                [ "d3d12_level_11_0_mutable_descriptor_type_valve", "d3d12_level_11_0_mutable_descriptor_type_ext" ],
+                "d3d12_level_11_1",
+                "d3d12_level_12_0",
+                "d3d12_level_12_1",
+                "d3d12_level_12_2",
+                "d3d12_level_12_2_sm6_0",
+                [ "d3d12_level_12_2_sm6_2_32_bit_only", "d3d12_level_12_2_sm6_2_32_all", "d3d12_level_12_2_sm6_2_32_bit_only_nv", "d3d12_level_12_2_sm6_2_32_all_nv" ],
+                [ "d3d12_level_12_2_min_shading_rate_8", "d3d12_level_12_2_min_shading_rate_16", "d3d12_level_12_2_min_shading_rate_32" ],
+                [ "d3d12_level_12_2_max_shading_rate_8", "d3d12_level_12_2_max_shading_rate_16", "d3d12_level_12_2_max_shading_rate_32" ]
             ]
         }
     },

--- a/VP_VKD3D_requirements.json
+++ b/VP_VKD3D_requirements.json
@@ -281,7 +281,14 @@
         },
         "d3d12_level_12_1": {
             "extensions": {
-                "VK_EXT_conservative_rasterization": 1
+                "VK_EXT_conservative_rasterization": 1,
+                "VK_EXT_fragment_shader_interlock": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                    "fragmentShaderPixelInterlock": true,
+                    "fragmentShaderSampleInterlock": true
+                }
             }
         },
         "d3d12_level_12_2_min_shading_rate_8": {

--- a/VP_VKD3D_requirements.json
+++ b/VP_VKD3D_requirements.json
@@ -694,7 +694,7 @@
         },
         "VP_VKD3D_d3d12_level_12_2_baseline": {
             "version": 1,
-            "api-version": "1.3.204",
+            "api-version": "1.3.226",
             "label": "VKD3D D3D12 Level 12.2 Baseline profile",
             "description": "VKD3D for D3D12 Feature Level 12.2 minimum requirements",
             "capabilities": [

--- a/VP_VKD3D_requirements.json
+++ b/VP_VKD3D_requirements.json
@@ -559,8 +559,8 @@
         "VP_VKD3D_d3d12_level_11_0_baseline": {
             "version": 1,
             "api-version": "1.3.204",
-            "label": "VKD3D D3D12 Level 11.0 Baseline profile",
-            "description": "VKD3D for D3D12 Feature Level 11.0 minimum requirements",
+            "label": "VKD3D-Proton D3D12 Level 11.0 Baseline profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 11.0 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -574,8 +574,8 @@
         "VP_VKD3D_d3d12_level_11_0_optimal": {
             "version": 1,
             "api-version": "1.3.235",
-            "label": "VKD3D D3D12 Level 11.0 Optimal profile",
-            "description": "VKD3D for D3D12 Feature Level 11.0 requirements for optimal performance",
+            "label": "VKD3D-Proton D3D12 Level 11.0 Optimal profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 11.0 requirements for optimal performance",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -590,8 +590,8 @@
         "VP_VKD3D_d3d12_level_11_1_baseline": {
             "version": 1,
             "api-version": "1.3.204",
-            "label": "VKD3D D3D12 Level 11.1 Baseline profile",
-            "description": "VKD3D for D3D12 Feature Level 11.1 minimum requirements",
+            "label": "VKD3D-proton D3D12 Level 11.1 Baseline profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 11.1 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -606,8 +606,8 @@
         "VP_VKD3D_d3d12_level_11_1_optimal": {
             "version": 1,
             "api-version": "1.3.235",
-            "label": "VKD3D D3D12 Level 11.1 Optimal profile",
-            "description": "VKD3D for D3D12 Feature Level 11.1 requirements for optimal performance",
+            "label": "VKD3D-Proton D3D12 Level 11.1 Optimal profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 11.1 requirements for optimal performance",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -623,8 +623,8 @@
         "VP_VKD3D_d3d12_level_12_0_baseline": {
             "version": 1,
             "api-version": "1.3.204",
-            "label": "VKD3D D3D12 Level 12.0 Baseline profile",
-            "description": "VKD3D for D3D12 Feature Level 12.0 minimum requirements",
+            "label": "VKD3D-Proton D3D12 Level 12.0 Baseline profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 12.0 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -640,8 +640,8 @@
         "VP_VKD3D_d3d12_level_12_0_optimal": {
             "version": 1,
             "api-version": "1.3.235",
-            "label": "VKD3D D3D12 Level 12.0 Optimal profile",
-            "description": "VKD3D for D3D12 Feature Level 12.0 requirements for optimal performance",
+            "label": "VKD3D-Proton D3D12 Level 12.0 Optimal profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 12.0 requirements for optimal performance",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -658,8 +658,8 @@
         "VP_VKD3D_d3d12_level_12_1_baseline": {
             "version": 1,
             "api-version": "1.3.204",
-            "label": "VKD3D D3D12 Level 12.1 Baseline profile",
-            "description": "VKD3D for D3D12 Feature Level 12.1 minimum requirements",
+            "label": "VKD3D-Proton D3D12 Level 12.1 Baseline profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 12.1 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -676,8 +676,8 @@
         "VP_VKD3D_d3d12_level_12_1_optimal": {
             "version": 1,
             "api-version": "1.3.235",
-            "label": "VKD3D D3D12 Level 12.1 Optimal profile",
-            "description": "VKD3D for D3D12 Feature Level 12.1 requirements for optimal performance",
+            "label": "VKD3D-Proton D3D12 Level 12.1 Optimal profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 12.1 requirements for optimal performance",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -695,8 +695,8 @@
         "VP_VKD3D_d3d12_level_12_2_baseline": {
             "version": 1,
             "api-version": "1.3.226",
-            "label": "VKD3D D3D12 Level 12.2 Baseline profile",
-            "description": "VKD3D for D3D12 Feature Level 12.2 minimum requirements",
+            "label": "VKD3D-Proton D3D12 Level 12.2 Baseline profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 12.2 minimum requirements",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",
@@ -718,8 +718,8 @@
         "VP_VKD3D_d3d12_level_12_2_optimal": {
             "version": 1,
             "api-version": "1.3.235",
-            "label": "VKD3D D3D12 Level 12.2 Optimal profile",
-            "description": "VKD3D for D3D12 Feature Level 12.2 requirements for optimal performance",
+            "label": "VKD3D-Proton D3D12 Level 12.2 Optimal profile",
+            "description": "VKD3D-Proton for D3D12 Feature Level 12.2 requirements for optimal performance",
             "capabilities": [
                 "vulkan10requirements",
                 "vulkan11requirements",


### PR DESCRIPTION
I created a Vulkan profiles JSON file to express VKD3D minimum requirements for each D3D level. This JSON files are defined by Vulkan Profiles schemas avaiable [here](https://schema.khronos.org/vulkan/) and can be used as part of the Vulkan SDK Profiles Toolset. ([PDF](https://www.lunarg.com/wp-content/uploads/2022/03/The-Vulkan-Profiles-Toolset-Solution-FEB2022.pdf), [Presentation](https://www.lunarg.com/wp-content/uploads/2022/08/Vulkan-SDK-Tools-to-Use-and-Create-Vulkan-Profiles-AUG-SIGGRAPH-2022.pdf))

I based myself on the repository source code as the main page requirements seem pretty sparsed.

This is an equivalent work from what we did for DXVK with this PR: https://github.com/doitsujin/dxvk/pull/2826

This PR is really for discussion purposes at this point so that I understand if you would be interested in such idea and the direction you would like it to take.

A couple of caveats :
- I had to create a new construct to express a "OR" of capability checks which I still need to . 
This is something we were pushing to avoid in the profiles concept because depending who produces and consumes a profile it can make things very hard for Vulkan application developers: "How to know what APIs to use when a profile is reported supported on a platform but has multiple variants to claim it reported?" The issue doesn't happen here because because it's VKD3D that creates the VkDevice instance.

Eg:
```
            "capabilities": [
                "vulkan10requirements",
                "vulkan11requirements",
                "d3d12_level_11_0",
                ["d3d12_level_11_0_bindless_uniform", "d3d12_level_11_0_bindless_storage"]
            ]
```
Means `VP_VKD3D_d3d12_level_11_0_baseline` requires "vulkan10requirements" AND "vulkan11requirements" AND "d3d12_level_11_0" AND ("d3d12_level_11_0_bindless_uniform" OR "d3d12_level_11_0_bindless_storage")

- VKD3D is a LOT more complex with capabilities checking than DXVK, at least partly due to D3D12 handling of features compared with D3D11. I am not quite sure it's really tracktable...
- I only created "baseline" profiles and no "optimal", "exhaustive" or "max" because it looks like VKD3D enables a lot of things my default based on the user system Vulkan capabilities and explicitly disable things it doesn't want (we can express disabled features actually). So it's not obvious to figure out what's actually used or not, I would have to do a very long investigation.

Looking forward your inputs!