### PR TITLE
meson/vkd3d-common: add lib_dl / threads_dep to the list of dependencies

### DIFF
--- a/libs/vkd3d-common/meson.build
+++ b/libs/vkd3d-common/meson.build
@@ -10,6 +10,7 @@ vkd3d_common_src = [
 
 vkd3d_common_lib = static_library('vkd3d_common', vkd3d_common_src, vkd3d_header_files,
   include_directories : vkd3d_private_includes,
+  dependencies        : vkd3d_extra_libs,
   override_options    : [ 'c_std='+vkd3d_c_std ])
 
 vkd3d_common_dep = declare_dependency(


### PR DESCRIPTION
This is needed to build in Mesa CI, which uses Debian testing and mold.

Signed-off-by: Martin Roukala (né Peres) <martin.roukala@mupuf.org>