### PR TITLE
ASan fixes

### DIFF
--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -419,6 +419,7 @@ int vkd3d_shader_compile_dxbc(const struct vkd3d_shader_code *dxbc,
         if ((ret = vkd3d_shader_validate_shader_type(parser.shader_version.type, shader_interface_info->stage)) < 0)
         {
             vkd3d_shader_scan_destroy(&scan_info);
+            vkd3d_shader_parser_destroy(&parser);
             return ret;
         }
     }

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -12436,8 +12436,9 @@ static void STDMETHODCALLTYPE d3d12_command_queue_ExecuteCommandLists(ID3D12Comm
         for (i = 0; i < command_list_count; ++i)
         {
             cmd_list = unsafe_impl_from_ID3D12CommandList(command_lists[i]);
-            memcpy(transitions, cmd_list->init_transitions,
-                   cmd_list->init_transitions_count * sizeof(*transitions));
+            if (cmd_list->init_transitions_count)
+                memcpy(transitions, cmd_list->init_transitions,
+                        cmd_list->init_transitions_count * sizeof(*transitions));
             transitions += cmd_list->init_transitions_count;
         }
     }


### PR DESCRIPTION
One leak on error path and one memcpy against NULL issue (technically UB), found with ASan while running tests.