### PR TITLE
Workaround spurious GPU hangs on NV with concurrent submissions to different queues

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -193,13 +193,6 @@ static void vkd3d_queue_flush_waiters(struct vkd3d_queue *vkd3d_queue,
 void vkd3d_queue_destroy(struct vkd3d_queue *queue, struct d3d12_device *device)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    int rc;
-
-    if ((rc = pthread_mutex_lock(&queue->mutex)))
-        ERR("Failed to lock mutex, error %d.\n", rc);
-
-    if (!rc)
-        pthread_mutex_unlock(&queue->mutex);
 
     /* Also waits for queue idle when we don't pass in a worker. */
     vkd3d_queue_flush_waiters(queue, NULL, vk_procs);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2777,6 +2777,9 @@ struct vkd3d_queue
     /* Access to VkQueue must be externally synchronized. */
     pthread_mutex_t mutex;
 
+    /* If not NULL, lock a shared mutex as well. */
+    pthread_mutex_t *global_mutex;
+
     VkQueue vk_queue;
 
     VkCommandPool barrier_pool;
@@ -4044,6 +4047,7 @@ struct d3d12_device
     struct vkd3d_vk_device_procs vk_procs;
 
     pthread_mutex_t mutex;
+    pthread_mutex_t global_submission_mutex;
 
     VkPhysicalDeviceMemoryProperties memory_properties;
 

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -334,3 +334,4 @@ decl_test(test_memory_model_uav_coherence_thread_group_dxil);
 decl_test(test_rasterizer_ordered_views_dxbc);
 decl_test(test_rasterizer_ordered_views_dxil);
 decl_test(test_vtable_origins);
+decl_test(test_concurrent_signal_stress);


### PR DESCRIPTION
`VKD3D_TEST_FILTER=test_concurrent_signal_stress VKD3D_CONFIG=skip_driver_workarounds ./tests/d3d12`

```
test_concurrent_signal_stress:1662:Test 2: Test failed: Failed to wait for event. GPU likely hung.

On driver 530.30.02 with RTX 3070 I get:
[21600.846408] NVRM: Xid (PCI:0000:08:00): 32, pid=225396, name=d3d12, Channel ID 00000036 intr0 00040000
[21600.846870] NVRM: Xid (PCI:0000:08:00): 32, pid=225396, name=d3d12, Channel ID 00000036 intr0 00040000
```

The test completes fine with workaround. Similar issue can be observed in test_fence_wait_multiple.