### PR TITLE
Add support for VK_EXT_image_sliced_view_of_3d

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -128,6 +128,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_SHADER_MODULE_IDENTIFIER, EXT_shader_module_identifier),
     VK_EXTENSION(EXT_DESCRIPTOR_BUFFER, EXT_descriptor_buffer),
     VK_EXTENSION_COND(EXT_PIPELINE_LIBRARY_GROUP_HANDLES, EXT_pipeline_library_group_handles, VKD3D_CONFIG_FLAG_DXR),
+    VK_EXTENSION(EXT_IMAGE_SLICED_VIEW_OF_3D, EXT_image_sliced_view_of_3d),
     /* AMD extensions */
     VK_EXTENSION(AMD_BUFFER_MARKER, AMD_buffer_marker),
     VK_EXTENSION(AMD_DEVICE_COHERENT_MEMORY, AMD_device_coherent_memory),
@@ -1600,6 +1601,13 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         info->pipeline_library_group_handles_features.sType =
                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT;
         vk_prepend_struct(&info->features2, &info->pipeline_library_group_handles_features);
+    }
+
+    if (vulkan_info->EXT_image_sliced_view_of_3d)
+    {
+        info->image_sliced_view_of_3d_features.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT;
+        vk_prepend_struct(&info->features2, &info->image_sliced_view_of_3d_features);
     }
 
     /* Core in Vulkan 1.1. */

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -494,9 +494,13 @@ VkExtent3D vkd3d_meta_get_clear_image_uav_workgroup_size(VkImageViewType view_ty
         }
         case VK_IMAGE_VIEW_TYPE_2D:
         case VK_IMAGE_VIEW_TYPE_2D_ARRAY:
-        case VK_IMAGE_VIEW_TYPE_3D:
         {
             VkExtent3D result = { 8, 8, 1 };
+            return result;
+        }
+        case VK_IMAGE_VIEW_TYPE_3D:
+        {
+            VkExtent3D result = { 4, 4, 4 };
             return result;
         }
         default:

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -859,6 +859,8 @@ static uint32_t vkd3d_view_entry_hash(const void *key)
             hash = hash_combine(hash, float_bits_to_uint32(k->u.texture.miplevel_clamp));
             hash = hash_combine(hash, k->u.texture.layer_idx);
             hash = hash_combine(hash, k->u.texture.layer_count);
+            hash = hash_combine(hash, k->u.texture.w_offset);
+            hash = hash_combine(hash, k->u.texture.w_size);
             hash = hash_combine(hash, k->u.texture.components.r);
             hash = hash_combine(hash, k->u.texture.components.g);
             hash = hash_combine(hash, k->u.texture.components.b);
