### PR TITLE
vkd3d: Only skip initial layout transition if single subresource.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6782,7 +6782,7 @@ static void d3d12_command_list_before_copy_texture_region(struct d3d12_command_l
 
     if (info->batch_type == VKD3D_BATCH_TYPE_COPY_IMAGE_TO_BUFFER)
     {
-        d3d12_command_list_track_resource_usage(list, dst_resource, true);
+        d3d12_command_list_track_resource_usage(list, src_resource, true);
 
         /* We're going to do an image layout transition, so we can handle pending buffer barriers while we're at it.
          * After that barrier completes, we implicitly synchronize any outstanding copies, so we can drop the tracking.

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2226,6 +2226,7 @@ struct vkd3d_image_copy_info
     } copy;
     /* TODO: split d3d12_command_list_copy_image too, so this can be a local variable of before_copy_texture_region. */
     bool writes_full_subresource;
+    bool writes_full_resource;
     VkImageLayout src_layout;
     VkImageLayout dst_layout;
 };


### PR DESCRIPTION
write_full_subresource may allow us to transition from UNDEFINED so that we can skip the initial layout transition, but not in the scenario where the resource has multiple subresources.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>