### PR TITLE
idl: Get rid of INLINE_WRAPPER macros.

### DIFF
--- a/demos/demo.h
+++ b/demos/demo.h
@@ -21,7 +21,6 @@
 #endif
 
 #include <vkd3d_windows.h>
-#define WIDL_C_INLINE_WRAPPERS
 #define COBJMACROS
 #include <vkd3d_d3d12.h>
 #include <inttypes.h>

--- a/demos/gears.c
+++ b/demos/gears.c
@@ -175,9 +175,10 @@ static void cxg_populate_command_list(struct cx_gears *cxg, unsigned int rt_idx)
     barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
     ID3D12GraphicsCommandList_ResourceBarrier(command_list, 1, &barrier);
 
-    rtv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(cxg->rtv_heap);
+    cxg->rtv_heap->lpVtbl->GetCPUDescriptorHandleForHeapStart(cxg->rtv_heap, &rtv_handle);
+
     rtv_handle.ptr += rt_idx * cxg->rtv_descriptor_size;
-    dsv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(cxg->dsv_heap);
+    cxg->dsv_heap->lpVtbl->GetCPUDescriptorHandleForHeapStart(cxg->dsv_heap, &dsv_handle);
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &rtv_handle, FALSE, &dsv_handle);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, rtv_handle, clear_colour, 0, NULL);
@@ -377,7 +378,7 @@ static void cxg_load_pipeline(struct cx_gears *cxg)
 
     cxg->rtv_descriptor_size = ID3D12Device_GetDescriptorHandleIncrementSize(cxg->device,
             D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    rtv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(cxg->rtv_heap);
+    cxg->rtv_heap->lpVtbl->GetCPUDescriptorHandleForHeapStart(cxg->rtv_heap, &rtv_handle);
     for (i = 0; i < ARRAY_SIZE(cxg->render_targets); ++i)
     {
         cxg->render_targets[i] = demo_swapchain_get_back_buffer(cxg->swapchain, i);
@@ -764,7 +765,7 @@ static void cxg_load_assets(struct cx_gears *cxg)
             D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear_value, &IID_ID3D12Resource, (void **)&cxg->ds);
     assert(SUCCEEDED(hr));
 
-    dsv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(cxg->dsv_heap);
+    cxg->dsv_heap->lpVtbl->GetCPUDescriptorHandleForHeapStart(cxg->dsv_heap, &dsv_handle);
     ID3D12Device_CreateDepthStencilView(cxg->device, cxg->ds, NULL, dsv_handle);
 
     heap_desc.Type = D3D12_HEAP_TYPE_UPLOAD;

--- a/demos/triangle.c
+++ b/demos/triangle.c
@@ -112,7 +112,8 @@ static void cxt_populate_command_list(struct cx_triangle *cxt)
     barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
     ID3D12GraphicsCommandList_ResourceBarrier(cxt->command_list, 1, &barrier);
 
-    rtv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(cxt->rtv_heap);
+    cxt->rtv_heap->lpVtbl->GetCPUDescriptorHandleForHeapStart(cxt->rtv_heap, &rtv_handle);
+
     rtv_handle.ptr += cxt->frame_idx * cxt->rtv_descriptor_size;
     ID3D12GraphicsCommandList_OMSetRenderTargets(cxt->command_list, 1, &rtv_handle, FALSE, NULL);
 
@@ -212,7 +213,7 @@ static void cxt_load_pipeline(struct cx_triangle *cxt)
 
     cxt->rtv_descriptor_size = ID3D12Device_GetDescriptorHandleIncrementSize(cxt->device,
             D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    rtv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(cxt->rtv_heap);
+    cxt->rtv_heap->lpVtbl->GetCPUDescriptorHandleForHeapStart(cxt->rtv_heap, &rtv_handle);
     for (i = 0; i < ARRAY_SIZE(cxt->render_targets); ++i)
     {
         cxt->render_targets[i] = demo_swapchain_get_back_buffer(cxt->swapchain, i);

--- a/include/vkd3d_win32.h
+++ b/include/vkd3d_win32.h
@@ -20,42 +20,13 @@
 #ifndef __VKD3D_WIN32_H
 #define __VKD3D_WIN32_H
 
-/* Hack for MinGW-w64 headers.
- *
- * We want to use WIDL C inline wrappers because some methods
- * in D3D12 interfaces return aggregate objects. Unfortunately,
- * WIDL C inline wrappers are broken when used with MinGW-w64
- * headers because FORCEINLINE expands to extern inline
- * which leads to the "multiple storage classes in declaration
- * specifiers" compiler error.
- *
- * This hack will define static to be meaningless when these
- * headers are included, which are the only things declared
- * static.
- */
-#ifdef __MINGW32__
-# define static
-#endif
-
 #define INITGUID
 #define COBJMACROS
-#define WIDL_C_INLINE_WRAPPERS
 #include <vkd3d_windows.h>
-
-/* Vulkan headers include static const declarations. Enable static keyword for
- * them.
- */
-#ifdef __MINGW32__
-# undef static
-#endif
 
 #define VK_USE_PLATFORM_WIN32_KHR
 #include <vulkan/vulkan.h>
 #include "private/vulkan_private_extensions.h"
-
-#ifdef __MINGW32__
-# define static
-#endif
 
 #include <dxgi1_6.h>
 
@@ -74,11 +45,6 @@
 #include <vkd3d_device_vkd3d_ext.h>
 #include <vkd3d_d3d12.h>
 #include <vkd3d_d3d12sdklayers.h>
-
-/* End of MinGW hack. All Windows headers have been included */
-#ifdef __MINGW32__
-# undef static
-#endif
 
 #define VKD3D_NO_WIN32_TYPES
 #define VKD3D_NO_VULKAN_H

--- a/tests/d3d12_com_wrappers.h
+++ b/tests/d3d12_com_wrappers.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Hans-Kristian Arntzen for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef __D3D12_COM_WRAPPERS_H
+#define __D3D12_COM_WRAPPERS_H
+
+/* WIDL headers tend to be broken with INLINE_WRAPPER calls.
+ * static and FORCEINLINE end up colliding.
+ * Roll our own aggregate wrappers as needed to avoid some very brittle workarounds. */
+#undef ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart
+#undef ID3D12DescriptorHeap_GetGPUDescriptorHandleForHeapStart
+#undef ID3D12Resource_GetDesc
+#undef ID3D12Device_GetAdapterLuid
+#undef ID3D12Heap_GetDesc
+#undef ID3D12Device_GetCustomHeapProperties
+#undef ID3D12CommandQueue_GetDesc
+#undef ID3D12Device_GetResourceAllocationInfo
+#undef ID3D12Device4_GetResourceAllocationInfo1
+
+static inline D3D12_CPU_DESCRIPTOR_HANDLE ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(ID3D12DescriptorHeap* This)
+{
+    D3D12_CPU_DESCRIPTOR_HANDLE __ret;
+    return *This->lpVtbl->GetCPUDescriptorHandleForHeapStart(This, &__ret);
+}
+
+static inline D3D12_GPU_DESCRIPTOR_HANDLE ID3D12DescriptorHeap_GetGPUDescriptorHandleForHeapStart(ID3D12DescriptorHeap* This)
+{
+    D3D12_GPU_DESCRIPTOR_HANDLE __ret;
+    return *This->lpVtbl->GetGPUDescriptorHandleForHeapStart(This, &__ret);
+}
+
+static inline D3D12_RESOURCE_DESC ID3D12Resource_GetDesc(ID3D12Resource* This)
+{
+    D3D12_RESOURCE_DESC __ret;
+    return *This->lpVtbl->GetDesc(This, &__ret);
+}
+
+static inline LUID ID3D12Device_GetAdapterLuid(ID3D12Device* This)
+{
+    LUID __ret;
+    return *This->lpVtbl->GetAdapterLuid(This, &__ret);
+}
+
+static inline D3D12_HEAP_DESC ID3D12Heap_GetDesc(ID3D12Heap* This)
+{
+    D3D12_HEAP_DESC __ret;
+    return *This->lpVtbl->GetDesc(This, &__ret);
+}
+
+static inline D3D12_HEAP_PROPERTIES ID3D12Device_GetCustomHeapProperties(ID3D12Device* This, UINT node_mask, D3D12_HEAP_TYPE heap_type)
+{
+    D3D12_HEAP_PROPERTIES __ret;
+    return *This->lpVtbl->GetCustomHeapProperties(This, &__ret, node_mask, heap_type);
+}
+
+static inline D3D12_COMMAND_QUEUE_DESC ID3D12CommandQueue_GetDesc(ID3D12CommandQueue* This)
+{
+    D3D12_COMMAND_QUEUE_DESC __ret;
+    return *This->lpVtbl->GetDesc(This, &__ret);
+}
+
+static inline D3D12_RESOURCE_ALLOCATION_INFO ID3D12Device_GetResourceAllocationInfo(ID3D12Device* This,
+        UINT visible_mask, UINT reource_desc_count, const D3D12_RESOURCE_DESC *resource_descs)
+{
+    D3D12_RESOURCE_ALLOCATION_INFO __ret;
+    return *This->lpVtbl->GetResourceAllocationInfo(This, &__ret, visible_mask, reource_desc_count, resource_descs);
+}
+
+static inline D3D12_RESOURCE_ALLOCATION_INFO ID3D12Device4_GetResourceAllocationInfo1(ID3D12Device4* This,
+        UINT visible_mask, UINT reource_desc_count, const D3D12_RESOURCE_DESC *resource_descs, D3D12_RESOURCE_ALLOCATION_INFO1 *resource_allocation_infos)
+{
+    D3D12_RESOURCE_ALLOCATION_INFO __ret;
+    return *This->lpVtbl->GetResourceAllocationInfo1(This, &__ret, visible_mask, reource_desc_count, resource_descs, resource_allocation_infos);
+}
+#endif

--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -29,12 +29,15 @@
 #endif
 
 #define COBJMACROS
+
 #include "vkd3d_test.h"
 #include "vkd3d_windows.h"
-#define WIDL_C_INLINE_WRAPPERS
 #include "vkd3d_d3d12.h"
 #include "vkd3d_device_vkd3d_ext.h"
 #include "vkd3d_d3d12sdklayers.h"
+
+/* Wrappers that work around broken WIDL headers for aggregate returns. */
+#include "d3d12_com_wrappers.h"
 
 #include <inttypes.h>
 #include <limits.h>

--- a/tests/vkd3d_api.c
+++ b/tests/vkd3d_api.c
@@ -18,7 +18,6 @@
 
 #define COBJMACROS
 #define INITGUID
-#define WIDL_C_INLINE_WRAPPERS
 #include "vkd3d_test.h"
 #include <vkd3d.h>
 


### PR DESCRIPTION
They break builds quite a lot since upstream widl and mingw64-tools widl don't agree on how this is supposed to work.
If we need the macros, we have to macro away static which breaks other things in the process.

The robust workaround is to roll our own wrappers for the functions where it's needed.