### PR TITLE
vkd3d: Implement HDR

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -121,6 +121,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_PIPELINE_CREATION_FEEDBACK, EXT_pipeline_creation_feedback),
     VK_EXTENSION(EXT_MESH_SHADER, EXT_mesh_shader),
     VK_EXTENSION(EXT_MUTABLE_DESCRIPTOR_TYPE, EXT_mutable_descriptor_type),
+    VK_EXTENSION(EXT_HDR_METADATA, EXT_hdr_metadata),
     /* AMD extensions */
     VK_EXTENSION(AMD_BUFFER_MARKER, AMD_buffer_marker),
     VK_EXTENSION(AMD_DEVICE_COHERENT_MEMORY, AMD_device_coherent_memory),

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -164,6 +164,7 @@ struct vkd3d_vulkan_info
     bool EXT_pipeline_creation_feedback;
     bool EXT_mesh_shader;
     bool EXT_mutable_descriptor_type; /* EXT promotion of VALVE one. */
+    bool EXT_hdr_metadata;
     /* AMD device extensions */
     bool AMD_buffer_marker;
     bool AMD_device_coherent_memory;

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -274,6 +274,9 @@ VK_DEVICE_EXT_PFN(vkCmdDrawMeshTasksEXT)
 VK_DEVICE_EXT_PFN(vkCmdDrawMeshTasksIndirectEXT)
 VK_DEVICE_EXT_PFN(vkCmdDrawMeshTasksIndirectCountEXT)
 
+/* VK_EXT_hdr_metadata */
+VK_DEVICE_EXT_PFN(vkSetHdrMetadataEXT)
+
 /* VK_KHR_surface */
 VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceSurfacePresentModesKHR)
 VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceSurfaceSupportKHR)


### PR DESCRIPTION
Implements HDR display support.

Tested with Deep Rock Galactic + RE: Village on Windows.

For completeness, we also should get IDXGIOutput::GetDesc1 ColorSpace + metadata setup, I tested with that hardcoded with the values for my display for now. But this completes the vkd3d-proton part and enables HDR to at least be enabled.