### PR TITLE
Warning message shows expected block size.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2086,8 +2086,8 @@ static bool d3d12_resource_validate_texture_format(const D3D12_RESOURCE_DESC1 *d
     if (align(desc->Width, format->block_width) != desc->Width
             || align(desc->Height, format->block_height) != desc->Height)
     {
-        WARN("Invalid size %"PRIu64"x%u for block compressed format %#x.\n",
-                desc->Width, desc->Height, desc->Format);
+        WARN("Invalid size %"PRIu64"x%u for block compressed format %#x (block size: %ux%u).\n",
+                desc->Width, desc->Height, desc->Format, format->block_width, format->block_height);
         return false;
     }
 


### PR DESCRIPTION
This could've helped when I ran into the fact that Windows incorrectly accepts a 1x1 BCn texture and returnes valid copyable footprints.