@@ -920,6 +922,8 @@ static bool vkd3d_view_entry_compare(const void *key, const struct hash_map_entr
                     k->u.texture.miplevel_clamp == e->key.u.texture.miplevel_clamp &&
                     k->u.texture.layer_idx == e->key.u.texture.layer_idx &&
                     k->u.texture.layer_count == e->key.u.texture.layer_count &&
+                    k->u.texture.w_offset == e->key.u.texture.w_offset &&
+                    k->u.texture.w_size == e->key.u.texture.w_size &&
                     k->u.texture.components.r == e->key.u.texture.components.r &&
                     k->u.texture.components.g == e->key.u.texture.components.g &&
                     k->u.texture.components.b == e->key.u.texture.components.b &&
@@ -3914,6 +3918,8 @@ static bool init_default_texture_view_desc(struct vkd3d_texture_view_desc *desc,
     desc->layer_idx = 0;
     desc->layer_count = d3d12_resource_desc_get_layer_count(&resource->desc);
     desc->image_usage = 0;
+    desc->w_offset = 0;
+    desc->w_size = UINT_MAX;
 
     switch (resource->desc.Dimension)
     {
@@ -3951,6 +3957,7 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
     VkImageViewUsageCreateInfo image_usage_create_info;
     const struct vkd3d_format *format = desc->format;
     VkImageViewMinLodCreateInfoEXT min_lod_desc;
+    VkImageViewSlicedCreateInfoEXT sliced_desc;
     VkImageView vk_view = VK_NULL_HANDLE;
     VkImageViewCreateInfo view_desc;
     struct vkd3d_view *object;
@@ -4004,6 +4011,17 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
         image_usage_create_info.usage = desc->image_usage;
         vk_prepend_struct(&view_desc, &image_usage_create_info);
 
+        if (desc->view_type == VK_IMAGE_VIEW_TYPE_3D &&
+                (desc->w_offset != 0 || desc->w_size != VK_REMAINING_3D_SLICES_EXT) &&
+                device->device_info.image_sliced_view_of_3d_features.imageSlicedViewOf3D)
+        {
+            sliced_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT;
+            sliced_desc.pNext = NULL;
+            sliced_desc.sliceOffset = desc->w_offset;
+            sliced_desc.sliceCount = desc->w_size;
+            vk_prepend_struct(&view_desc, &sliced_desc);
+        }
+
         if ((vr = VK_CALL(vkCreateImageView(device->vk_device, &view_desc, NULL, &vk_view))) < 0)
         {
             WARN("Failed to create Vulkan image view, vr %d.\n", vr);
@@ -4023,6 +4041,8 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
     object->info.texture.miplevel_idx = desc->miplevel_idx;
     object->info.texture.layer_idx = desc->layer_idx;
     object->info.texture.layer_count = desc->layer_count;
+    object->info.texture.w_offset = desc->w_offset;
+    object->info.texture.w_size = desc->w_size;
     *view = object;
     return true;
 }
@@ -5089,12 +5109,17 @@ static void vkd3d_create_texture_uav(vkd3d_cpu_descriptor_va_t desc_va,
             case D3D12_UAV_DIMENSION_TEXTURE3D:
                 key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_3D;
                 key.u.texture.miplevel_idx = desc->Texture3D.MipSlice;
-                if (desc->Texture3D.FirstWSlice ||
-                    ((desc->Texture3D.WSize != max(1u, (UINT)resource->desc.DepthOrArraySize >> desc->Texture3D.MipSlice)) &&
-                        (desc->Texture3D.WSize != UINT_MAX)))
+                key.u.texture.w_offset = desc->Texture3D.FirstWSlice;
+                key.u.texture.w_size = desc->Texture3D.WSize;
+                if (!device->device_info.image_sliced_view_of_3d_features.imageSlicedViewOf3D)
                 {
-                    FIXME("Unhandled depth view %u-%u.\n",
-                          desc->Texture3D.FirstWSlice, desc->Texture3D.WSize);
+                    if (desc->Texture3D.FirstWSlice ||
+                        ((desc->Texture3D.WSize != max(1u, (UINT)resource->desc.DepthOrArraySize >> desc->Texture3D.MipSlice)) &&
+                            desc->Texture3D.WSize != UINT_MAX))
+                    {
+                        FIXME("Unhandled depth view %u-%u.\n",
+                                desc->Texture3D.FirstWSlice, desc->Texture3D.WSize);
+                    }
                 }
                 break;
             default:

--- a/libs/vkd3d/shaders/cs_clear_uav_image_3d_float.comp
+++ b/libs/vkd3d/shaders/cs_clear_uav_image_3d_float.comp
@@ -1,6 +1,6 @@
 #version 450
 
-layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
 
 layout(binding = 0)
 writeonly uniform image3D dst;

--- a/libs/vkd3d/shaders/cs_clear_uav_image_3d_uint.comp
+++ b/libs/vkd3d/shaders/cs_clear_uav_image_3d_uint.comp
@@ -1,6 +1,6 @@
 #version 450
 
-layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
 
 layout(binding = 0)
 writeonly uniform uimage3D dst;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -175,6 +175,7 @@ struct vkd3d_vulkan_info
     bool EXT_shader_module_identifier;
     bool EXT_descriptor_buffer;
     bool EXT_pipeline_library_group_handles;
+    bool EXT_image_sliced_view_of_3d;
     /* AMD device extensions */
     bool AMD_buffer_marker;
     bool AMD_device_coherent_memory;
@@ -1089,6 +1090,8 @@ struct vkd3d_view
             unsigned int miplevel_idx;
             unsigned int layer_idx;
             unsigned int layer_count;
+            unsigned int w_offset;
+            unsigned int w_size;
         } texture;
     } info;
 };
@@ -1115,6 +1118,8 @@ struct vkd3d_texture_view_desc
     unsigned int miplevel_count;
     unsigned int layer_idx;
     unsigned int layer_count;
+    unsigned int w_offset;
+    unsigned int w_size;
     float miplevel_clamp;
     VkComponentMapping components;
     bool allowed_swizzle;
@@ -3754,6 +3759,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDevicePresentWaitFeaturesKHR present_wait_features;
     VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_features;
     VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT pipeline_library_group_handles_features;
+    VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT image_sliced_view_of_3d_features;
 
     VkPhysicalDeviceFeatures2 features2;
 


### PR DESCRIPTION
Fix some other issues while at it.

- Found 3D bug in UAV fallback copy path. Use imageOffset.z instead of baseLayer.
- Use 4x4x4 workgroup when UAV clearing 3D images.
- Consider WSize/WOffset when clearing UAV.

test_uav_3d_sliced_view now Passes RADV.