### PR TITLE
VK_EXT_shader_module_identifier - Phase 3

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2347,6 +2347,12 @@ static HRESULT vkd3d_create_shader_stage(struct d3d12_pipeline_state *state, str
             return hresult_from_vkd3d_result(ret);
         }
         TRACE("Called vkd3d_shader_compile_dxbc.\n");
+
+        if (stage == VK_SHADER_STAGE_FRAGMENT_BIT)
+        {
+            /* At this point we don't need the map anymore. */
+            vkd3d_shader_stage_io_map_free(&state->graphics.cached_desc.stage_io_map_ms_ps);
+        }
     }
 
     /* Debug compare SPIR-V we got from cache, and SPIR-V we got from compilation. */
@@ -3198,6 +3204,78 @@ static HRESULT d3d12_pipeline_state_validate_blend_state(struct d3d12_pipeline_s
     return S_OK;
 }
 
+static void d3d12_pipeline_state_graphics_load_spirv_from_cached_state(
+        struct d3d12_pipeline_state *state, struct d3d12_device *device,
+        const struct d3d12_pipeline_state_desc *desc,
+        const struct d3d12_cached_pipeline_state *cached_pso)
+{
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
+    unsigned int i, j;
+
+    /* We only accept SPIR-V from cache if we can successfully load all shaders.
+     * We cannot partially fall back since we cannot handle any situation where we need inter-stage code-gen fixups.
+     * In this situation, just generate full SPIR-V from scratch.
+     * This really shouldn't happen unless we have corrupt cache entries. */
+    for (i = 0; i < graphics->stage_count; i++)
+    {
+        if (FAILED(vkd3d_load_spirv_from_cached_state(device, cached_pso,
+                graphics->cached_desc.bytecode_stages[i], &graphics->code[i])))
+        {
+            for (j = 0; j < i; j++)
+            {
+                if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_LOG)
+                    INFO("Discarding cached SPIR-V for stage #%x.\n", graphics->cached_desc.bytecode_stages[i]);
+                vkd3d_shader_free_shader_code(&graphics->code[j]);
+                memset(&graphics->code[j], 0, sizeof(graphics->code[j]));
+            }
+            break;
+        }
+    }
+}
+
+static HRESULT d3d12_pipeline_state_graphics_create_shader_stages(
+        struct d3d12_pipeline_state *state, struct d3d12_device *device,
+        const struct d3d12_pipeline_state_desc *desc)
+{
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
+    unsigned int i;
+    HRESULT hr;
+
+    /* Now create the actual shader modules. If we managed to load SPIR-V from cache, use that directly. */
+    for (i = 0; i < graphics->stage_count; i++)
+    {
+        if (FAILED(hr = vkd3d_create_shader_stage(state, device,
+                &graphics->stages[i],
+                graphics->cached_desc.bytecode_stages[i], NULL,
+                &graphics->cached_desc.bytecode[i], &graphics->code[i])))
+            return hr;
+    }
+
+    return S_OK;
+}
+
+static void d3d12_pipeline_state_graphics_handle_meta(struct d3d12_pipeline_state *state,
+        struct d3d12_device *device)
+{
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
+    unsigned int i;
+
+    for (i = 0; i < graphics->stage_count; i++)
+    {
+        if (graphics->cached_desc.bytecode_stages[i] == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
+            graphics->patch_vertex_count = graphics->code[i].meta.patch_vertex_count;
+
+        if ((graphics->code[i].meta.flags & VKD3D_SHADER_META_FLAG_REPLACED) &&
+                device->debug_ring.active)
+        {
+            vkd3d_shader_debug_ring_init_spec_constant(device,
+                    &graphics->spec_info[i],
+                    graphics->code[i].meta.hash);
+            graphics->stages[i].pSpecializationInfo = &graphics->spec_info[i].spec_info;
+        }
+    }
+}
+
 static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *state,
         struct d3d12_device *device, const struct d3d12_pipeline_state_desc *desc,
         const struct d3d12_cached_pipeline_state *cached_pso)
@@ -3507,59 +3585,9 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         ++graphics->stage_count;
     }
 
