### PR TITLE
VK_EXT_shader_module_identifier - Phase 4/4

### DIFF
--- a/libs/vkd3d/cache.c
+++ b/libs/vkd3d/cache.c
@@ -198,6 +198,8 @@ enum vkd3d_pipeline_blob_chunk_type
     /* VkShaderStage is stored in upper 16 bits. */
     VKD3D_PIPELINE_BLOB_CHUNK_TYPE_SHADER_META = 4,
     VKD3D_PIPELINE_BLOB_CHUNK_TYPE_PSO_COMPAT = 5,
+    /* VkShaderStage is stored in upper 16 bits. */
+    VKD3D_PIPELINE_BLOB_CHUNK_TYPE_SHADER_IDENTIFIER = 6,
     VKD3D_PIPELINE_BLOB_CHUNK_TYPE_MASK = 0xffff,
     VKD3D_PIPELINE_BLOB_CHUNK_INDEX_SHIFT = 16,
 };
@@ -380,6 +382,16 @@ HRESULT d3d12_cached_pipeline_state_validate(struct d3d12_device *device,
         if (memcmp(blob->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE) != 0)
             return D3D12_ERROR_DRIVER_VERSION_MISMATCH;
 
+    if (pipeline_library_flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER)
+    {
+        if (memcmp(blob->cache_uuid,
+                device->device_info.shader_module_identifier_properties.shaderModuleIdentifierAlgorithmUUID,
+                VK_UUID_SIZE) != 0)
+        {
+            return D3D12_ERROR_DRIVER_VERSION_MISMATCH;
+        }
+    }
+
     /* In stream archives, we perform checksums ahead of time before accepting a stream blob into internal cache.
      * No need to do redundant work. */
     if (!(pipeline_library_flags & VKD3D_PIPELINE_LIBRARY_FLAG_STREAM_ARCHIVE))
@@ -470,6 +482,11 @@ bool d3d12_cached_pipeline_state_is_dummy(const struct d3d12_cached_pipeline_sta
 
     if (find_blob_chunk_masked(chunk, payload_size,
             VKD3D_PIPELINE_BLOB_CHUNK_TYPE_VARINT_SPIRV_LINK,
+            VKD3D_PIPELINE_BLOB_CHUNK_TYPE_MASK))
+        return false;
+
+    if (find_blob_chunk_masked(chunk, payload_size,
+            VKD3D_PIPELINE_BLOB_CHUNK_TYPE_SHADER_IDENTIFIER,
             VKD3D_PIPELINE_BLOB_CHUNK_TYPE_MASK))
         return false;
 
@@ -599,7 +616,8 @@ HRESULT vkd3d_create_pipeline_cache_from_d3d12_desc(struct d3d12_device *device,
 HRESULT vkd3d_get_cached_spirv_code_from_d3d12_desc(
         const struct d3d12_cached_pipeline_state *state,
         VkShaderStageFlagBits stage,
-        struct vkd3d_shader_code *spirv_code)
+        struct vkd3d_shader_code *spirv_code,
+        VkPipelineShaderStageModuleIdentifierCreateInfoEXT *identifier)
 {
     const struct vkd3d_pipeline_blob *blob = state->blob.pCachedBlob;
     const struct vkd3d_pipeline_blob_chunk_shader_meta *meta;
@@ -622,6 +640,22 @@ HRESULT vkd3d_get_cached_spirv_code_from_d3d12_desc(
         return E_FAIL;
     meta = CONST_CAST_CHUNK_DATA(chunk, shader_meta);
     memcpy(&spirv_code->meta, &meta->meta, sizeof(meta->meta));
+
+    if (state->library && (state->library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER))
+    {
+        /* Only return identifier if we can use it. */
+        chunk = find_blob_chunk(CONST_CAST_CHUNK_BASE(blob), payload_size,
+                VKD3D_PIPELINE_BLOB_CHUNK_TYPE_SHADER_IDENTIFIER | (stage << VKD3D_PIPELINE_BLOB_CHUNK_INDEX_SHIFT));
+
+        if (chunk && chunk->size <= VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT)
+        {
+            identifier->identifierSize = chunk->size;
+            identifier->pIdentifier = chunk->data;
+            spirv_code->size = 0;
+            spirv_code->code = NULL;
+            return S_OK;
+        }
+    }
 
     /* Aim to pull SPIR-V either from inlined chunk, or a link. */
     chunk = find_blob_chunk(CONST_CAST_CHUNK_BASE(blob), payload_size,
@@ -793,6 +827,33 @@ static void vkd3d_shader_code_serialize_inline(const struct vkd3d_shader_code *c
         meta->meta = code->meta;
         chunk = finish_and_iterate_blob_chunk(chunk);
     }
+
+    *inout_chunk = chunk;
+}
+
+static void vkd3d_shader_code_serialize_identifier(struct d3d12_pipeline_library *pipeline_library,
+        const struct vkd3d_shader_code *code,
+        const VkShaderModuleIdentifierEXT *identifier, VkShaderStageFlagBits stage,
+        struct vkd3d_pipeline_blob_chunk **inout_chunk)
+{
+    struct vkd3d_pipeline_blob_chunk *chunk = *inout_chunk;
+    struct vkd3d_pipeline_blob_chunk_shader_meta *meta;
+
+    if (!identifier->identifierSize)
+        return;
+
+    /* Store identifier. */
+    chunk->type = VKD3D_PIPELINE_BLOB_CHUNK_TYPE_SHADER_IDENTIFIER | (stage << VKD3D_PIPELINE_BLOB_CHUNK_INDEX_SHIFT);
+    chunk->size = identifier->identifierSize;
+    memcpy(chunk->data, identifier->identifier, chunk->size);
+    chunk = finish_and_iterate_blob_chunk(chunk);
+
+    /* Store meta information for SPIR-V. */
+    chunk->type = VKD3D_PIPELINE_BLOB_CHUNK_TYPE_SHADER_META | (stage << VKD3D_PIPELINE_BLOB_CHUNK_INDEX_SHIFT);
+    chunk->size = sizeof(*meta);
+    meta = CAST_CHUNK_DATA(chunk, shader_meta);
+    meta->meta = code->meta;
+    chunk = finish_and_iterate_blob_chunk(chunk);
 
     *inout_chunk = chunk;
 }
@@ -1017,6 +1078,27 @@ static VkResult vkd3d_serialize_pipeline_state_referenced(struct d3d12_pipeline_
         }
     }
 
+    if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER)
+    {
+        if (d3d12_pipeline_state_is_graphics(state))
+        {
+            for (i = 0; i < state->graphics.stage_count; i++)
+            {
+                vkd3d_shader_code_serialize_identifier(pipeline_library,
+                        &state->graphics.code[i],
+                        &state->graphics.identifiers[i], state->graphics.stages[i].stage,
+                        &chunk);
+            }
+        }
+        else if (d3d12_pipeline_state_is_compute(state))
+        {
+            vkd3d_shader_code_serialize_identifier(pipeline_library,
+                    &state->compute.code,
+                    &state->compute.identifier, VK_SHADER_STAGE_COMPUTE_BIT,
+                    &chunk);
+        }
+    }
+
     return VK_SUCCESS;
 }
 
@@ -1076,6 +1158,29 @@ VkResult vkd3d_serialize_pipeline_state(struct d3d12_pipeline_library *pipeline_
         }
     }
 
