### PR TITLE
Witcher 3 RT barrier workaround

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -11468,6 +11468,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_BuildRaytracingAccelerationStru
     build_info.build_info.scratchData.deviceAddress = desc->ScratchAccelerationStructureData;
 
     d3d12_command_list_end_current_render_pass(list, true);
+    d3d12_command_list_end_transfer_batch(list);
+
     VK_CALL(vkCmdBuildAccelerationStructuresKHR(list->vk_command_buffer, 1,
             &build_info.build_info, build_info.build_range_ptrs));
 
@@ -11520,6 +11522,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
     }
 
     d3d12_command_list_end_current_render_pass(list, true);
+    d3d12_command_list_end_transfer_batch(list);
     vkd3d_acceleration_structure_copy(list, dst_data, src_data, mode);
 
     VKD3D_BREADCRUMB_COMMAND(COPY_RTAS);
@@ -11603,6 +11606,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_DispatchRays(d3d12_command_list
     miss_table = convert_strided_range(&desc->MissShaderTable);
     hit_table = convert_strided_range(&desc->HitGroupTable);
     callable_table = convert_strided_range(&desc->CallableShaderTable);
+
+    d3d12_command_list_end_transfer_batch(list);
 
     if (!d3d12_command_list_update_raygen_state(list))
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2487,6 +2487,8 @@ struct d3d12_command_list
 
     struct d3d12_transfer_batch_state transfer_batch;
 
+    bool has_unsynced_accel_struct_build;
+
     struct vkd3d_private_store private_store;
 
 #ifdef VKD3D_ENABLE_BREADCRUMBS


### PR DESCRIPTION
This fixes a GPU hang when loading into the game with ray tracing enabled.

I've tried a lot of different things including lots of different tracking within a single command list and none of it worked.
I also noticed that they create the command lists to build acceleration structures on different threads, so my best guess is that they don't synchronize properly *across* command lists.