### PR TITLE
Implement VK_EXT_shader_module_identifier - Phase 1

### DIFF
--- a/libs/vkd3d/cache.c
+++ b/libs/vkd3d/cache.c
@@ -1573,10 +1573,11 @@ static HRESULT d3d12_pipeline_library_load_pipeline(struct d3d12_pipeline_librar
             if (root_signature)
                 pipeline_cache_compat.root_signature_compat_hash = root_signature->compatibility_hash;
         }
-        else if (!cached_state->private_root_signature)
+        else if (cached_state->root_signature_compat_hash_is_dxbc_derived)
         {
             /* If we have no explicit root signature and the existing PSO didn't either,
-             * just inherit the compat hash from PSO to avoid comparing them. */
+             * just inherit the compat hash from PSO to avoid comparing them.
+             * The hash depends entirely on the DXBC blob either way. */
             pipeline_cache_compat.root_signature_compat_hash = cached_state->pipeline_cache_compat.root_signature_compat_hash;
         }
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3136,7 +3136,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     uint32_t instance_divisors[D3D12_VS_INPUT_REGISTER_COUNT];
     uint32_t aligned_offsets[D3D12_VS_INPUT_REGISTER_COUNT];
     struct vkd3d_shader_transform_feedback_info xfb_info;
-    struct vkd3d_shader_interface_info shader_interface;
     bool have_attachment, can_compile_pipeline_early;
     struct vkd3d_shader_stage_io_map ms_ps_interface;
     struct vkd3d_shader_signature output_signature;
@@ -3376,9 +3375,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
             xfb_stage = VK_SHADER_STAGE_VERTEX_BIT;
     }
 
-    /* Stage / XFB info are overridden later. */
-    d3d12_pipeline_state_init_shader_interface(state, device, VK_SHADER_STAGE_ALL, &shader_interface);
-
     graphics->patch_vertex_count = 0;
 
     for (i = 0; i < ARRAY_SIZE(shader_stages); ++i)
