### PR TITLE
vkd3d: Properly ignore built-ins when validating blend state.

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3322,7 +3322,11 @@ static HRESULT d3d12_pipeline_state_validate_blend_state(struct d3d12_pipeline_s
          * an IO-sig entry with non-NULL format. */
         for (i = 0; i < sig->element_count; i++)
         {
+            if (sig->elements[i].sysval_semantic)
+                continue;
+
             register_index = sig->elements[i].register_index;
+
             if (register_index >= ARRAY_SIZE(desc->rtv_formats.RTFormats))
             {
                 WARN("Register index %u out of bounds.\n", register_index);


### PR DESCRIPTION
Built-ins (like depth, sample mask etc) all have a register index of -1, which would cause us to fail pipeline compilation.

Fixes a crash when opening the map in Dead Space.