### PR TITLE
Add test for rendering with no attachments

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4974,7 +4974,10 @@ static void d3d12_command_list_get_fb_extent(struct d3d12_command_list *list,
         *width = device->vk_info.device_limits.maxFramebufferWidth;
         *height = device->vk_info.device_limits.maxFramebufferHeight;
         if (layer_count)
-            *layer_count = 1;
+        {
+            /* Layered rendering works with no attachments. */
+            *layer_count = device->vk_info.device_limits.maxFramebufferLayers;
+        }
     }
 }
 

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -321,3 +321,4 @@ decl_test(test_fence_wait_robustness);
 decl_test(test_fence_wait_robustness_shared);
 decl_test(test_root_signature_empty_blob);
 decl_test(test_sparse_buffer_memory_lifetime);
+decl_test(test_rendering_no_attachments_layers);


### PR DESCRIPTION
This tweet suggested that there were bugs with rendering without attachments: https://twitter.com/SheriefFYI/status/1564830690977320960.

> "radv/amdgpu: The CS has been cancelled because the context is lost." Fellas, there's a good chance I'm running into a GPU hang on Steam Deck when rendering with neither color nor depth stencil targets attached (yes, that's actually valid for clustering etc.)

I had a look and I couldn't see we had any test coverage for this. The test checks layered rendering, since we had some questionable code when emitting rendering info, since layerCount was 1.

Both AMD and NV at least seem to ignore layerCount when using no attachments, but the spec is a little vague if this is legal. The closest I could find was:

> It is legal for a subpass to use no color or depth/stencil attachments, either because it has no attachment references or because all of them are VK_ATTACHMENT_UNUSED. This kind of subpass can use shader side effects such as image stores and atomics to produce an output. In this case, the subpass continues to use the width, height, and **layers** of the framebuffer to define the dimensions of the rendering area

The tests passed as-is, but to make it clearer what is supported, I bumped the layerCount when rendering with no attachments.