@@ -3466,10 +3462,14 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     for (i = 0; i < ARRAY_SIZE(shader_stages); i++)
     {
         const D3D12_SHADER_BYTECODE *b = (const void *)((uintptr_t)desc + shader_stages[i].offset);
+        struct vkd3d_shader_interface_info shader_interface;
         struct vkd3d_shader_compile_arguments compile_args;
 
         if (!(graphics->stage_flags & shader_stages[i].stage))
             continue;
+
+        /* TODO: Move this to vkd3d_create_shader_stage itself. */
+        d3d12_pipeline_state_init_shader_interface(state, device, shader_stages[i].stage, &shader_interface);
 
         if (shader_stages[i].stage == VK_SHADER_STAGE_MESH_BIT_EXT)
         {
@@ -3489,8 +3489,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         }
 
         shader_interface.xfb_info = shader_stages[i].stage == xfb_stage ? &xfb_info : NULL;
-        shader_interface.stage = shader_stages[i].stage;
-
         d3d12_pipeline_state_init_compile_arguments(state, device, shader_interface.stage, &compile_args);
 
         if (FAILED(hr = vkd3d_create_shader_stage(device,

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2316,7 +2316,29 @@ static void vkd3d_report_pipeline_creation_feedback_results(const VkPipelineCrea
     }
 }
 
-static HRESULT vkd3d_create_compute_pipeline(struct d3d12_device *device,
+static void d3d12_pipeline_state_init_compile_arguments(struct d3d12_pipeline_state *state,
+        struct d3d12_device *device, VkShaderStageFlagBits stage,
+        struct vkd3d_shader_compile_arguments *compile_arguments)
+{
+    memset(compile_arguments, 0, sizeof(*compile_arguments));
+    compile_arguments->target = VKD3D_SHADER_TARGET_SPIRV_VULKAN_1_0;
+    compile_arguments->target_extension_count = device->vk_info.shader_extension_count;
+    compile_arguments->target_extensions = device->vk_info.shader_extensions;
+    compile_arguments->quirks = &vkd3d_shader_quirk_info;
+
+    if (stage == VK_SHADER_STAGE_FRAGMENT_BIT)
+    {
+        /* Options which are exclusive to PS. Especially output swizzles must only be used in PS. */
+        compile_arguments->parameter_count = ARRAY_SIZE(state->graphics.cached_desc.ps_shader_parameters);
+        compile_arguments->parameters = state->graphics.cached_desc.ps_shader_parameters;
+        compile_arguments->dual_source_blending = state->graphics.cached_desc.is_dual_source_blending;
+        compile_arguments->output_swizzles = state->graphics.cached_desc.ps_output_swizzle;
+        compile_arguments->output_swizzle_count = state->graphics.rt_count;
+    }
+}
+
+static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
+        struct d3d12_device *device,
         const D3D12_SHADER_BYTECODE *code,
         const struct vkd3d_shader_interface_info *shader_interface,
         VkPipelineLayout vk_pipeline_layout, VkPipelineCache vk_cache, VkPipeline *vk_pipeline,
@@ -2333,11 +2355,7 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_device *device,
     VkResult vr;
     HRESULT hr;
 
-    memset(&compile_args, 0, sizeof(compile_args));
-    compile_args.target_extensions = device->vk_info.shader_extensions;
-    compile_args.target_extension_count = device->vk_info.shader_extension_count;
-    compile_args.target = VKD3D_SHADER_TARGET_SPIRV_VULKAN_1_0;
-    compile_args.quirks = &vkd3d_shader_quirk_info;
+    d3d12_pipeline_state_init_compile_arguments(state, device, VK_SHADER_STAGE_COMPUTE_BIT, &compile_args);
 
     pipeline_info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
     pipeline_info.pNext = NULL;
@@ -2437,7 +2455,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     vkd3d_load_spirv_from_cached_state(device, cached_pso,
             VK_SHADER_STAGE_COMPUTE_BIT, &state->compute.code);
 
-    hr = vkd3d_create_compute_pipeline(device,
+    hr = vkd3d_create_compute_pipeline(state, device,
             &desc->cs, &shader_interface,
             state->root_signature->compute.vk_pipeline_layout,
             state->vk_pso_cache,
@@ -3111,15 +3129,12 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         const struct d3d12_cached_pipeline_state *cached_pso)
 {
     const VkPhysicalDeviceFeatures *features = &device->device_info.features2.features;
-    unsigned int ps_output_swizzle[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
-    struct vkd3d_shader_compile_arguments compile_args, ps_compile_args;
     struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
     const D3D12_STREAM_OUTPUT_DESC *so_desc = &desc->stream_output;
     VkVertexInputBindingDivisorDescriptionEXT *binding_divisor;
     const struct vkd3d_vulkan_info *vk_info = &device->vk_info;
     uint32_t instance_divisors[D3D12_VS_INPUT_REGISTER_COUNT];
     uint32_t aligned_offsets[D3D12_VS_INPUT_REGISTER_COUNT];
-    struct vkd3d_shader_parameter ps_shader_parameters[1];
     struct vkd3d_shader_transform_feedback_info xfb_info;
     struct vkd3d_shader_interface_info shader_interface;
     bool have_attachment, can_compile_pipeline_early;
@@ -3185,6 +3200,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
                 rt_count, ARRAY_SIZE(graphics->blend_attachments));
         rt_count = ARRAY_SIZE(graphics->blend_attachments);
     }
+    graphics->rt_count = rt_count;
 
     if (!(graphics->stage_flags & VK_SHADER_STAGE_FRAGMENT_BIT))
     {
@@ -3203,12 +3219,12 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         if (desc->rtv_formats.RTFormats[i] == DXGI_FORMAT_UNKNOWN)
         {
             graphics->null_attachment_mask |= 1u << i;
-            ps_output_swizzle[i] = VKD3D_NO_SWIZZLE;
+            graphics->cached_desc.ps_output_swizzle[i] = VKD3D_NO_SWIZZLE;
             graphics->rtv_formats[i] = VK_FORMAT_UNDEFINED;
         }
         else if ((format = vkd3d_get_format(device, desc->rtv_formats.RTFormats[i], false)))
         {
-            ps_output_swizzle[i] = vkd3d_get_rt_format_swizzle(format);
+            graphics->cached_desc.ps_output_swizzle[i] = vkd3d_get_rt_format_swizzle(format);
             graphics->rtv_formats[i] = format->vk_format;
             graphics->rtv_active_mask |= 1u << i;
         }
@@ -3241,7 +3257,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
 
     for (i = rt_count; i < ARRAY_SIZE(graphics->rtv_formats); ++i)
         graphics->rtv_formats[i] = VK_FORMAT_UNDEFINED;
-    graphics->rt_count = rt_count;
 
     blend_desc_from_d3d12(&graphics->blend_desc, &desc->blend_state,
             graphics->rt_count, graphics->blend_attachments);
@@ -3312,26 +3327,13 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         }
     }
 
-    ps_shader_parameters[0].name = VKD3D_SHADER_PARAMETER_NAME_RASTERIZER_SAMPLE_COUNT;
-    ps_shader_parameters[0].type = VKD3D_SHADER_PARAMETER_TYPE_IMMEDIATE_CONSTANT;
-    ps_shader_parameters[0].data_type = VKD3D_SHADER_PARAMETER_DATA_TYPE_UINT32;
-    ps_shader_parameters[0].immediate_constant.u32 = sample_count;
+    graphics->cached_desc.ps_shader_parameters[0].name = VKD3D_SHADER_PARAMETER_NAME_RASTERIZER_SAMPLE_COUNT;
+    graphics->cached_desc.ps_shader_parameters[0].type = VKD3D_SHADER_PARAMETER_TYPE_IMMEDIATE_CONSTANT;
+    graphics->cached_desc.ps_shader_parameters[0].data_type = VKD3D_SHADER_PARAMETER_DATA_TYPE_UINT32;
+    graphics->cached_desc.ps_shader_parameters[0].immediate_constant.u32 = sample_count;
+    graphics->cached_desc.is_dual_source_blending = is_dual_source_blending(&desc->blend_state.RenderTarget[0]);
 
-    memset(&compile_args, 0, sizeof(compile_args));
-    compile_args.target = VKD3D_SHADER_TARGET_SPIRV_VULKAN_1_0;
-    compile_args.target_extension_count = vk_info->shader_extension_count;
-    compile_args.target_extensions = vk_info->shader_extensions;
-    compile_args.quirks = &vkd3d_shader_quirk_info;
-
-    /* Options which are exclusive to PS. Especially output swizzles must only be used in PS. */
-    ps_compile_args = compile_args;
-    ps_compile_args.parameter_count = ARRAY_SIZE(ps_shader_parameters);
-    ps_compile_args.parameters = ps_shader_parameters;
-    ps_compile_args.dual_source_blending = is_dual_source_blending(&desc->blend_state.RenderTarget[0]);
-    ps_compile_args.output_swizzles = ps_output_swizzle;
-    ps_compile_args.output_swizzle_count = rt_count;
-
-    if (ps_compile_args.dual_source_blending)
+    if (graphics->cached_desc.is_dual_source_blending)
     {
         /* If we're using dual source blending, we can only safely write to MRT 0.
          * Be defensive about programs which do not do this for us. */
@@ -3464,6 +3466,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     for (i = 0; i < ARRAY_SIZE(shader_stages); i++)
     {
         const D3D12_SHADER_BYTECODE *b = (const void *)((uintptr_t)desc + shader_stages[i].offset);
+        struct vkd3d_shader_compile_arguments compile_args;
 
         if (!(graphics->stage_flags & shader_stages[i].stage))
             continue;
@@ -3487,10 +3490,13 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
 
         shader_interface.xfb_info = shader_stages[i].stage == xfb_stage ? &xfb_info : NULL;
         shader_interface.stage = shader_stages[i].stage;
+
+        d3d12_pipeline_state_init_compile_arguments(state, device, shader_interface.stage, &compile_args);
+
         if (FAILED(hr = vkd3d_create_shader_stage(device,
                 &graphics->stages[stage_count],
                 shader_stages[i].stage, NULL, b, &shader_interface,
-                shader_stages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT ? &ps_compile_args : &compile_args,
+                &compile_args,
                 &graphics->code[stage_count])))
             goto fail;
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2389,34 +2389,41 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_device *device,
     return S_OK;
 }
 
+static void d3d12_pipeline_state_init_shader_interface(struct d3d12_pipeline_state *state,
+        struct d3d12_device *device,
+        VkShaderStageFlagBits stage,
+        struct vkd3d_shader_interface_info *shader_interface)
+{
+    const struct d3d12_root_signature *root_signature = state->root_signature;
+    memset(shader_interface, 0, sizeof(*shader_interface));
+    shader_interface->flags = d3d12_root_signature_get_shader_interface_flags(root_signature);
+    shader_interface->min_ssbo_alignment = d3d12_device_get_ssbo_alignment(device);
+    shader_interface->descriptor_tables.offset = root_signature->descriptor_table_offset;
+    shader_interface->descriptor_tables.count = root_signature->descriptor_table_count;
+    shader_interface->bindings = root_signature->bindings;
+    shader_interface->binding_count = root_signature->binding_count;
+    shader_interface->push_constant_buffers = root_signature->root_constants;
+    shader_interface->push_constant_buffer_count = root_signature->root_constant_count;
+    shader_interface->push_constant_ubo_binding = &root_signature->push_constant_ubo_binding;
+    shader_interface->offset_buffer_binding = &root_signature->offset_buffer_binding;
+    shader_interface->stage = stage;
+#ifdef VKD3D_ENABLE_DESCRIPTOR_QA
+    shader_interface->descriptor_qa_global_binding = &root_signature->descriptor_qa_global_info;
+    shader_interface->descriptor_qa_heap_binding = &root_signature->descriptor_qa_heap_binding;
+#endif
+}
+
 static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *state,
         struct d3d12_device *device, const struct d3d12_pipeline_state_desc *desc,
         const struct d3d12_cached_pipeline_state *cached_pso)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     struct vkd3d_shader_interface_info shader_interface;
-    const struct d3d12_root_signature *root_signature;
     HRESULT hr;
 
     state->pipeline_type = VKD3D_PIPELINE_TYPE_COMPUTE;
-    root_signature = state->root_signature;
-
-    memset(&shader_interface, 0, sizeof(shader_interface));
-    shader_interface.flags = d3d12_root_signature_get_shader_interface_flags(root_signature);
-    shader_interface.min_ssbo_alignment = d3d12_device_get_ssbo_alignment(device);
-    shader_interface.descriptor_tables.offset = root_signature->descriptor_table_offset;
-    shader_interface.descriptor_tables.count = root_signature->descriptor_table_count;
-    shader_interface.bindings = root_signature->bindings;
-    shader_interface.binding_count = root_signature->binding_count;
-    shader_interface.push_constant_buffers = root_signature->root_constants;
-    shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
-    shader_interface.push_constant_ubo_binding = &root_signature->push_constant_ubo_binding;
-    shader_interface.offset_buffer_binding = &root_signature->offset_buffer_binding;
-    shader_interface.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-#ifdef VKD3D_ENABLE_DESCRIPTOR_QA
-    shader_interface.descriptor_qa_global_binding = &root_signature->descriptor_qa_global_info;
-    shader_interface.descriptor_qa_heap_binding = &root_signature->descriptor_qa_heap_binding;
-#endif
+    d3d12_pipeline_state_init_shader_interface(state, device,
+            VK_SHADER_STAGE_COMPUTE_BIT, &shader_interface);
 
     if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE))
     {
@@ -2432,7 +2439,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
 
     hr = vkd3d_create_compute_pipeline(device,
             &desc->cs, &shader_interface,
-            root_signature->compute.vk_pipeline_layout,
+            state->root_signature->compute.vk_pipeline_layout,
             state->vk_pso_cache,
             &state->compute.vk_pipeline,
             &state->compute.code);
@@ -3115,7 +3122,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     struct vkd3d_shader_parameter ps_shader_parameters[1];
     struct vkd3d_shader_transform_feedback_info xfb_info;
     struct vkd3d_shader_interface_info shader_interface;
-    const struct d3d12_root_signature *root_signature;
     bool have_attachment, can_compile_pipeline_early;
     struct vkd3d_shader_stage_io_map ms_ps_interface;
     struct vkd3d_shader_signature output_signature;
@@ -3167,8 +3173,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
             return E_INVALIDARG;
         }
     }
-
-    root_signature = state->root_signature;
 
     sample_count = vk_samples_from_dxgi_sample_desc(&desc->sample_desc);
     if (desc->sample_desc.Count != 1 && desc->sample_desc.Quality)
@@ -3341,7 +3345,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     graphics->xfb_enabled = false;
     if (so_desc->NumEntries)
     {
-        if (!(root_signature->d3d12_flags & D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT))
+        if (!(state->root_signature->d3d12_flags & D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT))
         {
             WARN("Stream output is used without D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT.\n");
             hr = E_INVALIDARG;
@@ -3370,21 +3374,8 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
             xfb_stage = VK_SHADER_STAGE_VERTEX_BIT;
     }
 
-    memset(&shader_interface, 0, sizeof(shader_interface));
-    shader_interface.flags = d3d12_root_signature_get_shader_interface_flags(root_signature);
-    shader_interface.min_ssbo_alignment = d3d12_device_get_ssbo_alignment(device);
-    shader_interface.descriptor_tables.offset = root_signature->descriptor_table_offset;
-    shader_interface.descriptor_tables.count = root_signature->descriptor_table_count;
-    shader_interface.bindings = root_signature->bindings;
-    shader_interface.binding_count = root_signature->binding_count;
-    shader_interface.push_constant_buffers = root_signature->root_constants;
-    shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
-    shader_interface.push_constant_ubo_binding = &root_signature->push_constant_ubo_binding;
-    shader_interface.offset_buffer_binding = &root_signature->offset_buffer_binding;
-#ifdef VKD3D_ENABLE_DESCRIPTOR_QA
-    shader_interface.descriptor_qa_global_binding = &root_signature->descriptor_qa_global_info;
-    shader_interface.descriptor_qa_heap_binding = &root_signature->descriptor_qa_heap_binding;
-#endif
+    /* Stage / XFB info are overridden later. */
+    d3d12_pipeline_state_init_shader_interface(state, device, VK_SHADER_STAGE_ALL, &shader_interface);
 
     graphics->patch_vertex_count = 0;
 
@@ -3528,7 +3519,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     }
 
     if (graphics->attribute_count
-            && !(root_signature->d3d12_flags & D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT))
+            && !(state->root_signature->d3d12_flags & D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT))
     {
         WARN("Input layout is used without D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT.\n");
         hr = E_INVALIDARG;
@@ -3719,7 +3710,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     if (graphics->stage_flags & VK_SHADER_STAGE_MESH_BIT_EXT)
     {
         can_compile_pipeline_early = true;
-        graphics->pipeline_layout = root_signature->mesh.vk_pipeline_layout;
+        graphics->pipeline_layout = state->root_signature->mesh.vk_pipeline_layout;
     }
     else
     {
@@ -3728,7 +3719,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         can_compile_pipeline_early =
                 (desc->primitive_topology_type != D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH || graphics->patch_vertex_count != 0) &&
                 desc->primitive_topology_type != D3D12_PRIMITIVE_TOPOLOGY_TYPE_UNDEFINED;
-        graphics->pipeline_layout = root_signature->graphics.vk_pipeline_layout;
+        graphics->pipeline_layout = state->root_signature->graphics.vk_pipeline_layout;
     }
 
     graphics->pipeline = VK_NULL_HANDLE;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1583,6 +1583,14 @@ enum vkd3d_plane_optimal_flag
     VKD3D_DEPTH_STENCIL_PLANE_GENERAL = (1 << 2),
 };
 