+    if (pipeline_library && (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER))
+    {
+        if (d3d12_pipeline_state_is_graphics(state))
+        {
+            for (i = 0; i < state->graphics.stage_count; i++)
+            {
+                if (state->graphics.identifiers[i].identifierSize)
+                {
+                    vk_blob_size += VKD3D_PIPELINE_BLOB_CHUNK_SIZE_RAW(state->graphics.identifiers[i].identifierSize);
+                    vk_blob_size += VKD3D_PIPELINE_BLOB_CHUNK_SIZE(shader_meta);
+                }
+            }
+        }
+        else if (d3d12_pipeline_state_is_compute(state))
+        {
+            if (state->compute.identifier.identifierSize)
+            {
+                vk_blob_size += VKD3D_PIPELINE_BLOB_CHUNK_SIZE_RAW(state->compute.identifier.identifierSize);
+                vk_blob_size += VKD3D_PIPELINE_BLOB_CHUNK_SIZE(shader_meta);
+            }
+        }
+    }
+
     total_size += vk_blob_size;
 
     if (blob && *size < total_size)
@@ -1089,7 +1194,13 @@ VkResult vkd3d_serialize_pipeline_state(struct d3d12_pipeline_library *pipeline_
         blob->vkd3d_shader_interface_key = state->device->shader_interface_key;
         blob->vkd3d_build = vkd3d_build;
 
-        if (!pipeline_library || (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_USE_PIPELINE_CACHE_UUID))
+        if (pipeline_library && (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER))
+        {
+            memcpy(blob->cache_uuid,
+                    pipeline_library->device->device_info.shader_module_identifier_properties.shaderModuleIdentifierAlgorithmUUID,
+                    VK_UUID_SIZE);
+        }
+        else if (!pipeline_library || (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_USE_PIPELINE_CACHE_UUID))
             memcpy(blob->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE);
         else
             memset(blob->cache_uuid, 0, VK_UUID_SIZE);
@@ -1171,8 +1282,8 @@ struct vkd3d_serialized_pipeline_toc_entry
 };
 STATIC_ASSERT(sizeof(struct vkd3d_serialized_pipeline_toc_entry) == 16);
 
