### PR TITLE
Refactor how we allocate ReBAR memory.

### DIFF
--- a/libs/vkd3d/breadcrumbs.c
+++ b/libs/vkd3d/breadcrumbs.c
@@ -140,7 +140,7 @@ HRESULT vkd3d_breadcrumb_tracer_init(struct vkd3d_breadcrumb_tracer *tracer, str
                     VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD;
         }
 
-        if (FAILED(hr = vkd3d_allocate_buffer_memory(device, tracer->host_buffer,
+        if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, tracer->host_buffer,
                 memory_props, &tracer->host_buffer_memory)))
         {
             goto err;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -13380,7 +13380,7 @@ static HRESULT d3d12_command_signature_init_patch_commands_buffer(struct d3d12_c
             &buffer_desc, &signature->state_template.buffer)))
         return hr;
 
-    if (FAILED(hr = vkd3d_allocate_buffer_memory(device, signature->state_template.buffer,
+    if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, signature->state_template.buffer,
             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
             &signature->state_template.memory)))
         return hr;

--- a/libs/vkd3d/debug_ring.c
+++ b/libs/vkd3d/debug_ring.c
@@ -412,7 +412,7 @@ HRESULT vkd3d_shader_debug_ring_init(struct vkd3d_shader_debug_ring *ring,
         }
     }
 
