### PR TITLE
Embedded mutable descriptors

### DIFF
--- a/include/private/copy_utils.h
+++ b/include/private/copy_utils.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 Hans-Kristian Arntzen for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef __VKD3D_COPY_UTILS_H
+#define __VKD3D_COPY_UTILS_H
+
+#ifdef __SSE2__
+#include <emmintrin.h>
+#endif
+#include <stdint.h>
+#include <memory.h>
+
+#ifdef __SSE2__
+
+#define vkd3d_memcpy_aligned_64_non_temporal(dst, src) do { \
+    __m128i a, b, c, d; \
+    a = _mm_load_si128((const __m128i *)(src) + 0); \
+    b = _mm_load_si128((const __m128i *)(src) + 1); \
+    c = _mm_load_si128((const __m128i *)(src) + 2); \
+    d = _mm_load_si128((const __m128i *)(src) + 3); \
+    _mm_stream_si128((__m128i *)(dst) + 0, a); \
+    _mm_stream_si128((__m128i *)(dst) + 1, b); \
+    _mm_stream_si128((__m128i *)(dst) + 2, c); \
+    _mm_stream_si128((__m128i *)(dst) + 3, d); \
+} while(0)
+
+#define vkd3d_memcpy_aligned_32_non_temporal(dst, src) do { \
+    __m128i a, b; \
+    a = _mm_load_si128((const __m128i *)(src) + 0); \
+    b = _mm_load_si128((const __m128i *)(src) + 1); \
+    _mm_stream_si128((__m128i *)(dst) + 0, a); \
+    _mm_stream_si128((__m128i *)(dst) + 1, b); \
+} while(0)
+
+#define vkd3d_memcpy_aligned_16_non_temporal(dst, src) do { \
+    __m128i a; \
+    a = _mm_load_si128((const __m128i *)(src)); \
+    _mm_stream_si128((__m128i *)(dst), a); \
+} while(0)
+
+#define vkd3d_memcpy_aligned_64_cached(dst, src) do { \
+    __m128i a, b, c, d; \
+    a = _mm_load_si128((const __m128i *)(src) + 0); \
+    b = _mm_load_si128((const __m128i *)(src) + 1); \
+    c = _mm_load_si128((const __m128i *)(src) + 2); \
+    d = _mm_load_si128((const __m128i *)(src) + 3); \
+    _mm_store_si128((__m128i *)(dst) + 0, a); \
+    _mm_store_si128((__m128i *)(dst) + 1, b); \
+    _mm_store_si128((__m128i *)(dst) + 2, c); \
+    _mm_store_si128((__m128i *)(dst) + 3, d); \
+} while(0)
+
+#define vkd3d_memcpy_aligned_32_cached(dst, src) do { \
+    __m128i a, b; \
+    a = _mm_load_si128((const __m128i *)(src) + 0); \
+    b = _mm_load_si128((const __m128i *)(src) + 1); \
+    _mm_store_si128((__m128i *)(dst) + 0, a); \
+    _mm_store_si128((__m128i *)(dst) + 1, b); \
+} while(0)
+
+#define vkd3d_memcpy_aligned_16_cached(dst, src) do { \
+    __m128i a; \
+    a = _mm_load_si128((const __m128i *)(src)); \
+    _mm_store_si128((__m128i *)(dst), a); \
+} while(0)
+
+static inline void vkd3d_memcpy_aligned_non_temporal(void *dst_, const void *src_, size_t size)
+{
+    const uint8_t *src = src_;
+    uint8_t *dst = dst_;
+    size_t i;
+
+    for (i = 0; i < size; i += 16)
+        vkd3d_memcpy_aligned_16_non_temporal(dst + i, src + i);
+}
+
+static inline void vkd3d_memcpy_aligned_cached(void *dst_, const void *src_, size_t size)
+{
+    const uint8_t *src = src_;
+    uint8_t *dst = dst_;
+    size_t i;
+
+    for (i = 0; i < size; i += 16)
+        vkd3d_memcpy_aligned_16_cached(dst + i, src + i);
+}
+
+#define vkd3d_memcpy_non_temporal_barrier() _mm_sfence()
+#else
+#define vkd3d_memcpy_aligned_64_non_temporal(dst, src) memcpy((uint8_t *)(dst), (const uint8_t *)(src), 64)
+#define vkd3d_memcpy_aligned_32_non_temporal(dst, src) memcpy((uint8_t *)(dst), (const uint8_t *)(src), 32)
+#define vkd3d_memcpy_aligned_16_non_temporal(dst, src) memcpy((uint8_t *)(dst), (const uint8_t *)(src), 16)
+#define vkd3d_memcpy_aligned_non_temporal(dst, src, size) memcpy((uint8_t *)(dst), (const uint8_t *)(src), size)
+#define vkd3d_memcpy_aligned_64_cached(dst, src) memcpy((uint8_t *)(dst), (const uint8_t *)(src), 64)
+#define vkd3d_memcpy_aligned_32_cached(dst, src) memcpy((uint8_t *)(dst), (const uint8_t *)(src), 32)
+#define vkd3d_memcpy_aligned_16_cached(dst, src) memcpy((uint8_t *)(dst), (const uint8_t *)(src), 16)
+#define vkd3d_memcpy_aligned_cached(dst, src, size) memcpy((uint8_t *)(dst), (const uint8_t *)(src), size)
+#define vkd3d_memcpy_non_temporal_barrier() ((void)0)
+#endif
+
+#endif

