### PR TITLE
d3d12, d3d12core: Refactor to move main code to D3D12Core 

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -12,7 +12,8 @@ vkd3d_idl = [
   'vkd3d_dxgitype.idl',
   'vkd3d_swapchain_factory.idl',
   'vkd3d_command_list_vkd3d_ext.idl',
-  'vkd3d_device_vkd3d_ext.idl'
+  'vkd3d_device_vkd3d_ext.idl',
+  'vkd3d_core_interface.idl',
 ]
 
 vkd3d_header_files = idl_generator.process(vkd3d_idl)

--- a/include/private/vkd3d_debug.h
+++ b/include/private/vkd3d_debug.h
@@ -57,6 +57,14 @@ enum vkd3d_dbg_channel
     VKD3D_DBG_CHANNEL_COUNT
 };
 
+void vkd3d_dbg_disable_debug_file(void);
+
+#ifdef VKD3D_DEBUG_NO_FILE
+#define VKD3D_DBG_DISABLE_DEBUG_FILE() vkd3d_dbg_disable_debug_file()
+#else
+#define VKD3D_DBG_DISABLE_DEBUG_FILE() ((void)0)
+#endif
+
 enum vkd3d_dbg_level vkd3d_dbg_get_level(enum vkd3d_dbg_channel channel);
 
 void vkd3d_dbg_printf(enum vkd3d_dbg_channel channel, enum vkd3d_dbg_level level, const char *function,
@@ -83,6 +91,7 @@ const char *debugstr_w(const WCHAR *wstr);
         VKD3D_DBG_PRINTF
 
 #define VKD3D_DBG_PRINTF(...) \
+        VKD3D_DBG_DISABLE_DEBUG_FILE(); \
         vkd3d_dbg_printf(vkd3d_dbg_channel, vkd3d_dbg_level, __FUNCTION__, __VA_ARGS__); } while (0)
 
 #ifndef TRACE

--- a/include/private/vkd3d_string.h
+++ b/include/private/vkd3d_string.h
@@ -76,5 +76,22 @@ static inline bool vkd3d_string_compare(enum vkd3d_string_compare_mode mode, con
     }
 }
 
+static inline void vkd3d_strlcpy(char *dst, size_t dst_size, const char *src)
+{
+    if (dst_size > 0)
+    {
+        strncpy(dst, src, dst_size - 1);
+        dst[dst_size - 1] = '\0';
+    }
+}
+
+static inline void vkd3d_strlcat(char *dst, size_t dst_size, const char *src)
+{
+    if (dst_size > 0)
+    {
+        strncat(dst, src, dst_size - 1);
+        dst[dst_size - 1] = '\0';
+    }
+}
 
 #endif /* __VKD3D_STRING_H */

--- a/include/private/vkd3d_threads.h
+++ b/include/private/vkd3d_threads.h
@@ -35,7 +35,7 @@ struct pthread
     void * (*routine)(void *);
     void *arg;
 
-    HMODULE d3d12_reference;
+    HMODULE d3d12core_reference;
     HMODULE dxgi_reference;
 };
 typedef struct pthread *pthread_t;
@@ -61,22 +61,26 @@ static DWORD WINAPI win32_thread_wrapper_routine(void *arg)
     pthread_t thread = arg;
     thread->routine(thread->arg);
 
-    /* If a game unloads d3d12.dll or dxgi.dll while there are live device references (yikes),
+    /* If a game unloads d3d12core.dll or dxgi.dll while there are live device references (yikes),
      * we risk that one of our internal threads are running. This is bad obviously.
      * Works around a crash in Like a Dragon: Ishin! when pipeline cache is used.
      * The fix is to hold references to any dependent code while running threads.
-     * We can limit all this jank to the thread implementation. */
+     * We can limit all this jank to the thread implementation.
+     *
+     * After the update to d3d12core.dll split, this is extremely unlikely to cause problems
+     * since applications will release d3d12.dll, not d3d12core.dll. d3d12.dll does nothing interesting anymore,
+     * but releasing dxgi.dll is still a hypothetical risk. */
     if (thread->dxgi_reference)
     {
         TRACE("Releasing module reference for dxgi.dll: %p.\n", thread->dxgi_reference);
         FreeLibrary(thread->dxgi_reference);
     }
 
-    /* We are executing in d3d12.dll here, so we have to use the atomic FreeLibraryAndExit thread to make this work. */
-    if (thread->d3d12_reference)
+    /* We are executing in d3d12core.dll here, so we have to use the atomic FreeLibraryAndExit thread to make this work. */
+    if (thread->d3d12core_reference)
     {
-        TRACE("Releasing module reference for d3d12.dll and exiting thread: %p.\n", thread->d3d12_reference);
-        FreeLibraryAndExitThread(thread->d3d12_reference, 0);
+        TRACE("Releasing module reference for d3d12core.dll and exiting thread: %p.\n", thread->d3d12core_reference);
+        FreeLibraryAndExitThread(thread->d3d12core_reference, 0);
     }
 
     /* Otherwise, fall back to the implicit ExitThread(). */
