### PR TITLE
Added NO_UPLOAD_HVV for Forza Horizon 5

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -510,6 +510,8 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     { VKD3D_STRING_COMPARE_EXACT, "Dead Space.exe", VKD3D_CONFIG_FLAG_FORCE_DEDICATED_IMAGE_ALLOCATION, 0 },
     /* Witcher 3 (2023) (292030) */
     { VKD3D_STRING_COMPARE_EXACT, "witcher3.exe", VKD3D_CONFIG_FLAG_SIMULTANEOUS_UAV_SUPPRESS_COMPRESSION, 0 },
+    /* Forza Horizon 5 (1551360) */
+    { VKD3D_STRING_COMPARE_EXACT, "ForzaHorizon5.exe", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0 },
     { VKD3D_STRING_COMPARE_NEVER, NULL, 0, 0 }
 };
 


### PR DESCRIPTION
FH5 has severe performance drops (visible in the benchmark) with rebar enabled, and also freezes frequently ingame. With this workaround the game performs as expected (apart from the occasional hiccups) and no longer freezes.

Tested on 6900xt, latest master, Mesa 23.1