### PR TITLE
vkd3d: Enable promoted VK_EXT_mutable_descriptor_type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ These extensions will likely become mandatory later.
 - `VK_KHR_buffer_device_address`
 - `VK_EXT_image_view_min_lod`
 
-`VK_VALVE_mutable_descriptor_type` is also highly recommended, but not mandatory.
+`VK_EXT_mutable_descriptor_type` (or the vendor `VALVE` alias) is also highly recommended, but not mandatory.
 
 ### AMD (RADV)
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -120,6 +120,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_SCALAR_BLOCK_LAYOUT, EXT_scalar_block_layout),
     VK_EXTENSION(EXT_PIPELINE_CREATION_FEEDBACK, EXT_pipeline_creation_feedback),
     VK_EXTENSION(EXT_MESH_SHADER, EXT_mesh_shader),
+    VK_EXTENSION(EXT_MUTABLE_DESCRIPTOR_TYPE, EXT_mutable_descriptor_type),
     /* AMD extensions */
     VK_EXTENSION(AMD_BUFFER_MARKER, AMD_buffer_marker),
     VK_EXTENSION(AMD_DEVICE_COHERENT_MEMORY, AMD_device_coherent_memory),
@@ -1380,9 +1381,9 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->properties2, &info->shader_sm_builtins_properties);
     }
 
-    if (vulkan_info->VALVE_mutable_descriptor_type)
+    if (vulkan_info->VALVE_mutable_descriptor_type || vulkan_info->EXT_mutable_descriptor_type)
     {
-        info->mutable_descriptor_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_VALVE;
+        info->mutable_descriptor_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT;
         vk_prepend_struct(&info->features2, &info->mutable_descriptor_features);
     }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3907,7 +3907,7 @@ static void d3d12_descriptor_heap_write_null_descriptor_template(vkd3d_cpu_descr
     for (i = 0; i < num_writes; i++)
     {
         writes[i] = desc.heap->null_descriptor_template.writes[i];
-        if (writes[i].descriptorType == VK_DESCRIPTOR_TYPE_MUTABLE_VALVE)
+        if (writes[i].descriptorType == VK_DESCRIPTOR_TYPE_MUTABLE_EXT)
             writes[i].descriptorType = vk_mutable_descriptor_type;
         writes[i].dstArrayElement = offset;
     }
@@ -5520,7 +5520,7 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_pool(struct d3d12_descrip
     vk_pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT;
     if (!(descriptor_heap->desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) &&
             (descriptor_heap->device->bindless_state.flags & VKD3D_BINDLESS_MUTABLE_TYPE))
-        vk_pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_VALVE;
+        vk_pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT;
 
     vk_pool_info.maxSets = pool_count;
     vk_pool_info.poolSizeCount = pool_count;
@@ -5550,7 +5550,7 @@ static void d3d12_descriptor_heap_zero_initialize(struct d3d12_descriptor_heap *
 
     /* Clear out descriptor heap with the largest possible descriptor type we know of when using mutable descriptor type.
      * Purely for defensive purposes. */
-    if (vk_descriptor_type == VK_DESCRIPTOR_TYPE_MUTABLE_VALVE)
+    if (vk_descriptor_type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT)
         vk_descriptor_type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 
     write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -5890,7 +5890,7 @@ static void d3d12_descriptor_heap_add_null_descriptor_template(
         descriptor_heap->null_descriptor_template.image.imageView = VK_NULL_HANDLE;
         descriptor_heap->null_descriptor_template.buffer_view = VK_NULL_HANDLE;
         descriptor_heap->null_descriptor_template.has_mutable_descriptors =
-                descriptor_heap->device->vk_info.VALVE_mutable_descriptor_type;
+                descriptor_heap->device->device_info.mutable_descriptor_features.mutableDescriptorType;
     }
 
     descriptor_heap->null_descriptor_template.num_writes++;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -163,6 +163,7 @@ struct vkd3d_vulkan_info
     bool EXT_scalar_block_layout;
     bool EXT_pipeline_creation_feedback;
     bool EXT_mesh_shader;
+    bool EXT_mutable_descriptor_type; /* EXT promotion of VALVE one. */
     /* AMD device extensions */
     bool AMD_buffer_marker;
     bool AMD_device_coherent_memory;
@@ -3363,7 +3364,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features;
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features;
     VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features;
-    VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE mutable_descriptor_features;
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_features;
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline_features;
     VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure_features;
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragment_shading_rate_features;


### PR DESCRIPTION
Trivial alias, support both variants for now.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>