### PR TITLE
Add a system for tracing GPU timeline work

### DIFF
--- a/include/private/vkd3d_string.h
+++ b/include/private/vkd3d_string.h
@@ -88,8 +88,15 @@ static inline void vkd3d_strlcpy(char *dst, size_t dst_size, const char *src)
 {
     if (dst_size > 0)
     {
-        strncpy(dst, src, dst_size - 1);
-        dst[dst_size - 1] = '\0';
+        if (strlen(src) < dst_size)
+        {
+            strcpy(dst, src);
+        }
+        else
+        {
+            strncpy(dst, src, dst_size - 1);
+            dst[dst_size - 1] = '\0';
+        }
     }
 }
 

--- a/libs/vkd3d-common/debug.c
+++ b/libs/vkd3d-common/debug.c
@@ -238,13 +238,13 @@ void vkd3d_dbg_printf(enum vkd3d_dbg_channel channel, enum vkd3d_dbg_level level
     else if (wine_log_output)
     {
         char local_buffer[4096];
+        uint64_t ticks;
         size_t offset;
-        DWORD ticks;
 
         /* Try to match format of Wine log output. */
-        ticks = GetTickCount();
+        ticks = vkd3d_get_current_time_ns();
         offset = snprintf(local_buffer, sizeof(local_buffer),
-                "%3u.%03u:%04x:%04x:%s:vkd3d-proton:%s: ", ticks / 1000, ticks % 1000,
+                "%3u.%03u:%04x:%04x:%s:vkd3d-proton:%s: ", ticks / 1000000000, (ticks % 1000000000) / 1000000,
                 (UINT)GetCurrentProcessId(), tid,
                 debug_level_names[level], function);
         if (offset < sizeof(local_buffer))

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -18228,6 +18228,7 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
     VKD3D_REGION_DECL(queue_execute);
 
     vkd3d_set_thread_name("vkd3d_queue");
+    queue->submission_thread_tid = vkd3d_get_current_thread_id();
 
     if (FAILED(hr = d3d12_command_queue_transition_pool_init(&pool, queue)))
         ERR("Failed to initialize transition pool.\n");

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -26,7 +26,7 @@
 #include "vkd3d_renderdoc.h"
 #endif
 
-static HRESULT d3d12_fence_signal(struct d3d12_fence *fence, uint64_t value);
+static HRESULT d3d12_fence_signal(struct d3d12_fence *fence, struct vkd3d_fence_worker *worker, uint64_t value);
 static void d3d12_command_queue_add_submission(struct d3d12_command_queue *queue,
         const struct d3d12_command_queue_submission *sub);
 static void d3d12_fence_inc_ref(struct d3d12_fence *fence);
@@ -580,7 +580,7 @@ static void vkd3d_wait_for_gpu_timeline_semaphore(struct vkd3d_fence_worker *wor
     {
         local_fence = impl_from_ID3D12Fence1(fence->fence);
         TRACE("Signaling fence %p value %#"PRIx64".\n", local_fence, fence->value);
-        if (FAILED(hr = d3d12_fence_signal(local_fence, fence->value)))
+        if (FAILED(hr = d3d12_fence_signal(local_fence, worker, fence->value)))
             ERR("Failed to signal D3D12 fence, hr %#x.\n", hr);
     }
 
@@ -992,7 +992,7 @@ static uint64_t d3d12_fence_get_physical_wait_value_locked(struct d3d12_fence *f
         return target_physical_value;
 }
 
-static HRESULT d3d12_fence_signal(struct d3d12_fence *fence, uint64_t physical_value)
+static HRESULT d3d12_fence_signal(struct d3d12_fence *fence, struct vkd3d_fence_worker *worker, uint64_t physical_value)
 {
     bool did_signal;
     size_t i;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -606,6 +606,16 @@ static void *vkd3d_fence_worker_main(void *arg)
 
     vkd3d_set_thread_name("vkd3d_fence");
 
+    snprintf(worker->timeline.tid, sizeof(worker->timeline.tid),
+#ifdef _WIN32
+            "family %u, tid 0x%04x, prio %d",
+#else
+            "family %u, tid %u, prio %d",
+#endif
+            worker->queue->vkd3d_queue->vk_family_index,
+            vkd3d_get_current_thread_id(),
+            worker->queue->desc.Priority);
+
     cur_fence_count = 0;
     cur_fences_size = 0;
     cur_fences = NULL;
@@ -653,7 +663,8 @@ static void *vkd3d_fence_worker_main(void *arg)
     return NULL;
 }
 
-HRESULT vkd3d_fence_worker_start(struct vkd3d_fence_worker *worker,
+static HRESULT vkd3d_fence_worker_start(struct vkd3d_fence_worker *worker,
+        struct d3d12_command_queue *queue,
         struct d3d12_device *device)
 {
     int rc;
@@ -662,6 +673,7 @@ HRESULT vkd3d_fence_worker_start(struct vkd3d_fence_worker *worker,
 
     worker->should_exit = false;
     worker->device = device;
+    worker->queue = queue;
 
     worker->enqueued_fence_count = 0;
     worker->enqueued_fences = NULL;
@@ -690,7 +702,7 @@ HRESULT vkd3d_fence_worker_start(struct vkd3d_fence_worker *worker,
     return S_OK;
 }
 
-HRESULT vkd3d_fence_worker_stop(struct vkd3d_fence_worker *worker,
+static HRESULT vkd3d_fence_worker_stop(struct vkd3d_fence_worker *worker,
         struct d3d12_device *device)
 {
     int rc;
@@ -712,6 +724,7 @@ HRESULT vkd3d_fence_worker_stop(struct vkd3d_fence_worker *worker,
     pthread_cond_destroy(&worker->cond);
 
     vkd3d_free(worker->enqueued_fences);
+    vkd3d_free(worker->timeline.list_buffer);
     return S_OK;
 }
 
@@ -18401,7 +18414,7 @@ static HRESULT d3d12_command_queue_init(struct d3d12_command_queue *queue,
 
     d3d12_device_add_ref(queue->device = device);
 
-    if (FAILED(hr = vkd3d_fence_worker_start(&queue->fence_worker, device)))
+    if (FAILED(hr = vkd3d_fence_worker_start(&queue->fence_worker, queue, device)))
         goto fail_fence_worker_start;
 
     if ((rc = pthread_create(&queue->submission_thread, NULL, d3d12_command_queue_submission_worker_main, queue)) < 0)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3360,6 +3360,7 @@ static void d3d12_device_destroy(struct d3d12_device *device)
 
     vkd3d_cleanup_format_info(device);
     vkd3d_memory_info_cleanup(&device->memory_info, device);
+    vkd3d_queue_timeline_trace_cleanup(&device->queue_timeline_trace);
     vkd3d_shader_debug_ring_cleanup(&device->debug_ring, device);
 #ifdef VKD3D_ENABLE_BREADCRUMBS
     vkd3d_breadcrumb_tracer_cleanup_barrier_hashes(&device->breadcrumb_tracer);
@@ -8424,13 +8425,21 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     if (FAILED(hr = vkd3d_shader_debug_ring_init(&device->debug_ring, device)))
         goto out_cleanup_meta_ops;
 
+    if (FAILED(hr = vkd3d_queue_timeline_trace_init(&device->queue_timeline_trace, device)))
+        goto out_cleanup_debug_ring;
+
     vkd3d_scratch_pool_init(device);
 
 #ifdef VKD3D_ENABLE_BREADCRUMBS
     vkd3d_breadcrumb_tracer_init_barrier_hashes(&device->breadcrumb_tracer);
     if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_BREADCRUMBS)
+    {
         if (FAILED(hr = vkd3d_breadcrumb_tracer_init(&device->breadcrumb_tracer, device)))
-            goto out_cleanup_debug_ring;
+        {
+            vkd3d_breadcrumb_tracer_cleanup_barrier_hashes(&device->breadcrumb_tracer);
+            goto out_cleanup_queue_timeline_trace;
+        }
+    }
 #endif
 
     if (vkd3d_descriptor_debug_active_qa_checks())
@@ -8477,9 +8486,10 @@ out_cleanup_breadcrumb_tracer:
 #ifdef VKD3D_ENABLE_BREADCRUMBS
     if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_BREADCRUMBS)
         vkd3d_breadcrumb_tracer_cleanup(&device->breadcrumb_tracer, device);
-out_cleanup_debug_ring:
-    vkd3d_breadcrumb_tracer_cleanup_barrier_hashes(&device->breadcrumb_tracer);
 #endif
+out_cleanup_queue_timeline_trace:
+    vkd3d_queue_timeline_trace_cleanup(&device->queue_timeline_trace);
+out_cleanup_debug_ring:
     vkd3d_shader_debug_ring_cleanup(&device->debug_ring, device);
 out_cleanup_meta_ops:
     vkd3d_meta_ops_cleanup(&device->meta_ops, device);

--- a/libs/vkd3d/heap.c
+++ b/libs/vkd3d/heap.c
@@ -317,6 +317,9 @@ static HRESULT d3d12_heap_init(struct d3d12_heap *heap, struct d3d12_device *dev
         heap->allocation.chunk == NULL /* not suballocated */ &&
         (device->memory_properties.memoryTypes[heap->allocation.device_allocation.vk_memory_type].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
+    vkd3d_queue_timeline_trace_register_instantaneous(&device->queue_timeline_trace,
+            VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_HEAP_ALLOCATION, desc->SizeInBytes);
+
     d3d12_device_add_ref(heap->device);
     return S_OK;
 }

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -448,7 +448,7 @@ static HRESULT vkd3d_memory_transfer_queue_flush_locked(struct vkd3d_memory_tran
             vkd3d_queue_add_wait(queue_family->queues[i],
                     NULL,
                     queue->vk_semaphore,
-                    queue->next_signal_value);
+                    queue->next_signal_value, 0);
         }
     }
 

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -74,7 +74,8 @@ vkd3d_src = [
   'vkd3d_main.c',
   'raytracing_pipeline.c',
   'acceleration_structure.c',
-  'swapchain.c'
+  'swapchain.c',
+  'queue_timeline.c'
 ]
 
 if enable_renderdoc

--- a/libs/vkd3d/queue_timeline.c
+++ b/libs/vkd3d/queue_timeline.c
@@ -1,0 +1,568 @@
+/*
+ * Copyright 2023 Hans-Kristian Arntzen for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+#include "vkd3d_private.h"
+#include "vkd3d_platform.h"
+#include "vkd3d_threads.h"
+#include <assert.h>
+#include <stdio.h>
+
+#define NUM_ENTRIES (256 * 1024)
+
+HRESULT vkd3d_queue_timeline_trace_init(struct vkd3d_queue_timeline_trace *trace, struct d3d12_device *device)
+{
+    char env[VKD3D_PATH_MAX];
+    unsigned int i, j;
+
+    if (!vkd3d_get_env_var("VKD3D_QUEUE_PROFILE", env, sizeof(env)))
+        return S_OK;
+
+    trace->file = fopen(env, "w");
+    if (trace->file)
+    {
+        INFO("Creating timeline trace in: \"%s\".\n", env);
+        fputs("[\n", trace->file);
+    }
+    else
+        return S_OK;
+
+    pthread_mutex_init(&trace->lock, NULL);
+    pthread_mutex_init(&trace->ready_lock, NULL);
+
+    vkd3d_array_reserve((void**)&trace->vacant_indices, &trace->vacant_indices_size,
+            NUM_ENTRIES, sizeof(*trace->vacant_indices));
+
+    /* Reserve entry 0 as sentinel. */
+    for (i = 1; i < NUM_ENTRIES; i++)
+        trace->vacant_indices[trace->vacant_indices_count++] = i;
+
+    trace->state = vkd3d_calloc(NUM_ENTRIES, sizeof(*trace->state));
+    trace->base_ts = vkd3d_get_current_time_ns();
+
+    if (vkd3d_get_env_var("VKD3D_QUEUE_PROFILE_ABSOLUTE", env, sizeof(env)) &&
+            env[0] == '1')
+    {
+        /* Wine logs are QPC relative */
+        trace->base_ts = 0;
+
+        /* Force an event at ts = 0 so the trace gets absolute time. */
+        fprintf(trace->file,
+                "{ \"name\": \"dummy\", \"ph\": \"i\", \"tid\": \"0x%04x\", \"pid\": 0, \"ts\": 0.0 },\n",
+                vkd3d_get_current_thread_id());
+    }
+
+    for (i = 0; i < VKD3D_QUEUE_FAMILY_COUNT; i++)
+        if (device->queue_families[i])
+            for (j = 0; j < device->queue_families[i]->queue_count; j++)
+                device->queue_families[i]->queues[j]->need_virtual_wait_values = true;
+
+    trace->active = true;
+    return S_OK;
+}
+
+static void vkd3d_queue_timeline_trace_free_index(struct vkd3d_queue_timeline_trace *trace, unsigned int index)
+{
+    assert(trace->state[index].type != VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_NONE);
+    trace->state[index].type = VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_NONE;
+
+    pthread_mutex_lock(&trace->lock);
+    assert(trace->vacant_indices_count < trace->vacant_indices_size);
+    trace->vacant_indices[trace->vacant_indices_count++] = index;
+    pthread_mutex_unlock(&trace->lock);
+}
+
+static void vkd3d_queue_timeline_trace_free_indices(struct vkd3d_queue_timeline_trace *trace,
+        const unsigned int *indices, size_t count)
+{
+    size_t i;
+    pthread_mutex_lock(&trace->lock);
+
+    for (i = 0; i < count; i++)
+    {
+        assert(trace->state[indices[i]].type != VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_NONE);
+        trace->state[indices[i]].type = VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_NONE;
+    }
+
+    assert(trace->vacant_indices_count + count <= trace->vacant_indices_size);
+    memcpy(trace->vacant_indices + trace->vacant_indices_count, indices, count * sizeof(*indices));
+    trace->vacant_indices_count += count;
+    pthread_mutex_unlock(&trace->lock);
+}
+
+static unsigned int vkd3d_queue_timeline_trace_allocate_index(struct vkd3d_queue_timeline_trace *trace, uint64_t *submit_count)
+{
+    unsigned int index = 0;
+    pthread_mutex_lock(&trace->lock);
+    if (trace->vacant_indices_count == 0)
+    {
+        ERR("Failed to allocate queue timeline index.\n");
+        goto unlock;
+    }
+    index = trace->vacant_indices[--trace->vacant_indices_count];
+unlock:
+    if (submit_count)
+        *submit_count = ++trace->submit_count;
+    pthread_mutex_unlock(&trace->lock);
+    return index;
+}
+
+void vkd3d_queue_timeline_trace_cleanup(struct vkd3d_queue_timeline_trace *trace)
+{
+    if (!trace->active)
+        return;
+
+    pthread_mutex_destroy(&trace->lock);
+    pthread_mutex_destroy(&trace->ready_lock);
+    if (trace->file)
+        fclose(trace->file);
+
+    vkd3d_free(trace->vacant_indices);
+    vkd3d_free(trace->ready_command_lists);
+    vkd3d_free(trace->state);
+}
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_event_signal(struct vkd3d_queue_timeline_trace *trace,
+        vkd3d_native_sync_handle handle, d3d12_fence_iface *fence, uint64_t value)
+{
+    struct vkd3d_queue_timeline_trace_cookie cookie = {0};
+    struct vkd3d_queue_timeline_trace_state *state;
+
+    if (!trace->active)
+        return cookie;
+
+    cookie.index = vkd3d_queue_timeline_trace_allocate_index(trace, NULL);
+    if (!cookie.index)
+        return cookie;
+
+    state = &trace->state[cookie.index];
+    state->type = VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_EVENT;
+    state->start_ts = vkd3d_get_current_time_ns();
+
+#ifdef _WIN32
+    snprintf(state->desc, sizeof(state->desc), "event: %p, fence: %p, value %"PRIu64,
+            handle.handle, (void*)fence, value);
+#else
+    snprintf(state->desc, sizeof(state->desc), "event: %d, fence: %p, value %"PRIu64,
+            handle.fd, (void*)fence, value);
+#endif
+
+    return cookie;
+}
+
+void vkd3d_queue_timeline_trace_complete_event_signal(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_fence_worker *worker,
+        struct vkd3d_queue_timeline_trace_cookie cookie)
+{
+    const struct vkd3d_queue_timeline_trace_state *state;
+    double end_ts, start_ts;
+    unsigned int pid;
+
+    if (!trace->active || cookie.index == 0)
+        return;
+
+    state = &trace->state[cookie.index];
+    end_ts = (double)(vkd3d_get_current_time_ns() - trace->base_ts) * 1e-3;
+    start_ts = (double)(state->start_ts - trace->base_ts) * 1e-3;
+
+    if (worker)
+    {
+        pid = worker->queue->submission_thread_tid;
+        if (start_ts < worker->timeline.lock_end_event_ts)
+            start_ts = worker->timeline.lock_end_event_ts;
+        if (end_ts < start_ts)
+            end_ts = start_ts;
+        worker->timeline.lock_end_event_ts = end_ts;
+
+        fprintf(trace->file, "{ \"name\": \"%s\", \"ph\": \"X\", \"tid\": \"event\", \"pid\": \"0x%04x\", \"ts\": %f, \"dur\": %f },\n",
+                state->desc, pid, start_ts, end_ts - start_ts);
+    }
+    else
+    {
+        fprintf(trace->file, "{ \"name\": \"%s\", \"ph\": \"X\", \"tid\": \"inline\", \"pid\": \"shared fence\", \"ts\": %f, \"dur\": %f },\n",
+                state->desc, start_ts, end_ts - start_ts);
+    }
+
+    vkd3d_queue_timeline_trace_free_index(trace, cookie.index);
+}
+
+void vkd3d_queue_timeline_trace_complete_present_wait(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_queue_timeline_trace_cookie cookie)
+{
+    const struct vkd3d_queue_timeline_trace_state *state;
+    double end_ts, start_ts;
+
+    if (!trace->active || cookie.index == 0)
+        return;
+
+    state = &trace->state[cookie.index];
+    end_ts = (double)(vkd3d_get_current_time_ns() - trace->base_ts) * 1e-3;
+    start_ts = (double)(state->start_ts - trace->base_ts) * 1e-3;
+
+    fprintf(trace->file, "{ \"name\": \"%s\", \"ph\": \"X\", \"tid\": \"wait\", \"pid\": \"present\", \"ts\": %f, \"dur\": %f },\n",
+            state->desc, start_ts, end_ts - start_ts);
+
+    vkd3d_queue_timeline_trace_free_index(trace, cookie.index);
+}
+
+void vkd3d_queue_timeline_trace_complete_present_block(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_queue_timeline_trace_cookie cookie)
+{
+    const struct vkd3d_queue_timeline_trace_state *state;
+    double end_ts, start_ts;
+
+    if (!trace->active || cookie.index == 0)
+        return;
+
+    state = &trace->state[cookie.index];
+    end_ts = (double)(vkd3d_get_current_time_ns() - trace->base_ts) * 1e-3;
+    start_ts = (double)(state->start_ts - trace->base_ts) * 1e-3;
+
+    fprintf(trace->file, "{ \"name\": \"%s\", \"ph\": \"X\", \"tid\": \"0x%04x\", \"pid\": \"IDXGISwapChain::Present()\", \"ts\": %f, \"dur\": %f },\n",
+            state->desc, state->tid, start_ts, end_ts - start_ts);
+
+    vkd3d_queue_timeline_trace_free_index(trace, cookie.index);
+}
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_execute(struct vkd3d_queue_timeline_trace *trace,
+        ID3D12CommandList * const *command_lists, unsigned int count)
+{
+    struct vkd3d_queue_timeline_trace_cookie cookie = {0};
+    struct vkd3d_queue_timeline_trace_state *state;
+    uint64_t submission_count;
+    if (!trace->active)
+        return cookie;
+
+    cookie.index = vkd3d_queue_timeline_trace_allocate_index(trace, &submission_count);
+    if (!cookie.index)
+        return cookie;
+
+    state = &trace->state[cookie.index];
+    state->type = VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_SUBMISSION;
+    state->start_ts = vkd3d_get_current_time_ns();
+    snprintf(state->desc, sizeof(state->desc), "SUBMIT #%"PRIu64" (%u lists)", submission_count, count);
+
+    /* Might be useful later. */
+    (void)command_lists;
+
+    return cookie;
+}
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_signal(struct vkd3d_queue_timeline_trace *trace,
+        d3d12_fence_iface *fence, uint64_t value)
+{
+    struct vkd3d_queue_timeline_trace_cookie cookie = {0};
+    struct vkd3d_queue_timeline_trace_state *state;
+    if (!trace->active)
+        return cookie;
+
+    cookie.index = vkd3d_queue_timeline_trace_allocate_index(trace, NULL);
+    if (!cookie.index)
+        return cookie;
+
+    state = &trace->state[cookie.index];
+    state->type = VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_SIGNAL;
+    state->start_ts = vkd3d_get_current_time_ns();
+    state->start_submit_ts = state->start_ts;
+    snprintf(state->desc, sizeof(state->desc), "SIGNAL %p %"PRIu64, (void*)fence, value);
+    return cookie;
+}
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_wait(struct vkd3d_queue_timeline_trace *trace,
+        d3d12_fence_iface *fence, uint64_t value)
+{
+    struct vkd3d_queue_timeline_trace_cookie cookie = {0};
+    struct vkd3d_queue_timeline_trace_state *state;
+    if (!trace->active)
+        return cookie;
+
+    cookie.index = vkd3d_queue_timeline_trace_allocate_index(trace, NULL);
+    if (!cookie.index)
+        return cookie;
+
+    state = &trace->state[cookie.index];
+    state->type = VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_WAIT;
+    state->start_ts = vkd3d_get_current_time_ns();
+    state->start_submit_ts = state->start_ts;
+    snprintf(state->desc, sizeof(state->desc), "WAIT %p %"PRIu64, (void*)fence, value);
+    return cookie;
+}
+
+static struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_generic_op(struct vkd3d_queue_timeline_trace *trace,
+        enum vkd3d_queue_timeline_trace_state_type type, const char *tag)
+{
+    struct vkd3d_queue_timeline_trace_cookie cookie = {0};
+    struct vkd3d_queue_timeline_trace_state *state;
+    if (!trace->active)
+        return cookie;
+
+    cookie.index = vkd3d_queue_timeline_trace_allocate_index(trace, NULL);
+    if (!cookie.index)
+        return cookie;
+
+    state = &trace->state[cookie.index];
+    state->type = type;
+    state->start_ts = vkd3d_get_current_time_ns();
+    state->start_submit_ts = state->start_ts;
+    state->tid = vkd3d_get_current_thread_id();
+    vkd3d_strlcpy(state->desc, sizeof(state->desc), tag);
+    return cookie;
+}
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_swapchain_blit(struct vkd3d_queue_timeline_trace *trace, uint64_t present_id)
+{
+    char str[128];
+    snprintf(str, sizeof(str), "PRESENT (id = %"PRIu64") (blit)", present_id);
+    return vkd3d_queue_timeline_trace_register_generic_op(trace, VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_PRESENT_BLIT, str);
+}
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_command_list(struct vkd3d_queue_timeline_trace *trace)
+{
+    struct vkd3d_queue_timeline_trace_cookie cookie = {0};
+    struct vkd3d_queue_timeline_trace_state *state;
+    uint64_t submission_count;
+    if (!trace->active)
+        return cookie;
+
+    cookie.index = vkd3d_queue_timeline_trace_allocate_index(trace, &submission_count);
+    if (!cookie.index)
+        return cookie;
+
+    state = &trace->state[cookie.index];
+    state->type = VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_COMMAND_LIST;
+    state->start_ts = vkd3d_get_current_time_ns();
+    state->record_cookie = submission_count;
+    return cookie;
+}
+
+void vkd3d_queue_timeline_trace_close_command_list(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_queue_timeline_trace_cookie cookie)
+{
+    struct vkd3d_queue_timeline_trace_state *state;
+    if (!trace->active || cookie.index == 0)
+        return;
+
+    state = &trace->state[cookie.index];
+    state->record_end_ts = vkd3d_get_current_time_ns();
+    state->tid = vkd3d_get_current_thread_id();
+
+    /* Defer actual IO until fence workers are doing something. */
+    pthread_mutex_lock(&trace->ready_lock);
+    vkd3d_array_reserve((void**)&trace->ready_command_lists, &trace->ready_command_lists_size,
+            trace->ready_command_lists_count + 1, sizeof(*trace->ready_command_lists));
+    trace->ready_command_lists[trace->ready_command_lists_count++] = cookie.index;
+    pthread_mutex_unlock(&trace->ready_lock);
+}
+
+void vkd3d_queue_timeline_trace_register_instantaneous(struct vkd3d_queue_timeline_trace *trace,
+        enum vkd3d_queue_timeline_trace_state_type type, uint64_t value)
+{
+    struct vkd3d_queue_timeline_trace_state *state;
+    unsigned int index;
+
+    if (!trace->active)
+        return;
+
+    index = vkd3d_queue_timeline_trace_allocate_index(trace, NULL);
+    if (!index)
+        return;
+
+    state = &trace->state[index];
+    state->type = type;
+    state->start_ts = vkd3d_get_current_time_ns();
+    state->tid = vkd3d_get_current_thread_id();
+    state->record_cookie = value;
+
+    /* Defer actual IO until fence workers are doing something. */
+    pthread_mutex_lock(&trace->ready_lock);
+    vkd3d_array_reserve((void**)&trace->ready_command_lists, &trace->ready_command_lists_size,
+            trace->ready_command_lists_count + 1, sizeof(*trace->ready_command_lists));
+    trace->ready_command_lists[trace->ready_command_lists_count++] = index;
+    pthread_mutex_unlock(&trace->ready_lock);
+}
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_present_wait(struct vkd3d_queue_timeline_trace *trace, uint64_t present_id)
+{
+    char str[128];
+    snprintf(str, sizeof(str), "WAIT (id = %"PRIu64")", present_id);
+    return vkd3d_queue_timeline_trace_register_generic_op(trace, VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_PRESENT_WAIT, str);
+}
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_present_block(struct vkd3d_queue_timeline_trace *trace, uint64_t present_id)
+{
+    char str[128];
+    snprintf(str, sizeof(str), "PRESENT (id = %"PRIu64")", present_id);
+    return vkd3d_queue_timeline_trace_register_generic_op(trace, VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_PRESENT_BLOCK, str);
+}
+
+static void vkd3d_queue_timeline_trace_flush_instantaneous(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_fence_worker *worker)
+{
+    const struct vkd3d_queue_timeline_trace_state *list_state;
+    size_t list_count;
+    size_t i;
+
+    pthread_mutex_lock(&trace->ready_lock);
+    if (trace->ready_command_lists_count)
+    {
+        /* Copy to local buffer to not stall recording threads while doing IO. */
+        vkd3d_array_reserve((void**)&worker->timeline.list_buffer,
+                &worker->timeline.list_buffer_size,
+                trace->ready_command_lists_count, sizeof(*worker->timeline.list_buffer));
+        memcpy(worker->timeline.list_buffer,
+                trace->ready_command_lists, trace->ready_command_lists_count * sizeof(*worker->timeline.list_buffer));
+        list_count = trace->ready_command_lists_count;
+        trace->ready_command_lists_count = 0;
+        pthread_mutex_unlock(&trace->ready_lock);
+
+        for (i = 0; i < list_count; i++)
+        {
+            const char *generic_pid = NULL;
+            double start_ts;
+            double end_ts;
+
+            list_state = &trace->state[worker->timeline.list_buffer[i]];
+            start_ts = (double)(list_state->start_ts - trace->base_ts) * 1e-3;
+
+            switch (list_state->type)
+            {
+                case VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_COMMAND_LIST:
+                {
+                    end_ts = (double)(list_state->record_end_ts - trace->base_ts) * 1e-3;
+                    fprintf(trace->file,
+                            "{ \"name\": \"%"PRIu64 " (delay %.3f us)\", \"ph\": \"i\", \"tid\": \"0x%04x\", \"pid\": \"cmd reset\", \"ts\": %f },\n",
+                            list_state->record_cookie, end_ts - start_ts, list_state->tid, start_ts);
+                    fprintf(trace->file,
+                            "{ \"name\": \"%"PRIu64" (delay %.3f us)\", \"ph\": \"i\", \"tid\": \"0x%04x\", \"pid\": \"cmd close\", \"ts\": %f },\n",
+                            list_state->record_cookie, end_ts - start_ts, list_state->tid, end_ts);
+                    break;
+                }
+
+                case VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_QUEUE_PRESENT:
+                    generic_pid = "vkQueuePresentKHR";
+                    break;
+
+                case VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_HEAP_ALLOCATION:
+                    generic_pid = "heap allocate";
+                    break;
+
+                case VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_COMMAND_ALLOCATOR_RESET:
+                    generic_pid = "command allocator reset";
+                    break;
+
+                case VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_COMMITTED_RESOURCE_ALLOCATION:
+                    generic_pid = "committed resource alloc";
+                    break;
+
+                default:
+                    break;
+            }
+
+            if (generic_pid)
+            {
+                fprintf(trace->file,
+                        "{ \"name\": \"%"PRIu64"\", \"ph\": \"i\", \"tid\": \"0x%04x\", \"pid\": \"%s\", \"ts\": %f },\n",
+                        list_state->record_cookie, list_state->tid, generic_pid, start_ts);
+            }
+        }
+
+        vkd3d_queue_timeline_trace_free_indices(trace, worker->timeline.list_buffer, list_count);
+    }
+    else
+        pthread_mutex_unlock(&trace->ready_lock);
+}
+
+void vkd3d_queue_timeline_trace_complete_execute(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_fence_worker *worker,
+        struct vkd3d_queue_timeline_trace_cookie cookie)
+{
+    const struct vkd3d_queue_timeline_trace_state *state;
+    double end_ts, start_submit_ts, start_ts;
+    unsigned int pid;
+    const char *tid;
+    double *ts_lock;
+
+    if (!trace->active || cookie.index == 0)
+        return;
+
+    state = &trace->state[cookie.index];
+    start_ts = (double)(state->start_ts - trace->base_ts) * 1e-3;
+    start_submit_ts = (double)(state->start_submit_ts - trace->base_ts) * 1e-3;
+    end_ts = (double)(vkd3d_get_current_time_ns() - trace->base_ts) * 1e-3;
+
+    if (worker)
+    {
+        if (state->type == VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_SUBMISSION)
+            vkd3d_queue_timeline_trace_flush_instantaneous(trace, worker);
+
+        tid = worker->timeline.tid;
+        pid = worker->queue->submission_thread_tid;
+
+        if (state->type == VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_SUBMISSION)
+        {
+            fprintf(trace->file, "{ \"name\": \"%s\", \"ph\": \"i\", \"tid\": \"cpu\", \"pid\": \"0x%04x\", \"ts\": %f, \"s\": \"t\" },\n",
+                    state->desc, pid, start_ts);
+
+            if (start_ts < worker->timeline.lock_end_cpu_ts)
+                start_ts = worker->timeline.lock_end_cpu_ts;
+            if (start_submit_ts < start_ts)
+                start_submit_ts = start_ts;
+        }
+
+        ts_lock = &worker->timeline.lock_end_gpu_ts;
+
+        if (start_submit_ts < *ts_lock)
+            start_submit_ts = *ts_lock;
+        if (end_ts < start_submit_ts)
+            end_ts = start_submit_ts;
+        *ts_lock = end_ts;
+
+        fprintf(trace->file, "{ \"name\": \"%s\", \"ph\": \"X\", \"tid\": \"%s\", \"pid\": \"0x%04x\", \"ts\": %f, \"dur\": %f },\n",
+                state->desc, tid, pid, start_submit_ts, end_ts - start_submit_ts);
+
+        if (state->type == VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_SUBMISSION)
+        {
+            worker->timeline.lock_end_cpu_ts = start_submit_ts;
+            fprintf(trace->file,
+                    "{ \"name\": \"%s\", \"ph\": \"X\", \"tid\": \"submit\", \"pid\": \"0x%04x\", \"ts\": %f, \"dur\": %f },\n",
+                    state->desc, pid, start_ts, start_submit_ts - start_ts);
+        }
+    }
+
+    vkd3d_queue_timeline_trace_free_index(trace, cookie.index);
+}
+
+void vkd3d_queue_timeline_trace_begin_execute(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_queue_timeline_trace_cookie cookie)
+{
+    struct vkd3d_queue_timeline_trace_state *state;
+    if (!trace->active || cookie.index == 0)
+        return;
+
+    state = &trace->state[cookie.index];
+    state->start_submit_ts = vkd3d_get_current_time_ns();
+}

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3461,6 +3461,9 @@ HRESULT d3d12_resource_create_committed(struct d3d12_device *device, const D3D12
         object->mem.chunk == NULL /* not suballocated */ &&
         (device->memory_properties.memoryTypes[object->mem.device_allocation.vk_memory_type].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
+    vkd3d_queue_timeline_trace_register_instantaneous(&device->queue_timeline_trace,
+            VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_COMMITTED_RESOURCE_ALLOCATION, object->res.cookie);
+
     *resource = object;
     return S_OK;
 

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -2058,7 +2058,9 @@ static void dxgi_vk_swap_chain_present_iteration(struct dxgi_vk_swap_chain *chai
      * This would unnecessarily stall our progress. */
     if (chain->wait_thread.active && !chain->present.present_id_valid && chain->request.swap_interval > 0)
     {
-        chain->present.present_id += 1;
+        /* If we recreate swapchain, we still want to maintain a monotonically increasing counter here for
+         * profiling purposes. */
+        chain->present.present_id = chain->present.complete_count + 1;
         present_id.sType = VK_STRUCTURE_TYPE_PRESENT_ID_KHR;
         present_id.pNext = NULL;
         present_id.swapchainCount = 1;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2985,9 +2985,13 @@ struct vkd3d_queue
 
     VkSemaphoreSubmitInfo *wait_semaphores;
     size_t wait_semaphores_size;
+    uint64_t *wait_values_virtual;
+    size_t wait_values_virtual_size;
     d3d12_fence_iface **wait_fences;
     size_t wait_fences_size;
     uint32_t wait_count;
+
+    bool need_virtual_wait_values;
 };
 
 VkQueue vkd3d_queue_acquire(struct vkd3d_queue *queue);
@@ -2995,7 +2999,8 @@ HRESULT vkd3d_queue_create(struct d3d12_device *device, uint32_t family_index, u
         const VkQueueFamilyProperties *properties, struct vkd3d_queue **queue);
 void vkd3d_queue_destroy(struct vkd3d_queue *queue, struct d3d12_device *device);
 void vkd3d_queue_release(struct vkd3d_queue *queue);
-void vkd3d_queue_add_wait(struct vkd3d_queue *queue, d3d12_fence_iface *waiter, VkSemaphore semaphore, uint64_t value);
+void vkd3d_queue_add_wait(struct vkd3d_queue *queue, d3d12_fence_iface *waiter,
+        VkSemaphore semaphore, uint64_t value, uint64_t virtual_value);
 
 enum vkd3d_submission_type
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4627,6 +4627,7 @@ struct d3d12_device
     unsigned int format_compatibility_list_count;
     const struct vkd3d_format_compatibility_list *format_compatibility_lists;
     struct vkd3d_bindless_state bindless_state;
+    struct vkd3d_queue_timeline_trace queue_timeline_trace;
     struct vkd3d_memory_info memory_info;
     struct vkd3d_meta_ops meta_ops;
     struct vkd3d_view_map sampler_map;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3135,6 +3135,7 @@ struct d3d12_command_queue
     struct vkd3d_fence_worker fence_worker;
     struct vkd3d_private_store private_store;
     struct dxgi_vk_swap_chain_factory vk_swap_chain_factory;
+    unsigned int submission_thread_tid;
 };
 
 HRESULT d3d12_command_queue_create(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -221,6 +221,7 @@ struct vkd3d_waiting_fence
     uint64_t value;
     struct d3d12_command_allocator **command_allocators;
     size_t num_command_allocators;
+    struct vkd3d_queue_timeline_trace_cookie timeline_cookie;
     bool signal;
 };
 
@@ -271,6 +272,11 @@ struct vkd3d_fence_worker
 #define VKD3D_VA_NEXT_BITS (12)
 #define VKD3D_VA_NEXT_COUNT (1ull << VKD3D_VA_NEXT_BITS)
 #define VKD3D_VA_NEXT_MASK (VKD3D_VA_NEXT_COUNT - 1)
+
+HRESULT vkd3d_enqueue_timeline_semaphore(struct vkd3d_fence_worker *worker,
+        d3d12_fence_iface *fence, VkSemaphore timeline, uint64_t value, bool signal,
+        struct d3d12_command_allocator **command_allocators, size_t num_command_allocators,
+        const struct vkd3d_queue_timeline_trace_cookie *timeline_cookie);
 
 struct vkd3d_unique_resource;
 
@@ -527,6 +533,7 @@ struct vkd3d_waiting_event
     vkd3d_native_sync_handle handle;
     bool *latch;
     uint32_t *payload;
+    struct vkd3d_queue_timeline_trace_cookie timeline_cookie;
 };
 
 struct d3d12_fence
@@ -2900,6 +2907,7 @@ struct d3d12_command_list
     struct d3d12_transfer_batch_state transfer_batch;
     struct d3d12_wbi_batch_state wbi_batch;
     struct d3d12_rtas_batch_state rtas_batch;
+    struct vkd3d_queue_timeline_trace_cookie timeline_cookie;
 
     struct vkd3d_private_store private_store;
 
@@ -3083,6 +3091,8 @@ struct d3d12_command_queue_submission_execute
     unsigned int *breadcrumb_indices;
     size_t breadcrumb_indices_count;
 #endif
+
+    struct vkd3d_queue_timeline_trace_cookie timeline_cookie;
 
     bool debug_capture;
     bool split_submission;


### PR DESCRIPTION
A coarse system-level profile method.

The goal here is to be able to see at a glance D3D12 submissions along with presents and when they complete (with present wait). It dumps out a trivial JSON format that Chromium can consume in chrome://tracing.

There are some useful features that can help track down things:

- Command list reset/close is marked as an instantaneous event
- Various heavy creation calls are marked as well (to see if it causes stutter, etc)
- DXGISwapchain::Present time blocking is marked
- vkQueuePresentKHR time is marked
- Present wait blocking is marked
- CPU submission time
- GPU active time for a submission (ends when submission fence is signalled) not as accurate as gpuviz or something like that.
- Present blit on GPU timeline is displayed
- HANDLE signal from fence is outlined.

![queue_profile](https://github.com/HansKristian-Work/vkd3d-proton/assets/17786731/54923760-1287-4fcc-8bc8-83e9da89cf95)

as an example.