### PR TITLE
vkd3d: Actually fix blend state validation v2

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3322,10 +3322,11 @@ static HRESULT d3d12_pipeline_state_validate_blend_state(struct d3d12_pipeline_s
          * an IO-sig entry with non-NULL format. */
         for (i = 0; i < sig->element_count; i++)
         {
-            if (sig->elements[i].sysval_semantic)
-                continue;
-
             register_index = sig->elements[i].register_index;
+
+            /* Ignore built-in outputs like SV_DEPTH etc */
+            if (sig->elements[i].register_index == ~0u)
+                continue;
 
             if (register_index >= ARRAY_SIZE(desc->rtv_formats.RTFormats))
             {


### PR DESCRIPTION
So apparently I fucked up testing the previous one and it wasn't using my actual build. Sorry about that.

This one works. Built-in outputs do not have a sysval semantic anyway.