-#define VKD3D_PIPELINE_LIBRARY_VERSION_TOC MAKE_MAGIC('V','K','L',3)
-#define VKD3D_PIPELINE_LIBRARY_VERSION_STREAM MAKE_MAGIC('V','K','S',3)
+#define VKD3D_PIPELINE_LIBRARY_VERSION_TOC MAKE_MAGIC('V','K','L',4)
+#define VKD3D_PIPELINE_LIBRARY_VERSION_STREAM MAKE_MAGIC('V','K','S',4)
 
 struct vkd3d_serialized_pipeline_library_toc
 {
@@ -1184,6 +1295,10 @@ struct vkd3d_serialized_pipeline_library_toc
     uint32_t pipeline_count;
     uint64_t vkd3d_build;
     uint64_t vkd3d_shader_interface_key;
+    /* Refers to pipelineCacheUUID if we're using VkPipelineCache blobs,
+     * or shaderModuleIdentifierAlgorithmUUID if using shader module identifiers.
+     * With the nature of UUIDs, we don't risk random mismatches if
+     * a blob cache UUID is consumed by shader module identifiers and vice versa. */
     uint8_t cache_uuid[VK_UUID_SIZE];
     struct vkd3d_serialized_pipeline_toc_entry entries[];
 };
@@ -1776,7 +1891,14 @@ static void d3d12_pipeline_library_serialize_stream_archive_header(struct d3d12_
     header->reserved = 0;
     header->vkd3d_build = vkd3d_build;
     header->vkd3d_shader_interface_key = pipeline_library->device->shader_interface_key;
-    if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_USE_PIPELINE_CACHE_UUID)
+
+    if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER)
+    {
+        memcpy(header->cache_uuid,
+                pipeline_library->device->device_info.shader_module_identifier_properties.shaderModuleIdentifierAlgorithmUUID,
+                VK_UUID_SIZE);
+    }
+    else if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_USE_PIPELINE_CACHE_UUID)
         memcpy(header->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE);
     else
         memset(header->cache_uuid, 0, VK_UUID_SIZE);