--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -326,4 +326,12 @@ static inline uint64_t vkd3d_get_current_time_ticks(void)
 #endif
 }
 
+#if defined(__GNUC__) || defined(__clang__)
+#define VKD3D_EXPECT_TRUE(x) __builtin_expect(!!(x), 1)
+#define VKD3D_EXPECT_FALSE(x) __builtin_expect(!!(x), 0)
+#else
+#define VKD3D_EXPECT_TRUE(x) (x)
+#define VKD3D_EXPECT_FALSE(x) (x)
+#endif
+
 #endif  /* __VKD3D_COMMON_H */

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -209,7 +209,9 @@ enum vkd3d_shader_interface_flag
     VKD3D_SHADER_INTERFACE_BINDLESS_CBV_AS_STORAGE_BUFFER   = 0x00000002u,
     VKD3D_SHADER_INTERFACE_SSBO_OFFSET_BUFFER               = 0x00000004u,
     VKD3D_SHADER_INTERFACE_TYPED_OFFSET_BUFFER              = 0x00000008u,
-    VKD3D_SHADER_INTERFACE_DESCRIPTOR_QA_BUFFER             = 0x00000010u
+    VKD3D_SHADER_INTERFACE_DESCRIPTOR_QA_BUFFER             = 0x00000010u,
+    /* In this model, use descriptor_size_cbv_srv_uav as array stride for raw VA buffer. */
+    VKD3D_SHADER_INTERFACE_RAW_VA_ALIAS_DESCRIPTOR_BUFFER   = 0x00000020u,
 };
 
 struct vkd3d_shader_stage_io_entry
@@ -264,6 +266,10 @@ struct vkd3d_shader_interface_info
     VkShaderStageFlagBits stage;
 
     const struct vkd3d_shader_transform_feedback_info *xfb_info;
+
+    /* Used for either VKD3D_SHADER_INTERFACE_RAW_VA_ALIAS_DESCRIPTOR_BUFFER or local root signatures. */
+    uint32_t descriptor_size_cbv_srv_uav;
+    uint32_t descriptor_size_sampler;
 };
 
 struct vkd3d_shader_descriptor_table
@@ -304,7 +310,6 @@ struct vkd3d_shader_interface_local_info
     unsigned int shader_record_buffer_count;
     const struct vkd3d_shader_resource_binding *bindings;
     unsigned int binding_count;
-    uint32_t descriptor_size;
 };
 
 struct vkd3d_shader_transform_feedback_element

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -720,6 +720,21 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
     }
 #endif
 
