### PR TITLE
Add interop interface for D3D11On12

### DIFF
--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -35,3 +35,22 @@ interface ID3D12DeviceExt : IUnknown
     HRESULT CaptureUAVInfo(D3D12_UAV_INFO *uav_info);
 }
 
+[
+    uuid(39da4e09-bd1c-4198-9fae-86bbe3be41fd),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12DXVKInteropDevice : IUnknown
+{
+    HRESULT GetDXGIAdapter(REFIID iid, void **object);
+    HRESULT GetInstanceExtensions(UINT *extension_count, const char **extensions);
+    HRESULT GetDeviceExtensions(UINT *extension_count, const char **extensions);
+    HRESULT GetDeviceFeatures(const VkPhysicalDeviceFeatures2 **features);
+    HRESULT GetVulkanHandles(VkInstance *vk_instance, VkPhysicalDevice *vk_physical_device, VkDevice *vk_device);
+    HRESULT GetVulkanQueueInfo(ID3D12CommandQueue *queue, VkQueue *vk_queue, UINT32 *vk_queue_family);
+    void GetVulkanImageLayout(ID3D12Resource *resource, D3D12_RESOURCE_STATES state, VkImageLayout *vk_layout);
+    HRESULT GetVulkanResourceInfo(ID3D12Resource *resource, UINT64 *vk_handle, UINT64 *buffer_offset);
+    HRESULT LockCommandQueue(ID3D12CommandQueue *queue);
+    HRESULT UnlockCommandQueue(ID3D12CommandQueue *queue);
+}

--- a/include/vkd3d_vk_includes.h
+++ b/include/vkd3d_vk_includes.h
@@ -28,12 +28,15 @@
     typedef UINT64 VkSurfaceKHR;
 #endif 
 
+typedef struct VkPhysicalDeviceFeatures2 VkPhysicalDeviceFeatures2;
 typedef struct VkPhysicalDevice_T *VkPhysicalDevice;
 typedef struct VkCommandBuffer_T *VkCommandBuffer;
 typedef struct VkInstance_T *VkInstance;
 typedef struct VkDevice_T *VkDevice;
+typedef struct VkQueue_T *VkQueue;
 
 typedef enum VkResult VkResult;
+typedef enum VkImageLayout VkImageLayout;
 
 typedef enum D3D12_VK_EXTENSION
 {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8041,7 +8041,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_
     }
 }
 