@@ -1814,7 +1936,13 @@ static HRESULT d3d12_pipeline_library_serialize(struct d3d12_pipeline_library *p
     header->vkd3d_build = vkd3d_build;
     header->vkd3d_shader_interface_key = pipeline_library->device->shader_interface_key;
 
-    if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_USE_PIPELINE_CACHE_UUID)
+    if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER)
+    {
+        memcpy(header->cache_uuid,
+                pipeline_library->device->device_info.shader_module_identifier_properties.shaderModuleIdentifierAlgorithmUUID,
+                VK_UUID_SIZE);
+    }
+    else if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_USE_PIPELINE_CACHE_UUID)
         memcpy(header->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE);
     else
         memset(header->cache_uuid, 0, VK_UUID_SIZE);
@@ -2016,6 +2144,16 @@ static HRESULT d3d12_pipeline_library_validate_stream_format_header(struct d3d12
         if (memcmp(header->cache_uuid, device_properties->pipelineCacheUUID, VK_UUID_SIZE) != 0)
             return D3D12_ERROR_DRIVER_VERSION_MISMATCH;
 
+    if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER)
+    {
+        if (memcmp(header->cache_uuid,
+                device->device_info.shader_module_identifier_properties.shaderModuleIdentifierAlgorithmUUID,
+                VK_UUID_SIZE) != 0)
+        {
+            return D3D12_ERROR_DRIVER_VERSION_MISMATCH;
+        }
+    }
+
     return S_OK;
 }
 
@@ -2198,6 +2336,18 @@ static HRESULT d3d12_pipeline_library_read_blob_toc_format(struct d3d12_pipeline
         }
     }
 
+    if (pipeline_library->flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER)
+    {
+        if (memcmp(header->cache_uuid,
+                device->device_info.shader_module_identifier_properties.shaderModuleIdentifierAlgorithmUUID,
+                VK_UUID_SIZE) != 0)
+        {
+            if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_LOG)
+                INFO("Rejecting pipeline library due to shaderModuleIdentifierAlgorithmUUID mismatch.\n");
+            return D3D12_ERROR_DRIVER_VERSION_MISMATCH;
+        }
+    }
+
     total_toc_entries = header->pipeline_count + header->spirv_count + header->driver_cache_count;
 
     header_entry_size = offsetof(struct vkd3d_serialized_pipeline_library_toc, entries) +
@@ -2276,6 +2426,16 @@ static HRESULT d3d12_pipeline_library_init(struct d3d12_pipeline_library *pipeli
     pipeline_library->refcount = 1;
     pipeline_library->internal_refcount = 1;
     pipeline_library->flags = flags;
+
+    /* Mutually exclusive features. */
+    if ((flags & VKD3D_PIPELINE_LIBRARY_FLAG_USE_PIPELINE_CACHE_UUID) &&
+            (flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER))
+        return E_INVALIDARG;
+
+    /* Mutually exclusive features. */
+    if ((flags & VKD3D_PIPELINE_LIBRARY_FLAG_SAVE_FULL_SPIRV) &&
+            (flags & VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER))
+        return E_INVALIDARG;
 
     if (!blob_length && blob)
         return E_INVALIDARG;
@@ -3010,7 +3170,9 @@ HRESULT vkd3d_pipeline_library_init_disk_cache(struct vkd3d_pipeline_library_dis
     if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_SHADER_CACHE_SYNC))
         flags |= VKD3D_PIPELINE_LIBRARY_FLAG_STREAM_ARCHIVE_PARSE_ASYNC;
 
-    if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_NO_SERIALIZE_SPIRV))
+    if (device->device_info.shader_module_identifier_features.shaderModuleIdentifier)
+        flags |= VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER;
+    else if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_NO_SERIALIZE_SPIRV))
         flags |= VKD3D_PIPELINE_LIBRARY_FLAG_SAVE_FULL_SPIRV;
 
     /* For internal caches, we're mostly just concerned with caching SPIR-V.

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -122,6 +122,8 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_MESH_SHADER, EXT_mesh_shader),
     VK_EXTENSION(EXT_MUTABLE_DESCRIPTOR_TYPE, EXT_mutable_descriptor_type),
     VK_EXTENSION(EXT_HDR_METADATA, EXT_hdr_metadata),
+    VK_EXTENSION(EXT_PIPELINE_CREATION_CACHE_CONTROL, EXT_pipeline_creation_cache_control),
+    VK_EXTENSION(EXT_SHADER_MODULE_IDENTIFIER, EXT_shader_module_identifier),
     /* AMD extensions */
     VK_EXTENSION(AMD_BUFFER_MARKER, AMD_buffer_marker),
     VK_EXTENSION(AMD_DEVICE_COHERENT_MEMORY, AMD_device_coherent_memory),
