### PR TITLE
Revert "vkd3d: Add NO_UPLOAD_HVV workaround on Elden Ring."

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -532,12 +532,10 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     { VKD3D_STRING_COMPARE_EXACT, "SOTTR.exe", VKD3D_CONFIG_FLAG_FORCE_NO_INVARIANT_POSITION, 0 },
     /* Elden Ring (1245620).
      * Game is really churny on committed memory allocations, and does not use NOT_ZEROED. Clearing works causes bubbles.
-     * It seems to work just fine however to skip the clears.
-     * No upload HVV works around disasterous CPU performance during skeleton animations, reported by multiple users.
-     * No obvious benefit for ReBAR in this title anyways. */
+     * It seems to work just fine however to skip the clears. */
     { VKD3D_STRING_COMPARE_EXACT, "eldenring.exe",
             VKD3D_CONFIG_FLAG_MEMORY_ALLOCATOR_SKIP_CLEAR | VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_IGNORE_MISMATCH_DRIVER |
-            VKD3D_CONFIG_FLAG_RECYCLE_COMMAND_POOLS | VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0 },
+            VKD3D_CONFIG_FLAG_RECYCLE_COMMAND_POOLS, 0 },
     /* Serious Sam 4 (257420).
      * Invariant workarounds cause graphical glitches when rendering foliage on NV. */
     { VKD3D_STRING_COMPARE_EXACT, "Sam4.exe", VKD3D_CONFIG_FLAG_FORCE_NO_INVARIANT_POSITION, 0 },


### PR DESCRIPTION
This reverts commit 53f00dfecc0332495ec899835c1581328a25af85.

The assertion that it did not affect GPU perf was wrong after all.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>