### PR TITLE
Clean up bind point handling

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5552,10 +5552,9 @@ static void d3d12_command_list_update_hoisted_descriptors(struct d3d12_command_l
     bindings->dirty_flags &= ~VKD3D_PIPELINE_DIRTY_HOISTED_DESCRIPTORS;
 }
 
-static void d3d12_command_list_update_descriptors(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point)
+static void d3d12_command_list_update_descriptors(struct d3d12_command_list *list)
 {
-    struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
+    struct vkd3d_pipeline_bindings *bindings = d3d12_command_list_get_bindings(list, list->active_pipeline_type);
     const struct d3d12_root_signature *rs = bindings->root_signature;
     const struct d3d12_bind_point_layout *bind_point_layout;
     VkPipelineBindPoint vk_bind_point;
@@ -5608,7 +5607,7 @@ static bool d3d12_command_list_update_compute_state(struct d3d12_command_list *l
     if (!d3d12_command_list_update_compute_pipeline(list))
         return false;
 
-    d3d12_command_list_update_descriptors(list, VK_PIPELINE_BIND_POINT_COMPUTE);
+    d3d12_command_list_update_descriptors(list);
 
     return true;
 }
@@ -5623,7 +5622,7 @@ static bool d3d12_command_list_update_raygen_state(struct d3d12_command_list *li
 
     /* DXR uses compute bind point for descriptors, we will redirect internally to
      * raygen bind point in Vulkan. */
-    d3d12_command_list_update_descriptors(list, VK_PIPELINE_BIND_POINT_COMPUTE);
+    d3d12_command_list_update_descriptors(list);
 
     /* If we have a static sampler set for local root signatures, bind it now.
      * Don't bother with dirty tracking of this for time being.
@@ -5843,7 +5842,7 @@ static bool d3d12_command_list_begin_render_pass(struct d3d12_command_list *list
     if (list->dynamic_state.dirty_flags)
         d3d12_command_list_update_dynamic_state(list);
 
-    d3d12_command_list_update_descriptors(list, VK_PIPELINE_BIND_POINT_GRAPHICS);
+    d3d12_command_list_update_descriptors(list);
 
     if (list->rendering_info.state_flags & VKD3D_RENDERING_ACTIVE)
     {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -3738,7 +3738,7 @@ static size_t get_query_heap_stride(D3D12_QUERY_HEAP_TYPE heap_type)
 }
 
 static void d3d12_command_list_invalidate_root_parameters(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point, bool invalidate_descriptor_heaps);
+        struct vkd3d_pipeline_bindings *bindings, bool invalidate_descriptor_heaps);
 
 static bool d3d12_command_list_gather_pending_queries(struct d3d12_command_list *list)
 {
@@ -4065,7 +4065,7 @@ static bool d3d12_command_list_gather_pending_queries(struct d3d12_command_list 
     result = true;
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+    d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
 
     VKD3D_BREADCRUMB_COMMAND(GATHER_VIRTUAL_QUERY);
 
@@ -4132,10 +4132,8 @@ static void d3d12_command_list_invalidate_push_constants(struct vkd3d_pipeline_b
 }
 
 static void d3d12_command_list_invalidate_root_parameters(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point, bool invalidate_descriptor_heaps)
+        struct vkd3d_pipeline_bindings *bindings, bool invalidate_descriptor_heaps)
 {
-    struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
-
     if (!bindings->root_signature)
         return;
 
@@ -4852,7 +4850,8 @@ static void d3d12_command_list_reset_api_state(struct d3d12_command_list *list,
     list->dynamic_state.fragment_shading_rate.combiner_ops[0] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
     list->dynamic_state.fragment_shading_rate.combiner_ops[1] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
 
-    memset(list->pipeline_bindings, 0, sizeof(list->pipeline_bindings));
+    memset(&list->graphics_bindings, 0, sizeof(list->graphics_bindings));
+    memset(&list->compute_bindings, 0, sizeof(list->compute_bindings));
     memset(list->descriptor_heaps, 0, sizeof(list->descriptor_heaps));
 
     list->state = NULL;
@@ -4900,8 +4899,8 @@ static void d3d12_command_list_reset_state(struct d3d12_command_list *list,
 static inline void d3d12_command_list_invalidate_all_state(struct d3d12_command_list *list)
 {
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_GRAPHICS, true);
-    d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+    d3d12_command_list_invalidate_root_parameters(list, &list->graphics_bindings, true);
+    d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
     list->index_buffer.is_dirty = true;
 }
 
@@ -5920,7 +5919,7 @@ static bool d3d12_command_list_emit_predicated_command(struct d3d12_command_list
     d3d12_command_list_end_current_render_pass(list, true);
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+    d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
 
     args.predicate_va = list->predicate_va;
     args.dst_arg_va = scratch->va;
@@ -6440,7 +6439,7 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         }
 
         d3d12_command_list_invalidate_current_pipeline(list, true);
-        d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_GRAPHICS, true);
+        d3d12_command_list_invalidate_root_parameters(list, &list->graphics_bindings, true);
 
         memset(&dst_view_desc, 0, sizeof(dst_view_desc));
         dst_view_desc.image = dst_resource->res.vk_image;
@@ -7556,7 +7555,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_
         {
             /* DXR uses compute bind points for descriptors. When binding an RTPSO, invalidate all compute state
              * to make sure we broadcast state correctly to COMPUTE or RT bind points in Vulkan. */
-            d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+            d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
         }
 
         if (state)
@@ -8030,6 +8029,12 @@ static void STDMETHODCALLTYPE d3d12_command_list_ExecuteBundle(d3d12_command_lis
     d3d12_bundle_execute(bundle, iface);
 }
 
+static void vkd3d_pipeline_bindings_set_dirty_sets(struct vkd3d_pipeline_bindings *bindings, uint64_t dirty_mask)
+{
+    bindings->descriptor_heap_dirty_mask = dirty_mask;
+    bindings->dirty_flags |= VKD3D_PIPELINE_DIRTY_HOISTED_DESCRIPTORS;
+}
+
 static void STDMETHODCALLTYPE d3d12_command_list_SetDescriptorHeaps(d3d12_command_list_iface *iface,
         UINT heap_count, ID3D12DescriptorHeap *const *heaps)
 {
@@ -8067,19 +8072,13 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetDescriptorHeaps(d3d12_comman
         }
     }
 
-    for (i = 0; i < ARRAY_SIZE(list->pipeline_bindings); i++)
-    {
-        struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[i];
-        bindings->descriptor_heap_dirty_mask = dirty_mask;
-        bindings->dirty_flags |= VKD3D_PIPELINE_DIRTY_HOISTED_DESCRIPTORS;
-    }
+    vkd3d_pipeline_bindings_set_dirty_sets(&list->graphics_bindings, dirty_mask);
+    vkd3d_pipeline_bindings_set_dirty_sets(&list->compute_bindings, dirty_mask);
 }
 
 static void d3d12_command_list_set_root_signature(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point, const struct d3d12_root_signature *root_signature)
