### PR TITLE
vkd3d: Remove IdentifierCreateInfo in late compile.

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2474,6 +2474,11 @@ static HRESULT vkd3d_late_compile_shader_stages(struct d3d12_pipeline_state *sta
             {
                 break;
             }
+
+            /* When a shader module is specified, VkPipelineShaderStageModuleIdentifierCreateInfoEXT must have an
+             * identifierSize of 0 or be absent. */
+            vk_remove_struct(&graphics->stages[i],
+                    VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT);
         }
 
         /* We'll keep the module around here, no need to keep code/size pairs around for this.
@@ -2642,6 +2647,11 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
                 &required_subgroup_size_info, NULL,
                 spirv_code)))
             return hr;
+
+        /* When a shader module is specified, VkPipelineShaderStageModuleIdentifierCreateInfoEXT must have an
+         * identifierSize of 0 or be absent. */
+        vk_remove_struct(&pipeline_info.stage,
+                VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT);
 
         vr = VK_CALL(vkCreateComputePipelines(device->vk_device,
                 vk_cache, 1, &pipeline_info, NULL, &state->compute.vk_pipeline));

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4033,6 +4033,19 @@ static inline void vk_prepend_struct(void *header, void *structure)
     vk_header->pNext = vk_structure;
 }
 
+static inline void vk_remove_struct(void *header, VkStructureType type)
+{
+    VkBaseInStructure *chain;
+    for (chain = (VkBaseInStructure *)header; chain->pNext; chain = (VkBaseInStructure *)chain->pNext)
+    {
+        if (chain->pNext->sType == type)
+        {
+            chain->pNext = chain->pNext->pNext;
+            break;
+        }
+    }
+}
+
 #define VKD3D_NULL_BUFFER_SIZE 16
 
 struct vkd3d_view_key


### PR DESCRIPTION
Fixes validation warning.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>