### PR TITLE
vkd3d: Add RE2 and RE7 to CACAO workaround and remove RE4 demo

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -570,12 +570,15 @@ static const struct vkd3d_shader_quirk_info wolong_quirks = {
 
 /* The subgroup check in CACAO shader is botched and does not handle Wave64 properly.
  * Just pretend the subgroup size is non-sensical to use the normal FFX CACAO code path. */
-static const struct vkd3d_shader_quirk_hash re4_hashes[] = {
+static const struct vkd3d_shader_quirk_hash re_hashes[] = {
+    /* RE4 */
     { 0xa100b53736f9c1bfull, VKD3D_SHADER_QUIRK_FORCE_SUBGROUP_SIZE_1 },
+    /* RE2 and RE7 */
+    { 0x1c4c8782b75c498bull, VKD3D_SHADER_QUIRK_FORCE_SUBGROUP_SIZE_1 },
 };
 
-static const struct vkd3d_shader_quirk_info re4_quirks = {
-    re4_hashes, ARRAY_SIZE(re4_hashes), 0,
+static const struct vkd3d_shader_quirk_info re_quirks = {
+    re_hashes, ARRAY_SIZE(re_hashes), 0,
 };
 
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
@@ -589,9 +592,12 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "Borderlands3.exe", &borderlands3_quirks },
     /* Wo Long: Fallen Dynasty (2285240) */
     { VKD3D_STRING_COMPARE_EXACT, "WoLong.exe", &wolong_quirks },
+    /* Resident Evil 2 (883710) */
+    { VKD3D_STRING_COMPARE_EXACT, "re2.exe", &re_quirks },
+    /* Resident Evil 7 (418370) */
+    { VKD3D_STRING_COMPARE_EXACT, "re7.exe", &re_quirks },
     /* Resident Evil 4 (2050650) */
-    { VKD3D_STRING_COMPARE_EXACT, "re4.exe", &re4_quirks },
-    { VKD3D_STRING_COMPARE_EXACT, "re4demo.exe", &re4_quirks },
+    { VKD3D_STRING_COMPARE_EXACT, "re4.exe", &re_quirks },
     /* MSVC fails to compile empty array. */
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };


### PR DESCRIPTION
Add shader hash used in RE2 and RE7 to list of workaround hashes. Remove RE4 demo as it has a new shader with a fix.