-    if (FAILED(vkd3d_allocate_buffer_memory(device, ring->host_buffer,
+    if (FAILED(vkd3d_allocate_internal_buffer_memory(device, ring->host_buffer,
             memory_props, &ring->host_buffer_memory)))
         goto err_free_buffers;
 
@@ -437,7 +437,7 @@ HRESULT vkd3d_shader_debug_ring_init(struct vkd3d_shader_debug_ring *ring,
             memory_props |= VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD;
     }
 
-    if (FAILED(vkd3d_allocate_buffer_memory(device, ring->device_atomic_buffer,
+    if (FAILED(vkd3d_allocate_internal_buffer_memory(device, ring->device_atomic_buffer,
             memory_props, &ring->device_atomic_buffer_memory)))
         goto err_free_buffers;
 

--- a/libs/vkd3d/descriptor_debug.c
+++ b/libs/vkd3d/descriptor_debug.c
@@ -230,7 +230,7 @@ HRESULT vkd3d_descriptor_debug_alloc_global_info(
         return hr;
     }
 
-    if (FAILED(hr = vkd3d_allocate_buffer_memory(device, global_info->vk_buffer,
+    if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, global_info->vk_buffer,
             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
             &global_info->device_allocation)))
     {

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -1566,31 +1566,3 @@ HRESULT vkd3d_allocate_buffer_memory(struct d3d12_device *device, VkBuffer vk_bu
 
     return hr;
 }
-
-HRESULT vkd3d_allocate_image_memory(struct d3d12_device *device, VkImage vk_image,
-        VkMemoryPropertyFlags type_flags,
-        struct vkd3d_device_memory_allocation *allocation)
-{
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    VkMemoryRequirements memory_requirements;
-    VkBindImageMemoryInfo bind_info;
-    VkResult vr;
-    HRESULT hr;
-
-    VK_CALL(vkGetImageMemoryRequirements(device->vk_device, vk_image, &memory_requirements));
-
-    if (FAILED(hr = vkd3d_allocate_device_memory(device, memory_requirements.size,
-            type_flags, memory_requirements.memoryTypeBits, NULL, allocation)))
-        return hr;
-
-    bind_info.sType = VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO;
-    bind_info.pNext = NULL;
-    bind_info.image = vk_image;
-    bind_info.memory = allocation->vk_memory;
-    bind_info.memoryOffset = 0;
-
-    if (FAILED(vr = VK_CALL(vkBindImageMemory2KHR(device->vk_device, 1, &bind_info))))
-        return hresult_from_vk_result(vr);
-
-    return hr;
-}

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -1534,7 +1534,7 @@ HRESULT vkd3d_allocate_heap_memory(struct d3d12_device *device, struct vkd3d_mem
     return hr;
 }
 
-HRESULT vkd3d_allocate_buffer_memory(struct d3d12_device *device, VkBuffer vk_buffer,
+HRESULT vkd3d_allocate_internal_buffer_memory(struct d3d12_device *device, VkBuffer vk_buffer,
         VkMemoryPropertyFlags type_flags,
         struct vkd3d_device_memory_allocation *allocation)
 {

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -169,14 +169,10 @@ void vkd3d_free_device_memory(struct d3d12_device *device, const struct vkd3d_de
 }
 
 static HRESULT vkd3d_try_allocate_device_memory(struct d3d12_device *device,
-        VkDeviceSize size, VkMemoryPropertyFlags type_flags, uint32_t base_type_mask,
+        VkDeviceSize size, VkMemoryPropertyFlags type_flags, const uint32_t base_type_mask,
         void *pNext, struct vkd3d_device_memory_allocation *allocation)
 {
     const VkPhysicalDeviceMemoryProperties *memory_props = &device->memory_properties;
-    /* We consider CACHED optional here if we cannot find a memory type that supports it.
-     * Failing to allocate CACHED is not a scenario where we would fall back. */
-    const VkMemoryPropertyFlags optional_flags_host = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-    const VkMemoryPropertyFlags optional_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     struct vkd3d_memory_info *memory_info = &device->memory_info;
     VkMemoryAllocateInfo allocate_info;
@@ -186,101 +182,109 @@ static HRESULT vkd3d_try_allocate_device_memory(struct d3d12_device *device,
     uint32_t type_mask;
     VkResult vr;
 
-    /* buffer_mask / sampled_mask etc will generally take care of this,
-     * but for certain fallback scenarios where we select other memory
-     * types, we need to mask here as well. */
-    type_mask = base_type_mask & device->memory_info.global_mask;
-
+    type_mask = base_type_mask;
     allocate_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
     allocate_info.pNext = pNext;
     allocate_info.allocationSize = size;
+    allocate_info.memoryTypeIndex = UINT32_MAX;
 
     while (type_mask)
     {
         uint32_t type_index = vkd3d_bitmask_iter32(&type_mask);
-
-        if ((memory_props->memoryTypes[type_index].propertyFlags & type_flags) != type_flags)
-            continue;
-
-        allocate_info.memoryTypeIndex = type_index;
-
-        budget_sensitive = !!(device->memory_info.budget_sensitive_mask & (1u << type_index));
-        if (budget_sensitive)
+        if ((memory_props->memoryTypes[type_index].propertyFlags & type_flags) == type_flags)
         {
-            type_budget = &memory_info->type_budget[type_index];
-            type_current = &memory_info->type_current[type_index];
-            pthread_mutex_lock(&memory_info->budget_lock);
-            if (*type_current + size > *type_budget)
-            {
-                if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_LOG_MEMORY_BUDGET)
-                {
-                    INFO("Attempting to allocate from memory type %u, but exceeding fixed budget: %"PRIu64" + %"PRIu64" > %"PRIu64".\n",
-                            type_index, *type_current, size, *type_budget);
-                }
-                pthread_mutex_unlock(&memory_info->budget_lock);
-
-                /* If we're out of DEVICE budget, don't try other types. */
-                if (type_flags & optional_flags)
-                    return E_OUTOFMEMORY;
-                else
-                    continue;
-            }
+            allocate_info.memoryTypeIndex = type_index;
+            break;
         }
+    }
 
-        vr = VK_CALL(vkAllocateMemory(device->vk_device, &allocate_info, NULL, &allocation->vk_memory));
+    if (allocate_info.memoryTypeIndex == UINT32_MAX)
+    {
+        /* We consider CACHED optional here if we cannot find a memory type that supports it.
+         * Failing to allocate CACHED is not a scenario where we would fall back. */
+        const VkMemoryPropertyFlags optional_flags_host = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+        const VkMemoryPropertyFlags optional_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 
-        if (budget_sensitive)
+        /* If we got here it means the requested type simply does not exist.
+         * This can happen if we request PCI-e BAR,
+         * but the driver somehow refuses to allow DEVICE | HOST_VISIBLE for a particular resource.
+         * The fallback logic assumes that we attempted to allocate memory from a particular heap, and it will try
+         * another allocation if it can identify at least 2 GPU heaps, but in this case, the calling code
+         * might infer that we failed to allocate from a single supported GPU heap, and therefore there is no need
+         * to try more. We still have not actually tried anything, so query the memory types again. */
+        if (type_flags & (optional_flags | optional_flags_host))
         {
-            if (vr == VK_SUCCESS)
-            {
-                *type_current += size;
-                if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_LOG_MEMORY_BUDGET)
-                {
-                    INFO("Allocated memory of type %u, new total allocated size %"PRIu64" MiB.\n",
-                            type_index, *type_current / (1024 * 1024));
-                }
-            }
-            pthread_mutex_unlock(&memory_info->budget_lock);
+            return vkd3d_try_allocate_device_memory(device, size,
+                    type_flags & ~(optional_flags | optional_flags_host),
+                    base_type_mask, pNext, allocation);
         }
-        else if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_LOG_MEMORY_BUDGET)
+        else
         {
-            INFO("%s memory of type #%u, size %"PRIu64" KiB.\n",
-                    (vr == VK_SUCCESS ? "Allocated" : "Failed to allocate"),
-                    type_index, allocate_info.allocationSize / 1024);
-        }
-
-        if (vr == VK_SUCCESS)
-        {
-            allocation->vk_memory_type = type_index;
-            allocation->size = size;
-            return S_OK;
-        }
-        else if (type_flags & optional_flags)
-        {
-            /* If we fail to allocate DEVICE_LOCAL memory, immediately fail the call.
-             * This way we avoid any attempt to fall back to PCI-e BAR memory types
-             * which are also DEVICE_LOCAL.
-             * After failure, the calling code removes the DEVICE_LOCAL_BIT flag and tries again,
-             * where we will fall back to system memory instead. */
+            FIXME("Found no suitable memory type for requested type_flags #%x.\n", type_flags);
             return E_OUTOFMEMORY;
         }
     }
 
-    /* If we got here it means the requested type simply does not exist.
-     * This can happen if we request PCI-e BAR,
-     * but the driver somehow refuses to allow DEVICE | HOST_VISIBLE for a particular resource.
-     * The fallback logic assumes that we attempted to allocate memory from a particular heap, and it will try
-     * another allocation if it can identify at least 2 GPU heaps, but in this case, the calling code
-     * might infer that we failed to allocate from a single supported GPU heap, and therefore there is no need
-     * to try more. We still have not actually tried anything, so query the memory types again. */
-    if (type_flags & (optional_flags | optional_flags_host))
+    /* Once we have found a suitable memory type, only attempt to allocate that memory type.
+     * This avoids some problems by design:
+     * - If we want to allocate DEVICE_LOCAL memory, we don't try to fallback to PCI-e BAR memory by mistake.
+     * - If we want to allocate system memory, we don't try to fallback to PCI-e BAR memory by mistake.
+     * - There is no reasonable scenario where we can expect one memory type to fail, and another memory type
+     *   with more memory property bits set to pass. This makes use of the rule where memory types which are a super-set
+     *   of another must have a larger type index.
+     * - We will only attempt to allocate PCI-e BAR memory if DEVICE_LOCAL | HOST_VISIBLE is set, otherwise we
+     *   will find a candidate memory type which is either DEVICE_LOCAL or HOST_VISIBLE before we find a PCI-e BAR type.
+     * - For iGPU where everything is DEVICE_LOCAL | HOST_VISIBLE, we will just find that memory type first anyways,
+     *   but there we don't have anything to worry about w.r.t. PCI-e BAR.
+     */
+
+    /* Budgets only really apply to PCI-e BAR or other "special" types which always have a fallback. */
+    budget_sensitive = !!(device->memory_info.budget_sensitive_mask & (1u << allocate_info.memoryTypeIndex));
+    if (budget_sensitive)
     {
-        return vkd3d_try_allocate_device_memory(device, size,
-                type_flags & ~(optional_flags | optional_flags_host),
-                base_type_mask, pNext, allocation);
+        type_budget = &memory_info->type_budget[allocate_info.memoryTypeIndex];
+        type_current = &memory_info->type_current[allocate_info.memoryTypeIndex];
+        pthread_mutex_lock(&memory_info->budget_lock);
+        if (*type_current + size > *type_budget)
+        {
+            if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_LOG_MEMORY_BUDGET)
+            {
+                INFO("Attempting to allocate from memory type %u, but exceeding fixed budget: %"PRIu64" + %"PRIu64" > %"PRIu64".\n",
+                        allocate_info.memoryTypeIndex, *type_current, size, *type_budget);
+            }
+            pthread_mutex_unlock(&memory_info->budget_lock);
+            return E_OUTOFMEMORY;
+        }
     }
-    else
+
+    vr = VK_CALL(vkAllocateMemory(device->vk_device, &allocate_info, NULL, &allocation->vk_memory));
+
+    if (budget_sensitive)
+    {
+        if (vr == VK_SUCCESS)
+        {
+            *type_current += size;
+            if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_LOG_MEMORY_BUDGET)
+            {
+                INFO("Allocated memory of type %u, new total allocated size %"PRIu64" MiB.\n",
+                        allocate_info.memoryTypeIndex, *type_current / (1024 * 1024));
+            }
+        }
+        pthread_mutex_unlock(&memory_info->budget_lock);
+    }
+    else if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_LOG_MEMORY_BUDGET)
+    {
+        INFO("%s memory of type #%u, size %"PRIu64" KiB.\n",
+                (vr == VK_SUCCESS ? "Allocated" : "Failed to allocate"),
+                allocate_info.memoryTypeIndex, allocate_info.allocationSize / 1024);
+    }
+
+    if (vr != VK_SUCCESS)
         return E_OUTOFMEMORY;
+
+    allocation->vk_memory_type = allocate_info.memoryTypeIndex;
+    allocation->size = size;
+    return S_OK;
 }
 
 static bool vkd3d_memory_info_type_mask_covers_multiple_memory_heaps(
@@ -534,9 +538,7 @@ static HRESULT vkd3d_memory_allocation_init(struct vkd3d_memory_allocation *allo
      * we must not look at heap_flags, since we might end up noping out
      * the memory types we want to allocate with. */
     type_mask = memory_requirements.memoryTypeBits;
-    if (info->flags & VKD3D_ALLOCATION_FLAG_DEDICATED)
-        type_mask &= device->memory_info.global_mask;
-    else
+    if (!(info->flags & VKD3D_ALLOCATION_FLAG_DEDICATED))
         type_mask &= vkd3d_select_memory_types(device, &info->heap_properties, info->heap_flags);
 
     /* Allocate actual backing storage */
@@ -1319,7 +1321,6 @@ static HRESULT vkd3d_memory_allocator_try_suballocate_memory(struct vkd3d_memory
     HRESULT hr;
     size_t i;
 
-    type_mask &= device->memory_info.global_mask;
     type_mask &= memory_requirements->memoryTypeBits;
 
     for (i = 0; i < allocator->chunks_count; i++)

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -74,11 +74,7 @@ static HRESULT vkd3d_select_memory_flags(struct d3d12_device *device, const D3D1
             break;
 
         case D3D12_HEAP_TYPE_UPLOAD:
-            *type_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-            if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_FORCE_HOST_CACHED)
-                *type_flags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-            else if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV))
-                *type_flags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+            *type_flags = device->memory_info.upload_heap_memory_properties;
             break;
 
         case D3D12_HEAP_TYPE_READBACK:

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5748,7 +5748,7 @@ static HRESULT d3d12_descriptor_heap_init_data_buffer(struct d3d12_descriptor_he
 
         property_flags = device->memory_info.descriptor_heap_memory_properties;
 
-        if (FAILED(hr = vkd3d_allocate_buffer_memory(device, descriptor_heap->vk_buffer,
+        if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, descriptor_heap->vk_buffer,
                 property_flags, &descriptor_heap->device_allocation)))
             return hr;
 
@@ -6346,7 +6346,7 @@ HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_H
             return hr;
         }
 
-        if (FAILED(hr = vkd3d_allocate_buffer_memory(device, object->vk_buffer,
+        if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, object->vk_buffer,
                 VK_MEMORY_HEAP_DEVICE_LOCAL_BIT, &object->device_allocation)))
         {
             VK_CALL(vkDestroyBuffer(device->vk_device, object->vk_buffer, NULL));

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2402,7 +2402,7 @@ static HRESULT d3d12_resource_bind_sparse_metadata(struct d3d12_resource *resour
     VK_CALL(vkGetImageMemoryRequirements(device->vk_device, resource->res.vk_image, &memory_requirements));
 
     if ((vr = vkd3d_allocate_device_memory(device, metadata_size, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            memory_requirements.memoryTypeBits, NULL, &sparse->vk_metadata_memory)))
+            memory_requirements.memoryTypeBits, NULL, true, &sparse->vk_metadata_memory)))
     {
         ERR("Failed to allocate device memory for sparse metadata, vr %d.\n", vr);
         hr = hresult_from_vk_result(vr);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -955,7 +955,7 @@ static inline struct d3d12_resource *impl_from_ID3D12Resource(ID3D12Resource *if
 
 HRESULT vkd3d_allocate_device_memory(struct d3d12_device *device,
         VkDeviceSize size, VkMemoryPropertyFlags type_flags, uint32_t type_mask,
-        void *pNext, struct vkd3d_device_memory_allocation *allocation);
+        void *pNext, bool respect_budget, struct vkd3d_device_memory_allocation *allocation);
 void vkd3d_free_device_memory(struct d3d12_device *device,
         const struct vkd3d_device_memory_allocation *allocation);
 HRESULT vkd3d_allocate_internal_buffer_memory(struct d3d12_device *device, VkBuffer vk_buffer,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2988,6 +2988,9 @@ struct vkd3d_memory_info
      * For images, we only include memory types which are OPTIMAL tiled. */
     struct vkd3d_memory_info_domain non_cpu_accessible_domain;
 
+    VkMemoryPropertyFlags upload_heap_memory_properties;
+    VkMemoryPropertyFlags descriptor_heap_memory_properties;
+
     uint32_t budget_sensitive_mask;
     VkDeviceSize type_budget[VK_MAX_MEMORY_TYPES];
     VkDeviceSize type_current[VK_MAX_MEMORY_TYPES];

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2976,7 +2976,6 @@ struct vkd3d_memory_info_domain
 
 struct vkd3d_memory_info
 {
-    uint32_t global_mask;
     /* Includes normal system memory, but also resizable BAR memory.
      * Only types which have HOST_VISIBLE_BIT can be in this domain.
      * For images, we only include memory types which are LINEAR tiled. */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -958,7 +958,7 @@ HRESULT vkd3d_allocate_device_memory(struct d3d12_device *device,
         void *pNext, struct vkd3d_device_memory_allocation *allocation);
 void vkd3d_free_device_memory(struct d3d12_device *device,
         const struct vkd3d_device_memory_allocation *allocation);
-HRESULT vkd3d_allocate_buffer_memory(struct d3d12_device *device, VkBuffer vk_buffer,
+HRESULT vkd3d_allocate_internal_buffer_memory(struct d3d12_device *device, VkBuffer vk_buffer,
         VkMemoryPropertyFlags type_flags,
         struct vkd3d_device_memory_allocation *allocation);
 HRESULT vkd3d_create_buffer(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -961,9 +961,6 @@ void vkd3d_free_device_memory(struct d3d12_device *device,
 HRESULT vkd3d_allocate_buffer_memory(struct d3d12_device *device, VkBuffer vk_buffer,
         VkMemoryPropertyFlags type_flags,
         struct vkd3d_device_memory_allocation *allocation);
-HRESULT vkd3d_allocate_image_memory(struct d3d12_device *device, VkImage vk_image,
-        VkMemoryPropertyFlags type_flags,
-        struct vkd3d_device_memory_allocation *allocation);
 HRESULT vkd3d_create_buffer(struct d3d12_device *device,
         const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags,
         const D3D12_RESOURCE_DESC1 *desc, VkBuffer *vk_buffer);


### PR DESCRIPTION
For descriptor buffers to work optimally, we need to consider:

- Applying the ReBAR budget is problematic. We really want descriptors in ReBAR regardless of what app did with UPLOAD heaps.
- Remove the global mask. Allows some allocations to use BAR and some to skip.
- Add ~5GB limit. Avoids OOMing 4 GB cards in some cases where they work with no_upload_hvv.
- Refactor memory properties for UPLOAD / descriptor heaps to be resolved up front.
- Rename vkd3d_allocate_buffer_memory is only used for internal private allocations, so clarify that in code.
- For smol BAR, do not use BAR for UPLOAD heap, but allow it for internal descriptor allocations.

Fix #1273.