### PR TITLE
vkd3d: Properly initialize BuildSizesInfoKHR when breadcrumbs are ena…

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -12270,6 +12270,9 @@ static void STDMETHODCALLTYPE d3d12_command_list_BuildRaytracingAccelerationStru
     {
         VkAccelerationStructureBuildSizesInfoKHR size_info;
 
+        memset(&size_info, 0, sizeof(size_info));
+        size_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
+
         if (desc->Inputs.Flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE)
         {
             build_info.build_info.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;


### PR DESCRIPTION
…bled.