### PR TITLE
d3d12core: Set the interface pointer returned by GetDebugInterface to NULL.

### DIFF
--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -372,6 +372,9 @@ HRESULT STDMETHODCALLTYPE d3d12core_GetDebugInterface(d3d12core_interface *core,
 {
     TRACE("iid %s, debug %p.\n", debugstr_guid(iid), debug);
 
+    if (debug)
+        *debug = NULL;
+
     WARN("Returning DXGI_ERROR_SDK_COMPONENT_MISSING.\n");
     return DXGI_ERROR_SDK_COMPONENT_MISSING;
 }


### PR DESCRIPTION
Minecraft Legends depends on this behavior. I've checked and this is how native D3D12 behaves.