### PR TITLE
vkd3d: Update to disable KHR_present_wait only on NV 525.60.x drivers.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1207,9 +1207,10 @@ static void vkd3d_physical_device_info_apply_workarounds(struct vkd3d_physical_d
         info->properties2.properties.limits.minStorageBufferOffsetAlignment = 4;
 
     if (info->driver_properties.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY &&
-            VKD3D_DRIVER_VERSION_MAJOR_NV(info->properties2.properties.driverVersion) == 525)
+            VKD3D_DRIVER_VERSION_MAJOR_NV(info->properties2.properties.driverVersion) == 525 &&
+            VKD3D_DRIVER_VERSION_MINOR_NV(info->properties2.properties.driverVersion) == 60)
     {
-        WARN("Disabling VK_KHR_present_wait on NV 525.x drivers due to GPU hangs on PRIME setups.\n");
+        WARN("Disabling VK_KHR_present_wait on NV 525.60.x drivers due to GPU hangs on PRIME setups.\n");
         device->vk_info.KHR_present_wait = false;
         device->vk_info.KHR_present_id = false;
         device->device_info.present_wait_features.presentWait = false;


### PR DESCRIPTION
The [release notes](https://www.nvidia.com/download/driverResults.aspx/198284/en-us/) for 525.78.01 mention this appears to be fixed with this driver:
* Fixed a bug where usage of `VK_KHR_present_id` could cause applications to crash with Xid 32 errors.

so narow down the version check to 525.60.x as for 525.60.x there were [525.60.11](https://download.nvidia.com/XFree86/Linux-x86_64/525.60.11/) and [525.60.13](https://download.nvidia.com/XFree86/Linux-x86_64/525.60.13/) (CUDA).

Note: I didn't yet had the opportunity to actually test this, also while  `VK_KHR_present_id` is mentioned I'm unsure if the same is true for `VK_KHR_present_wait`. I also don't have a PRIME setup to test with but ran into the issue earlier on a regular desktop with a single descrete GPU where e.g Deep Rock Galactic DX12 stopped working for me after the upgrade to 525.60.11 until either running a vkd3d version implementing the workaround or manually passing `VKD3D_DISABLE_EXTENSIONS=VK_KHR_present_id,VK_KHR_present_wait %command%`.