+        struct vkd3d_pipeline_bindings *bindings, const struct d3d12_root_signature *root_signature)
 {
-    struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
-
     if (bindings->root_signature == root_signature)
         return;
 
@@ -8089,7 +8088,7 @@ static void d3d12_command_list_set_root_signature(struct d3d12_command_list *lis
     if (root_signature && root_signature->vk_sampler_set)
         bindings->static_sampler_set = root_signature->vk_sampler_set;
 
-    d3d12_command_list_invalidate_root_parameters(list, bind_point, true);
+    d3d12_command_list_invalidate_root_parameters(list, bindings, true);
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootSignature(d3d12_command_list_iface *iface,
@@ -8099,7 +8098,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootSignature(d3d12_c
 
     TRACE("iface %p, root_signature %p.\n", iface, root_signature);
 
-    d3d12_command_list_set_root_signature(list, VK_PIPELINE_BIND_POINT_COMPUTE,
+    d3d12_command_list_set_root_signature(list, &list->compute_bindings,
             impl_from_ID3D12RootSignature(root_signature));
 }
 
@@ -8110,14 +8109,13 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootSignature(d3d12_
 
     TRACE("iface %p, root_signature %p.\n", iface, root_signature);
 
-    d3d12_command_list_set_root_signature(list, VK_PIPELINE_BIND_POINT_GRAPHICS,
+    d3d12_command_list_set_root_signature(list, &list->graphics_bindings,
             impl_from_ID3D12RootSignature(root_signature));
 }
 
 static void d3d12_command_list_set_descriptor_table(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point, unsigned int index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
+        struct vkd3d_pipeline_bindings *bindings, unsigned int index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
 {
-    struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
     const struct d3d12_root_signature *root_signature = bindings->root_signature;
     const struct vkd3d_shader_descriptor_table *table;
 
@@ -8141,7 +8139,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootDescriptorTable(d
     TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n",
             iface, root_parameter_index, base_descriptor.ptr);
 
-    d3d12_command_list_set_descriptor_table(list, VK_PIPELINE_BIND_POINT_COMPUTE,
+    d3d12_command_list_set_descriptor_table(list, &list->compute_bindings,
             root_parameter_index, base_descriptor);
 }
 
@@ -8153,15 +8151,14 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootDescriptorTable(
     TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n",
             iface, root_parameter_index, base_descriptor.ptr);
 
-    d3d12_command_list_set_descriptor_table(list, VK_PIPELINE_BIND_POINT_GRAPHICS,
+    d3d12_command_list_set_descriptor_table(list, &list->graphics_bindings,
             root_parameter_index, base_descriptor);
 }
 
 static void d3d12_command_list_set_root_constants(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point, unsigned int index, unsigned int offset,
+        struct vkd3d_pipeline_bindings *bindings, unsigned int index, unsigned int offset,
         unsigned int count, const void *data)
 {
-    struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
     const struct d3d12_root_signature *root_signature = bindings->root_signature;
     const struct vkd3d_shader_root_constant *c;
     VKD3D_UNUSED unsigned int i;
@@ -8190,7 +8187,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRoot32BitConstant(d3d
     TRACE("iface %p, root_parameter_index %u, data 0x%08x, dst_offset %u.\n",
             iface, root_parameter_index, data, dst_offset);
 
-    d3d12_command_list_set_root_constants(list, VK_PIPELINE_BIND_POINT_COMPUTE,
+    d3d12_command_list_set_root_constants(list, &list->compute_bindings,
             root_parameter_index, dst_offset, 1, &data);
 }
 
@@ -8202,7 +8199,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRoot32BitConstant(d3
     TRACE("iface %p, root_parameter_index %u, data 0x%08x, dst_offset %u.\n",
             iface, root_parameter_index, data, dst_offset);
 
-    d3d12_command_list_set_root_constants(list, VK_PIPELINE_BIND_POINT_GRAPHICS,
+    d3d12_command_list_set_root_constants(list, &list->graphics_bindings,
             root_parameter_index, dst_offset, 1, &data);
 }
 
@@ -8214,7 +8211,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRoot32BitConstants(d3
     TRACE("iface %p, root_parameter_index %u, constant_count %u, data %p, dst_offset %u.\n",
             iface, root_parameter_index, constant_count, data, dst_offset);
 
-    d3d12_command_list_set_root_constants(list, VK_PIPELINE_BIND_POINT_COMPUTE,
+    d3d12_command_list_set_root_constants(list, &list->compute_bindings,
             root_parameter_index, dst_offset, constant_count, data);
 }
 
@@ -8226,14 +8223,13 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRoot32BitConstants(d
     TRACE("iface %p, root_parameter_index %u, constant_count %u, data %p, dst_offset %u.\n",
             iface, root_parameter_index, constant_count, data, dst_offset);
 
-    d3d12_command_list_set_root_constants(list, VK_PIPELINE_BIND_POINT_GRAPHICS,
+    d3d12_command_list_set_root_constants(list, &list->graphics_bindings,
             root_parameter_index, dst_offset, constant_count, data);
 }
 
 static void d3d12_command_list_set_push_descriptor_info(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point, unsigned int index, D3D12_GPU_VIRTUAL_ADDRESS gpu_address)
+        struct vkd3d_pipeline_bindings *bindings, unsigned int index, D3D12_GPU_VIRTUAL_ADDRESS gpu_address)
 {
-    struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
     const struct d3d12_root_signature *root_signature = bindings->root_signature;
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     const struct vkd3d_vulkan_info *vk_info = &list->device->vk_info;
@@ -8306,15 +8302,14 @@ static void d3d12_command_list_set_root_descriptor_va(struct d3d12_command_list 
 }
 
 static void d3d12_command_list_set_root_descriptor(struct d3d12_command_list *list,
-        VkPipelineBindPoint bind_point, unsigned int index, D3D12_GPU_VIRTUAL_ADDRESS gpu_address)
+        struct vkd3d_pipeline_bindings *bindings, unsigned int index, D3D12_GPU_VIRTUAL_ADDRESS gpu_address)
 {
-    struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
     struct vkd3d_root_descriptor_info *descriptor = &bindings->root_descriptors[index];
 
     if (bindings->root_signature->root_descriptor_raw_va_mask & (1ull << index))
         d3d12_command_list_set_root_descriptor_va(list, descriptor, gpu_address);
     else
-        d3d12_command_list_set_push_descriptor_info(list, bind_point, index, gpu_address);
+        d3d12_command_list_set_push_descriptor_info(list, bindings, index, gpu_address);
 
     bindings->root_descriptor_dirty_mask |= 1ull << index;
     bindings->root_descriptor_active_mask |= 1ull << index;
@@ -8332,7 +8327,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootConstantBufferVie
     TRACE("iface %p, root_parameter_index %u, address %#"PRIx64".\n",
             iface, root_parameter_index, address);
 
-    d3d12_command_list_set_root_descriptor(list, VK_PIPELINE_BIND_POINT_COMPUTE,
+    d3d12_command_list_set_root_descriptor(list, &list->compute_bindings,
             root_parameter_index, address);
 }
 
@@ -8344,7 +8339,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootConstantBufferVi
     TRACE("iface %p, root_parameter_index %u, address %#"PRIx64".\n",
             iface, root_parameter_index, address);
 
-    d3d12_command_list_set_root_descriptor(list, VK_PIPELINE_BIND_POINT_GRAPHICS,
+    d3d12_command_list_set_root_descriptor(list, &list->graphics_bindings,
             root_parameter_index, address);
 }
 
@@ -8356,7 +8351,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootShaderResourceVie
     TRACE("iface %p, root_parameter_index %u, address %#"PRIx64".\n",
             iface, root_parameter_index, address);
 
-    d3d12_command_list_set_root_descriptor(list, VK_PIPELINE_BIND_POINT_COMPUTE,
+    d3d12_command_list_set_root_descriptor(list, &list->compute_bindings,
             root_parameter_index, address);
 }
 
@@ -8368,7 +8363,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootShaderResourceVi
     TRACE("iface %p, root_parameter_index %u, address %#"PRIx64".\n",
             iface, root_parameter_index, address);
 
-    d3d12_command_list_set_root_descriptor(list, VK_PIPELINE_BIND_POINT_GRAPHICS,
+    d3d12_command_list_set_root_descriptor(list, &list->graphics_bindings,
             root_parameter_index, address);
 }
 
@@ -8380,7 +8375,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootUnorderedAccessVi
     TRACE("iface %p, root_parameter_index %u, address %#"PRIx64".\n",
             iface, root_parameter_index, address);
 
-    d3d12_command_list_set_root_descriptor(list, VK_PIPELINE_BIND_POINT_COMPUTE,
+    d3d12_command_list_set_root_descriptor(list, &list->compute_bindings,
             root_parameter_index, address);
 }
 
@@ -8392,7 +8387,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootUnorderedAccessV
     TRACE("iface %p, root_parameter_index %u, address %#"PRIx64".\n",
             iface, root_parameter_index, address);
 
-    d3d12_command_list_set_root_descriptor(list, VK_PIPELINE_BIND_POINT_GRAPHICS,
+    d3d12_command_list_set_root_descriptor(list, &list->graphics_bindings,
             root_parameter_index, address);
 }
 
@@ -8840,7 +8835,7 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
     d3d12_command_list_end_current_render_pass(list, false);
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+    d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
 
     clear_args.clear_color = *clear_color;
 
@@ -9007,7 +9002,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     d3d12_command_list_end_current_render_pass(list, false);
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+    d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
 
     assert(args->has_view);
     assert(d3d12_resource_is_texture(resource));
@@ -9730,7 +9725,7 @@ static void d3d12_command_list_resolve_binary_occlusion_queries(struct d3d12_com
     unsigned int i;
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+    d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
 
     vk_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
     vk_barrier.pNext = NULL;
@@ -9934,7 +9929,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPredication(d3d12_command_li
              * VK_EXT_conditional_rendering. We'll handle the predicate operation here
              * so setting VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT is not necessary. */
             d3d12_command_list_invalidate_current_pipeline(list, true);
-            d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+            d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
 
             resolve_args.src_va = d3d12_resource_get_va(resource, aligned_buffer_offset);
             resolve_args.dst_va = scratch.va;
@@ -10445,7 +10440,7 @@ static void d3d12_command_list_execute_indirect_state_template(
             {
                 uint32_t index = arg->ConstantBufferView.RootParameterIndex;
                 d3d12_command_list_set_root_descriptor(list,
-                        VK_PIPELINE_BIND_POINT_GRAPHICS, index, 0);
+                        &list->graphics_bindings, index, 0);
                 break;
             }
 
@@ -10454,7 +10449,7 @@ static void d3d12_command_list_execute_indirect_state_template(
                 uint32_t zeroes[D3D12_MAX_ROOT_COST];
                 memset(zeroes, 0, sizeof(uint32_t) * arg->Constant.Num32BitValuesToSet);
                 d3d12_command_list_set_root_constants(list,
-                        VK_PIPELINE_BIND_POINT_GRAPHICS, arg->Constant.RootParameterIndex,
+                        &list->graphics_bindings, arg->Constant.RootParameterIndex,
                         arg->Constant.DestOffsetIn32BitValues,
                         arg->Constant.Num32BitValuesToSet, zeroes);
                 break;
@@ -11110,7 +11105,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState1(d3d12_command
     if (list->active_pipeline_type != VKD3D_PIPELINE_TYPE_RAY_TRACING)
     {
         list->active_pipeline_type = VKD3D_PIPELINE_TYPE_RAY_TRACING;
-        d3d12_command_list_invalidate_root_parameters(list, VK_PIPELINE_BIND_POINT_COMPUTE, true);
+        d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true);
     }
 
 #ifdef VKD3D_ENABLE_BREADCRUMBS

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5477,7 +5477,7 @@ static void d3d12_command_list_update_root_descriptors(struct d3d12_command_list
 
         descriptor_write_count += 1;
     }
-    else if (va_count && bindings->layout.vk_push_stages)
+    else if (va_count && push_stages)
     {
         VK_CALL(vkCmdPushConstants(list->vk_command_buffer,
                 layout, push_stages,
@@ -5557,6 +5557,7 @@ static void d3d12_command_list_update_descriptors(struct d3d12_command_list *lis
 {
     struct vkd3d_pipeline_bindings *bindings = &list->pipeline_bindings[bind_point];
     const struct d3d12_root_signature *rs = bindings->root_signature;
+    const struct d3d12_bind_point_layout *bind_point_layout;
     VkPipelineBindPoint vk_bind_point;
     VkShaderStageFlags push_stages;
     VkPipelineLayout layout;
@@ -5564,18 +5565,9 @@ static void d3d12_command_list_update_descriptors(struct d3d12_command_list *lis
     if (!rs)
         return;
 
-    if (list->active_pipeline_type == VKD3D_PIPELINE_TYPE_RAY_TRACING)
-    {
-        /* We might have to emit to RT bind point,
-         * but we pretend we're in compute bind point. */
-        layout = bindings->rt_layout.vk_pipeline_layout;
-        push_stages = bindings->rt_layout.vk_push_stages;
-    }
-    else
-    {
-        layout = bindings->layout.vk_pipeline_layout;
-        push_stages = bindings->layout.vk_push_stages;
-    }
+    bind_point_layout = d3d12_root_signature_get_layout(rs, list->active_pipeline_type);
+    layout = bind_point_layout->vk_pipeline_layout;
+    push_stages = bind_point_layout->vk_push_stages;
 
     vk_bind_point = vk_bind_point_from_pipeline_type(list->active_pipeline_type);
 
@@ -8094,21 +8086,6 @@ static void d3d12_command_list_set_root_signature(struct d3d12_command_list *lis
 
     bindings->root_signature = root_signature;
     bindings->static_sampler_set = VK_NULL_HANDLE;
-
-    switch (bind_point)
-    {
-        case VK_PIPELINE_BIND_POINT_GRAPHICS:
-            bindings->layout = root_signature->graphics;
-            break;
-
-        case VK_PIPELINE_BIND_POINT_COMPUTE:
-            bindings->layout = root_signature->compute;
-            bindings->rt_layout = root_signature->raygen;
-            break;
-
-        default:
-            break;
-    }
 
     if (root_signature && root_signature->vk_sampler_set)
         bindings->static_sampler_set = root_signature->vk_sampler_set;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2336,7 +2336,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     const struct d3d12_root_signature *root_signature;
     HRESULT hr;
 
-    state->vk_bind_point = VK_PIPELINE_BIND_POINT_COMPUTE;
+    state->pipeline_type = VKD3D_PIPELINE_TYPE_COMPUTE;
 
     if (desc->root_signature)
         root_signature = impl_from_ID3D12RootSignature(desc->root_signature);
@@ -3083,7 +3083,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         {VK_SHADER_STAGE_FRAGMENT_BIT,                offsetof(struct d3d12_pipeline_state_desc, ps)},
     };
 
-    state->vk_bind_point = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    state->pipeline_type = VKD3D_PIPELINE_TYPE_GRAPHICS;
 
     graphics->stage_count = 0;
     graphics->primitive_topology_type = desc->primitive_topology_type;
@@ -3679,9 +3679,9 @@ fail:
 bool d3d12_pipeline_state_has_replaced_shaders(struct d3d12_pipeline_state *state)
 {
     unsigned int i;
-    if (state->vk_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE)
+    if (state->pipeline_type == VKD3D_PIPELINE_TYPE_COMPUTE)
         return !!(state->compute.code.meta.flags & VKD3D_SHADER_META_FLAG_REPLACED);
-    else if (state->vk_bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS)
+    else if (state->pipeline_type == VKD3D_PIPELINE_TYPE_GRAPHICS)
     {
         for (i = 0; i < state->graphics.stage_count; i++)
             if (state->graphics.code[i].meta.flags & VKD3D_SHADER_META_FLAG_REPLACED)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2036,8 +2036,6 @@ struct vkd3d_root_descriptor_info
 struct vkd3d_pipeline_bindings
 {
     const struct d3d12_root_signature *root_signature;
-    /* RT in DXR happens in COMPUTE bind point. */
-    struct d3d12_bind_point_layout layout, rt_layout;
 
     VkDescriptorSet static_sampler_set;
     uint32_t dirty_flags; /* vkd3d_pipeline_dirty_flags */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -57,8 +57,6 @@
 #define VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS 8u
 #define VKD3D_MAX_MUTABLE_DESCRIPTOR_TYPES 6u
 
-#define VKD3D_PIPELINE_BIND_POINT_COUNT 2u
-
 #define VKD3D_TILE_SIZE 65536
 
 typedef ID3D12Fence1 d3d12_fence_iface;
@@ -2266,7 +2264,8 @@ struct d3d12_command_list
 
     struct vkd3d_rendering_info rendering_info;
     struct vkd3d_dynamic_state dynamic_state;
-    struct vkd3d_pipeline_bindings pipeline_bindings[VKD3D_PIPELINE_BIND_POINT_COUNT];
+    struct vkd3d_pipeline_bindings graphics_bindings;
+    struct vkd3d_pipeline_bindings compute_bindings;
     enum vkd3d_pipeline_type active_pipeline_type;
 
     VkDescriptorSet descriptor_heaps[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
@@ -2333,11 +2332,11 @@ static inline struct vkd3d_pipeline_bindings *d3d12_command_list_get_bindings(
             break;
 
         case VKD3D_PIPELINE_TYPE_GRAPHICS:
-            return &list->pipeline_bindings[VK_PIPELINE_BIND_POINT_GRAPHICS];
+            return &list->graphics_bindings;
 
         case VKD3D_PIPELINE_TYPE_COMPUTE:
         case VKD3D_PIPELINE_TYPE_RAY_TRACING:
-            return &list->pipeline_bindings[VK_PIPELINE_BIND_POINT_COMPUTE];
+            return &list->compute_bindings;
     }
 
     return NULL;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1659,7 +1659,8 @@ struct d3d12_pipeline_state
         struct d3d12_graphics_pipeline_state graphics;
         struct d3d12_compute_pipeline_state compute;
     };
-    VkPipelineBindPoint vk_bind_point;
+
+    enum vkd3d_pipeline_type pipeline_type;
     VkPipelineCache vk_pso_cache;
     spinlock_t lock;
 
@@ -1672,12 +1673,12 @@ struct d3d12_pipeline_state
 
 static inline bool d3d12_pipeline_state_is_compute(const struct d3d12_pipeline_state *state)
 {
-    return state && state->vk_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE;
+    return state && state->pipeline_type == VKD3D_PIPELINE_TYPE_COMPUTE;
 }
 
 static inline bool d3d12_pipeline_state_is_graphics(const struct d3d12_pipeline_state *state)
 {
-    return state && state->vk_bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS;
+    return state && state->pipeline_type == VKD3D_PIPELINE_TYPE_GRAPHICS;
 }
 
 /* This returns true for invalid D3D12 API usage. Game intends to use depth-stencil tests,
@@ -2268,7 +2269,7 @@ struct d3d12_command_list
     struct vkd3d_rendering_info rendering_info;
     struct vkd3d_dynamic_state dynamic_state;
     struct vkd3d_pipeline_bindings pipeline_bindings[VKD3D_PIPELINE_BIND_POINT_COUNT];
-    VkPipelineBindPoint active_bind_point;
+    enum vkd3d_pipeline_type active_pipeline_type;
 
     VkDescriptorSet descriptor_heaps[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
 


### PR DESCRIPTION
Introduces a new enum rather than using VkPipelineBindPoint everywhere, and cleans up how D3D12 binding info is stored and accessed.

The plan is to add another value to the `vkd3d_pipeline_type` enum for mesh shading pipelines, so we can distinguish those from regular graphics pipelines.