-    /* We only accept SPIR-V from cache if we can successfully load all shaders.
-     * We cannot partially fall back since we cannot handle any situation where we need inter-stage code-gen fixups.
-     * In this situation, just generate full SPIR-V from scratch.
-     * This really shouldn't happen unless we have corrupt cache entries. */
-    for (i = 0; i < graphics->stage_count; i++)
-    {
-        if (FAILED(vkd3d_load_spirv_from_cached_state(device, cached_pso,
-                graphics->cached_desc.bytecode_stages[i], &graphics->code[i])))
-        {
-            for (j = 0; j < i; j++)
-            {
-                if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_LOG)
-                    INFO("Discarding cached SPIR-V for stage #%x.\n", graphics->cached_desc.bytecode_stages[j]);
-                vkd3d_shader_free_shader_code(&graphics->code[j]);
-                memset(&graphics->code[j], 0, sizeof(graphics->code[j]));
-            }
-            break;
-        }
-    }
-
-    /* Now create the actual shader modules. If we managed to load SPIR-V from cache, use that directly.
-     * Make sure we don't reset graphics->stage_count since that is a potential memory leak if
-     * we fail to create shader module for whatever reason. */
-    for (i = 0; i < graphics->stage_count; i++)
-    {
-        if (FAILED(hr = vkd3d_create_shader_stage(state, device,
-                &graphics->stages[i],
-                graphics->cached_desc.bytecode_stages[i], NULL,
-                &graphics->cached_desc.bytecode[i], &graphics->code[i])))
-            goto fail;
-
-        if (graphics->cached_desc.bytecode_stages[i] == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
-        {
-            graphics->patch_vertex_count = graphics->code[i].meta.patch_vertex_count;
-        }
-        else if (graphics->cached_desc.bytecode_stages[i] == VK_SHADER_STAGE_FRAGMENT_BIT)
-        {
-            /* We have consumed the MS/PS map at this point. */
-            vkd3d_shader_stage_io_map_free(&state->graphics.cached_desc.stage_io_map_ms_ps);
-        }
-
-        if ((graphics->code[i].meta.flags & VKD3D_SHADER_META_FLAG_REPLACED) &&
-                device->debug_ring.active)
-        {
-            vkd3d_shader_debug_ring_init_spec_constant(device,
-                    &graphics->spec_info[i],
-                    graphics->code[i].meta.hash);
-            graphics->stages[i].pSpecializationInfo = &graphics->spec_info[i].spec_info;
-        }
-    }
-
     graphics->attribute_count = (graphics->stage_flags & VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT)
             ? 0 : desc->input_layout.NumElements;
+
     if (graphics->attribute_count > ARRAY_SIZE(graphics->attributes))
     {
         FIXME("InputLayout.NumElements %zu > %zu, ignoring extra elements.\n",
@@ -3755,6 +3783,14 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         hr = E_INVALIDARG;
         goto fail;
     }
+
+    d3d12_pipeline_state_graphics_load_spirv_from_cached_state(state, device, desc, cached_pso);
+    if (FAILED(hr = d3d12_pipeline_state_graphics_create_shader_stages(state, device, desc)))
+        goto fail;
+
+    /* At this point, we will have valid meta structures set up.
+     * Deduce further PSO information from these structs. */
+    d3d12_pipeline_state_graphics_handle_meta(state, device);
 
     if (graphics->stage_flags & VK_SHADER_STAGE_MESH_BIT_EXT)
     {

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -4275,6 +4275,8 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
     if (d3d12_graphics_pipeline_state_has_unknown_dsv_format_with_test(graphics) && dsv_format)
         TRACE("Compiling %p with fallback DSV format %#x.\n", state, dsv_format->vk_format);
 
+    /* FIXME: This gets modified on late recompilation, could there be thread safety issues here?
+     * For GENERAL depth-stencil, this mask should not matter at all, but there might be edge cases for tracked DSV. */
     graphics->dsv_plane_optimal_mask = d3d12_graphics_pipeline_state_get_plane_optimal_mask(graphics, dsv_format);
 
     if (key)

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3850,7 +3850,28 @@ static HRESULT d3d12_pipeline_state_init_static_pipeline(struct d3d12_pipeline_s
 static HRESULT d3d12_pipeline_state_finish_graphics(struct d3d12_pipeline_state *state)
 {
     struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
+    unsigned int i;
+    void *new_code;
     HRESULT hr;
+
+    /* If we got here successfully without SPIR-V code,
+     * it means we'll need to defer compilation from DXBC -> SPIR-V.
+     * Dupe the DXBC code.
+     * TODO: This codepath is not relevant yet. */
+    for (i = 0; i < graphics->stage_count; i++)
+    {
+        if (graphics->code[i].size || graphics->stages[i].module != VK_NULL_HANDLE ||
+                !graphics->cached_desc.bytecode[i].BytecodeLength)
+            continue;
+
+        new_code = vkd3d_malloc(graphics->cached_desc.bytecode[i].BytecodeLength);
+        if (!new_code)
+            return E_OUTOFMEMORY;
+        memcpy(new_code, graphics->cached_desc.bytecode[i].pShaderBytecode,
+                graphics->cached_desc.bytecode[i].BytecodeLength);
+        graphics->cached_desc.bytecode[i].pShaderBytecode = new_code;
+        graphics->cached_desc.bytecode_duped_mask |= 1u << i;
+    }
 
     list_init(&graphics->compiled_fallback_pipelines);
     if (FAILED(hr = vkd3d_private_store_init(&state->private_store)))

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -4076,6 +4076,10 @@ HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindP
     {
         VK_CALL(vkDestroyPipelineCache(device->vk_device, object->vk_pso_cache, NULL));
         object->vk_pso_cache = VK_NULL_HANDLE;
+
+        /* Set this explicitly so we avoid attempting to touch code[i] when serializing the PSO blob.
+         * We are at risk of compiling code on the fly in some upcoming situations. */
+        object->pso_is_loaded_from_cached_blob = true;
     }
     else if (device->disk_cache.library)
     {

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2016,6 +2016,18 @@ static void vkd3d_shader_transform_feedback_info_free(struct vkd3d_shader_transf
     vkd3d_free(xfb_info);
 }
 
+static void d3d12_pipeline_state_free_cached_desc(struct d3d12_graphics_pipeline_state_cached_desc *cached_desc)
+{
+    unsigned int i;
+    vkd3d_shader_transform_feedback_info_free(cached_desc->xfb_info);
+    vkd3d_shader_stage_io_map_free(&cached_desc->stage_io_map_ms_ps);
+    while (cached_desc->bytecode_duped_mask)
+    {
+        i = vkd3d_bitmask_iter32(&cached_desc->bytecode_duped_mask);
+        vkd3d_free((void*)cached_desc->bytecode[i].pShaderBytecode);
+    }
+}
+
 static struct vkd3d_shader_transform_feedback_info *vkd3d_shader_transform_feedback_info_dup(
         const D3D12_STREAM_OUTPUT_DESC *so_desc)
 {
@@ -2080,10 +2092,8 @@ void d3d12_pipeline_state_dec_ref(struct d3d12_pipeline_state *state)
         if (state->root_signature)
             d3d12_root_signature_dec_ref(state->root_signature);
 
-        if (state->pipeline_type == VKD3D_PIPELINE_TYPE_GRAPHICS)
-            vkd3d_shader_transform_feedback_info_free(state->graphics.cached_desc.xfb_info);
-        else if (state->pipeline_type == VKD3D_PIPELINE_TYPE_MESH_GRAPHICS)
-            vkd3d_shader_stage_io_map_free(&state->graphics.cached_desc.stage_io_map_ms_ps);
+        if (state->pipeline_type == VKD3D_PIPELINE_TYPE_GRAPHICS || state->pipeline_type == VKD3D_PIPELINE_TYPE_MESH_GRAPHICS)
+            d3d12_pipeline_state_free_cached_desc(&state->graphics.cached_desc);
         vkd3d_free(state);
     }
 }
@@ -3204,9 +3214,9 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     struct vkd3d_shader_signature input_signature;
     VkSampleCountFlagBits sample_count;
     const struct vkd3d_format *format;
-    unsigned int i, j, stage_count;
     unsigned int instance_divisor;
     VkVertexInputRate input_rate;
+    unsigned int i, j;
     size_t rt_count;
     uint32_t mask;
     HRESULT hr;
@@ -3217,7 +3227,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
         enum VkShaderStageFlagBits stage;
         ptrdiff_t offset;
     }
-    shader_stages[] =
+    shader_stages_lut[] =
     {
         {VK_SHADER_STAGE_VERTEX_BIT,                  offsetof(struct d3d12_pipeline_state_desc, vs)},
         {VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,    offsetof(struct d3d12_pipeline_state_desc, hs)},
@@ -3439,15 +3449,16 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
 
     graphics->patch_vertex_count = 0;
 
-    for (i = 0; i < ARRAY_SIZE(shader_stages); ++i)
+    /* Parse interface data from DXBC blobs. */
+    for (i = 0; i < ARRAY_SIZE(shader_stages_lut); ++i)
     {
-        const D3D12_SHADER_BYTECODE *b = (const void *)((uintptr_t)desc + shader_stages[i].offset);
+        const D3D12_SHADER_BYTECODE *b = (const void *)((uintptr_t)desc + shader_stages_lut[i].offset);
         const struct vkd3d_shader_code dxbc = {b->pShaderBytecode, b->BytecodeLength};
 
-        if (!(graphics->stage_flags & shader_stages[i].stage))
+        if (!(graphics->stage_flags & shader_stages_lut[i].stage))
             continue;
 
-        switch (shader_stages[i].stage)
+        switch (shader_stages_lut[i].stage)
         {
             case VK_SHADER_STAGE_VERTEX_BIT:
                 if ((ret = vkd3d_shader_parse_input_signature(&dxbc, &input_signature)) < 0)
@@ -3488,6 +3499,11 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
                 goto fail;
         }
 
+        /* Not owned yet. If we return from pipeline creation without having concrete SPIR-V,
+         * we'll have to dupe the bytecode and potentially compile to SPIR-V late. */
+        graphics->cached_desc.bytecode[graphics->stage_count] = *b;
+        graphics->cached_desc.bytecode_stages[graphics->stage_count] = shader_stages_lut[i].stage;
+
         ++graphics->stage_count;
     }
 
@@ -3495,65 +3511,51 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
      * We cannot partially fall back since we cannot handle any situation where we need inter-stage code-gen fixups.
      * In this situation, just generate full SPIR-V from scratch.
      * This really shouldn't happen unless we have corrupt cache entries. */
-    stage_count = 0;
-    for (i = 0; i < ARRAY_SIZE(shader_stages); i++)
+    for (i = 0; i < graphics->stage_count; i++)
     {
-        if (!(graphics->stage_flags & shader_stages[i].stage))
-            continue;
-
         if (FAILED(vkd3d_load_spirv_from_cached_state(device, cached_pso,
-                shader_stages[i].stage, &graphics->code[stage_count])))
+                graphics->cached_desc.bytecode_stages[i], &graphics->code[i])))
         {
-            for (j = 0; j < stage_count; j++)
+            for (j = 0; j < i; j++)
             {
                 if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_LOG)
-                    INFO("Discarding cached SPIR-V for stage #%x.\n", shader_stages[i].stage);
+                    INFO("Discarding cached SPIR-V for stage #%x.\n", graphics->cached_desc.bytecode_stages[j]);
                 vkd3d_shader_free_shader_code(&graphics->code[j]);
                 memset(&graphics->code[j], 0, sizeof(graphics->code[j]));
             }
             break;
         }
-
-        ++stage_count;
     }
 
     /* Now create the actual shader modules. If we managed to load SPIR-V from cache, use that directly.
      * Make sure we don't reset graphics->stage_count since that is a potential memory leak if
      * we fail to create shader module for whatever reason. */
-    stage_count = 0;
-    for (i = 0; i < ARRAY_SIZE(shader_stages); i++)
+    for (i = 0; i < graphics->stage_count; i++)
     {
-        const D3D12_SHADER_BYTECODE *b = (const void *)((uintptr_t)desc + shader_stages[i].offset);
-
-        if (!(graphics->stage_flags & shader_stages[i].stage))
-            continue;
-
         if (FAILED(hr = vkd3d_create_shader_stage(state, device,
-                &graphics->stages[stage_count],
-                shader_stages[i].stage, NULL, b,
-                &graphics->code[stage_count])))
+                &graphics->stages[i],
+                graphics->cached_desc.bytecode_stages[i], NULL,
+                &graphics->cached_desc.bytecode[i], &graphics->code[i])))
             goto fail;
 
