### PR TITLE
vkd3d: Add NO_UPLOAD_HVV workaround on Age of Empires IV.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -566,6 +566,8 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     { VKD3D_STRING_COMPARE_EXACT, "Spider-Man.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
     /* Marvel’s Spider-Man: Miles Morales (1817190) */
     { VKD3D_STRING_COMPARE_EXACT, "MilesMorales.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
+    /* Age of Empires IV: Anniversary Edition (1466860) */
+    { VKD3D_STRING_COMPARE_EXACT, "RelicCardinal.exe", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0 },
     { VKD3D_STRING_COMPARE_NEVER, NULL, 0, 0 }
 };
 


### PR DESCRIPTION
Having constructions sites of buildings on the screen dramatically drops FPS.

https://github.com/HansKristian-Work/vkd3d-proton/issues/1323

Signed-off-by: Timo Gurr <timo.gurr@gmail.com>

(Additional note: I don't own the game myself)