### PR TITLE
Remove use of ms_abi for native builds

### DIFF
--- a/include/vkd3d_d3d12.idl
+++ b/include/vkd3d_d3d12.idl
@@ -22,6 +22,10 @@ import "vkd3d_dxgibase.idl";
 
 import "vkd3d_d3dcommon.idl";
 
+cpp_quote("#pragma push_macro(\"WIDL_EXPLICIT_AGGREGATE_RETURNS\")")
+cpp_quote("#undef WIDL_EXPLICIT_AGGREGATE_RETURNS")
+cpp_quote("#define WIDL_EXPLICIT_AGGREGATE_RETURNS")
+
 cpp_quote("#ifndef _D3D12_CONSTANTS")
 cpp_quote("#define _D3D12_CONSTANTS")
 
@@ -4358,3 +4362,5 @@ typedef HRESULT (__stdcall *PFN_D3D12_ENABLE_EXPERIMENTAL_FEATURES)(UINT num_fea
 typedef HRESULT (__stdcall *PFN_D3D12_GET_INTERFACE)(REFCLSID clsid, REFIID iid, void **debug);
 
 [local] HRESULT __stdcall D3D12GetInterface(REFCLSID clsid, REFIID iid, void **debug);
+
+cpp_quote("#pragma pop_macro(\"WIDL_EXPLICIT_AGGREGATE_RETURNS\")")

--- a/include/vkd3d_windows.h
+++ b/include/vkd3d_windows.h
@@ -171,16 +171,7 @@ typedef struct SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
 # define CONTAINING_RECORD(address, type, field) \
         ((type *)((char *)(address) - offsetof(type, field)))
 
-# ifdef __x86_64__
-#  define __stdcall __attribute__((ms_abi))
-# else
-#  if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2)) || defined(__APPLE__)
-#   define __stdcall __attribute__((__stdcall__)) __attribute__((__force_align_arg_pointer__))
-#  else
-#   define __stdcall __attribute__((__stdcall__))
-#  endif
-# endif
-
+# define __stdcall
 # define WINAPI __stdcall
 # define STDMETHODCALLTYPE __stdcall
 


### PR DESCRIPTION
This brings the native headers in line with the official DirectX headers and dxvk