### PR TITLE
vkd3d: Get rid of held SPIR-V code in 99.9% in cases.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2113,9 +2113,8 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     acceleration_structure = &physical_device_info->acceleration_structure_features;
     acceleration_structure->accelerationStructureCaptureReplay = VK_FALSE;
 
-    /* Don't need or require these. */
+    /* Don't need or require this. Dynamic patch control points is nice, but not required. */
     physical_device_info->extended_dynamic_state2_features.extendedDynamicState2LogicOp = VK_FALSE;
-    physical_device_info->extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints = VK_FALSE;
 
     if (!physical_device_info->descriptor_indexing_properties.robustBufferAccessUpdateAfterBind)
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1669,10 +1669,10 @@ enum vkd3d_dynamic_state_flag
     VKD3D_DYNAMIC_STATE_STENCIL_REFERENCE     = (1 << 3),
     VKD3D_DYNAMIC_STATE_DEPTH_BOUNDS          = (1 << 4),
     VKD3D_DYNAMIC_STATE_TOPOLOGY              = (1 << 5),
-    VKD3D_DYNAMIC_STATE_VERTEX_BUFFER         = (1 << 6),
-    VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE  = (1 << 7),
-    VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE = (1 << 8),
-    VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART     = (1 << 9),
+    VKD3D_DYNAMIC_STATE_VERTEX_BUFFER_STRIDE  = (1 << 6),
+    VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE = (1 << 7),
+    VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART     = (1 << 8),
+    VKD3D_DYNAMIC_STATE_PATCH_CONTROL_POINTS  = (1 << 9),
 };
 
 struct vkd3d_shader_debug_ring_spec_constants
@@ -1810,6 +1810,7 @@ struct d3d12_pipeline_state
     struct d3d12_device *device;
     bool root_signature_compat_hash_is_dxbc_derived;
     bool pso_is_loaded_from_cached_blob;
+    bool pso_is_fully_dynamic;
 
     struct vkd3d_private_store private_store;
 };
@@ -1903,7 +1904,6 @@ struct vkd3d_pipeline_key
     uint32_t strides[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
     VkFormat dsv_format;
 
-    bool dynamic_stride;
     bool dynamic_topology;
 };
 
@@ -2199,7 +2199,6 @@ struct vkd3d_dynamic_state
     uint32_t active_flags; /* vkd3d_dynamic_state_flags */
     uint32_t dirty_flags; /* vkd3d_dynamic_state_flags */
     uint32_t dirty_vbos;
-    uint32_t dirty_vbo_strides;
 
     uint32_t viewport_count;
     VkViewport viewports[D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE];

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -265,6 +265,7 @@ VK_DEVICE_EXT_PFN(vkCmdSetViewportWithCountEXT)
 
 /* VK_EXT_extended_dynamic_state2 */
 VK_DEVICE_EXT_PFN(vkCmdSetPrimitiveRestartEnableEXT)
+VK_DEVICE_EXT_PFN(vkCmdSetPatchControlPointsEXT)
 
 /* VK_EXT_external_memory_host */
 VK_DEVICE_EXT_PFN(vkGetMemoryHostPointerPropertiesEXT)


### PR DESCRIPTION
Saves a ton of memory on first run of an application.

Two pieces are required to make this work:
- Assume that dynamic VBO stride problems are not real in practice. They don't work quite like how you expect on native AMD drivers either.
- Handle dynamic patch control points. We can fallback and retain SPIR-V if we are at risk of fallback compile.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>