-static VkImageLayout vk_image_layout_from_d3d12_resource_state(
+VkImageLayout vk_image_layout_from_d3d12_resource_state(
         struct d3d12_command_list *list, const struct d3d12_resource *resource, D3D12_RESOURCE_STATES state)
 {
     /* Simultaneous access is always general, until we're forced to treat it differently in

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2006,7 +2006,9 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
 
     vulkan_info->vertex_attrib_zero_divisor = physical_device_info->vertex_divisor_features.vertexAttributeInstanceRateZeroDivisor;
 
-    /* Disable unused Vulkan features. */
+    /* Disable unused Vulkan features. The following features need
+     * to remain enabled for DXVK in order to support D3D11on12:
+     * hostQueryReset, vulkanMemoryModel, synchronization2. */
     features->shaderTessellationAndGeometryPointSize = VK_FALSE;
 
     physical_device_info->vulkan_1_1_features.protectedMemory = VK_FALSE;
@@ -2020,8 +2022,6 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     physical_device_info->vulkan_1_2_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
     physical_device_info->vulkan_1_2_features.bufferDeviceAddressMultiDevice = VK_FALSE;
     physical_device_info->vulkan_1_2_features.imagelessFramebuffer = VK_FALSE;
-    physical_device_info->vulkan_1_2_features.hostQueryReset = VK_FALSE;
-    physical_device_info->vulkan_1_2_features.vulkanMemoryModel = VK_FALSE;
     physical_device_info->vulkan_1_2_features.vulkanMemoryModelDeviceScope = VK_FALSE;
     physical_device_info->vulkan_1_2_features.vulkanMemoryModelAvailabilityVisibilityChains = VK_FALSE;
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -910,16 +910,17 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     }
 
     vr = vk_global_procs->vkCreateInstance(&instance_info, NULL, &vk_instance);
-    vkd3d_free((void *)extensions);
     if (vr < 0)
     {
         ERR("Failed to create Vulkan instance, vr %d.\n", vr);
+        vkd3d_free((void *)extensions);
         return hresult_from_vk_result(vr);
     }
 
     if (FAILED(hr = vkd3d_load_vk_instance_procs(&instance->vk_procs, vk_global_procs, vk_instance)))
     {
         ERR("Failed to load instance procs, hr %#x.\n", hr);
+        vkd3d_free((void *)extensions);
         if (instance->vk_procs.vkDestroyInstance)
             instance->vk_procs.vkDestroyInstance(vk_instance, NULL);
         return hr;
@@ -927,6 +928,9 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
 
     instance->vk_instance = vk_instance;
     instance->instance_version = loader_version;
+
+    instance->vk_info.extension_count = instance_info.enabledExtensionCount;
+    instance->vk_info.extension_names = extensions;
 
     TRACE("Created Vulkan instance %p, version %u.%u.\n", vk_instance,
             VK_VERSION_MAJOR(loader_version),
@@ -1008,6 +1012,7 @@ static void vkd3d_destroy_instance(struct vkd3d_instance *instance)
     if (instance->vk_debug_callback)
         VK_CALL(vkDestroyDebugUtilsMessengerEXT(vk_instance, instance->vk_debug_callback, NULL));
 
+    vkd3d_free((void *)instance->vk_info.extension_names);
     VK_CALL(vkDestroyInstance(vk_instance, NULL));
 
     vkd3d_free(instance);
@@ -2462,10 +2467,11 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
         WARN("Disabled extensions that can cause Vulkan device creation to fail, retrying.\n");
         vr = VK_CALL(vkCreateDevice(physical_device, &device_info, NULL, &vk_device));
     }
-    vkd3d_free((void *)extensions);
+
     if (vr < 0)
     {
         ERR("Failed to create Vulkan device, vr %d.\n", vr);
+        vkd3d_free((void *)extensions);
         return hresult_from_vk_result(vr);
     }
 
@@ -2485,6 +2491,9 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
         device->vk_procs.vkDestroyDevice(vk_device, NULL);
         return hr;
     }
+
+    device->vk_info.extension_count = device_info.enabledExtensionCount;
+    device->vk_info.extension_names = extensions;
 
     TRACE("Created Vulkan device %p.\n", vk_device);
 
@@ -2946,6 +2955,7 @@ static void d3d12_device_destroy(struct d3d12_device *device)
         vkd3d_renderdoc_end_capture(device->vkd3d_instance->vk_instance);
 #endif
 
+    vkd3d_free((void *)device->vk_info.extension_names);
     VK_CALL(vkDestroyDevice(device->vk_device, NULL));
     rwlock_destroy(&device->fragment_output_lock);
     rwlock_destroy(&device->vertex_input_lock);
@@ -6915,6 +6925,8 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
 
     vkd3d_instance_incref(device->vkd3d_instance = instance);
     device->vk_info = instance->vk_info;
+    device->vk_info.extension_count = 0;
+    device->vk_info.extension_names = NULL;
 
     device->adapter_luid = create_info->adapter_luid;
     device->removed_reason = S_OK;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2852,6 +2852,7 @@ void d3d12_device_return_query_pool(struct d3d12_device *device, const struct vk
 
 /* ID3D12Device */
 extern ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_AddRef(ID3D12DeviceExt *iface);
+extern ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_AddRef(ID3D12DXVKInteropDevice *iface);
 
 HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
         REFIID riid, void **object)
@@ -2882,6 +2883,14 @@ HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
         struct d3d12_device *device = impl_from_ID3D12Device(iface);
         d3d12_device_vkd3d_ext_AddRef(&device->ID3D12DeviceExt_iface);
         *object = &device->ID3D12DeviceExt_iface;
+        return S_OK;
+    }
+
+    if (IsEqualGUID(riid, &IID_ID3D12DXVKInteropDevice))
+    {
+        struct d3d12_device *device = impl_from_ID3D12Device(iface);
+        d3d12_dxvk_interop_device_AddRef(&device->ID3D12DXVKInteropDevice_iface);
+        *object = &device->ID3D12DXVKInteropDevice_iface;
         return S_OK;
     }
 