+    if (shader_interface_info->flags & VKD3D_SHADER_INTERFACE_RAW_VA_ALIAS_DESCRIPTOR_BUFFER)
+    {
+        const struct dxil_spv_option_physical_address_descriptor_indexing helper =
+                { { DXIL_SPV_OPTION_PHYSICAL_ADDRESS_DESCRIPTOR_INDEXING },
+                    shader_interface_info->descriptor_size_cbv_srv_uav / sizeof(VkDeviceAddress),
+                    0 };
+
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            ERR("dxil-spirv does not support PHYSICAL_ADDRESS_DESCRIPTOR_INDEXING.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
     {
         const struct dxil_spv_option_bindless_offset_buffer_layout helper =
                 { { DXIL_SPV_OPTION_BINDLESS_OFFSET_BUFFER_LAYOUT },
@@ -1206,11 +1221,26 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
     {
         const struct dxil_spv_option_sbt_descriptor_size_log2 helper =
                 { { DXIL_SPV_OPTION_SBT_DESCRIPTOR_SIZE_LOG2 },
-                    vkd3d_bitmask_tzcnt32(shader_interface_local_info->descriptor_size),
-                    vkd3d_bitmask_tzcnt32(shader_interface_local_info->descriptor_size) };
+                    vkd3d_bitmask_tzcnt32(shader_interface_info->descriptor_size_cbv_srv_uav),
+                    vkd3d_bitmask_tzcnt32(shader_interface_info->descriptor_size_sampler) };
         if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
         {
             ERR("dxil-spirv does not support SBT_DESCRIPTOR_SIZE_LOG2.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
+    if (shader_interface_info->flags & VKD3D_SHADER_INTERFACE_RAW_VA_ALIAS_DESCRIPTOR_BUFFER)
+    {
+        const struct dxil_spv_option_physical_address_descriptor_indexing helper =
+                { { DXIL_SPV_OPTION_PHYSICAL_ADDRESS_DESCRIPTOR_INDEXING },
+                    shader_interface_info->descriptor_size_cbv_srv_uav / sizeof(VkDeviceAddress),
+                    0 };
+
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            ERR("dxil-spirv does not support PHYSICAL_ADDRESS_DESCRIPTOR_INDEXING.\n");
             ret = VKD3D_ERROR_NOT_IMPLEMENTED;
             goto end;
         }

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -189,7 +189,16 @@ static dxil_spv_bool dxil_remap_inner(
 
                 /* Acceleration structures are mapped to SSBO uvec2[] array instead of normal heap. */
                 if (d3d_binding->kind == DXIL_SPV_RESOURCE_KIND_RT_ACCELERATION_STRUCTURE)
+                {
                     vk_binding->descriptor_type = DXIL_SPV_VULKAN_DESCRIPTOR_TYPE_SSBO;
+                }
+                else if (descriptor_type == VKD3D_SHADER_DESCRIPTOR_TYPE_UAV &&
+                        (binding->flags & VKD3D_SHADER_BINDING_FLAG_AUX_BUFFER) &&
+                        !(binding->flags & VKD3D_SHADER_BINDING_FLAG_RAW_VA))
+                {
+                    /* Force texel buffer path for UAV counters if we need to. */
+                    vk_binding->descriptor_type = DXIL_SPV_VULKAN_DESCRIPTOR_TYPE_TEXEL_BUFFER;
+                }
             }
             else
             {
@@ -548,7 +557,6 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
         const struct vkd3d_shader_compile_arguments *compiler_args)
 {
     struct vkd3d_dxil_remap_userdata remap_userdata;
-    unsigned int non_raw_va_binding_count = 0;
     unsigned int raw_va_binding_count = 0;
     unsigned int num_root_descriptors = 0;
     unsigned int root_constant_words = 0;
@@ -614,27 +622,11 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
 
     for (i = 0; i < shader_interface_info->binding_count; i++)
     {
-        /* Bindless UAV counters are implemented as physical storage buffer pointers.
-         * For simplicity, dxil-spirv only accepts either fully RAW VA, or all non-raw VA. */
-        if ((shader_interface_info->bindings[i].flags &
-             (VKD3D_SHADER_BINDING_FLAG_AUX_BUFFER | VKD3D_SHADER_BINDING_FLAG_BINDLESS)) ==
-            (VKD3D_SHADER_BINDING_FLAG_AUX_BUFFER | VKD3D_SHADER_BINDING_FLAG_BINDLESS))
-        {
-            if (shader_interface_info->bindings[i].flags & VKD3D_SHADER_BINDING_FLAG_RAW_VA)
-                raw_va_binding_count++;
-            else
-                non_raw_va_binding_count++;
-        }
+        if (shader_interface_info->bindings[i].flags & VKD3D_SHADER_BINDING_FLAG_RAW_VA)
+            raw_va_binding_count++;
 
         if (vkd3d_shader_binding_is_root_descriptor(&shader_interface_info->bindings[i]))
             num_root_descriptors++;
-    }
-
-    if (raw_va_binding_count && non_raw_va_binding_count)
-    {
-        ERR("dxil-spirv currently cannot mix and match bindless UAV counters with RAW VA and texel buffer.\n");
-        ret = VKD3D_ERROR_NOT_IMPLEMENTED;
-        goto end;
     }
 
     /* Root constants come after root descriptors. Offset the counts. */
@@ -971,8 +963,6 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
     const struct vkd3d_shader_resource_binding *resource_binding;
     const struct vkd3d_shader_root_parameter *root_parameter;
     struct vkd3d_dxil_remap_userdata remap_userdata;
-    unsigned int non_raw_va_binding_count = 0;
-    unsigned int raw_va_binding_count = 0;
     unsigned int num_root_descriptors = 0;
     unsigned int root_constant_words = 0;
     dxil_spv_converter converter = NULL;
@@ -1031,22 +1021,8 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
         root_constant_words = max_size;
 
     for (i = 0; i < shader_interface_info->binding_count; i++)
-    {
-        /* Bindless UAV counters are implemented as physical storage buffer pointers.
-         * For simplicity, dxil-spirv only accepts either fully RAW VA, or all non-raw VA. */
-        if ((shader_interface_info->bindings[i].flags &
-             (VKD3D_SHADER_BINDING_FLAG_AUX_BUFFER | VKD3D_SHADER_BINDING_FLAG_BINDLESS)) ==
-            (VKD3D_SHADER_BINDING_FLAG_AUX_BUFFER | VKD3D_SHADER_BINDING_FLAG_BINDLESS))
-        {
-            if (shader_interface_info->bindings[i].flags & VKD3D_SHADER_BINDING_FLAG_RAW_VA)
-                raw_va_binding_count++;
-            else
-                non_raw_va_binding_count++;
-        }
-
         if (vkd3d_shader_binding_is_root_descriptor(&shader_interface_info->bindings[i]))
             num_root_descriptors++;
-    }
 
     /* Push local root parameters. We cannot rely on callbacks here
      * since the local root signature has a physical layout in ShaderRecordKHR
@@ -1134,13 +1110,6 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
                 ret = VKD3D_ERROR_INVALID_ARGUMENT;
                 goto end;
         }
-    }
-
-    if (raw_va_binding_count && non_raw_va_binding_count)
-    {
-        ERR("dxil-spirv currently cannot mix and match bindless UAV counters with RAW VA and texel buffer.\n");
-        ret = VKD3D_ERROR_NOT_IMPLEMENTED;
-        goto end;
     }
 
     /* Root constants come after root descriptors. Offset the counts. */

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -9306,6 +9306,19 @@ static uint32_t vkd3d_dxbc_compiler_get_resource_index(struct vkd3d_dxbc_compile
     }
 #endif
 
+    /* The physical VAs might not be tightly packed, so apply that here.
+     * Important that we apply this stride after descriptor QA check. */
+    if ((binding->flags & VKD3D_SHADER_BINDING_FLAG_RAW_VA) &&
+            (binding->flags & VKD3D_SHADER_BINDING_FLAG_AUX_BUFFER) &&
+            (compiler->shader_interface.flags & VKD3D_SHADER_INTERFACE_RAW_VA_ALIAS_DESCRIPTOR_BUFFER))
+    {
+        index_id = vkd3d_spirv_build_op_imul(builder,
+                vkd3d_spirv_get_type_id(builder, VKD3D_TYPE_UINT, 1),
+                vkd3d_dxbc_compiler_get_constant_uint(compiler,
+                        compiler->shader_interface.descriptor_size_cbv_srv_uav / sizeof(VkDeviceAddress)),
+                index_id);
+    }
+
     /* AMD drivers rely on the index being marked as nonuniform */
     if (reg->modifier == VKD3DSPRM_NONUNIFORM)
         vkd3d_dxbc_compiler_decorate_nonuniform(compiler, index_id);

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -14116,6 +14116,11 @@ static void d3d12_command_queue_add_submission_locked(struct d3d12_command_queue
 static void d3d12_command_queue_add_submission(struct d3d12_command_queue *queue,
         const struct d3d12_command_queue_submission *sub)
 {
+    /* Ensure that any non-temporal writes from CopyDescriptors are ordered properly
+     * with the submission thread that calls vkQueueSubmit. */
+    if (d3d12_device_use_embedded_mutable_descriptors(queue->device))
+        vkd3d_memcpy_non_temporal_barrier();
+
     pthread_mutex_lock(&queue->queue_lock);
     d3d12_command_queue_add_submission_locked(queue, sub);
     pthread_mutex_unlock(&queue->queue_lock);

--- a/libs/vkd3d/command_list_profiled.h
+++ b/libs/vkd3d/command_list_profiled.h
@@ -150,13 +150,13 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootSignature_profil
 static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootDescriptorTable_profiled(d3d12_command_list_iface *iface,
         UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
 {
-    COMMAND_LIST_PROFILED_CALL(SetComputeRootDescriptorTable, iface, root_parameter_index, base_descriptor);
+    COMMAND_LIST_PROFILED_CALL(SetComputeRootDescriptorTable_default, iface, root_parameter_index, base_descriptor);
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootDescriptorTable_profiled(d3d12_command_list_iface *iface,
         UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
 {
-    COMMAND_LIST_PROFILED_CALL(SetGraphicsRootDescriptorTable, iface, root_parameter_index, base_descriptor);
+    COMMAND_LIST_PROFILED_CALL(SetGraphicsRootDescriptorTable_default, iface, root_parameter_index, base_descriptor);
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRoot32BitConstant_profiled(d3d12_command_list_iface *iface,

--- a/libs/vkd3d/device_profiled.h
+++ b/libs/vkd3d/device_profiled.h
@@ -64,21 +64,21 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateRootSignature_profiled(d3d12
 static void STDMETHODCALLTYPE d3d12_device_CreateConstantBufferView_profiled(d3d12_device_iface *iface,
         const D3D12_CONSTANT_BUFFER_VIEW_DESC *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
 {
-    DEVICE_PROFILED_CALL(CreateConstantBufferView, iface, desc, descriptor);
+    DEVICE_PROFILED_CALL(CreateConstantBufferView_default, iface, desc, descriptor);
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CreateShaderResourceView_profiled(d3d12_device_iface *iface,
         ID3D12Resource *resource, const D3D12_SHADER_RESOURCE_VIEW_DESC *desc,
         D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
 {
-    DEVICE_PROFILED_CALL(CreateShaderResourceView, iface, resource, desc, descriptor);
+    DEVICE_PROFILED_CALL(CreateShaderResourceView_default, iface, resource, desc, descriptor);
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CreateUnorderedAccessView_profiled(d3d12_device_iface *iface,
         ID3D12Resource *resource, ID3D12Resource *counter_resource,
         const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
 {
-    DEVICE_PROFILED_CALL(CreateUnorderedAccessView, iface, resource, counter_resource, desc, descriptor);
+    DEVICE_PROFILED_CALL(CreateUnorderedAccessView_default, iface, resource, counter_resource, desc, descriptor);
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CreateRenderTargetView_profiled(d3d12_device_iface *iface,
@@ -98,7 +98,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateDepthStencilView_profiled(d3d12
 static void STDMETHODCALLTYPE d3d12_device_CreateSampler_profiled(d3d12_device_iface *iface,
         const D3D12_SAMPLER_DESC *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
 {
-    DEVICE_PROFILED_CALL(CreateSampler, iface, desc, descriptor);
+    DEVICE_PROFILED_CALL(CreateSampler_default, iface, desc, descriptor);
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CopyDescriptors_profiled(d3d12_device_iface *iface,
@@ -146,7 +146,7 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_profiled(d3d12_
 {
     VKD3D_REGION_DECL(CopyDescriptorsSimple);
     VKD3D_REGION_BEGIN(CopyDescriptorsSimple);
-    d3d12_device_CopyDescriptorsSimple(iface, descriptor_count, dst_descriptor_range_offset,
+    d3d12_device_CopyDescriptorsSimple_default(iface, descriptor_count, dst_descriptor_range_offset,
             src_descriptor_range_offset, descriptor_heap_type);
     VKD3D_REGION_END_ITERATIONS(CopyDescriptorsSimple, descriptor_count);
 }

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -1706,6 +1706,11 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
     shader_interface_info.stage = VK_SHADER_STAGE_ALL;
     shader_interface_info.xfb_info = NULL;
 
+    shader_interface_info.descriptor_size_cbv_srv_uav = d3d12_device_get_descriptor_handle_increment_size(
+            object->device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    shader_interface_info.descriptor_size_sampler = d3d12_device_get_descriptor_handle_increment_size(
+            object->device, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+
     if (!d3d12_state_object_pipeline_data_find_global_state_objects(data,
             &global_signature, &shader_config, &pipeline_config))
         return E_INVALIDARG;
@@ -1769,7 +1774,6 @@ static HRESULT d3d12_state_object_compile_pipeline(struct d3d12_state_object *ob
             shader_interface_local_info.local_root_parameter_count = local_signature->parameter_count;
             shader_interface_local_info.shader_record_constant_buffers = local_signature->root_constants;
             shader_interface_local_info.shader_record_buffer_count = local_signature->root_constant_count;
-            shader_interface_local_info.descriptor_size = VKD3D_RESOURCE_DESC_INCREMENT;
 
             if (local_signature->static_sampler_count)
             {

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -5691,6 +5691,10 @@ static bool vkd3d_bindless_supports_embedded_mutable_type(struct d3d12_device *d
             (device->device_info.descriptor_buffer_properties.samplerDescriptorSize - 1))
         return false;
 
+    /* Sampler descriptor has to be at least 16 byte, so we can use fast path for copies. */
+    if (device->device_info.descriptor_buffer_properties.samplerDescriptorSize < 16)
+        return false;
+
     /* If descriptor buffers must be bound at large alignment, we cannot do magic packing tricks. */
     if (device->device_info.descriptor_buffer_properties.descriptorBufferOffsetAlignment >
             device->device_info.descriptor_buffer_properties.robustStorageBufferDescriptorSize)


### PR DESCRIPTION
This introduces the idea of "embedded" mutable descriptors.

In this descriptor model, we can embed all information we need for
a given descriptor within the descriptor buffer payload itself.

This requires that the descriptor buffer implementation of the driver
supports some key properties:

- Size >= 32 (we need to reserve 5 LSBs to signal log2 offset to planar
  metadata in case that exists)
- Texel buffer and SSBO can be placed side by side in the mutable
  payload (these are usually 16 bytes each)
- Descriptor buffers can be bound at SSBO descriptor size alignment.
  We are clever here and bind the same descriptor buffer at an offset
  to achieve the packed texel buffer + SSBO descriptor.
- RTAS SRVs is implemented by viewing the descriptor buffer as an SSBO
  directly and shader applies a stride to load the BDA based on
  sizeof(mutable descriptor).
- UAV counters are implemented by repurposing the texel buffer.
  Could have used BDA, but it is somewhat less robust against app bugs
  when we alias texel buffer descriptor with it. We already had code
  paths in place to deal with the pre-BDA world, so this is fine.
- If Size is very large, like on RADV (64 byte) we can take
  advantage of that by embedding the metadata inside the mutable
  descriptor as well. This mostly just serves to save on CPU memory
  and avoids having to check for CPU -> CPU descriptor copies.

This allows us to massively optimize descriptor copies to the point
where the descriptor copy itself is an unrolled memcpy.

To further make this work well, we need to introduce vtable variants.
This improves performance quite a lot for descriptor copies, and is
overall cleaner.

In the descriptor copy micro-benchmark that copies one descriptor at a
time under ideal cache situations,
I observe 12.5 ns -> 2.5 ns per descriptor.

With the vtable variant system in place, it should be possible to add
special optimizations for implementations which do not hit this
optimization path.