### PR TITLE
vkd3d: Ensure debug labels are properly emitted with profiling.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8173,7 +8173,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_
             snprintf(buffer, sizeof(buffer), "[%s %016"PRIx64" \"%s\"]",
                     vk_stage_to_d3d(VK_SHADER_STAGE_COMPUTE_BIT),
                     state->compute.code.meta.hash,
-                    state->compute.code_debug.debug_entry_point_name);
+                    state->compute.code_debug.debug_entry_point_name ?
+                            state->compute.code_debug.debug_entry_point_name : "N/A");
             label.color[0] = 1.0f;
             label.color[1] = 0.5f;
             label.color[2] = 0.0f;
@@ -8191,7 +8192,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetPipelineState(d3d12_command_
                         "[%s %016"PRIx64" \"%s\"] ",
                         vk_stage_to_d3d(state->graphics.stages[i].stage),
                         state->graphics.code[i].meta.hash,
-                        state->graphics.code_debug[i].debug_entry_point_name);
+                        state->graphics.code_debug[i].debug_entry_point_name ?
+                                state->graphics.code_debug[i].debug_entry_point_name : "N/A");
             }
 
             label.color[0] = 0.0f;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -672,7 +672,10 @@ static void vkd3d_instance_deduce_config_flags_from_environment(void)
             vkd3d_get_env_var("RADV_THREAD_TRACE_TRIGGER", env, sizeof(env)))
     {
         INFO("RADV thread trace is enabled. Forcing debug utils to be enabled for labels.\n");
-        vkd3d_config_flags |= VKD3D_CONFIG_FLAG_DEBUG_UTILS;
+        /* Disable caching so we can get full debug information when emitting labels. */
+        vkd3d_config_flags |= VKD3D_CONFIG_FLAG_DEBUG_UTILS |
+                VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE |
+                VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_APP_CACHE_ONLY;
     }
 }
 


### PR DESCRIPTION
Need to disable caching so we get full debug information when emitting labels.