@@ -6904,6 +6913,7 @@ static void d3d12_device_replace_vtable(struct d3d12_device *device)
 }
 
 extern CONST_VTBL struct ID3D12DeviceExtVtbl d3d12_device_vkd3d_ext_vtbl;
+extern CONST_VTBL struct ID3D12DXVKInteropDeviceVtbl d3d12_dxvk_interop_device_vtbl;
 
 static HRESULT d3d12_device_init(struct d3d12_device *device,
         struct vkd3d_instance *instance, const struct vkd3d_device_create_info *create_info)
@@ -6941,6 +6951,7 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     }
     
     device->ID3D12DeviceExt_iface.lpVtbl = &d3d12_device_vkd3d_ext_vtbl;
+    device->ID3D12DXVKInteropDevice_iface.lpVtbl = &d3d12_dxvk_interop_device_vtbl;
 
     if ((rc = rwlock_init(&device->vertex_input_lock)))
     {

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -232,3 +232,188 @@ CONST_VTBL struct ID3D12DeviceExtVtbl d3d12_device_vkd3d_ext_vtbl =
     d3d12_device_vkd3d_ext_CaptureUAVInfo
 };
 
+
+static inline struct d3d12_device *d3d12_device_from_ID3D12DXVKInteropDevice(ID3D12DXVKInteropDevice *iface)
+{
+    return CONTAINING_RECORD(iface, struct d3d12_device, ID3D12DXVKInteropDevice_iface);
+}
+
+ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_AddRef(ID3D12DXVKInteropDevice *iface)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+    return d3d12_device_add_ref(device);
+}
+
+static ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_Release(ID3D12DXVKInteropDevice *iface)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+    return d3d12_device_release(device);
+}
+
+extern HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
+        REFIID riid, void **object);
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_QueryInterface(ID3D12DXVKInteropDevice *iface,
+        REFIID iid, void **out)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+    TRACE("iface %p, iid %s, out %p.\n", iface, debugstr_guid(iid), out);
+    return d3d12_device_QueryInterface(&device->ID3D12Device_iface, iid, out);
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDXGIAdapter(ID3D12DXVKInteropDevice *iface,
+        REFIID iid, void **object)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+    TRACE("iface %p, iid %s, object %p.\n", iface, debugstr_guid(iid), object);
+    return IUnknown_QueryInterface(device->parent, iid, object);
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanHandles(ID3D12DXVKInteropDevice *iface,
+        VkInstance *vk_instance, VkPhysicalDevice *vk_physical_device, VkDevice *vk_device)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+    TRACE("iface %p, vk_instance %p, vk_physical_device %p, vk_device %p \n", iface, vk_instance, vk_physical_device, vk_device);
+    if (!vk_device || !vk_instance || !vk_physical_device)
+        return E_INVALIDARG;
+
+    *vk_instance = device->vkd3d_instance->vk_instance;
+    *vk_physical_device = device->vk_physical_device;
+    *vk_device = device->vk_device;
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetInstanceExtensions(ID3D12DXVKInteropDevice *iface, UINT *extension_count, const char **extensions)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+    struct vkd3d_instance *instance = device->vkd3d_instance;
+
+    TRACE("iface %p, extension_count %u, extensions %p.\n", iface, extension_count, extensions);
+
+    if (extensions && (*extension_count < instance->vk_info.extension_count))
+        return E_INVALIDARG;
+
+    *extension_count = instance->vk_info.extension_count;
+
+    if (!extensions)
+        return S_OK;
+
+    memcpy(extensions, instance->vk_info.extension_names,
+            sizeof(*extensions) * instance->vk_info.extension_count);
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceExtensions(ID3D12DXVKInteropDevice *iface, UINT *extension_count, const char **extensions)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+
+    TRACE("iface %p, extension_count %u, extensions %p.\n", iface, extension_count, extensions);
+
+    if (extensions && (*extension_count < device->vk_info.extension_count))
+        return E_INVALIDARG;
+
+    *extension_count = device->vk_info.extension_count;
+
+    if (!extensions)
+        return S_OK;
+
+    memcpy(extensions, device->vk_info.extension_names,
+            sizeof(*extensions) * device->vk_info.extension_count);
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceFeatures(ID3D12DXVKInteropDevice *iface, const VkPhysicalDeviceFeatures2 **features)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+
+    TRACE("iface %p, features %p.\n", iface, features);
+
+    *features = &device->device_info.features2;
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanQueueInfo(ID3D12DXVKInteropDevice *iface,
+        ID3D12CommandQueue *queue, VkQueue *vk_queue, UINT32 *vk_queue_family)
+{
+    TRACE("iface %p, queue %p, vk_queue %p, vk_queue_family %p.\n", iface, queue, vk_queue, vk_queue_family);
+
+    /* This only gets called during D3D11 device creation */
+    *vk_queue = vkd3d_acquire_vk_queue(queue);
+    vkd3d_release_vk_queue(queue);
+
+    *vk_queue_family = vkd3d_get_vk_queue_family_index(queue);
+    return S_OK;
+}
+
+static void STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanImageLayout(ID3D12DXVKInteropDevice *iface,
+        ID3D12Resource *resource, D3D12_RESOURCE_STATES state, VkImageLayout *vk_layout)
+{
+    struct d3d12_resource *resource_impl = impl_from_ID3D12Resource(resource);
+
+    TRACE("iface %p, resource %p, state %#x.\n", iface, resource, state);
+
+    *vk_layout = vk_image_layout_from_d3d12_resource_state(NULL, resource_impl, state);
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanResourceInfo(ID3D12DXVKInteropDevice *iface,
+        ID3D12Resource *resource, UINT64 *vk_handle, UINT64 *buffer_offset)
+{
+    struct d3d12_resource *resource_impl = impl_from_ID3D12Resource(resource);
+
+    TRACE("iface %p, resource %p, vk_handle %p.\n", iface, resource, vk_handle);
+
+    if (resource_impl->desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+    {
+        *vk_handle = (UINT64)resource_impl->res.vk_buffer;
+        *buffer_offset = (UINT64)resource_impl->mem.offset;
+    }
+    else
+    {
+        *vk_handle = (UINT64)resource_impl->res.vk_image;
+        *buffer_offset = 0;
+    }
+
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_LockCommandQueue(ID3D12DXVKInteropDevice *iface, ID3D12CommandQueue *queue)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
+
+    TRACE("iface %p, queue %p.\n", iface, queue);
+
+    /* Flushing the transfer queue adds a wait to all other queues, and the
+     * acquire operation will drain the queue, ensuring that any pending clear
+     * or upload happens before D3D11 submissions on the GPU timeline. */
+    vkd3d_memory_transfer_queue_flush(&device->memory_transfers);
+    vkd3d_acquire_vk_queue(queue);
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_UnlockCommandQueue(ID3D12DXVKInteropDevice *iface, ID3D12CommandQueue *queue)
+{
+    TRACE("iface %p, queue %p.\n", iface, queue);
+
+    vkd3d_release_vk_queue(queue);
+    return S_OK;
+}
+
+CONST_VTBL struct ID3D12DXVKInteropDeviceVtbl d3d12_dxvk_interop_device_vtbl =
+{
+    /* IUnknown methods */
+    d3d12_dxvk_interop_device_QueryInterface,
+    d3d12_dxvk_interop_device_AddRef,
+    d3d12_dxvk_interop_device_Release,
+
+    /* ID3D12DXVKInteropDevice methods */
+    d3d12_dxvk_interop_device_GetDXGIAdapter,
+    d3d12_dxvk_interop_device_GetInstanceExtensions,
+    d3d12_dxvk_interop_device_GetDeviceExtensions,
+    d3d12_dxvk_interop_device_GetDeviceFeatures,
+    d3d12_dxvk_interop_device_GetVulkanHandles,
+    d3d12_dxvk_interop_device_GetVulkanQueueInfo,
+    d3d12_dxvk_interop_device_GetVulkanImageLayout,
+    d3d12_dxvk_interop_device_GetVulkanResourceInfo,
+    d3d12_dxvk_interop_device_LockCommandQueue,
+    d3d12_dxvk_interop_device_UnlockCommandQueue,
+};

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -985,6 +985,8 @@ VkImageSubresource vk_image_subresource_from_d3d12(
         const struct vkd3d_format *format, uint32_t subresource_idx,
         unsigned int miplevel_count, unsigned int layer_count,
         bool all_aspects);
+VkImageLayout vk_image_layout_from_d3d12_resource_state(
+        struct d3d12_command_list *list, const struct d3d12_resource *resource, D3D12_RESOURCE_STATES state);
 UINT d3d12_plane_index_from_vk_aspect(VkImageAspectFlagBits aspect);
 
 HRESULT d3d12_resource_create_committed(struct d3d12_device *device, const D3D12_RESOURCE_DESC1 *desc,
@@ -3953,6 +3955,9 @@ struct vkd3d_descriptor_qa_heap_buffer_data;
 /* ID3D12DeviceExt */
 typedef ID3D12DeviceExt d3d12_device_vkd3d_ext_iface;
 
+/* ID3D12DXVKInteropDevice */
+typedef ID3D12DXVKInteropDevice d3d12_dxvk_interop_device_iface;
+
 struct d3d12_device_scratch_pool
 {
     struct vkd3d_scratch_buffer scratch_buffers[VKD3D_SCRATCH_BUFFER_COUNT];
@@ -3963,6 +3968,7 @@ struct d3d12_device
 {
     d3d12_device_iface ID3D12Device_iface;
     d3d12_device_vkd3d_ext_iface ID3D12DeviceExt_iface;
+    d3d12_dxvk_interop_device_iface ID3D12DXVKInteropDevice_iface;
     LONG refcount;
 
     VkDevice vk_device;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -164,6 +164,9 @@ struct vkd3d_vulkan_info
     bool VALVE_mutable_descriptor_type;
     bool VALVE_descriptor_set_host_mapping;
 
+    unsigned int extension_count;
+    const char* const* extension_names;
+
     bool rasterization_stream;
     bool transform_feedback_queries;
 


### PR DESCRIPTION
This allows DXVK to use an existing Vulkan device and instance from vkd3d-proton and implement the basic [ID3D11On12Device](https://learn.microsoft.com/en-us/windows/win32/api/d3d11on12/nn-d3d11on12-id3d11on12device) interop interface.

There's also `ID3D11On12Device2` which allows importing resources from the D3D11 side into D3D12, and while DXVK currently does not implement this (in part because MinGW headers do not support that interface at this time), an easy way to do so would be to create all eligible resourcs as D3D12 resources on our end and just import them into D3D11 in the same way we do with `CreateWrappedResource`, so we would not need to extend the interface further.

The tricky part is command submission, as this requires a bunch of synchronization on both sides. D3D11On12 receives a D3D12 command queue to submit to, and D3D11 submissions happen in-order with any D3D12 submissions to the same queue, meaning that
1) Side effects of D3D12 submissions must be visible to any D3D11 command recorded afterwards, and
2) After explicitly calling `ID3D11DeviceContext::Flush`, any side effects from prior D3D11 commands must be visible to subsequent D3D12 submissions.

The `Lock/UnlockCommandQueue` methods in the interop interface aim to guarantee 1) in addition to satisfying Vulkan's thread safety requirements for queues, while 2) is handled entirely within DXVK by stalling the calling thread on explicit calls to `Flush` until the Vulkan queue submission has taken place on the CPU timeline.

Sharing spare resources between D3D11 and D3D12 is much more complicated and currently not supported.

Update: Fixed weird native CI issue but had to change the interface.