+struct d3d12_graphics_pipeline_state_cached_desc
+{
+    /* Information needed to compile to SPIR-V. */
+    unsigned int ps_output_swizzle[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
+    struct vkd3d_shader_parameter ps_shader_parameters[1];
+    bool is_dual_source_blending;
+};
+
 struct d3d12_graphics_pipeline_state
 {
     struct vkd3d_shader_debug_ring_spec_info spec_info[VKD3D_MAX_SHADER_STAGES];
@@ -1590,6 +1598,8 @@ struct d3d12_graphics_pipeline_state
     struct vkd3d_shader_code code[VKD3D_MAX_SHADER_STAGES];
     VkShaderStageFlags stage_flags;
     size_t stage_count;
+
+    struct d3d12_graphics_pipeline_state_cached_desc cached_desc;
 
     VkVertexInputAttributeDescription attributes[D3D12_VS_INPUT_REGISTER_COUNT];
     VkVertexInputRate input_rates[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1670,8 +1670,9 @@ struct d3d12_pipeline_state
     spinlock_t lock;
 
     struct vkd3d_pipeline_cache_compatibility pipeline_cache_compat;
-    struct d3d12_root_signature *private_root_signature;
+    struct d3d12_root_signature *root_signature;
     struct d3d12_device *device;
+    bool root_signature_compat_hash_is_dxbc_derived;
 
     struct vkd3d_private_store private_store;
 };


### PR DESCRIPTION
Begins the process of refactoring how PSOs are created.

The overall goal of the first PR phases is to refactor how we init the various interface structs for the vkd3d-shader compilation steps.