### PR TITLE
Workaround questionable damage shader in Borderlands 3

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -360,6 +360,9 @@ enum vkd3d_shader_quirk
     /* For Position builtins in Output storage class, emit Invariant decoration.
      * Normally, games have to emit Precise math for position, but if they forget ... */
     VKD3D_SHADER_QUIRK_INVARIANT_POSITION = (1 << 2),
+
+    /* Forces NoContract on every expression that can take it. */
+    VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH = (1 << 3),
 };
 
 struct vkd3d_shader_quirk_hash

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -7893,7 +7893,7 @@ static void vkd3d_dxbc_compiler_emit_alu_instruction(struct vkd3d_dxbc_compiler 
 
     val_id = vkd3d_spirv_build_op_trv(builder, &builder->function_stream, op, type_id,
             src_ids, instruction->src_count);
-    if (instruction->flags & VKD3DSI_PRECISE_XYZW)
+    if ((compiler->quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH) || (instruction->flags & VKD3DSI_PRECISE_XYZW))
         vkd3d_spirv_build_op_decorate(builder, val_id, SpvDecorationNoContraction, NULL, 0);
 
     vkd3d_dxbc_compiler_emit_store_dst(compiler, dst, val_id);
@@ -8034,8 +8034,11 @@ static void vkd3d_dxbc_compiler_emit_ext_glsl_instruction(struct vkd3d_dxbc_comp
         val_id = vkd3d_spirv_build_op_select(builder, type_id, cmp_id, val_id, sub_id);
     }
 
-    if (glsl_inst == GLSLstd450Fma && (instruction->flags & VKD3DSI_PRECISE_XYZW))
+    if (glsl_inst == GLSLstd450Fma && ((compiler->quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH) ||
+            (instruction->flags & VKD3DSI_PRECISE_XYZW)))
+    {
         vkd3d_spirv_build_op_decorate(builder, val_id, SpvDecorationNoContraction, NULL, 0);
+    }
 
     vkd3d_dxbc_compiler_emit_store_dst(compiler, dst, val_id);
 }
@@ -8148,7 +8151,8 @@ static void vkd3d_dxbc_compiler_emit_dot(struct vkd3d_dxbc_compiler *compiler,
         val_id = vkd3d_dxbc_compiler_emit_construct_vector(compiler,
                 component_type, component_count, val_id, 0, 1);
     }
-    if (instruction->flags & VKD3DSI_PRECISE_XYZW)
+
+    if ((compiler->quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH) || (instruction->flags & VKD3DSI_PRECISE_XYZW))
         vkd3d_spirv_build_op_decorate(builder, val_id, SpvDecorationNoContraction, NULL, 0);
 
     vkd3d_dxbc_compiler_emit_store_dst(compiler, dst, val_id);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -586,6 +586,17 @@ static const struct vkd3d_shader_quirk_info f1_2019_2020_quirks = {
     NULL, 0, VKD3D_SHADER_QUIRK_FORCE_TGSM_BARRIERS,
 };
 
+static const struct vkd3d_shader_quirk_hash borderlands3_hashes[] = {
+    /* Shader breaks due to floor(a / exp(x)) being refactored to floor(a * exp(-x))
+     * and shader does not expect this.
+     * See https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/19910. */
+    { 0xbf0af7db6a7fb86bull, VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH },
+};
+
+static const struct vkd3d_shader_quirk_info borderlands3_quirks = {
+    borderlands3_hashes, ARRAY_SIZE(borderlands3_hashes), 0,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
@@ -593,6 +604,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
     /* F1 2019 (928600) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2019_dx12.exe", &f1_2019_2020_quirks },
+    /* Borderlands 3 (397540) */
+    { VKD3D_STRING_COMPARE_EXACT, "Borderlands3.exe", &borderlands3_quirks },
     /* MSVC fails to compile empty array. */
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };


### PR DESCRIPTION
Fix #1282.

As identified in https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/19910, the shader relies on an extremely weird arithmetic expression to not refactor.

```
    r1.z = r1.x * 3.3219280242919921875;
    r1.z = exp2(r1.z);
    r0.w /= r1.z;
    r0.w = floor(r0.w);
```

If this is written as:

```
    r1.z = r1.x * 3.3219280242919921875;
    r1.z = exp2(r1.z);
    precise float tmp = r0.w / r1.z;
    r0.w = tmp;
    r0.w = floor(r0.w);
```

It works.

Adds a quirk config to force NO_CONTRACT on all math.