-        if (shader_stages[i].stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
+        if (graphics->cached_desc.bytecode_stages[i] == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
         {
-            graphics->patch_vertex_count = graphics->code[stage_count].meta.patch_vertex_count;
+            graphics->patch_vertex_count = graphics->code[i].meta.patch_vertex_count;
         }
-        else if (shader_stages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT)
+        else if (graphics->cached_desc.bytecode_stages[i] == VK_SHADER_STAGE_FRAGMENT_BIT)
         {
             /* We have consumed the MS/PS map at this point. */
             vkd3d_shader_stage_io_map_free(&state->graphics.cached_desc.stage_io_map_ms_ps);
         }
 
-        if ((graphics->code[stage_count].meta.flags & VKD3D_SHADER_META_FLAG_REPLACED) &&
+        if ((graphics->code[i].meta.flags & VKD3D_SHADER_META_FLAG_REPLACED) &&
                 device->debug_ring.active)
         {
             vkd3d_shader_debug_ring_init_spec_constant(device,
-                    &graphics->spec_info[stage_count],
-                    graphics->code[stage_count].meta.hash);
-            graphics->stages[stage_count].pSpecializationInfo = &graphics->spec_info[stage_count].spec_info;
+                    &graphics->spec_info[i],
+                    graphics->code[i].meta.hash);
+            graphics->stages[i].pSpecializationInfo = &graphics->spec_info[i].spec_info;
         }
-
-        ++stage_count;
     }
 
     graphics->attribute_count = (graphics->stage_flags & VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT)
@@ -3945,10 +3947,8 @@ HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindP
             d3d12_root_signature_dec_ref(object->root_signature);
         d3d12_pipeline_state_free_spirv_code(object);
         d3d12_pipeline_state_destroy_shader_modules(object, device);
-        if (object->pipeline_type == VKD3D_PIPELINE_TYPE_GRAPHICS)
-            vkd3d_shader_transform_feedback_info_free(object->graphics.cached_desc.xfb_info);
-        else if (object->pipeline_type == VKD3D_PIPELINE_TYPE_MESH_GRAPHICS)
-            vkd3d_shader_stage_io_map_free(&object->graphics.cached_desc.stage_io_map_ms_ps);
+        if (object->pipeline_type == VKD3D_PIPELINE_TYPE_GRAPHICS || object->pipeline_type == VKD3D_PIPELINE_TYPE_MESH_GRAPHICS)
+            d3d12_pipeline_state_free_cached_desc(&object->graphics.cached_desc);
         VK_CALL(vkDestroyPipelineCache(device->vk_device, object->vk_pso_cache, NULL));
 
         vkd3d_free(object);

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3918,7 +3918,7 @@ HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindP
     hr = S_OK;
 
     if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE))