@@ -1543,6 +1545,23 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         info->mesh_shader_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT;
         vk_prepend_struct(&info->features2, &info->mesh_shader_features);
         vk_prepend_struct(&info->properties2, &info->mesh_shader_properties);
+    }
+
+    if (vulkan_info->EXT_pipeline_creation_cache_control)
+    {
+        info->pipeline_creation_cache_control_features.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
+        vk_prepend_struct(&info->features2, &info->pipeline_creation_cache_control_features);
+    }
+
+    if (vulkan_info->EXT_shader_module_identifier)
+    {
+        info->shader_module_identifier_features.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT;
+        info->shader_module_identifier_properties.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_PROPERTIES_EXT;
+        vk_prepend_struct(&info->features2, &info->shader_module_identifier_features);
+        vk_prepend_struct(&info->properties2, &info->shader_module_identifier_properties);
     }
 
     /* Core in Vulkan 1.1. */

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2418,6 +2418,90 @@ static HRESULT vkd3d_compile_shader_stage(struct d3d12_pipeline_state *state, st
     return S_OK;
 }
 
+static bool vkd3d_shader_stages_require_work_locked(struct d3d12_pipeline_state *state)
+{
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
+    unsigned int i;
+
+    for (i = 0; i < graphics->stage_count; i++)
+    {
+        if (!graphics->code[i].size && graphics->stages[i].module == VK_NULL_HANDLE &&
+                graphics->cached_desc.bytecode[i].BytecodeLength)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static HRESULT vkd3d_late_compile_shader_stages(struct d3d12_pipeline_state *state)
+{
+    /* We are at risk of having to compile pipelines late if we return from CreatePipelineState without
+     * either code[i] or module being non-null. */
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
+    bool need_compile;
+    unsigned int i;
+    HRESULT hr;
+
+    rwlock_lock_read(&state->lock);
+    need_compile = vkd3d_shader_stages_require_work_locked(state);
+    rwlock_unlock_read(&state->lock);
+
+    if (!need_compile)
+        return S_OK;
+
+    /* Taking a writer lock here is kinda horrible,
+     * but we really shouldn't hit this path except in extreme circumstances. */
+    hr = S_OK;
+    rwlock_lock_write(&state->lock);
+
+    /* Need to verify that need_compile did not change between unlocking reader and locking writer. */
+    need_compile = vkd3d_shader_stages_require_work_locked(state);
+    if (!need_compile)
+        goto early_out;
+
+    for (i = 0; i < graphics->stage_count; i++)
+    {
+        if (graphics->stages[i].module == VK_NULL_HANDLE && !graphics->code[i].size &&
+                graphics->cached_desc.bytecode[i].BytecodeLength)
+        {
+            if (FAILED(hr = vkd3d_compile_shader_stage(state, state->device, graphics->cached_desc.bytecode_stages[i],
+                    &graphics->cached_desc.bytecode[i], &graphics->code[i])))
+                break;
+        }
+
+        if (graphics->stages[i].module == VK_NULL_HANDLE)
+        {
+            if (FAILED(hr = d3d12_pipeline_state_create_shader_module(state->device,
+                    &graphics->stages[i].module,
+                    &graphics->code[i])))
+            {
+                break;
+            }
+        }
+
+        /* We'll keep the module around here, no need to keep code/size pairs around for this.
+         * If we're in a situation where late compile is relevant, we're using PSO cached blobs,
+         * so we never expect to serialize out SPIR-V either way. */
+        vkd3d_shader_free_shader_code(&graphics->code[i]);
+        graphics->code[i].code = NULL;
+        graphics->code[i].size = 0;
+
+        /* Don't need the DXBC blob anymore either. */
+        if (graphics->cached_desc.bytecode_duped_mask & (1u << i))
+        {
+            vkd3d_free((void*)graphics->cached_desc.bytecode[i].pShaderBytecode);
+            memset(&graphics->cached_desc.bytecode[i], 0, sizeof(graphics->cached_desc.bytecode[i]));
+            graphics->cached_desc.bytecode_duped_mask &= ~(1u << i);
+        }
+    }
+
+early_out:
+    rwlock_unlock_write(&state->lock);
+    return hr;
+}
+
 static void vkd3d_report_pipeline_creation_feedback_results(const VkPipelineCreationFeedbackCreateInfoEXT *feedback)
 {
     uint32_t i;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -165,6 +165,8 @@ struct vkd3d_vulkan_info
     bool EXT_mesh_shader;
     bool EXT_mutable_descriptor_type; /* EXT promotion of VALVE one. */
     bool EXT_hdr_metadata;
+    bool EXT_pipeline_creation_cache_control;
+    bool EXT_shader_module_identifier;
     /* AMD device extensions */
     bool AMD_buffer_marker;
     bool AMD_device_coherent_memory;
@@ -3343,6 +3345,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceMaintenance4PropertiesKHR maintenance4_properties;
     VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV device_generated_commands_properties_nv;
     VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties;
+    VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT shader_module_identifier_properties;
 
     VkPhysicalDeviceProperties2KHR properties2;
 
@@ -3389,6 +3392,8 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR ray_tracing_maintenance1_features;
     VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV device_generated_commands_features_nv;
     VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features;
+    VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT pipeline_creation_cache_control_features;
+    VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_identifier_features;
 
     VkPhysicalDeviceFeatures2 features2;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1608,6 +1608,8 @@ struct d3d12_graphics_pipeline_state
     VkPipelineShaderStageCreateInfo stages[VKD3D_MAX_SHADER_STAGES];
     struct vkd3d_shader_code code[VKD3D_MAX_SHADER_STAGES];
     VkShaderStageFlags stage_flags;
+    VkShaderModuleIdentifierEXT identifiers[VKD3D_MAX_SHADER_STAGES];
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT identifier_create_infos[VKD3D_MAX_SHADER_STAGES];
     size_t stage_count;
 
     struct d3d12_graphics_pipeline_state_cached_desc cached_desc;
@@ -1662,6 +1664,8 @@ struct d3d12_compute_pipeline_state
 {
     VkPipeline vk_pipeline;
     struct vkd3d_shader_code code;
+    VkShaderModuleIdentifierEXT identifier;
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT identifier_create_info;
 };
 
 /* To be able to load a pipeline from cache, this information must match exactly,
@@ -1888,6 +1892,7 @@ enum vkd3d_pipeline_library_flags
     VKD3D_PIPELINE_LIBRARY_FLAG_STREAM_ARCHIVE = 1 << 4,
     /* We expect to parse archive from thread, so consider thread safety and cancellation points. */
     VKD3D_PIPELINE_LIBRARY_FLAG_STREAM_ARCHIVE_PARSE_ASYNC = 1 << 5,
+    VKD3D_PIPELINE_LIBRARY_FLAG_SHADER_IDENTIFIER = 1 << 6,
 };
 
 HRESULT d3d12_pipeline_library_create(struct d3d12_device *device, const void *blob,
@@ -1901,7 +1906,8 @@ HRESULT vkd3d_create_pipeline_cache_from_d3d12_desc(struct d3d12_device *device,
 HRESULT vkd3d_get_cached_spirv_code_from_d3d12_desc(
         const struct d3d12_cached_pipeline_state *state,
         VkShaderStageFlagBits stage,
-        struct vkd3d_shader_code *spirv_code);
+        struct vkd3d_shader_code *spirv_code,
+        VkPipelineShaderStageModuleIdentifierCreateInfoEXT *identifier);
 VkResult vkd3d_serialize_pipeline_state(struct d3d12_pipeline_library *pipeline_library,
         const struct d3d12_pipeline_state *state, size_t *size, void *data);
 HRESULT d3d12_cached_pipeline_state_validate(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1686,7 +1686,7 @@ struct d3d12_pipeline_state
 
     enum vkd3d_pipeline_type pipeline_type;
     VkPipelineCache vk_pso_cache;
-    spinlock_t lock;
+    rwlock_t lock;
 
     struct vkd3d_pipeline_cache_compatibility pipeline_cache_compat;
     struct d3d12_root_signature *root_signature;

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -332,6 +332,9 @@ VK_DEVICE_EXT_PFN(vkDestroyIndirectCommandsLayoutNV)
 VK_DEVICE_EXT_PFN(vkGetGeneratedCommandsMemoryRequirementsNV)
 VK_DEVICE_EXT_PFN(vkCmdExecuteGeneratedCommandsNV)
 
+/* VK_EXT_shader_module_identifier */
+VK_DEVICE_EXT_PFN(vkGetShaderModuleIdentifierEXT)
+
 #undef VK_INSTANCE_PFN
 #undef VK_INSTANCE_EXT_PFN
 #undef VK_DEVICE_PFN


### PR DESCRIPTION
Goal here is to shrink the vkd3d-proton.cache by 95% or so. I verified that I'm hitting "successfully created from identifier" in various scenarios.

I also verified the feasibility with Fossilize.

The basic idea we need to validate is that if we have the shader identifier cache, and a Fossilize archive of the pipelines, we can achieve 100% cache hits after a FOZ replay. I verified this in our test suite.

In the validation run, everything works as expected. In real games, pipeline_library_log confirms that all pipelines are created from identifier. I also verified that on a driver update, we fail to create from identifier, and we fall back to creating SPIR-V. The next run after that, we hit in the shader caches again, as expected.

```
#!/bin/bash

rm vkd3d-proton.cache*
rm -f /tmp/test-suite.*

delete_shader_caches()
{
	rm -rf ~/.cache/mesa_shader_cache
	rm -rf ~/.nv
	rm -rf ~/.cache/nv
}

delete_shader_caches

echo "=== First run ==="
FOSSILIZE=1 FOSSILIZE_DUMP_PATH=/tmp/test-suite VKD3D_TEST_FILTER="$1" VKD3D_CONFIG=pipeline_library_log,shader_cache_sync ./tests/d3d12 2>&1 | grep IDENTIFIER
echo "=== First run done ... ==="

fossilize-merge-db /tmp/test-suite.foz /tmp/test-suite.*.foz

delete_shader_caches

fossilize-replay /tmp/test-suite.foz --progress --spirv-val
echo "=== Verification run ==="
VKD3D_TEST_FILTER="$1" VKD3D_CONFIG=pipeline_library_log,shader_cache_sync ./tests/d3d12 2>&1 | grep IDENTIFIER
echo "=== Done ==="
```

NOTE: The full test suite ends up consuming >256 VkInstance creations, so the write-only cache system fails eventually (normal applications will never hit this scenario). The upper limit can be increased with a simple hack to Fossilize:

```
diff --git a/fossilize_db.cpp b/fossilize_db.cpp
index ce75f84..c270335 100644
--- a/fossilize_db.cpp
+++ b/fossilize_db.cpp
@@ -1883,7 +1883,7 @@ struct ConcurrentDatabase : DatabaseInterface
         {
             // Lazily create a new database. Open the database file exclusively to work concurrently with other processes.
             // Don't try forever.
-            for (unsigned index = 1; index < 256 && !writeonly_interface; index++)
+            for (unsigned index = 1; index < 1024 && !writeonly_interface; index++)
             {
```