### PR TITLE
vkd3d: Reset current_buffer_index when changing swapchain size.

### DIFF
--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -2304,7 +2304,16 @@ static HRESULT d3d12_swapchain_resize_buffers(struct d3d12_swapchain *swapchain,
     new_desc = swapchain->desc;
 
     if (buffer_count)
+    {
+        if (swapchain->current_buffer_index >= buffer_count)
+        {
+            /* Current buffer index may overflow here, so reset it. */
+            swapchain->current_buffer_index = 0;
+            WARN("Resetting current buffer index due to future overflow.\n");
+        }
         new_desc.BufferCount = buffer_count;
+    }
+
     if (!width || !height)
     {
         RECT client_rect;


### PR DESCRIPTION
If application lowers the count, we might access resources out of bounds later.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>