-        if (FAILED(hr = vkd3d_create_pipeline_cache_from_d3d12_desc(device, &desc->cached_pso, &object->vk_pso_cache)))
+        if (FAILED(hr = vkd3d_create_pipeline_cache_from_d3d12_desc(device, desc_cached_pso, &object->vk_pso_cache)))
             ERR("Failed to create pipeline cache, hr %d.\n", hr);
 
     if (SUCCEEDED(hr))

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1908,16 +1908,12 @@ static ULONG STDMETHODCALLTYPE d3d12_pipeline_state_AddRef(ID3D12PipelineState *
 }
 
 static HRESULT d3d12_pipeline_state_create_shader_module(struct d3d12_device *device,
-        VkPipelineShaderStageCreateInfo *stage_desc, const struct vkd3d_shader_code *code)
+        VkShaderModule *vk_module, const struct vkd3d_shader_code *code)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkShaderModuleCreateInfo shader_desc;
     char hash_str[16 + 1];
     VkResult vr;
-
-    /* If we kept the module around, no need to create it again. */
-    if (stage_desc->module != VK_NULL_HANDLE)
-        return S_OK;
 
     shader_desc.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
     shader_desc.pNext = NULL;
@@ -1925,7 +1921,7 @@ static HRESULT d3d12_pipeline_state_create_shader_module(struct d3d12_device *de
     shader_desc.codeSize = code->size;
     shader_desc.pCode = code->code;
 
-    vr = VK_CALL(vkCreateShaderModule(device->vk_device, &shader_desc, NULL, &stage_desc->module));
+    vr = VK_CALL(vkCreateShaderModule(device->vk_device, &shader_desc, NULL, vk_module));
     if (vr < 0)
     {
         WARN("Failed to create Vulkan shader module, vr %d.\n", vr);
@@ -1934,7 +1930,7 @@ static HRESULT d3d12_pipeline_state_create_shader_module(struct d3d12_device *de
 
     /* Helpful for tooling like RenderDoc. */
     sprintf(hash_str, "%016"PRIx64, code->meta.hash);
-    vkd3d_set_vk_object_name(device, (uint64_t)stage_desc->module, VK_OBJECT_TYPE_SHADER_MODULE, hash_str);
+    vkd3d_set_vk_object_name(device, (uint64_t)*vk_module, VK_OBJECT_TYPE_SHADER_MODULE, hash_str);
     return S_OK;
 }
 
@@ -2308,62 +2304,18 @@ static void d3d12_pipeline_state_init_compile_arguments(struct d3d12_pipeline_st
     }
 }
 
-static HRESULT vkd3d_create_shader_stage(struct d3d12_pipeline_state *state, struct d3d12_device *device,
+static HRESULT vkd3d_setup_shader_stage(struct d3d12_pipeline_state *state, struct d3d12_device *device,
         VkPipelineShaderStageCreateInfo *stage_desc, VkShaderStageFlagBits stage,
         VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT *required_subgroup_size_info,
-        const D3D12_SHADER_BYTECODE *code, struct vkd3d_shader_code *spirv_code)
+        const struct vkd3d_shader_code *spirv_code)
 {
-    struct vkd3d_shader_code dxbc = {code->pShaderBytecode, code->BytecodeLength};
-    struct vkd3d_shader_interface_info shader_interface;
-    struct vkd3d_shader_compile_arguments compile_args;
-    vkd3d_shader_hash_t recovered_hash = 0;
-    vkd3d_shader_hash_t compiled_hash = 0;
-    int ret;
-
     stage_desc->sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stage_desc->pNext = NULL;
     stage_desc->flags = 0;
     stage_desc->stage = stage;
     stage_desc->pName = "main";
     stage_desc->pSpecializationInfo = NULL;
-
-    if (spirv_code->code && (vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_SANITIZE_SPIRV))
-    {
-        recovered_hash = vkd3d_shader_hash(spirv_code);
-        vkd3d_shader_free_shader_code(spirv_code);
-        memset(spirv_code, 0, sizeof(*spirv_code));
-    }
-
-    if (!spirv_code->code)
-    {
-        TRACE("Calling vkd3d_shader_compile_dxbc.\n");
-
-        d3d12_pipeline_state_init_shader_interface(state, device, stage, &shader_interface);
-        d3d12_pipeline_state_init_compile_arguments(state, device, stage, &compile_args);
-
-        if ((ret = vkd3d_shader_compile_dxbc(&dxbc, spirv_code, 0, &shader_interface, &compile_args)) < 0)
-        {
-            WARN("Failed to compile shader, vkd3d result %d.\n", ret);
-            return hresult_from_vkd3d_result(ret);
-        }
-        TRACE("Called vkd3d_shader_compile_dxbc.\n");
-
-        if (stage == VK_SHADER_STAGE_FRAGMENT_BIT)
-        {
-            /* At this point we don't need the map anymore. */
-            vkd3d_shader_stage_io_map_free(&state->graphics.cached_desc.stage_io_map_ms_ps);
-        }
-    }
-
-    /* Debug compare SPIR-V we got from cache, and SPIR-V we got from compilation. */
-    if (recovered_hash)
-    {
-        compiled_hash = vkd3d_shader_hash(spirv_code);
-        if (compiled_hash == recovered_hash)
-            INFO("SPIR-V match for cache reference OK!\n");
-        else
-            INFO("SPIR-V mismatch for cache reference!\n");
-    }
+    stage_desc->module = VK_NULL_HANDLE;
 
     if (!d3d12_device_validate_shader_meta(device, &spirv_code->meta))
         return E_INVALIDARG;
@@ -2411,8 +2363,58 @@ static HRESULT vkd3d_create_shader_stage(struct d3d12_pipeline_state *state, str
         }
     }
 
-    stage_desc->module = VK_NULL_HANDLE;
-    return d3d12_pipeline_state_create_shader_module(device, stage_desc, spirv_code);
+    return d3d12_pipeline_state_create_shader_module(device, &stage_desc->module, spirv_code);
+}
+
+static HRESULT vkd3d_compile_shader_stage(struct d3d12_pipeline_state *state, struct d3d12_device *device,
+        VkShaderStageFlagBits stage, const D3D12_SHADER_BYTECODE *code, struct vkd3d_shader_code *spirv_code)
+{
+    struct vkd3d_shader_code dxbc = {code->pShaderBytecode, code->BytecodeLength};
+    struct vkd3d_shader_interface_info shader_interface;
+    struct vkd3d_shader_compile_arguments compile_args;
+    vkd3d_shader_hash_t recovered_hash = 0;
+    vkd3d_shader_hash_t compiled_hash = 0;
+    int ret;
+
+    if (spirv_code->code && (vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_SANITIZE_SPIRV))
+    {
+        recovered_hash = vkd3d_shader_hash(spirv_code);
+        vkd3d_shader_free_shader_code(spirv_code);
+        memset(spirv_code, 0, sizeof(*spirv_code));
+    }
+
+    if (!spirv_code->code)
+    {
+        TRACE("Calling vkd3d_shader_compile_dxbc.\n");
+
+        d3d12_pipeline_state_init_shader_interface(state, device, stage, &shader_interface);
+        d3d12_pipeline_state_init_compile_arguments(state, device, stage, &compile_args);
+
+        if ((ret = vkd3d_shader_compile_dxbc(&dxbc, spirv_code, 0, &shader_interface, &compile_args)) < 0)
+        {
+            WARN("Failed to compile shader, vkd3d result %d.\n", ret);
+            return hresult_from_vkd3d_result(ret);
+        }
+        TRACE("Called vkd3d_shader_compile_dxbc.\n");
+
+        if (stage == VK_SHADER_STAGE_FRAGMENT_BIT)
+        {
+            /* At this point we don't need the map anymore. */
+            vkd3d_shader_stage_io_map_free(&state->graphics.cached_desc.stage_io_map_ms_ps);
+        }
+    }
+
+    /* Debug compare SPIR-V we got from cache, and SPIR-V we got from compilation. */
+    if (recovered_hash)
+    {
+        compiled_hash = vkd3d_shader_hash(spirv_code);
+        if (compiled_hash == recovered_hash)
+            INFO("SPIR-V match for cache reference OK!\n");
+        else
+            INFO("SPIR-V mismatch for cache reference!\n");
+    }
+
+    return S_OK;
 }
 
 static void vkd3d_report_pipeline_creation_feedback_results(const VkPipelineCreationFeedbackCreateInfoEXT *feedback)
