### PR TITLE
vkd3d: Implement EXT_swapchain_maintenance1 and replace fence wait with semaphore

### DIFF
--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -271,6 +271,12 @@ static HRESULT vkd3d_create_instance_global(struct vkd3d_instance **out_instance
 #endif
     };
 
+    static const char * const optional_instance_extensions[] =
+    {
+        VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME,
+        VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME,
+    };
+
     if (!load_vulkan())
     {
         ERR("Failed to load Vulkan library.\n");
@@ -281,8 +287,8 @@ static HRESULT vkd3d_create_instance_global(struct vkd3d_instance **out_instance
     instance_create_info.pfn_vkGetInstanceProcAddr = vulkan_vkGetInstanceProcAddr;
     instance_create_info.instance_extensions = instance_extensions;
     instance_create_info.instance_extension_count = ARRAY_SIZE(instance_extensions);
-    instance_create_info.optional_instance_extensions = NULL;
-    instance_create_info.optional_instance_extension_count = 0;
+    instance_create_info.optional_instance_extensions = optional_instance_extensions;
+    instance_create_info.optional_instance_extension_count = ARRAY_SIZE(optional_instance_extensions);
 
     if (FAILED(hr = vkd3d_create_instance(&instance_create_info, out_instance)))
         WARN("Failed to create vkd3d instance, hr %#x.\n", hr);
@@ -305,7 +311,11 @@ static HRESULT STDMETHODCALLTYPE d3d12core_CreateDevice(d3d12core_interface *cor
     static const char * const device_extensions[] =
     {
         VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-        VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,
+    };
+
+    static const char * const optional_device_extensions[] =
+    {
+        VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME,
     };
 
     TRACE("adapter %p, minimum_feature_level %#x, iid %s, device %p.\n",
@@ -335,8 +345,8 @@ static HRESULT STDMETHODCALLTYPE d3d12core_CreateDevice(d3d12core_interface *cor
     device_create_info.instance_create_info = NULL;
     device_create_info.device_extensions = device_extensions;
     device_create_info.device_extension_count = ARRAY_SIZE(device_extensions);
-    device_create_info.optional_device_extensions = NULL;
-    device_create_info.optional_device_extension_count = 0;
+    device_create_info.optional_device_extensions = optional_device_extensions;
+    device_create_info.optional_device_extension_count = ARRAY_SIZE(optional_device_extensions);
 
 #ifdef _WIN32
     device_create_info.vk_physical_device = d3d12_find_physical_device(instance, vulkan_vkGetInstanceProcAddr, &adapter_desc);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1457,6 +1457,18 @@ static void vkd3d_physical_device_info_apply_workarounds(struct vkd3d_physical_d
             device->device_info.present_id_features.presentId = false;
         }
 
+        /* Two known bugs in the wild:
+         * - presentID = 0 handling when toggling present mode is broken.
+         * - swapchain fence is not enough to avoid DEVICE_LOST when resizing swapchain.
+         */
+        if (info->vulkan_1_2_properties.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY &&
+                info->swapchain_maintenance1_features.swapchainMaintenance1)
+        {
+            WARN("Disabling VK_EXT_swapchain_maintenance1 on NV due to driver bugs.\n");
+            device->device_info.swapchain_maintenance1_features.swapchainMaintenance1 = VK_FALSE;
+            device->vk_info.EXT_swapchain_maintenance1 = false;
+        }
+
         if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE)
         {
             /* RADV's internal memory cache implementation (pipelineCache == VK_NULL_HANDLE)

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -89,9 +89,12 @@ struct dxgi_vk_swap_chain
 
     struct
     {
-        /* When resizing user buffers, we need to make sure all pending blits have completed on GPU. */
-        VkSemaphore vk_blit_semaphore;
-        uint64_t blit_count;
+        /* When resizing user buffers or emit commands internally,
+         * we need to make sure all pending blits have completed on GPU. */
+        VkSemaphore vk_internal_blit_semaphore;
+        VkSemaphore vk_complete_semaphore;
+        uint64_t internal_blit_count;
+        uint64_t complete_count;
 
         /* PresentID or frame latency fence is used depending on features and if we're really presenting on-screen. */
         ID3D12Fence1 *frame_latency_fence;
@@ -109,22 +112,23 @@ struct dxgi_vk_swap_chain
          * We don't need to wait on these fences on main thread. */
         VkCommandPool vk_blit_command_pool;
         VkCommandBuffer vk_blit_command_buffers[DXGI_MAX_SWAP_CHAIN_BUFFERS];
-        VkFence vk_blit_fences[DXGI_MAX_SWAP_CHAIN_BUFFERS];
+        uint64_t backbuffer_blit_timelines[DXGI_MAX_SWAP_CHAIN_BUFFERS];
 
         VkSwapchainKHR vk_swapchain;
         VkImage vk_backbuffer_images[DXGI_MAX_SWAP_CHAIN_BUFFERS];
         VkImageView vk_backbuffer_image_views[DXGI_MAX_SWAP_CHAIN_BUFFERS];
         VkSemaphore vk_release_semaphores[DXGI_MAX_SWAP_CHAIN_BUFFERS];
 
-        /* Since we're presenting in a thread, there's no particular reason to use WSI acquire semaphores.
-         * Removes a lot of edge cases. */
-        VkFence vk_acquire_fence;
+        VkSemaphore vk_acquire_semaphore[DXGI_MAX_SWAP_CHAIN_BUFFERS];
+        bool acquire_semaphore_signalled[DXGI_MAX_SWAP_CHAIN_BUFFERS];
+        uint64_t acquire_semaphore_consumed_at_blit[DXGI_MAX_SWAP_CHAIN_BUFFERS];
+        uint32_t acquire_semaphore_index;
+
         uint32_t current_backbuffer_index;
         uint32_t backbuffer_width;
         uint32_t backbuffer_height;
         uint32_t backbuffer_count;
         VkFormat backbuffer_format;
-        bool acquire_fence_pending;
 
         struct vkd3d_swapchain_info pipeline;
 
@@ -171,10 +175,54 @@ struct dxgi_vk_swap_chain
     } wait_thread;
 };
 
+static void dxgi_vk_swap_chain_drain_internal_blit_semaphore(struct dxgi_vk_swap_chain *chain, uint64_t value);
+
+static void dxgi_vk_swap_chain_wait_acquire_semaphore(struct dxgi_vk_swap_chain *chain,
+        VkSemaphore vk_semaphore, bool blocking)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
+    VkSemaphoreSubmitInfo signal_info;
+    VkSemaphoreSubmitInfo wait_info;
+    VkSubmitInfo2 submit_info;
+    VkQueue vk_queue;
+    VkResult vr;
+
+    memset(&submit_info, 0, sizeof(submit_info));
+    memset(&wait_info, 0, sizeof(wait_info));
+    memset(&signal_info, 0, sizeof(signal_info));
+    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+    submit_info.waitSemaphoreInfoCount = 1;
+    submit_info.pWaitSemaphoreInfos = &wait_info;
+
+    wait_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+    wait_info.semaphore = vk_semaphore;
+    wait_info.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+
+    submit_info.pSignalSemaphoreInfos = &signal_info;
+    submit_info.signalSemaphoreInfoCount = 1;
+    signal_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+    signal_info.semaphore = chain->present.vk_internal_blit_semaphore;
+    signal_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    signal_info.value = ++chain->present.internal_blit_count;
+
+    vk_queue = vkd3d_queue_acquire(chain->queue->vkd3d_queue);
+    vr = VK_CALL(vkQueueSubmit2(vk_queue, 1, &submit_info, VK_NULL_HANDLE));
+    if (vr < 0)
+    {
+        ERR("Failed to submit, vr %d\n", vr);
+        VKD3D_DEVICE_REPORT_FAULT_AND_BREADCRUMB_IF(chain->queue->device, vr == VK_ERROR_DEVICE_LOST);
+    }
+    vkd3d_queue_release(chain->queue->vkd3d_queue);
+
+    if (vr == VK_SUCCESS && blocking)
+        dxgi_vk_swap_chain_drain_internal_blit_semaphore(chain, chain->present.internal_blit_count);
+}
+
 static void dxgi_vk_swap_chain_drain_queue(struct dxgi_vk_swap_chain *chain)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
     VkQueue vk_queue;
+    unsigned int i;
 
     /* Full wait-idle. */
     vk_queue = vkd3d_acquire_vk_queue(&chain->queue->ID3D12CommandQueue_iface);
@@ -186,20 +234,29 @@ static void dxgi_vk_swap_chain_drain_queue(struct dxgi_vk_swap_chain *chain)
     else
         ERR("Failed to acquire queue.\n");
 
+    /* Submitting work inline is safe since we have drained all outstanding CPU work
+     * on the queue after calling vkd3d_acquire_vk_queue(). */
+
+    /* If we have a lingering semaphore acquire that never went anywhere, ensure it is waited on.
+     * QueueWaitIdle will not cover acquire semaphores. */
+    for (i = 0; i < ARRAY_SIZE(chain->present.vk_acquire_semaphore); i++)
+        if (chain->present.vk_acquire_semaphore[i] && chain->present.acquire_semaphore_signalled[i])
+            dxgi_vk_swap_chain_wait_acquire_semaphore(chain, chain->present.vk_acquire_semaphore[i], true);
+
     /* Ensures that all pending ReleaseSemaphore() calls are also made.
      * This happens on the fence waiter queues, so it's not enough to call vkQueueWaitIdle to be 100% sure.
      * The fence waiter thread processes requests in-order,
      * so if we observe that an EVENT has been signalled,
      * we know all pending semaphore signals have happened as well. */
 
-    /* This is safe since we have drained all outstanding CPU work on the queue after calling vkd3d_acquire_vk_queue(). */
     chain->present.frame_latency_count += 1;
     d3d12_command_queue_signal_inline(chain->queue, chain->present.frame_latency_fence, chain->present.frame_latency_count);
     d3d12_fence_set_event_on_completion(impl_from_ID3D12Fence1(chain->present.frame_latency_fence),
             chain->present.frame_latency_count, NULL);
 }
 
-static void dxgi_vk_swap_chain_drain_blit_semaphore(struct dxgi_vk_swap_chain *chain, uint64_t value)
+static void dxgi_vk_swap_chain_wait_semaphore(struct dxgi_vk_swap_chain *chain,
+        VkSemaphore vk_timeline, uint64_t value)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
     VkSemaphoreWaitInfo wait_info;
@@ -208,10 +265,9 @@ static void dxgi_vk_swap_chain_drain_blit_semaphore(struct dxgi_vk_swap_chain *c
     if (!value)
         return;
 
+    memset(&wait_info, 0, sizeof(wait_info));
     wait_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
-    wait_info.pNext = NULL;
-    wait_info.flags = 0;
-    wait_info.pSemaphores = &chain->present.vk_blit_semaphore;
+    wait_info.pSemaphores = &vk_timeline;
     wait_info.pValues = &value;
     wait_info.semaphoreCount = 1;
     vr = VK_CALL(vkWaitSemaphores(chain->queue->device->vk_device, &wait_info, UINT64_MAX));
@@ -219,9 +275,19 @@ static void dxgi_vk_swap_chain_drain_blit_semaphore(struct dxgi_vk_swap_chain *c
         ERR("Failed to wait for present semaphore, vr %d.\n", vr);
 }
 
+static void dxgi_vk_swap_chain_drain_complete_semaphore(struct dxgi_vk_swap_chain *chain, uint64_t value)
+{
+    dxgi_vk_swap_chain_wait_semaphore(chain, chain->present.vk_complete_semaphore, value);
+}
+
+static void dxgi_vk_swap_chain_drain_internal_blit_semaphore(struct dxgi_vk_swap_chain *chain, uint64_t value)
+{
+    dxgi_vk_swap_chain_wait_semaphore(chain, chain->present.vk_internal_blit_semaphore, value);
+}
+
 static void dxgi_vk_swap_chain_drain_user_images(struct dxgi_vk_swap_chain *chain)
 {
-    dxgi_vk_swap_chain_drain_blit_semaphore(chain, chain->user.blit_count);
+    dxgi_vk_swap_chain_drain_complete_semaphore(chain, chain->user.blit_count);
 }
 
 static void dxgi_vk_swap_chain_push_present_id(struct dxgi_vk_swap_chain *chain, uint64_t present_id, uint64_t begin_frame_time_ns)
@@ -236,8 +302,6 @@ static void dxgi_vk_swap_chain_push_present_id(struct dxgi_vk_swap_chain *chain,
     pthread_cond_signal(&chain->wait_thread.cond);
     pthread_mutex_unlock(&chain->wait_thread.lock);
 }
-
-static void dxgi_vk_swap_chain_wait_and_reset_acquire_fence(struct dxgi_vk_swap_chain *chain);
 
 static void dxgi_vk_swap_chain_cleanup(struct dxgi_vk_swap_chain *chain)
 {
@@ -266,17 +330,15 @@ static void dxgi_vk_swap_chain_cleanup(struct dxgi_vk_swap_chain *chain)
     }
     vkd3d_native_sync_handle_destroy(chain->present_request_done_event);
 
-    VK_CALL(vkDestroySemaphore(chain->queue->device->vk_device, chain->present.vk_blit_semaphore, NULL));
+    VK_CALL(vkDestroySemaphore(chain->queue->device->vk_device, chain->present.vk_internal_blit_semaphore, NULL));
+    VK_CALL(vkDestroySemaphore(chain->queue->device->vk_device, chain->present.vk_complete_semaphore, NULL));
     VK_CALL(vkDestroyCommandPool(chain->queue->device->vk_device, chain->present.vk_blit_command_pool, NULL));
     for (i = 0; i < ARRAY_SIZE(chain->present.vk_release_semaphores); i++)
         VK_CALL(vkDestroySemaphore(chain->queue->device->vk_device, chain->present.vk_release_semaphores[i], NULL));
     for (i = 0; i < ARRAY_SIZE(chain->present.vk_backbuffer_image_views); i++)
         VK_CALL(vkDestroyImageView(chain->queue->device->vk_device, chain->present.vk_backbuffer_image_views[i], NULL));
-
-    dxgi_vk_swap_chain_wait_and_reset_acquire_fence(chain);
-    VK_CALL(vkDestroyFence(chain->queue->device->vk_device, chain->present.vk_acquire_fence, NULL));
-    for (i = 0; i < ARRAY_SIZE(chain->present.vk_blit_fences); i++)
-        VK_CALL(vkDestroyFence(chain->queue->device->vk_device, chain->present.vk_blit_fences[i], NULL));
+    for (i = 0; i < ARRAY_SIZE(chain->present.vk_acquire_semaphore); i++)
+        VK_CALL(vkDestroySemaphore(chain->queue->device->vk_device, chain->present.vk_acquire_semaphore[i], NULL));
 
     VK_CALL(vkDestroySwapchainKHR(chain->queue->device->vk_device, chain->present.vk_swapchain, NULL));
 
@@ -987,7 +1049,6 @@ static HRESULT dxgi_vk_swap_chain_init_sync_objects(struct dxgi_vk_swap_chain *c
 {
     const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
     VkSemaphoreTypeCreateInfoKHR type_info;
-    VkFenceCreateInfo fence_create_info;
     VkSemaphoreCreateInfo create_info;
     VkResult vr;
     char env[8];
@@ -1074,20 +1135,19 @@ static HRESULT dxgi_vk_swap_chain_init_sync_objects(struct dxgi_vk_swap_chain *c
     type_info.initialValue = 0;
     type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
 
-    vr = VK_CALL(vkCreateSemaphore(chain->queue->device->vk_device, &create_info, NULL, &chain->present.vk_blit_semaphore));
+    vr = VK_CALL(vkCreateSemaphore(chain->queue->device->vk_device, &create_info,
+            NULL, &chain->present.vk_complete_semaphore));
     if (vr < 0)
     {
         ERR("Failed to create timeline semaphore, vr %d.\n", vr);
         return hresult_from_vkd3d_result(vr);
     }
 
-    fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-    fence_create_info.pNext = NULL;
-    fence_create_info.flags = 0;
-    vr = VK_CALL(vkCreateFence(chain->queue->device->vk_device, &fence_create_info, NULL, &chain->present.vk_acquire_fence));
+    vr = VK_CALL(vkCreateSemaphore(chain->queue->device->vk_device, &create_info,
+            NULL, &chain->present.vk_internal_blit_semaphore));
     if (vr < 0)
     {
-        ERR("Failed to create fence, vr %d\n", vr);
+        ERR("Failed to create timeline semaphore, vr %d.\n", vr);
         return hresult_from_vkd3d_result(vr);
     }
 
@@ -1106,29 +1166,6 @@ static void dxgi_vk_swap_chain_drain_waiter(struct dxgi_vk_swap_chain *chain)
     }
 }
 
-static void dxgi_vk_swap_chain_wait_and_reset_acquire_fence(struct dxgi_vk_swap_chain *chain)
-{
-    const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
-    VkDevice vk_device = chain->queue->device->vk_device;
-    VkResult vr;
-
-    if (chain->present.acquire_fence_pending)
-    {
-        /* We're doing this in a thread.
-         * There is little reason to add complexity with semaphores since behavior is
-         * implementation defined regarding if AcquireNextImage is synchronous or not. */
-        vr = VK_CALL(vkWaitForFences(vk_device, 1, &chain->present.vk_acquire_fence, VK_TRUE, UINT64_MAX));
-        if (vr < 0)
-            ERR("Failed to wait for fence, vr %d\n", vr);
-        VKD3D_DEVICE_REPORT_FAULT_AND_BREADCRUMB_IF(chain->queue->device, vr == VK_ERROR_DEVICE_LOST);
-        vr = VK_CALL(vkResetFences(vk_device, 1, &chain->present.vk_acquire_fence));
-        if (vr < 0)
-            ERR("Failed to reset fence, vr %d\n", vr);
-        VKD3D_DEVICE_REPORT_FAULT_AND_BREADCRUMB_IF(chain->queue->device, vr == VK_ERROR_DEVICE_LOST);
-        chain->present.acquire_fence_pending = false;
-    }
-}
-
 static void dxgi_vk_swap_chain_destroy_swapchain_in_present_task(struct dxgi_vk_swap_chain *chain)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
@@ -1137,8 +1174,6 @@ static void dxgi_vk_swap_chain_destroy_swapchain_in_present_task(struct dxgi_vk_
 
     if (!chain->present.vk_swapchain)
         return;
-
-    dxgi_vk_swap_chain_wait_and_reset_acquire_fence(chain);
 
     /* TODO: Can replace this stall with VK_KHR_present_wait,
      * but when destroying vk_release_semaphore we might be in a state where we submitted blit command buffer,
@@ -1436,12 +1471,15 @@ static void dxgi_vk_swap_chain_present_signal_blit_semaphore(struct dxgi_vk_swap
     VkQueue vk_queue;
     VkResult vr;
 
-    chain->present.blit_count += 1;
+    /* Could have used the internal timeline for this, but it complicates user thread
+     * waiting. It expects lock-step timelines, so we need to guarantee a 1:1 ratio of Present() calls
+     * to increments here. */
+    chain->present.complete_count += 1;
 
     memset(&signal_semaphore_info, 0, sizeof(signal_semaphore_info));
     signal_semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
-    signal_semaphore_info.semaphore = chain->present.vk_blit_semaphore;
-    signal_semaphore_info.value = chain->present.blit_count;
+    signal_semaphore_info.semaphore = chain->present.vk_complete_semaphore;
+    signal_semaphore_info.value = chain->present.complete_count;
     signal_semaphore_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
 
     memset(&submit_info, 0, sizeof(submit_info));
@@ -1520,9 +1558,10 @@ static void dxgi_vk_swap_chain_record_render_pass(struct dxgi_vk_swap_chain *cha
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &image_barrier;
 
-    /* srcStage = NONE since we're using fences to acquire WSI. */
+    /* srcStage = COLOR_ATTACHMENT to link up to acquire semaphore. */
     memset(&image_barrier, 0, sizeof(image_barrier));
     image_barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+    image_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     image_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     image_barrier.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
     image_barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -1599,13 +1638,13 @@ static bool dxgi_vk_swap_chain_submit_blit(struct dxgi_vk_swap_chain *chain, uin
 {
     const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
     VkDevice vk_device = chain->queue->device->vk_device;
+    VkSemaphoreSubmitInfo signal_semaphore_info[2];
     VkSemaphoreCreateInfo semaphore_create_info;
-    VkSemaphoreSubmitInfo signal_semaphore_info;
+    VkSemaphoreSubmitInfo wait_semaphore_info;
     VkCommandBufferAllocateInfo allocate_info;
     VkCommandBufferSubmitInfo cmd_buffer_info;
     VkCommandBufferBeginInfo cmd_begin_info;
-    VkFenceCreateInfo fence_create_info;
-    VkSubmitInfo2 submit_info;
+    VkSubmitInfo2 submit_infos[2];
     VkCommandBuffer vk_cmd;
     VkQueue vk_queue;
     VkResult vr;
@@ -1641,34 +1680,7 @@ static bool dxgi_vk_swap_chain_submit_blit(struct dxgi_vk_swap_chain *chain, uin
         }
     }
 
-    if (chain->present.vk_blit_fences[swapchain_index])
-    {
-        vr = VK_CALL(vkWaitForFences(vk_device, 1, &chain->present.vk_blit_fences[swapchain_index], VK_TRUE, UINT64_MAX));
-        VKD3D_DEVICE_REPORT_FAULT_AND_BREADCRUMB_IF(chain->queue->device, vr == VK_ERROR_DEVICE_LOST);
-        if (vr < 0)
-        {
-            ERR("Failed to wait for fence, vr %d\n", vr);
-            return false;
-        }
-        vr = VK_CALL(vkResetFences(vk_device, 1, &chain->present.vk_blit_fences[swapchain_index]));
-        if (vr < 0)
-        {
-            ERR("Failed to reset fence, vr %d\n", vr);
-            return false;
-        }
-    }
-    else
-    {
-        fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-        fence_create_info.pNext = NULL;
-        fence_create_info.flags = 0;
-        vr = VK_CALL(vkCreateFence(vk_device, &fence_create_info, NULL, &chain->present.vk_blit_fences[swapchain_index]));
-        if (vr < 0)
-        {
-            ERR("Failed to create fence, vr %d.\n", vr);
-            return false;
-        }
-    }
+    dxgi_vk_swap_chain_drain_internal_blit_semaphore(chain, chain->present.backbuffer_blit_timelines[swapchain_index]);
 
     vk_cmd = chain->present.vk_blit_command_buffers[swapchain_index];
 
@@ -1680,28 +1692,59 @@ static bool dxgi_vk_swap_chain_submit_blit(struct dxgi_vk_swap_chain *chain, uin
     dxgi_vk_swap_chain_record_render_pass(chain, vk_cmd, swapchain_index);
     VK_CALL(vkEndCommandBuffer(vk_cmd));
 
-    memset(&signal_semaphore_info, 0, sizeof(signal_semaphore_info));
-    signal_semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
-    signal_semaphore_info.semaphore = chain->present.vk_release_semaphores[swapchain_index];
-    signal_semaphore_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    assert(chain->present.acquire_semaphore_signalled[chain->present.acquire_semaphore_index]);
+    memset(&wait_semaphore_info, 0, sizeof(wait_semaphore_info));
+    wait_semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+    wait_semaphore_info.semaphore = chain->present.vk_acquire_semaphore[chain->present.acquire_semaphore_index];
+    wait_semaphore_info.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+
+    memset(signal_semaphore_info, 0, sizeof(signal_semaphore_info));
+    signal_semaphore_info[0].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+    signal_semaphore_info[0].semaphore = chain->present.vk_release_semaphores[swapchain_index];
+    signal_semaphore_info[0].stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+
+    chain->present.internal_blit_count += 1;
+    signal_semaphore_info[1].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+    signal_semaphore_info[1].semaphore = chain->present.vk_internal_blit_semaphore;
+    signal_semaphore_info[1].value = chain->present.internal_blit_count;
+    signal_semaphore_info[1].stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
 
     memset(&cmd_buffer_info, 0, sizeof(cmd_buffer_info));
     cmd_buffer_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO;
     cmd_buffer_info.commandBuffer = vk_cmd;
 
-    memset(&submit_info, 0, sizeof(submit_info));
-    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
-    submit_info.commandBufferInfoCount = 1;
-    submit_info.pCommandBufferInfos = &cmd_buffer_info;
-    submit_info.signalSemaphoreInfoCount = 1;
-    submit_info.pSignalSemaphoreInfos = &signal_semaphore_info;
+    memset(submit_infos, 0, sizeof(submit_infos));
+    submit_infos[0].sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+    submit_infos[0].commandBufferInfoCount = 1;
+    submit_infos[0].pCommandBufferInfos = &cmd_buffer_info;
+    submit_infos[0].pWaitSemaphoreInfos = &wait_semaphore_info;
+    submit_infos[0].waitSemaphoreInfoCount = 1;
+    submit_infos[0].signalSemaphoreInfoCount = 1;
+    submit_infos[0].pSignalSemaphoreInfos = &signal_semaphore_info[0];
+
+    /* Internal blit semaphore must be signaled after we signal vk_release_semaphores.
+     * To guarantee this, the signals must happen in different batches. */
+    submit_infos[1].sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+    submit_infos[1].signalSemaphoreInfoCount = 1;
+    submit_infos[1].pSignalSemaphoreInfos = &signal_semaphore_info[1];
 
     vk_queue = vkd3d_queue_acquire(chain->queue->vkd3d_queue);
-    vr = VK_CALL(vkQueueSubmit2(vk_queue, 1, &submit_info, chain->present.vk_blit_fences[swapchain_index]));
+    vr = VK_CALL(vkQueueSubmit2(vk_queue, ARRAY_SIZE(submit_infos), submit_infos, VK_NULL_HANDLE));
     vkd3d_queue_release(chain->queue->vkd3d_queue);
     VKD3D_DEVICE_REPORT_FAULT_AND_BREADCRUMB_IF(chain->queue->device, vr == VK_ERROR_DEVICE_LOST);
+
     if (vr < 0)
+    {
         ERR("Failed to submit swapchain blit, vr %d.\n", vr);
+    }
+    else
+    {
+        chain->present.backbuffer_blit_timelines[swapchain_index] =
+                chain->present.internal_blit_count;
+        chain->present.acquire_semaphore_consumed_at_blit[chain->present.acquire_semaphore_index] =
+                chain->present.internal_blit_count;
+        chain->present.acquire_semaphore_signalled[chain->present.acquire_semaphore_index] = false;
+    }
 
     return vr == VK_SUCCESS;
 }
@@ -1712,10 +1755,51 @@ static void dxgi_vk_swap_chain_present_recreate_swapchain_if_required(struct dxg
         dxgi_vk_swap_chain_recreate_swapchain_in_present_task(chain);
 }
 
+static VkResult dxgi_vk_swap_chain_ensure_unsignaled_acquire_semaphore(struct dxgi_vk_swap_chain *chain,
+        uint32_t index, bool blocking)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
+    VkSemaphoreCreateInfo sem_info;
+    VkResult vr = VK_SUCCESS;
+    uint64_t drain_count;
+
+    if (blocking)
+    {
+        /* Any pending wait must have been satisfied before we queue up a new signal. */
+        drain_count = chain->present.acquire_semaphore_consumed_at_blit[index];
+        if (drain_count)
+            dxgi_vk_swap_chain_drain_internal_blit_semaphore(chain, drain_count);
+    }
+
+    if (chain->present.acquire_semaphore_signalled[index])
+    {
+        /* There is no pending wait, so we insert it now. */
+        dxgi_vk_swap_chain_wait_acquire_semaphore(chain, chain->present.vk_acquire_semaphore[index], blocking);
+        chain->present.acquire_semaphore_consumed_at_blit[index] = chain->present.internal_blit_count;
+        chain->present.acquire_semaphore_signalled[index] = false;
+    }
+
+    if (!chain->present.vk_acquire_semaphore[index])
+    {
+        memset(&sem_info, 0, sizeof(sem_info));
+        sem_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+        if ((vr = VK_CALL(vkCreateSemaphore(chain->queue->device->vk_device, &sem_info,
+                NULL, &chain->present.vk_acquire_semaphore[index]))) != VK_SUCCESS)
+        {
+            ERR("Failed to create semaphore, vr %d\n", vr);
+            chain->present.vk_acquire_semaphore[index] = VK_NULL_HANDLE;
+        }
+    }
+
+    return vr;
+}
+
 static VkResult dxgi_vk_swap_chain_try_acquire_next_image(struct dxgi_vk_swap_chain *chain)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
     VkDevice vk_device = chain->queue->device->vk_device;
+    uint32_t semaphore_index;
     VkResult vr;
 
     if (!chain->present.vk_swapchain)
@@ -1723,15 +1807,31 @@ static VkResult dxgi_vk_swap_chain_try_acquire_next_image(struct dxgi_vk_swap_ch
     if (chain->present.current_backbuffer_index != UINT32_MAX)
         return VK_SUCCESS;
 
-    assert(!chain->present.acquire_fence_pending);
+    /* Ensure that we wait for semaphores before leaving it behind to avoid
+     * having to do a blocking wait later. This can happen if we acquired successfully, but got
+     * SUBOPTIMAL. That would leave a semaphore floating if we don't wait for it. */
+    semaphore_index = chain->present.acquire_semaphore_index;
+    vr = dxgi_vk_swap_chain_ensure_unsignaled_acquire_semaphore(chain, semaphore_index, false);
+    if (vr != VK_SUCCESS)
+        return vr;
+
+    chain->present.acquire_semaphore_index = (chain->present.acquire_semaphore_index + 1) %
+            ARRAY_SIZE(chain->present.vk_acquire_semaphore);
+    semaphore_index = chain->present.acquire_semaphore_index;
+
+    /* This should never actually block unless something unexpected happens. */
+    vr = dxgi_vk_swap_chain_ensure_unsignaled_acquire_semaphore(chain, semaphore_index, true);
+    if (vr != VK_SUCCESS)
+        return vr;
+
     vr = VK_CALL(vkAcquireNextImageKHR(vk_device, chain->present.vk_swapchain, UINT64_MAX,
-            VK_NULL_HANDLE, chain->present.vk_acquire_fence,
+            chain->present.vk_acquire_semaphore[semaphore_index], VK_NULL_HANDLE,
             &chain->present.current_backbuffer_index));
 
     if (vr < 0)
         chain->present.current_backbuffer_index = UINT32_MAX;
     else
-        chain->present.acquire_fence_pending = true;
+        chain->present.acquire_semaphore_signalled[semaphore_index] = true;
 
     return vr;
 }
@@ -1754,7 +1854,6 @@ static void dxgi_vk_swap_chain_present_iteration(struct dxgi_vk_swap_chain *chai
 
     vr = dxgi_vk_swap_chain_try_acquire_next_image(chain);
     VKD3D_DEVICE_REPORT_FAULT_AND_BREADCRUMB_IF(chain->queue->device, vr == VK_ERROR_DEVICE_LOST);
-    dxgi_vk_swap_chain_wait_and_reset_acquire_fence(chain);
 
     /* Handle any errors and retry as needed. If we cannot make meaningful forward progress, just give up and retry later. */
     if (vr == VK_SUBOPTIMAL_KHR || vr < 0)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -174,6 +174,11 @@ struct vkd3d_vulkan_info
     bool VALVE_mutable_descriptor_type;
     bool VALVE_descriptor_set_host_mapping;
 
+    /* Optional extensions which are enabled externally as optional extensions
+     * if swapchain/surface extensions are enabled. */
+    bool EXT_surface_maintenance1;
+    bool EXT_swapchain_maintenance1;
+
     unsigned int extension_count;
     const char* const* extension_names;
 
@@ -4339,6 +4344,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceLineRasterizationFeaturesEXT line_rasterization_features;
     VkPhysicalDeviceImageCompressionControlFeaturesEXT image_compression_control_features;
     VkPhysicalDeviceFaultFeaturesEXT fault_features;
+    VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT swapchain_maintenance1_features;
 
     VkPhysicalDeviceFeatures2 features2;
 

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -274,6 +274,9 @@ VK_INSTANCE_EXT_PFN(vkDestroySurfaceKHR)
 VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceSurfaceFormatsKHR)
 VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceSurfaceCapabilitiesKHR)
 
+/* VK_KHR_get_surface_capabilities2 */
+VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceSurfaceCapabilities2KHR)
+
 /* VK_KHR_win32_surface */
 #ifdef VK_KHR_win32_surface
 VK_INSTANCE_EXT_PFN(vkCreateWin32SurfaceKHR)


### PR DESCRIPTION
VkFence wait on Mesa is not a noop after all.
There can be very long stalls leading to very strange frame pacing graphs when GPU is rendering slower than refresh rate in windowed modes.

Waiting for semaphores fixes this and with present_wait, there is little reason to not use semaphores when there's a meaningful improvement in jitter.