### PR TITLE
tests: Add VTable origin test

### DIFF
--- a/tests/d3d12_device.c
+++ b/tests/d3d12_device.c
@@ -1354,8 +1354,11 @@ void test_object_interface(void)
         hr = ID3D12Object_GetPrivateData(object, &WKPDID_D3DDebugObjectName, &size, NULL);
         ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", hr);
 
+#if 0
+        /* NULL name crashes on Windows 11 22621. */
         hr = ID3D12Object_SetName(object, NULL);
         ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+#endif
 
         hr = ID3D12Object_GetPrivateData(object, &WKPDID_D3DDebugObjectNameW, &size, NULL);
         ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", hr);

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -330,3 +330,4 @@ decl_test(test_memory_model_uav_coherence_thread_group_dxbc);
 decl_test(test_memory_model_uav_coherence_thread_group_dxil);
 decl_test(test_rasterizer_ordered_views_dxbc);
 decl_test(test_rasterizer_ordered_views_dxil);
+decl_test(test_vtable_origins);


### PR DESCRIPTION
This proves that the VTable comes from D3D12Core now under modern Windows.

Some apps will likely end up checking for this in future.

Signed-off-by: Joshua Ashton <joshua@froggi.es>