### PR TITLE
vkd3d: Clamp maxAnisotropy.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5204,6 +5204,12 @@ static HRESULT d3d12_create_sampler(struct d3d12_device *device,
     sampler_desc.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
     sampler_desc.unnormalizedCoordinates = VK_FALSE;
 
+    if (sampler_desc.maxAnisotropy < 1.0f)
+        sampler_desc.anisotropyEnable = VK_FALSE;
+
+    if (sampler_desc.anisotropyEnable)
+        sampler_desc.maxAnisotropy = min(16.0f, sampler_desc.maxAnisotropy);
+
     if (d3d12_sampler_needs_border_color(desc->AddressU, desc->AddressV, desc->AddressW))
         sampler_desc.borderColor = vk_border_color_from_d3d12(device, desc->BorderColor);
 


### PR DESCRIPTION
Witcher 3 uses a maxAnisotropy value of 0.0 which is illegal and crashes the Nvidia Vulkan driver.

Docs:
> Clamping value used if D3D12_FILTER_ANISOTROPIC or D3D12_FILTER_COMPARISON_ANISOTROPIC is specified in Filter. Valid values are between 1 and 16.

Alternatively we could also disable anisotropy when a game passes a value of 0.0.