### PR TITLE
vkd3d: Take into account heap offset for image offset alignment.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3009,7 +3009,7 @@ HRESULT d3d12_resource_create_placed(struct d3d12_device *device, const D3D12_RE
 
         /* Align manually. This works because we padded the required allocation size reported to the app. */
         VK_CALL(vkGetImageMemoryRequirements(device->vk_device, object->res.vk_image, &memory_requirements));
-        heap_offset = align(heap_offset, memory_requirements.alignment);
+        heap_offset = align(heap->allocation.offset + heap_offset, memory_requirements.alignment) - heap->allocation.offset;
 
         if (heap_offset + memory_requirements.size > heap->allocation.resource.size)
         {


### PR DESCRIPTION
We can't make the assumption that the heap will be aligned to the image alignment in case the image alignment needs to be larger than the default alignment.

Signed-off-by: Bas Nieuwenhuizen <bas@basnieuwenhuizen.nl>