@@ -94,12 +98,12 @@ static inline int pthread_create(pthread_t *out_thread, void *attr, void * (*thr
     thread->arg = arg;
 
     /* Need GetModuleHandleEx which lets us get a refcount. */
-    if (!GetModuleHandleExA(0, "d3d12.dll", &thread->d3d12_reference))
-        thread->d3d12_reference = NULL;
+    if (!GetModuleHandleExA(0, "d3d12core.dll", &thread->d3d12core_reference))
+        thread->d3d12core_reference = NULL;
     if (!GetModuleHandleExA(0, "dxgi.dll", &thread->dxgi_reference))
         thread->dxgi_reference = NULL;
 
-    TRACE("Module reference for d3d12.dll: %p.\n", thread->d3d12_reference);
+    TRACE("Module reference for d3d12core.dll: %p.\n", thread->d3d12core_reference);
     TRACE("Module reference for dxgi.dll: %p.\n", thread->dxgi_reference);
 
     thread->thread = CreateThread(NULL, 0, win32_thread_wrapper_routine, thread, 0, &thread->id);
@@ -107,8 +111,8 @@ static inline int pthread_create(pthread_t *out_thread, void *attr, void * (*thr
     {
         if (thread->dxgi_reference)
             FreeLibrary(thread->dxgi_reference);
-        if (thread->d3d12_reference)
-            FreeLibrary(thread->d3d12_reference);
+        if (thread->d3d12core_reference)
+            FreeLibrary(thread->d3d12core_reference);
         vkd3d_free(thread);
         return -1;
     }

--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -22,6 +22,7 @@
 #include <vkd3d_types.h>
 
 #ifndef VKD3D_NO_WIN32_TYPES
+# define COBJMACROS
 # include <vkd3d_windows.h>
 
 # define WIDL_C_INLINE_WRAPPERS
@@ -35,6 +36,7 @@
 # endif
 
 # include <vkd3d_d3d12.h>
+# include <vkd3d_core_interface.h>
 # undef WIDL_C_INLINE_WRAPPERS
 #endif  /* VKD3D_NO_WIN32_TYPES */
 

--- a/include/vkd3d_core_interface.idl
+++ b/include/vkd3d_core_interface.idl
@@ -1,0 +1,37 @@
+/*
+ * * Copyright 2023 Joshua Ashton for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+import "vkd3d_d3d12.idl";
+
+[
+    uuid(18da885c-a7b5-464e-a121-ccb75d4dfc31),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface IVKD3DCoreInterface
+{
+    HRESULT CreateDevice(IUnknown *adapter, D3D_FEATURE_LEVEL minimum_feature_level, REFIID iid, void **device);
+    HRESULT CreateRootSignatureDeserializer(const void *data, SIZE_T data_size, REFIID iid, void **deserializer);
+    HRESULT SerializeRootSignature(const D3D12_ROOT_SIGNATURE_DESC *root_signature_desc, D3D_ROOT_SIGNATURE_VERSION version, ID3DBlob **blob, ID3DBlob **error_blob);
+    HRESULT CreateVersionedRootSignatureDeserializer(const void *data, SIZE_T data_size, REFIID iid, void **deserializer);
+    HRESULT SerializeVersionedRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *desc, ID3DBlob **blob, ID3DBlob **error_blob);
+    HRESULT GetDebugInterface(REFIID iid, void** debug);
+    HRESULT EnableExperimentalFeatures(UINT feature_count, const IID *iids, void *configurations, UINT *configurations_sizes);
+    HRESULT GetInterface(REFCLSID rcslid, REFIID iid, void** debug);
+}
+cpp_quote("DEFINE_GUID(CLSID_VKD3DCore,       0xed53efad, 0xda21, 0x4d96, 0xa1, 0xbc, 0xe7, 0x34, 0xe0, 0x78, 0x87, 0x9c );")

--- a/include/vkd3d_d3d12.idl
+++ b/include/vkd3d_d3d12.idl
@@ -4353,3 +4353,7 @@ typedef HRESULT (__stdcall *PFN_D3D12_ENABLE_EXPERIMENTAL_FEATURES)(UINT num_fea
 
 [local] HRESULT __stdcall D3D12EnableExperimentalFeatures(UINT num_features,
         const IID *iids, void *config_structs, UINT *config_struct_sizes);
+
+typedef HRESULT (__stdcall *PFN_D3D12_GET_INTERFACE)(REFCLSID clsid, REFIID iid, void **debug);
+
+[local] HRESULT __stdcall D3D12GetInterface(REFCLSID clsid, REFIID iid, void **debug);

--- a/include/vkd3d_sonames.h
+++ b/include/vkd3d_sonames.h
@@ -23,10 +23,13 @@
 
 #if defined(_WIN32)
 #define SONAME_LIBVULKAN "vulkan-1.dll"
+#define SONAME_D3D12CORE "d3d12core.dll"
 #elif defined(__linux__)
 #define SONAME_LIBVULKAN "libvulkan.so.1"
+#define SONAME_D3D12CORE "libvkd3d-proton-d3d12core.so"
 #elif defined(__APPLE__)
 #define SONAME_LIBVULKAN "libvulkan.1.dylib"
+#define SONAME_D3D12CORE "vkd3d-proton-d3d12core.dylib"
 #else
 #error "Unrecognized platform."
 #endif

--- a/include/vkd3d_unknown.idl
+++ b/include/vkd3d_unknown.idl
@@ -23,6 +23,7 @@ cpp_quote("#define __VKD3D_UNKNOWN_H")
 cpp_quote("#if 0")
 typedef IID *REFIID;
 typedef IID *REFGUID;
+typedef IID *REFCLSID;
 cpp_quote("#endif")
 
 cpp_quote("#if !defined(_WIN32)")

--- a/include/vkd3d_win32.h
+++ b/include/vkd3d_win32.h
@@ -58,6 +58,7 @@
 #include <vkd3d_command_list_vkd3d_ext.h>
 #include <vkd3d_device_vkd3d_ext.h>
 #include <vkd3d_d3d12.h>
+#include <vkd3d_core_interface.h>
 #undef WIDL_C_INLINE_WRAPPERS
 
 #include <vkd3d_d3d12sdklayers.h>

--- a/include/vkd3d_windows.h
+++ b/include/vkd3d_windows.h
@@ -208,9 +208,11 @@ typedef struct SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
 # if defined(__cplusplus) && !defined(CINTERFACE)
 #  define REFIID const IID &
 #  define REFGUID const GUID &
+#  define REFCLSID const GUID &
 # else
 #  define REFIID const IID * const
 #  define REFGUID const GUID * const
+#  define REFCLSID const GUID * const
 # endif
 
 #if defined(__cplusplus) && !defined(CINTERFACE)

--- a/libs/d3d12/main.c
+++ b/libs/d3d12/main.c
@@ -66,6 +66,9 @@ static void load_d3d12core_once(void)
         if ((d3d12core_module = LoadLibraryA(SONAME_D3D12CORE)))
             d3d12core_D3D12GetInterface = (PFN_D3D12_GET_INTERFACE)(void *)GetProcAddress(d3d12core_module, "D3D12GetInterface");
 #else
+        /* We link directly to d3d12core, however we still need to dlopen + dlsym
+         * as both shared libraries export D3D12GetInterface, so we need to do this
+         * to avoid confusing the linker. */
         if ((d3d12core_module = dlopen(SONAME_D3D12CORE, RTLD_NOW)))
             d3d12core_D3D12GetInterface = (PFN_D3D12_GET_INTERFACE)dlsym(d3d12core_module, "D3D12GetInterface");
 #endif

--- a/libs/d3d12/main.c
+++ b/libs/d3d12/main.c
@@ -74,9 +74,16 @@ static void load_d3d12core_once(void)
 #endif
 
         if (!d3d12core_D3D12GetInterface)
+        {
+            WARN("Did not find d3d12core implementation.\n");
             return;
+        }
 
-        d3d12core_D3D12GetInterface(&CLSID_VKD3DCore, &IID_IVKD3DCoreInterface, (void**)&core);
+        if (FAILED(d3d12core_D3D12GetInterface(&CLSID_VKD3DCore, &IID_IVKD3DCoreInterface, (void**)&core)))
+        {
+            ERR("Failed to find vkd3d-proton d3d12core interfaces. Make sure d3d12core.dll is installed as well. WINEDLLOVERRIDES=d3d12core=b may be needed.\n");
+            core = NULL;
+        }
     }
 }
 

--- a/libs/d3d12/main.c
+++ b/libs/d3d12/main.c
@@ -21,6 +21,11 @@
 
 #define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
 
+/* Make sure that we don't create a log file intended for d3d12core.dll.
+ * These modules are now split, and we'll either block d3d12core log file from being created (Win32),
+ * or the log file for d3d12.dll disappears into the aether. */
+#define VKD3D_DBG_NO_FILE
+
 #define INITGUID
 
 #define VK_NO_PROTOTYPES

--- a/libs/d3d12/main.c
+++ b/libs/d3d12/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2018 Józef Kucia for CodeWeavers
  * Copyright 2020 Joshua Ashton for Valve Software
+ * Copyright 2023 Hans-Kristian Arntzen for Valve Corporation
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,6 +20,8 @@
  */
 
 #define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+
+#define INITGUID
 
 #define VK_NO_PROTOTYPES
 #ifdef _WIN32
@@ -46,302 +49,49 @@
 static pthread_once_t library_once = PTHREAD_ONCE_INIT;
 
 #ifdef _WIN32
-static HMODULE vulkan_module = NULL;
+static HMODULE d3d12core_module = NULL;
 #else
-static void *vulkan_module = NULL;
+static void *d3d12core_module = NULL;
 #endif
-static PFN_vkGetInstanceProcAddr vulkan_vkGetInstanceProcAddr = NULL;
 
-static void load_vulkan_once(void)
+static IVKD3DCoreInterface* core = NULL;
+
+static void load_d3d12core_once(void)
 {
-    if (!vulkan_module)
+    if (!d3d12core_module)
     {
-#ifdef _WIN32
-        /* If possible, load winevulkan directly in order to bypass
-         * issues with third-party overlays hooking the Vulkan loader */
-        static const char *vulkan_dllnames[] =
-        {
-            "winevulkan.dll",
-            "vulkan-1.dll",
-        };
-
-        unsigned int i;
-
-        for (i = 0; i < ARRAY_SIZE(vulkan_dllnames); i++)
-        {
-            vulkan_module = LoadLibraryA(vulkan_dllnames[i]);
-
-            if (vulkan_module)
-            {
-                vulkan_vkGetInstanceProcAddr = (void*)GetProcAddress(vulkan_module, "vkGetInstanceProcAddr");
-
-                if (vulkan_vkGetInstanceProcAddr)
-                    break;
-
-                FreeLibrary(vulkan_module);
-                vulkan_module = NULL;
-            }
-        }
-#else
-        vulkan_module = dlopen(SONAME_LIBVULKAN, RTLD_LAZY);
-        vulkan_vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)dlsym(vulkan_module, "vkGetInstanceProcAddr");
-#endif
-    }
-}
-
-static bool load_vulkan(void)
-{
-    pthread_once(&library_once, load_vulkan_once);
-    return vulkan_vkGetInstanceProcAddr != NULL;
-}
-
-HRESULT WINAPI DLLEXPORT D3D12GetDebugInterface(REFIID iid, void **debug)
-{
-    TRACE("iid %s, debug %p.\n", debugstr_guid(iid), debug);
-
-    WARN("Returning DXGI_ERROR_SDK_COMPONENT_MISSING.\n");
-    return DXGI_ERROR_SDK_COMPONENT_MISSING;
-}
-
-HRESULT WINAPI DLLEXPORT D3D12EnableExperimentalFeatures(UINT feature_count,
-        const IID *iids, void *configurations, UINT *configurations_sizes)
-{
-    FIXME("feature_count %u, iids %p, configurations %p, configurations_sizes %p stub!\n",
-            feature_count, iids, configurations, configurations_sizes);
-
-    return E_NOINTERFACE;
-}
+        PFN_D3D12_GET_INTERFACE d3d12core_D3D12GetInterface = NULL;
 
 #ifdef _WIN32
-/* TODO: We need to attempt to dlopen() native DXVK DXGI. */
-static HRESULT d3d12_get_adapter(IDXGIAdapter **dxgi_adapter, IUnknown *adapter)
-{
-    IDXGIFactory4 *factory = NULL;
-    HRESULT hr;
-
-    if (!adapter)
-    {
-        if (FAILED(hr = CreateDXGIFactory1(&IID_IDXGIFactory4, (void **)&factory)))
-        {
-            WARN("Failed to create DXGI factory, hr %#x.\n", hr);
-            goto done;
-        }
-
-        if (FAILED(hr = IDXGIFactory4_EnumAdapters(factory, 0, dxgi_adapter)))
-        {
-            WARN("Failed to enumerate primary adapter, hr %#x.\n", hr);
-            goto done;
-        }
-    }
-    else
-    {
-        if (FAILED(hr = IUnknown_QueryInterface(adapter, &IID_IDXGIAdapter, (void **)dxgi_adapter)))
-        {
-            WARN("Invalid adapter %p, hr %#x.\n", adapter, hr);
-            goto done;
-        }
-    }
-
-done:
-    if (factory)
-        IDXGIFactory4_Release(factory);
-
-    return hr;
-}
-
-static VkPhysicalDevice d3d12_find_physical_device(struct vkd3d_instance *instance,
-        PFN_vkGetInstanceProcAddr pfn_vkGetInstanceProcAddr, struct DXGI_ADAPTER_DESC *adapter_desc)
-{
-    PFN_vkGetPhysicalDeviceProperties2 pfn_vkGetPhysicalDeviceProperties2;
-    PFN_vkGetPhysicalDeviceProperties pfn_vkGetPhysicalDeviceProperties;
-    PFN_vkEnumeratePhysicalDevices pfn_vkEnumeratePhysicalDevices;
-    VkPhysicalDevice vk_physical_device = VK_NULL_HANDLE;
-    VkPhysicalDeviceIDProperties id_properties;
-    VkPhysicalDeviceProperties2 properties2;
-    VkPhysicalDevice *vk_physical_devices;
-    VkInstance vk_instance;
-    unsigned int i;
-    uint32_t count;
-    VkResult vr;
-
-    vk_instance = vkd3d_instance_get_vk_instance(instance);
-
-    pfn_vkEnumeratePhysicalDevices = (void *)pfn_vkGetInstanceProcAddr(vk_instance, "vkEnumeratePhysicalDevices");
-    pfn_vkGetPhysicalDeviceProperties = (void *)pfn_vkGetInstanceProcAddr(vk_instance, "vkGetPhysicalDeviceProperties");
-    pfn_vkGetPhysicalDeviceProperties2 = (void *)pfn_vkGetInstanceProcAddr(vk_instance, "vkGetPhysicalDeviceProperties2");
-
-    if ((vr = pfn_vkEnumeratePhysicalDevices(vk_instance, &count, NULL)) < 0)
-    {
-        WARN("Failed to get device count, vr %d.\n", vr);
-        return VK_NULL_HANDLE;
-    }
-    if (!count)
-    {
-        WARN("No physical device available.\n");
-        return VK_NULL_HANDLE;
-    }
-
-    if (!(vk_physical_devices = calloc(count, sizeof(*vk_physical_devices))))
-        return VK_NULL_HANDLE;
-
-    if ((vr = pfn_vkEnumeratePhysicalDevices(vk_instance, &count, vk_physical_devices)) < 0)
-        goto done;
-
-    TRACE("Matching adapters by LUIDs.\n");
-
-    for (i = 0; i < count; ++i)
-    {
-        pfn_vkGetPhysicalDeviceProperties(vk_physical_devices[i], &properties2.properties);
-
-        /* Skip over physical devices below our minimum API version */
-        if (properties2.properties.apiVersion < VKD3D_MIN_API_VERSION)
-        {
-            WARN("Skipped adapter %s as it is below our minimum API version.", properties2.properties.deviceName);
-            continue;
-        }
-
-        id_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
-        id_properties.pNext = NULL;
-
-        properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-        properties2.pNext = &id_properties;
-
-        pfn_vkGetPhysicalDeviceProperties2(vk_physical_devices[i], &properties2);
-
-        if (id_properties.deviceLUIDValid && !memcmp(id_properties.deviceLUID, &adapter_desc->AdapterLuid, VK_LUID_SIZE))
-        {
-            vk_physical_device = vk_physical_devices[i];
-            break;
-        }
-    }
-
-    if (!vk_physical_device)
-    {
-        TRACE("Matching adapters by PCI IDs.\n");
-
-        for (i = 0; i < count; ++i)
-        {
-            pfn_vkGetPhysicalDeviceProperties(vk_physical_devices[i], &properties2.properties);
-
-            if (properties2.properties.deviceID == adapter_desc->DeviceId &&
-                properties2.properties.vendorID == adapter_desc->VendorId)
-            {
-                vk_physical_device = vk_physical_devices[i];
-                break;
-            }
-        }
-    }
-
-    if (!vk_physical_device)
-    {
-        FIXME("Could not find Vulkan physical device for DXGI adapter.\n");
-        WARN("Using first available physical device...\n");
-        vk_physical_device = vk_physical_devices[0];
-    }
-
-done:
-    free(vk_physical_devices);
-    return vk_physical_device;
-}
-#endif
-
-static HRESULT vkd3d_create_instance_global(struct vkd3d_instance **out_instance)
-{
-    struct vkd3d_instance_create_info instance_create_info;
-    HRESULT hr = S_OK;
-
-    static const char * const instance_extensions[] =
-    {
-        VK_KHR_SURFACE_EXTENSION_NAME,
-#ifdef _WIN32
-        VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+        if ((d3d12core_module = LoadLibraryA(SONAME_D3D12CORE)))
+            d3d12core_D3D12GetInterface = (PFN_D3D12_GET_INTERFACE)(void *)GetProcAddress(d3d12core_module, "D3D12GetInterface");
 #else
-        /* TODO: We need to attempt to dlopen() native DXVK DXGI and handle this more gracefully. */
-        "VK_KHR_xcb_surface",
+        if ((d3d12core_module = dlopen(SONAME_D3D12CORE, RTLD_NOW)))
+            d3d12core_D3D12GetInterface = (PFN_D3D12_GET_INTERFACE)dlsym(d3d12core_module, "D3D12GetInterface");
 #endif
-    };
 
-    if (!load_vulkan())
-    {
-        ERR("Failed to load Vulkan library.\n");
-        return E_FAIL;
+        if (!d3d12core_D3D12GetInterface)
+            return;
+
+        d3d12core_D3D12GetInterface(&CLSID_VKD3DCore, &IID_IVKD3DCoreInterface, (void**)&core);
     }
+}
 
-    memset(&instance_create_info, 0, sizeof(instance_create_info));
-    instance_create_info.pfn_vkGetInstanceProcAddr = vulkan_vkGetInstanceProcAddr;
-    instance_create_info.instance_extensions = instance_extensions;
-    instance_create_info.instance_extension_count = ARRAY_SIZE(instance_extensions);
-    instance_create_info.optional_instance_extensions = NULL;
-    instance_create_info.optional_instance_extension_count = 0;
-
-    if (FAILED(hr = vkd3d_create_instance(&instance_create_info, out_instance)))
-        WARN("Failed to create vkd3d instance, hr %#x.\n", hr);
-
-    return hr;
+static bool load_d3d12core(void)
+{
+    pthread_once(&library_once, load_d3d12core_once);
+    return core != NULL;
 }
 
 HRESULT WINAPI DLLEXPORT D3D12CreateDevice(IUnknown *adapter, D3D_FEATURE_LEVEL minimum_feature_level,
         REFIID iid, void **device)
 {
-    struct vkd3d_device_create_info device_create_info;
-    struct vkd3d_instance *instance;
-    HRESULT hr;
-
-#ifdef _WIN32
-    struct DXGI_ADAPTER_DESC adapter_desc;
-    IDXGIAdapter *dxgi_adapter;
-#endif
-
-    static const char * const device_extensions[] =
-    {
-        VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-        VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,
-    };
-
     TRACE("adapter %p, minimum_feature_level %#x, iid %s, device %p.\n",
             adapter, minimum_feature_level, debugstr_guid(iid), device);
 
-#ifdef _WIN32
-    if (FAILED(hr = d3d12_get_adapter(&dxgi_adapter, adapter)))
-        return hr;
-
-    if (FAILED(hr = IDXGIAdapter_GetDesc(dxgi_adapter, &adapter_desc)))
-    {
-        WARN("Failed to get adapter desc, hr %#x.\n", hr);
-        goto out_release_adapter;
-    }
-#else
-    /* TODO: We need to attempt to dlopen() native DXVK DXGI and handle this more gracefully. */
-    if (adapter)
-        FIXME("Ignoring adapter.\n");
-#endif
-
-    if (FAILED(hr = vkd3d_create_instance_global(&instance)))
-        return hr;
-
-    memset(&device_create_info, 0, sizeof(device_create_info));
-    device_create_info.minimum_feature_level = minimum_feature_level;
-    device_create_info.instance = instance;
-    device_create_info.instance_create_info = NULL;
-    device_create_info.device_extensions = device_extensions;
-    device_create_info.device_extension_count = ARRAY_SIZE(device_extensions);
-    device_create_info.optional_device_extensions = NULL;
-    device_create_info.optional_device_extension_count = 0;
-
-#ifdef _WIN32
-    device_create_info.vk_physical_device = d3d12_find_physical_device(instance, vulkan_vkGetInstanceProcAddr, &adapter_desc);
-    device_create_info.parent = (IUnknown *)dxgi_adapter;
-    memcpy(&device_create_info.adapter_luid, &adapter_desc.AdapterLuid, VK_LUID_SIZE);
-#endif
-
-    hr = vkd3d_create_device(&device_create_info, iid, device);
-    vkd3d_instance_decref(instance);
-
-#ifdef _WIN32
-out_release_adapter:
-    IDXGIAdapter_Release(dxgi_adapter);
-#endif
-    return hr;
+    if (!load_d3d12core())
+        return E_NOINTERFACE;
+    return IVKD3DCoreInterface_CreateDevice(core, adapter, minimum_feature_level, iid, device);
 }
 
 HRESULT WINAPI DLLEXPORT D3D12CreateRootSignatureDeserializer(const void *data, SIZE_T data_size,
@@ -350,7 +100,9 @@ HRESULT WINAPI DLLEXPORT D3D12CreateRootSignatureDeserializer(const void *data, 
     TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
             data, data_size, debugstr_guid(iid), deserializer);
 
-    return vkd3d_create_root_signature_deserializer(data, data_size, iid, deserializer);
+    if (!load_d3d12core())
+        return E_NOINTERFACE;
+    return IVKD3DCoreInterface_CreateRootSignatureDeserializer(core, data, data_size, iid, deserializer);
 }
 
 HRESULT WINAPI DLLEXPORT D3D12SerializeRootSignature(const D3D12_ROOT_SIGNATURE_DESC *root_signature_desc,
@@ -359,7 +111,9 @@ HRESULT WINAPI DLLEXPORT D3D12SerializeRootSignature(const D3D12_ROOT_SIGNATURE_
     TRACE("root_signature_desc %p, version %#x, blob %p, error_blob %p.\n",
             root_signature_desc, version, blob, error_blob);
 
-    return vkd3d_serialize_root_signature(root_signature_desc, version, blob, error_blob);
+    if (!load_d3d12core())
+        return E_NOINTERFACE;
+    return IVKD3DCoreInterface_SerializeRootSignature(core, root_signature_desc, version, blob, error_blob);
 }
 
 HRESULT WINAPI DLLEXPORT D3D12CreateVersionedRootSignatureDeserializer(const void *data, SIZE_T data_size,
@@ -368,7 +122,9 @@ HRESULT WINAPI DLLEXPORT D3D12CreateVersionedRootSignatureDeserializer(const voi
     TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
             data, data_size, debugstr_guid(iid), deserializer);
 
-    return vkd3d_create_versioned_root_signature_deserializer(data, data_size, iid, deserializer);
+    if (!load_d3d12core())
+        return E_NOINTERFACE;
+    return IVKD3DCoreInterface_CreateVersionedRootSignatureDeserializer(core, data, data_size, iid, deserializer);
 }
 
 HRESULT WINAPI DLLEXPORT D3D12SerializeVersionedRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *desc,
@@ -376,5 +132,36 @@ HRESULT WINAPI DLLEXPORT D3D12SerializeVersionedRootSignature(const D3D12_VERSIO
 {
     TRACE("desc %p, blob %p, error_blob %p.\n", desc, blob, error_blob);
 
-    return vkd3d_serialize_versioned_root_signature(desc, blob, error_blob);
+    if (!load_d3d12core())
+        return E_NOINTERFACE;
+    return IVKD3DCoreInterface_SerializeVersionedRootSignature(core, desc, blob, error_blob);
+}
+
+HRESULT WINAPI DLLEXPORT D3D12GetDebugInterface(REFIID iid, void **debug)
+{
+    TRACE("iid %s, debug %p.\n", debugstr_guid(iid), debug);
+
+    if (!load_d3d12core())
+        return E_NOINTERFACE;
+    return IVKD3DCoreInterface_GetDebugInterface(core, iid, debug);
+}
+
+HRESULT WINAPI DLLEXPORT D3D12EnableExperimentalFeatures(UINT feature_count,
+        const IID *iids, void *configurations, UINT *configurations_sizes)
+{
+    FIXME("feature_count %u, iids %p, configurations %p, configurations_sizes %p stub!\n",
+            feature_count, iids, configurations, configurations_sizes);
+
+    if (!load_d3d12core())
+        return E_NOINTERFACE;
+    return IVKD3DCoreInterface_EnableExperimentalFeatures(core, feature_count, iids, configurations, configurations_sizes);
+}
+
+HRESULT WINAPI DLLEXPORT D3D12GetInterface(REFCLSID rcslid, REFIID iid, void **debug)
+{
+    TRACE("rcslid %s iid %s, debug %p.\n", debugstr_guid(rcslid), debugstr_guid(iid), debug);
+
+    if (!load_d3d12core())
+        return E_NOINTERFACE;
+    return IVKD3DCoreInterface_GetInterface(core, rcslid, iid, debug);
 }

--- a/libs/d3d12/meson.build
+++ b/libs/d3d12/meson.build
@@ -4,7 +4,7 @@ d3d12_src = [
 
 if vkd3d_platform == 'windows'
   d3d12_name_prefix = ''
-  d3d12_dependencies = [ vkd3d_dep, lib_dxgi ]
+  d3d12_dependencies = [ vkd3d_common_dep, lib_dxgi ]
 else
   d3d12_name_prefix = 'libvkd3d-proton-'
   # Link explicitly against d3d12core here so that we can alway find it
@@ -14,7 +14,7 @@ else
   # but dlopen will still find it since it is embedded in DT_RUNPATH (see objdump -p).
   # If the libraries are installed, the DT_RUNPATH is dropped, but at that point, LD_LIBRARY_PATH is more or less
   # expected.
-  d3d12_dependencies = [ vkd3d_dep, lib_dl, d3d12core_dep ]
+  d3d12_dependencies = [ vkd3d_common_dep, lib_dl, d3d12core_dep ]
 endif
 
 d3d12_needs_defs = (not vkd3d_is_msvc) and (vkd3d_platform == 'windows')

--- a/libs/d3d12/meson.build
+++ b/libs/d3d12/meson.build
@@ -7,7 +7,14 @@ if vkd3d_platform == 'windows'
   d3d12_dependencies = [ vkd3d_dep, lib_dxgi ]
 else
   d3d12_name_prefix = 'libvkd3d-proton-'
-  d3d12_dependencies = [ vkd3d_dep, lib_dl ]
+  # Link explicitly against d3d12core here so that we can alway find it
+  # when just doing a `meson build` build, without it needing to be in
+  # LD_LIBRARY_PATH.
+  # We don't directly access any symbols in d3d12core, so d3d12.so will not actually link against d3d12core.so,
+  # but dlopen will still find it since it is embedded in DT_RUNPATH (see objdump -p).
+  # If the libraries are installed, the DT_RUNPATH is dropped, but at that point, LD_LIBRARY_PATH is more or less
+  # expected.
+  d3d12_dependencies = [ vkd3d_dep, lib_dl, d3d12core_dep ]
 endif
 
 d3d12_needs_defs = (not vkd3d_is_msvc) and (vkd3d_platform == 'windows')

--- a/libs/d3d12core/d3d12core.def
+++ b/libs/d3d12core/d3d12core.def
@@ -1,0 +1,5 @@
+LIBRARY d3d12core.dll
+
+EXPORTS
+    D3D12GetInterface
+    D3D12SDKVersion DATA PRIVATE

--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -417,7 +417,10 @@ HRESULT WINAPI DLLEXPORT D3D12GetInterface(REFCLSID rcslid, REFIID iid, void **d
     if (IsEqualGUID(rcslid, &CLSID_VKD3DCore))
     {
         if (IsEqualGUID(iid, &IID_IVKD3DCoreInterface))
+        {
             *debug = (void*)&d3d12core_interface_instance;
+            return S_OK;
+        }
     }
     return E_NOINTERFACE;
 }

--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Hans-Kristian Arntzen for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+/* We need to specify the __declspec(dllexport) attribute
+ * on MinGW because otherwise the stdcall aliases/fixups
+ * don't get exported.
+ */
+#if defined(_MSC_VER)
+  #define DLLEXPORT
+#elif defined(__MINGW32__)
+  #define DLLEXPORT __declspec(dllexport)
+#endif
+
+/* Some applications check if this file exists to determine if Agility SDK is supported,
+ * but we implement everything in d3d12.dll and ignore app-provided d3d12core.dll anyways.
+ * Just expose a stub .dll. */
+
+HRESULT WINAPI DLLEXPORT D3D12GetInterface(REFCLSID rcslid, REFIID iid, void **debug)
+{
+    /* Don't bother with logging here, it just ends up bloating this stub .dll.
+     * We can inspect if this is loaded from wine logs if we have to. */
+    return E_NOINTERFACE;
+}
+
+/* Just expose the latest stable AgilitySDK version.
+ * This is actually exported as a UINT and not a function it seems. */
+DLLEXPORT const UINT D3D12SDKVersion = 608;
+

--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2018 Józef Kucia for CodeWeavers
+ * Copyright 2020 Joshua Ashton for Valve Software
  * Copyright 2023 Hans-Kristian Arntzen for Valve Corporation
  *
  * This library is free software; you can redistribute it and/or
@@ -14,10 +16,21 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
  */
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+
+#define VK_NO_PROTOTYPES
+#ifdef _WIN32
+#include "vkd3d_win32.h"
+#endif
+#include "vkd3d_sonames.h"
+#include "vkd3d.h"
+#include "vkd3d_atomic.h"
+#include "vkd3d_debug.h"
+#include "vkd3d_threads.h"
+#include "vkd3d_core_interface.h"
 
 /* We need to specify the __declspec(dllexport) attribute
  * on MinGW because otherwise the stdcall aliases/fixups
@@ -27,20 +40,389 @@
   #define DLLEXPORT
 #elif defined(__MINGW32__)
   #define DLLEXPORT __declspec(dllexport)
+#else
+  #define DLLEXPORT __attribute__((visibility("default")))
+  #include <dlfcn.h>
 #endif
 
-/* Some applications check if this file exists to determine if Agility SDK is supported,
- * but we implement everything in d3d12.dll and ignore app-provided d3d12core.dll anyways.
- * Just expose a stub .dll. */
+typedef IVKD3DCoreInterface d3d12core_interface;
+HRESULT WINAPI DLLEXPORT D3D12GetInterface(REFCLSID rcslid, REFIID iid, void** debug);
+
+static pthread_once_t library_once = PTHREAD_ONCE_INIT;
+
+#ifdef _WIN32
+static HMODULE vulkan_module = NULL;
+#else
+static void *vulkan_module = NULL;
+#endif
+static PFN_vkGetInstanceProcAddr vulkan_vkGetInstanceProcAddr = NULL;
+
+static void load_vulkan_once(void)
+{
+    if (!vulkan_module)
+    {
+#ifdef _WIN32
+        /* If possible, load winevulkan directly in order to bypass
+         * issues with third-party overlays hooking the Vulkan loader */
+        static const char *vulkan_dllnames[] =
+        {
+            "winevulkan.dll",
+            "vulkan-1.dll",
+        };
+
+        unsigned int i;
+
+        for (i = 0; i < ARRAY_SIZE(vulkan_dllnames); i++)
+        {
+            vulkan_module = LoadLibraryA(vulkan_dllnames[i]);
+
+            if (vulkan_module)
+            {
+                vulkan_vkGetInstanceProcAddr = (void*)GetProcAddress(vulkan_module, "vkGetInstanceProcAddr");
+
+                if (vulkan_vkGetInstanceProcAddr)
+                    break;
+
+                FreeLibrary(vulkan_module);
+                vulkan_module = NULL;
+            }
+        }
+#else
+        vulkan_module = dlopen(SONAME_LIBVULKAN, RTLD_LAZY);
+        vulkan_vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)dlsym(vulkan_module, "vkGetInstanceProcAddr");
+#endif
+    }
+}
+
+static bool load_vulkan(void)
+{
+    pthread_once(&library_once, load_vulkan_once);
+    return vulkan_vkGetInstanceProcAddr != NULL;
+}
+
+#ifdef _WIN32
+/* TODO: We need to attempt to dlopen() native DXVK DXGI. */
+static HRESULT d3d12_get_adapter(IDXGIAdapter **dxgi_adapter, IUnknown *adapter)
+{
+    IDXGIFactory4 *factory = NULL;
+    HRESULT hr;
+
+    if (!adapter)
+    {
+        if (FAILED(hr = CreateDXGIFactory1(&IID_IDXGIFactory4, (void **)&factory)))
+        {
+            WARN("Failed to create DXGI factory, hr %#x.\n", hr);
+            goto done;
+        }
+
+        if (FAILED(hr = IDXGIFactory4_EnumAdapters(factory, 0, dxgi_adapter)))
+        {
+            WARN("Failed to enumerate primary adapter, hr %#x.\n", hr);
+            goto done;
+        }
+    }
+    else
+    {
+        if (FAILED(hr = IUnknown_QueryInterface(adapter, &IID_IDXGIAdapter, (void **)dxgi_adapter)))
+        {
+            WARN("Invalid adapter %p, hr %#x.\n", adapter, hr);
+            goto done;
+        }
+    }
+
+done:
+    if (factory)
+        IDXGIFactory4_Release(factory);
+
+    return hr;
+}
+
+static VkPhysicalDevice d3d12_find_physical_device(struct vkd3d_instance *instance,
+        PFN_vkGetInstanceProcAddr pfn_vkGetInstanceProcAddr, struct DXGI_ADAPTER_DESC *adapter_desc)
+{
+    PFN_vkGetPhysicalDeviceProperties2 pfn_vkGetPhysicalDeviceProperties2;
+    PFN_vkGetPhysicalDeviceProperties pfn_vkGetPhysicalDeviceProperties;
+    PFN_vkEnumeratePhysicalDevices pfn_vkEnumeratePhysicalDevices;
+    VkPhysicalDevice vk_physical_device = VK_NULL_HANDLE;
+    VkPhysicalDeviceIDProperties id_properties;
+    VkPhysicalDeviceProperties2 properties2;
+    VkPhysicalDevice *vk_physical_devices;
+    VkInstance vk_instance;
+    unsigned int i;
+    uint32_t count;
+    VkResult vr;
+
+    vk_instance = vkd3d_instance_get_vk_instance(instance);
+
+    pfn_vkEnumeratePhysicalDevices = (void *)pfn_vkGetInstanceProcAddr(vk_instance, "vkEnumeratePhysicalDevices");
+    pfn_vkGetPhysicalDeviceProperties = (void *)pfn_vkGetInstanceProcAddr(vk_instance, "vkGetPhysicalDeviceProperties");
+    pfn_vkGetPhysicalDeviceProperties2 = (void *)pfn_vkGetInstanceProcAddr(vk_instance, "vkGetPhysicalDeviceProperties2");
+
+    if ((vr = pfn_vkEnumeratePhysicalDevices(vk_instance, &count, NULL)) < 0)
+    {
+        WARN("Failed to get device count, vr %d.\n", vr);
+        return VK_NULL_HANDLE;
+    }
+    if (!count)
+    {
+        WARN("No physical device available.\n");
+        return VK_NULL_HANDLE;
+    }
+
+    if (!(vk_physical_devices = calloc(count, sizeof(*vk_physical_devices))))
+        return VK_NULL_HANDLE;
+
+    if ((vr = pfn_vkEnumeratePhysicalDevices(vk_instance, &count, vk_physical_devices)) < 0)
+        goto done;
+
+    TRACE("Matching adapters by LUIDs.\n");
+
+    for (i = 0; i < count; ++i)
+    {
+        pfn_vkGetPhysicalDeviceProperties(vk_physical_devices[i], &properties2.properties);
+
+        /* Skip over physical devices below our minimum API version */
+        if (properties2.properties.apiVersion < VKD3D_MIN_API_VERSION)
+        {
+            WARN("Skipped adapter %s as it is below our minimum API version.", properties2.properties.deviceName);
+            continue;
+        }
+
+        id_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+        id_properties.pNext = NULL;
+
+        properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+        properties2.pNext = &id_properties;
+
+        pfn_vkGetPhysicalDeviceProperties2(vk_physical_devices[i], &properties2);
+
+        if (id_properties.deviceLUIDValid && !memcmp(id_properties.deviceLUID, &adapter_desc->AdapterLuid, VK_LUID_SIZE))
+        {
+            vk_physical_device = vk_physical_devices[i];
+            break;
+        }
+    }
+
+    if (!vk_physical_device)
+    {
+        TRACE("Matching adapters by PCI IDs.\n");
+
+        for (i = 0; i < count; ++i)
+        {
+            pfn_vkGetPhysicalDeviceProperties(vk_physical_devices[i], &properties2.properties);
+
+            if (properties2.properties.deviceID == adapter_desc->DeviceId &&
+                properties2.properties.vendorID == adapter_desc->VendorId)
+            {
+                vk_physical_device = vk_physical_devices[i];
+                break;
+            }
+        }
+    }
+
+    if (!vk_physical_device)
+    {
+        FIXME("Could not find Vulkan physical device for DXGI adapter.\n");
+        WARN("Using first available physical device...\n");
+        vk_physical_device = vk_physical_devices[0];
+    }
+
+done:
+    free(vk_physical_devices);
+    return vk_physical_device;
+}
+#endif
+
+static HRESULT vkd3d_create_instance_global(struct vkd3d_instance **out_instance)
+{
+    struct vkd3d_instance_create_info instance_create_info;
+    HRESULT hr = S_OK;
+
+    static const char * const instance_extensions[] =
+    {
+        VK_KHR_SURFACE_EXTENSION_NAME,
+#ifdef _WIN32
+        VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+#else
+        /* TODO: We need to attempt to dlopen() native DXVK DXGI and handle this more gracefully. */
+        "VK_KHR_xcb_surface",
+#endif
+    };
+
+    if (!load_vulkan())
+    {
+        ERR("Failed to load Vulkan library.\n");
+        return E_FAIL;
+    }
+
+    memset(&instance_create_info, 0, sizeof(instance_create_info));
+    instance_create_info.pfn_vkGetInstanceProcAddr = vulkan_vkGetInstanceProcAddr;
+    instance_create_info.instance_extensions = instance_extensions;
+    instance_create_info.instance_extension_count = ARRAY_SIZE(instance_extensions);
+    instance_create_info.optional_instance_extensions = NULL;
+    instance_create_info.optional_instance_extension_count = 0;
+
+    if (FAILED(hr = vkd3d_create_instance(&instance_create_info, out_instance)))
+        WARN("Failed to create vkd3d instance, hr %#x.\n", hr);
+
+    return hr;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12core_CreateDevice(d3d12core_interface *core,
+        IUnknown *adapter, D3D_FEATURE_LEVEL minimum_feature_level, REFIID iid, void **device)
+{
+    struct vkd3d_device_create_info device_create_info;
+    struct vkd3d_instance *instance;
+    HRESULT hr;
+
+#ifdef _WIN32
+    struct DXGI_ADAPTER_DESC adapter_desc;
+    IDXGIAdapter *dxgi_adapter;
+#endif
+
+    static const char * const device_extensions[] =
+    {
+        VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+        VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,
+    };
+
+    TRACE("adapter %p, minimum_feature_level %#x, iid %s, device %p.\n",
+            adapter, minimum_feature_level, debugstr_guid(iid), device);
+
+#ifdef _WIN32
+    if (FAILED(hr = d3d12_get_adapter(&dxgi_adapter, adapter)))
+        return hr;
+
+    if (FAILED(hr = IDXGIAdapter_GetDesc(dxgi_adapter, &adapter_desc)))
+    {
+        WARN("Failed to get adapter desc, hr %#x.\n", hr);
+        goto out_release_adapter;
+    }
+#else
+    /* TODO: We need to attempt to dlopen() native DXVK DXGI and handle this more gracefully. */
+    if (adapter)
+        FIXME("Ignoring adapter.\n");
+#endif
+
+    if (FAILED(hr = vkd3d_create_instance_global(&instance)))
+        return hr;
+
+    memset(&device_create_info, 0, sizeof(device_create_info));
+    device_create_info.minimum_feature_level = minimum_feature_level;
+    device_create_info.instance = instance;
+    device_create_info.instance_create_info = NULL;
+    device_create_info.device_extensions = device_extensions;
+    device_create_info.device_extension_count = ARRAY_SIZE(device_extensions);
+    device_create_info.optional_device_extensions = NULL;
+    device_create_info.optional_device_extension_count = 0;
+
+#ifdef _WIN32
+    device_create_info.vk_physical_device = d3d12_find_physical_device(instance, vulkan_vkGetInstanceProcAddr, &adapter_desc);
+    device_create_info.parent = (IUnknown *)dxgi_adapter;
+    memcpy(&device_create_info.adapter_luid, &adapter_desc.AdapterLuid, VK_LUID_SIZE);
+#endif
+
+    hr = vkd3d_create_device(&device_create_info, iid, device);
+    vkd3d_instance_decref(instance);
+
+#ifdef _WIN32
+out_release_adapter:
+    IDXGIAdapter_Release(dxgi_adapter);
+#endif
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE d3d12core_CreateRootSignatureDeserializer(d3d12core_interface *core,
+        const void *data, SIZE_T data_size, REFIID iid, void **deserializer)
+{
+    TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
+            data, data_size, debugstr_guid(iid), deserializer);
+
+    return vkd3d_create_root_signature_deserializer(data, data_size, iid, deserializer);
+}
+
+HRESULT STDMETHODCALLTYPE d3d12core_SerializeRootSignature(d3d12core_interface *core,
+        const D3D12_ROOT_SIGNATURE_DESC *root_signature_desc, D3D_ROOT_SIGNATURE_VERSION version, ID3DBlob **blob, ID3DBlob **error_blob)
+{
+    TRACE("root_signature_desc %p, version %#x, blob %p, error_blob %p.\n",
+            root_signature_desc, version, blob, error_blob);
+
+    return vkd3d_serialize_root_signature(root_signature_desc, version, blob, error_blob);
+}
+
+HRESULT STDMETHODCALLTYPE d3d12core_CreateVersionedRootSignatureDeserializer(d3d12core_interface *core,
+        const void *data, SIZE_T data_size, REFIID iid, void **deserializer)
+{
+    TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
+            data, data_size, debugstr_guid(iid), deserializer);
+
+    return vkd3d_create_versioned_root_signature_deserializer(data, data_size, iid, deserializer);
+}
+
+HRESULT STDMETHODCALLTYPE d3d12core_SerializeVersionedRootSignature(d3d12core_interface *core,
+        const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *desc, ID3DBlob **blob, ID3DBlob **error_blob)
+{
+    TRACE("desc %p, blob %p, error_blob %p.\n", desc, blob, error_blob);
+
+    return vkd3d_serialize_versioned_root_signature(desc, blob, error_blob);
+}
+
+HRESULT STDMETHODCALLTYPE d3d12core_GetDebugInterface(d3d12core_interface *core,
+        REFIID iid, void** debug)
+{
+    TRACE("iid %s, debug %p.\n", debugstr_guid(iid), debug);
+
+    WARN("Returning DXGI_ERROR_SDK_COMPONENT_MISSING.\n");
+    return DXGI_ERROR_SDK_COMPONENT_MISSING;
+}
+
+HRESULT STDMETHODCALLTYPE d3d12core_EnableExperimentalFeatures(d3d12core_interface *core,
+        UINT feature_count, const IID *iids, void *configurations, UINT *configurations_sizes)
+{
+    FIXME("feature_count %u, iids %p, configurations %p, configurations_sizes %p stub!\n",
+            feature_count, iids, configurations, configurations_sizes);
+
+    return E_NOINTERFACE;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12core_GetInterface(d3d12core_interface *core,
+        REFCLSID rcslid, REFIID iid, void **debug)
+{
+    TRACE("rcslid %s iid %s, debug %p.\n", debugstr_guid(rcslid), debugstr_guid(iid), debug);
+
+    return D3D12GetInterface(rcslid, iid, debug);
+}
+
+static CONST_VTBL struct IVKD3DCoreInterfaceVtbl d3d12core_interface_vtbl =
+{
+    d3d12core_CreateDevice,
+    d3d12core_CreateRootSignatureDeserializer,
+    d3d12core_SerializeRootSignature,
+    d3d12core_CreateVersionedRootSignatureDeserializer,
+    d3d12core_SerializeVersionedRootSignature,
+    d3d12core_GetDebugInterface,
+    d3d12core_EnableExperimentalFeatures,
+    d3d12core_GetInterface,
+};
+
+static const d3d12core_interface d3d12core_interface_instance =
+{
+    .lpVtbl = &d3d12core_interface_vtbl,
+};
 
 HRESULT WINAPI DLLEXPORT D3D12GetInterface(REFCLSID rcslid, REFIID iid, void **debug)
 {
-    /* Don't bother with logging here, it just ends up bloating this stub .dll.
-     * We can inspect if this is loaded from wine logs if we have to. */
+    TRACE("rcslid %s iid %s, debug %p.\n", debugstr_guid(rcslid), debugstr_guid(iid), debug);
+
+    if (IsEqualGUID(rcslid, &CLSID_VKD3DCore))
+    {
+        if (IsEqualGUID(iid, &IID_IVKD3DCoreInterface))
+            *debug = (void*)&d3d12core_interface_instance;
+    }
     return E_NOINTERFACE;
 }
+
 
 /* Just expose the latest stable AgilitySDK version.
  * This is actually exported as a UINT and not a function it seems. */
 DLLEXPORT const UINT D3D12SDKVersion = 608;
-

--- a/libs/d3d12core/meson.build
+++ b/libs/d3d12core/meson.build
@@ -2,12 +2,25 @@ d3d12core_src = [
   'main.c'
 ]
 
+if vkd3d_platform == 'windows'
+  d3d12core_name_prefix = ''
+  d3d12core_dependencies = [ vkd3d_dep, lib_dxgi ]
+else
+  d3d12core_name_prefix = 'libvkd3d-proton-'
+  d3d12core_dependencies = [ vkd3d_dep, lib_dl ]
+endif
+
 d3d12core_needs_defs = (not vkd3d_is_msvc) and (vkd3d_platform == 'windows')
 
 d3d12core_lib = shared_library('d3d12core', d3d12core_src,
-  name_prefix         : '',
+  name_prefix         : d3d12core_name_prefix,
+  dependencies        : d3d12core_dependencies,
+  include_directories : vkd3d_private_includes,
   install             : true,
   objects             : d3d12core_needs_defs ? 'd3d12core.def' : [],
   vs_module_defs      : 'd3d12core.def',
   override_options    : [ 'c_std='+vkd3d_c_std ])
 
+d3d12core_dep = declare_dependency(
+  link_with           : d3d12core_lib,
+  include_directories : vkd3d_public_includes)

--- a/libs/d3d12core/meson.build
+++ b/libs/d3d12core/meson.build
@@ -1,0 +1,13 @@
+d3d12core_src = [
+  'main.c'
+]
+
+d3d12core_needs_defs = (not vkd3d_is_msvc) and (vkd3d_platform == 'windows')
+
+d3d12core_lib = shared_library('d3d12core', d3d12core_src,
+  name_prefix         : '',
+  install             : true,
+  objects             : d3d12core_needs_defs ? 'd3d12core.def' : [],
+  vs_module_defs      : 'd3d12core.def',
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+

--- a/libs/meson.build
+++ b/libs/meson.build
@@ -2,6 +2,4 @@ subdir('vkd3d-common')
 subdir('vkd3d-shader')
 subdir('vkd3d')
 subdir('d3d12')
-if vkd3d_platform == 'windows'
-  subdir('d3d12core')
-endif
+subdir('d3d12core')

--- a/libs/meson.build
+++ b/libs/meson.build
@@ -1,5 +1,5 @@
 subdir('vkd3d-common')
 subdir('vkd3d-shader')
 subdir('vkd3d')
-subdir('d3d12')
 subdir('d3d12core')
+subdir('d3d12')

--- a/libs/meson.build
+++ b/libs/meson.build
@@ -2,3 +2,6 @@ subdir('vkd3d-common')
 subdir('vkd3d-shader')
 subdir('vkd3d')
 subdir('d3d12')
+if vkd3d_platform == 'windows'
+  subdir('d3d12core')
+endif

--- a/libs/vkd3d-common/debug.c
+++ b/libs/vkd3d-common/debug.c
@@ -57,6 +57,12 @@ static unsigned int vkd3d_dbg_level[VKD3D_DBG_CHANNEL_COUNT];
 static spinlock_t vkd3d_dbg_initialized;
 static pthread_once_t vkd3d_dbg_once = PTHREAD_ONCE_INIT;
 static FILE *vkd3d_log_file;
+static bool vkd3d_disable_file;
+
+void vkd3d_dbg_disable_debug_file(void)
+{
+    vkd3d_disable_file = true;
+}
 
 #ifdef _WIN32
 typedef int (*PFN_wine_log)(const char *);
@@ -102,7 +108,7 @@ static void vkd3d_dbg_init_once(void)
         vkd3d_dbg_buffer.buffer = malloc(vkd3d_dbg_buffer.size);
     }
 
-    if (vkd3d_get_env_var("VKD3D_LOG_FILE", vkd3d_debug, sizeof(vkd3d_debug)))
+    if (!vkd3d_disable_file && vkd3d_get_env_var("VKD3D_LOG_FILE", vkd3d_debug, sizeof(vkd3d_debug)))
     {
         /* Avoid extra formatting overhead when using buffered. */
         vkd3d_log_file = fopen(vkd3d_debug, vkd3d_dbg_buffer.buffer ? "wb" : "w");

--- a/libs/vkd3d-common/debug.c
+++ b/libs/vkd3d-common/debug.c
@@ -148,14 +148,16 @@ enum vkd3d_dbg_level vkd3d_dbg_get_level(enum vkd3d_dbg_channel channel)
 
 void vkd3d_dbg_printf(enum vkd3d_dbg_channel channel, enum vkd3d_dbg_level level, const char *function, const char *fmt, ...)
 {
-    FILE *log_file = vkd3d_log_file ? vkd3d_log_file : stderr;
     static spinlock_t spin;
     unsigned int tid;
+    FILE *log_file;
     va_list args;
 
     if (vkd3d_dbg_get_level(channel) < level)
         return;
     assert(level < ARRAY_SIZE(debug_level_names));
+
+    log_file = vkd3d_log_file ? vkd3d_log_file : stderr;
 
     va_start(args, fmt);
     tid = vkd3d_get_current_thread_id();

--- a/setup_vkd3d_proton.sh
+++ b/setup_vkd3d_proton.sh
@@ -187,3 +187,4 @@ uninstall() {
 }
 
 $action d3d12
+$action d3d12core

--- a/tests/d3d12_device.c
+++ b/tests/d3d12_device.c
@@ -1354,11 +1354,14 @@ void test_object_interface(void)
         hr = ID3D12Object_GetPrivateData(object, &WKPDID_D3DDebugObjectName, &size, NULL);
         ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", hr);
 
+#if 0
+        /* NULL name crashes on Windows 11 22621. */
         hr = ID3D12Object_SetName(object, NULL);
         ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
 
         hr = ID3D12Object_GetPrivateData(object, &WKPDID_D3DDebugObjectNameW, &size, NULL);
         ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", hr);
+#endif
 
         hr = ID3D12Object_SetPrivateData(object, &WKPDID_D3DDebugObjectName, sizeof(terminated_name_a), terminated_name_a);
         ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);

--- a/tests/d3d12_device.c
+++ b/tests/d3d12_device.c
@@ -1506,3 +1506,44 @@ void test_enumerate_meta_commands(void)
     refcount = ID3D12Device5_Release(device5);
     ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
 }
+
+void test_vtable_origins(void)
+{
+#ifdef _WIN32
+    HMODULE d3d12core_module, vtable_module;
+    MEMORY_BASIC_INFORMATION info;
+    ID3D12Device *device;
+    SIZE_T ret;
+
+    if (!(device = create_device()))
+    {
+        skip("Failed to create device.\n");
+        return;
+    }
+
+    /* Skip this test if running on an older version of
+     * Windows from before the D3D12 + D3D12Core split. */
+    if (!(d3d12core_module = GetModuleHandleA("d3d12core")))
+    {
+        skip("No D3D12Core module, skipping.\n");
+        ID3D12Device_Release(device);
+        return;
+    }
+
+    ret = VirtualQuery(device->lpVtbl, &info, sizeof(info));
+    ok(ret, "VirtualQuery of ID3D12Device VTable failed.\n");
+    if (!ret)
+    {
+        skip("VirtualQuery failed, skipping vtable test.\n");
+        ID3D12Device_Release(device);
+        return;
+    }
+
+    vtable_module = (HMODULE)info.AllocationBase;
+
+    /* Ensure the vtable for ID3D12Device comes from D3D12Core.dll */
+    todo ok(vtable_module == d3d12core_module, "VTable for ID3D12Device not provided by D3D12Core.\n");
+
+    ID3D12Device_Release(device);
+#endif
+}

--- a/tests/d3d12_device.c
+++ b/tests/d3d12_device.c
@@ -1542,7 +1542,7 @@ void test_vtable_origins(void)
     vtable_module = (HMODULE)info.AllocationBase;
 
     /* Ensure the vtable for ID3D12Device comes from D3D12Core.dll */
-    todo ok(vtable_module == d3d12core_module, "VTable for ID3D12Device not provided by D3D12Core.\n");
+    ok(vtable_module == d3d12core_module, "VTable for ID3D12Device not provided by D3D12Core.\n");
 
     ID3D12Device_Release(device);
 #endif

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -333,3 +333,4 @@ decl_test(test_memory_model_uav_coherence_thread_group_dxbc);
 decl_test(test_memory_model_uav_coherence_thread_group_dxil);
 decl_test(test_rasterizer_ordered_views_dxbc);
 decl_test(test_rasterizer_ordered_views_dxil);
+decl_test(test_vtable_origins);


### PR DESCRIPTION
Move the main bulk of the code to d3d12core, and expose an interface to access.

This allows us to pass the new test that prove that the vtable is resident in d3d12core going forward.

Essentially turns d3d12 into a slim wrapper.

Signed-off-by: Joshua Ashton <joshua@froggi.es>