### PR TITLE
meson: Use regular system widl.

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -3,7 +3,6 @@ c = 'i686-w64-mingw32-gcc'
 cpp = 'i686-w64-mingw32-g++'
 ar = 'i686-w64-mingw32-ar'
 strip = 'i686-w64-mingw32-strip'
-widl = 'i686-w64-mingw32-widl'
 
 [properties]
 c_args=['-msse', '-msse2']

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -3,7 +3,6 @@ c = 'x86_64-w64-mingw32-gcc'
 cpp = 'x86_64-w64-mingw32-g++'
 ar = 'x86_64-w64-mingw32-ar'
 strip = 'x86_64-w64-mingw32-strip'
-widl = 'x86_64-w64-mingw32-widl'
 
 [properties]
 c_link_args = ['-static', '-static-libgcc']


### PR DESCRIPTION
x86_64-w64-mingw32-widl isn't really used anymore.