### PR TITLE
ci: Use github-checkout-action v3

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 


### PR DESCRIPTION
Fixes Node.js 12 deprecation warning.