@@ -2478,11 +2480,16 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     pipeline_info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
     pipeline_info.pNext = NULL;
     pipeline_info.flags = 0;
-    if (FAILED(hr = vkd3d_create_shader_stage(state, device,
-            &pipeline_info.stage,
-            VK_SHADER_STAGE_COMPUTE_BIT, &required_subgroup_size_info,
-            code, spirv_code)))
+
+    if (FAILED(hr = vkd3d_compile_shader_stage(state, device,
+            VK_SHADER_STAGE_COMPUTE_BIT, code, spirv_code)))
         return hr;
+
+    if (FAILED(hr = vkd3d_setup_shader_stage(state, device,
+            &pipeline_info.stage, VK_SHADER_STAGE_COMPUTE_BIT, &required_subgroup_size_info,
+            spirv_code)))
+        return hr;
+
     pipeline_info.layout = state->root_signature->compute.vk_pipeline_layout;
     pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
     pipeline_info.basePipelineIndex = -1;
@@ -3224,7 +3231,7 @@ static void d3d12_pipeline_state_graphics_load_spirv_from_cached_state(
             for (j = 0; j < i; j++)
             {
                 if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_LOG)
-                    INFO("Discarding cached SPIR-V for stage #%x.\n", graphics->cached_desc.bytecode_stages[i]);
+                    INFO("Discarding cached SPIR-V for stage #%x.\n", graphics->cached_desc.bytecode_stages[j]);
                 vkd3d_shader_free_shader_code(&graphics->code[j]);
                 memset(&graphics->code[j], 0, sizeof(graphics->code[j]));
             }
