### PR TITLE
build: Declare setup command explicitely

### DIFF
--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -21,7 +21,7 @@ jobs:
       uses: Joshua-Ashton/arch-mingw-github-action@v8
       with:
         command: |
-          meson -Denable_tests=True -Denable_extras=True --cross-file=build-win32.txt --buildtype release build-mingw-x86
+          meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win32.txt --buildtype release build-mingw-x86
           ninja -C build-mingw-x86
 
     - name: Build MinGW x64
@@ -29,7 +29,7 @@ jobs:
       uses: Joshua-Ashton/arch-mingw-github-action@v8
       with:
         command: |
-          meson -Denable_tests=True -Denable_extras=True --cross-file=build-win64.txt --buildtype release build-mingw-x64
+          meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win64.txt --buildtype release build-mingw-x64
           ninja -C build-mingw-x64
 
     - name: Build Native GCC x86
@@ -40,7 +40,7 @@ jobs:
           export CC="gcc -m32"
           export CXX="g++ -m32"
           export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig"
-          meson -Denable_tests=True -Denable_extras=True --buildtype release build-native-gcc-x86
+          meson setup -Denable_tests=True -Denable_extras=True --buildtype release build-native-gcc-x86
           ninja -C build-native-gcc-x86
 
     - name: Build Native GCC x64
@@ -50,7 +50,7 @@ jobs:
         command: |
           export CC="gcc"
           export CXX="g++"
-          meson -Denable_tests=True -Denable_extras=True --buildtype release build-native-gcc-x64
+          meson setup -Denable_tests=True -Denable_extras=True --buildtype release build-native-gcc-x64
           ninja -C build-native-gcc-x64
 
     - name: Build Native Clang x86
@@ -61,7 +61,7 @@ jobs:
           export CC="clang -m32"
           export CXX="clang++ -m32"
           export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig"
-          meson -Denable_tests=True -Denable_extras=True --buildtype release build-native-clang-x86
+          meson setup -Denable_tests=True -Denable_extras=True --buildtype release build-native-clang-x86
           ninja -C build-native-clang-x86
 
     - name: Build Native Clang x64
@@ -71,5 +71,5 @@ jobs:
         command: |
           export CC="clang"
           export CXX="clang++"
-          meson -Denable_tests=True -Denable_extras=True --buildtype release build-native-clang-x64
+          meson setup -Denable_tests=True -Denable_extras=True --buildtype release build-native-clang-x64
           ninja -C build-native-clang-x64

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -40,7 +40,7 @@ jobs:
         & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x86 -host_arch=x64 -no_logo && set" `
           | % { , ($_ -Split '=', 2) } `
           | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
-        meson -Denable_tests=True -Denable_extras=True --buildtype release --backend vs2022 build-msvc-x86
+        meson setup -Denable_tests=True -Denable_extras=True --buildtype release --backend vs2022 build-msvc-x86
         msbuild -m build-msvc-x86/vkd3d-proton.sln
 
     - name: Build MSVC x64
@@ -49,5 +49,5 @@ jobs:
         & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x64 -host_arch=x64 -no_logo && set" `
           | % { , ($_ -Split '=', 2) } `
           | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
-        meson -Denable_tests=True -Denable_extras=True --buildtype release --backend vs2022 build-msvc-x64
+        meson setup -Denable_tests=True -Denable_extras=True --buildtype release --backend vs2022 build-msvc-x64
         msbuild -m build-msvc-x64/vkd3d-proton.sln

--- a/package-release.sh
+++ b/package-release.sh
@@ -56,7 +56,7 @@ function build_arch {
 
   cd "$VKD3D_SRC_DIR"
 
-  meson "$@"                           \
+  meson setup "$@"                     \
         --buildtype "${opt_buildtype}" \
         --prefix "$VKD3D_BUILD_DIR"    \
         $opt_strip                     \


### PR DESCRIPTION
This resolves the following meson warning:

```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```
