### PR TITLE
d3d12: Allocate VkInstance as a global singleton.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -214,7 +214,6 @@ struct vkd3d_instance
 
     struct vkd3d_vulkan_info vk_info;
     struct vkd3d_vk_global_procs vk_global_procs;
-    void *libvulkan;
 
     VkDebugUtilsMessengerEXT vk_debug_callback;
 


### PR DESCRIPTION
VkInstance creation is expensive and even for singleton device, we end up creating an instance for no good reason.

Move to a global singleton that is released if application releases last ID3D12Device reference.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>