@@ -3244,10 +3251,15 @@ static HRESULT d3d12_pipeline_state_graphics_create_shader_stages(
     /* Now create the actual shader modules. If we managed to load SPIR-V from cache, use that directly. */
     for (i = 0; i < graphics->stage_count; i++)
     {
-        if (FAILED(hr = vkd3d_create_shader_stage(state, device,
+        if (FAILED(hr = vkd3d_compile_shader_stage(state, device,
+                graphics->cached_desc.bytecode_stages[i],
+                &graphics->cached_desc.bytecode[i], &graphics->code[i])))
+            return hr;
+
+        if (FAILED(hr = vkd3d_setup_shader_stage(state, device,
                 &graphics->stages[i],
                 graphics->cached_desc.bytecode_stages[i], NULL,
-                &graphics->cached_desc.bytecode[i], &graphics->code[i])))
+                &graphics->code[i])))
             return hr;
     }
 
@@ -4377,7 +4389,8 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
         {
             if (stages[i].module == VK_NULL_HANDLE && graphics->code[i].code)
             {
-                if (FAILED(hr = d3d12_pipeline_state_create_shader_module(device, &stages[i], &graphics->code[i])))
+                if (FAILED(hr = d3d12_pipeline_state_create_shader_module(device,
+                        &stages[i].module, &graphics->code[i])))
                 {
                     /* This is kind of fatal and should only happen for out-of-memory. */
                     ERR("Unexpected failure (hr %x) in creating fallback SPIR-V module.\n", hr);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1690,6 +1690,7 @@ struct d3d12_pipeline_state
     struct d3d12_root_signature *root_signature;
     struct d3d12_device *device;
     bool root_signature_compat_hash_is_dxbc_derived;
+    bool pso_is_loaded_from_cached_blob;
 
     struct vkd3d_private_store private_store;
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1592,6 +1592,10 @@ struct d3d12_graphics_pipeline_state_cached_desc
     VkShaderStageFlagBits xfb_stage;
     struct vkd3d_shader_transform_feedback_info *xfb_info;
     struct vkd3d_shader_stage_io_map stage_io_map_ms_ps;
+
+    D3D12_SHADER_BYTECODE bytecode[VKD3D_MAX_SHADER_STAGES];
+    VkShaderStageFlagBits bytecode_stages[VKD3D_MAX_SHADER_STAGES];
+    uint32_t bytecode_duped_mask;
 };
 
 struct d3d12_graphics_pipeline_state


### PR DESCRIPTION
This continues the refactor, and focuses on splitting out the code as much as possible so that we can compile SPIR-V late as desired. Should also be a nice refactor in general, since the existing graphics pipeline creation is an insane mess.

Also sets up systems so that we can duplicate DXBC blobs in case we have to compile to SPIR-V late. This can happen if we get a successful module identifier compile, but a future fallback pipeline might not exist in driver cache. In this case we'll have to fall back to creating SPIR-V modules on demand. On future runs of the application, we should never miss in the driver cache (ideally).