### PR TITLE
Force initial placed transition for Assassin's Creed Valhalla

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -561,6 +561,9 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     { VKD3D_STRING_COMPARE_EXACT, "LostJudgment.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
     /* Marvel's Spider-Man Remastered (1817070) */
     { VKD3D_STRING_COMPARE_EXACT, "Spider-Man.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
+    /* Assassin's Creed Valhalla */
+    { VKD3D_STRING_COMPARE_EXACT, "ACValhalla.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
+    { VKD3D_STRING_COMPARE_EXACT, "ACValhalla_Plus.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
     { VKD3D_STRING_COMPARE_NEVER, NULL, 0, 0 }
 };
 


### PR DESCRIPTION
Caught some "Application uses placed resource that must be initialized explicitly" while trying to debug CPU hangs on NV. Does not fix that particular issue, but maybe it will let us avoid other headaches in this game.

[ACValhalla.log](https://github.com/HansKristian-Work/vkd3d-proton/files/9815401/ACValhalla.log)