### PR TITLE
meta: Create a simple issue template

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report crashes, rendering issues etc.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Please describe your issue as accurately as possible. Include screenshots or videos if relevant
+
+### Software information
+Name of the game, settings used etc.
+
+### System information
+- GPU:
+- Driver:
+- Wine version: 
+- VKD3D-Proton version: 
+
+### Log files
+Proton or Wine logs.


### PR DESCRIPTION
A simple issue template based on the one used for dxvk. Can be expanded as needed