### PR TITLE
Improve behavior when VRAM is oversubscribed.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -97,6 +97,8 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_IMAGE_SLICED_VIEW_OF_3D, EXT_image_sliced_view_of_3d),
     VK_EXTENSION(EXT_GRAPHICS_PIPELINE_LIBRARY, EXT_graphics_pipeline_library),
     VK_EXTENSION(EXT_FRAGMENT_SHADER_INTERLOCK, EXT_fragment_shader_interlock),
+    VK_EXTENSION(EXT_PAGEABLE_DEVICE_LOCAL_MEMORY, EXT_pageable_device_local_memory),
+    VK_EXTENSION(EXT_MEMORY_PRIORITY, EXT_memory_priority),
     /* AMD extensions */
     VK_EXTENSION(AMD_BUFFER_MARKER, AMD_buffer_marker),
     VK_EXTENSION(AMD_DEVICE_COHERENT_MEMORY, AMD_device_coherent_memory),
@@ -1573,6 +1575,20 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->features2, &info->fragment_shader_interlock_features);
     }
 
+    if (vulkan_info->EXT_memory_priority)
+    {
+        info->memory_priority_features.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT;
+        vk_prepend_struct(&info->features2, &info->memory_priority_features);
+    }
+
+    if (vulkan_info->EXT_pageable_device_local_memory)
+    {
+        info->pageable_device_memory_features.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT;
+        vk_prepend_struct(&info->features2, &info->pageable_device_memory_features);
+    }
+
     VK_CALL(vkGetPhysicalDeviceFeatures2(device->vk_physical_device, &info->features2));
     VK_CALL(vkGetPhysicalDeviceProperties2(device->vk_physical_device, &info->properties2));
 }
@@ -2627,6 +2643,7 @@ static HRESULT d3d12_device_create_scratch_buffer(struct d3d12_device *device, e
         alloc_info.heap_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
         alloc_info.heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS | D3D12_HEAP_FLAG_CREATE_NOT_ZEROED;
         alloc_info.extra_allocation_flags = VKD3D_ALLOCATION_FLAG_INTERNAL_SCRATCH;
+        alloc_info.vk_memory_priority = vkd3d_convert_to_vk_prio(D3D12_RESIDENCY_PRIORITY_NORMAL);
 
         if (FAILED(hr = vkd3d_allocate_heap_memory(device, &device->memory_allocator,
                 &alloc_info, &scratch->allocation)))
@@ -2644,6 +2661,7 @@ static HRESULT d3d12_device_create_scratch_buffer(struct d3d12_device *device, e
         alloc_info.heap_flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS | D3D12_HEAP_FLAG_CREATE_NOT_ZEROED;
         alloc_info.optional_memory_properties = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         alloc_info.flags = VKD3D_ALLOCATION_FLAG_GLOBAL_BUFFER | VKD3D_ALLOCATION_FLAG_INTERNAL_SCRATCH;
+        alloc_info.vk_memory_priority = vkd3d_convert_to_vk_prio(D3D12_RESIDENCY_PRIORITY_NORMAL);
 
         if (FAILED(hr = vkd3d_allocate_memory(device, &device->memory_allocator,
                 &alloc_info, &scratch->allocation)))
@@ -2662,6 +2680,7 @@ static HRESULT d3d12_device_create_scratch_buffer(struct d3d12_device *device, e
         alloc_info.heap_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
         alloc_info.heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS | D3D12_HEAP_FLAG_CREATE_NOT_ZEROED;
         alloc_info.extra_allocation_flags = VKD3D_ALLOCATION_FLAG_INTERNAL_SCRATCH;
+        alloc_info.vk_memory_priority = vkd3d_convert_to_vk_prio(D3D12_RESIDENCY_PRIORITY_NORMAL);
 
         if (FAILED(hr = vkd3d_allocate_heap_memory(device, &device->memory_allocator,
                 &alloc_info, &scratch->allocation)))
@@ -5106,17 +5125,135 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_OpenSharedHandleByName(d3d12_devic
 static HRESULT STDMETHODCALLTYPE d3d12_device_MakeResident(d3d12_device_iface *iface,
         UINT object_count, ID3D12Pageable * const *objects)
 {
-    FIXME_ONCE("iface %p, object_count %u, objects %p stub!\n",
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+
+    TRACE("iface %p, object_count %u, objects %p\n",
             iface, object_count, objects);
 
+    if (device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory)
+    {
+        uint32_t i;
+
+        for (i = 0; i < object_count; i++)
+        {
+            VkDeviceMemory memory = VK_NULL_HANDLE;
+            D3D12_RESIDENCY_PRIORITY priority;
+            ID3D12Resource *resource_iface;
+            ID3D12Heap *heap_iface;
+
+            if (SUCCEEDED(ID3D12Pageable_QueryInterface(objects[i], &IID_ID3D12Heap, (void**)&heap_iface)))
+            {
+                struct d3d12_heap *heap_object = impl_from_ID3D12Heap(heap_iface);
+
+                if (heap_object->priority.allows_dynamic_residency)
+                {
+                    memory = heap_object->allocation.device_allocation.vk_memory;
+                    spinlock_acquire(&heap_object->priority.spinlock);
+                    priority = heap_object->priority.d3d12priority;
+                    heap_object->priority.residency_count++;
+                    spinlock_release(&heap_object->priority.spinlock);
+                }
+
+                ID3D12Heap_Release(heap_iface);
+            }
+            else if (SUCCEEDED(ID3D12Pageable_QueryInterface(objects[i], &IID_ID3D12Resource, (void**)&resource_iface)))
+            {
+                struct d3d12_resource *resource_object = impl_from_ID3D12Resource(resource_iface);
+
+                if (resource_object->priority.allows_dynamic_residency)
+                {
+                    memory = resource_object->mem.device_allocation.vk_memory;
+                    spinlock_acquire(&resource_object->priority.spinlock);
+                    priority = resource_object->priority.d3d12priority;
+                    resource_object->priority.residency_count++;
+                    spinlock_release(&resource_object->priority.spinlock);
+                }
+
+                ID3D12Resource_Release(resource_iface);
+            }
+
+            if (memory)
+            {
+                VK_CALL(vkSetDeviceMemoryPriorityEXT(device->vk_device, memory, vkd3d_convert_to_vk_prio(priority)));
+            }
+        }
+    }
+
     return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_device_EnqueueMakeResident(d3d12_device_iface *iface,
+        D3D12_RESIDENCY_FLAGS flags, UINT num_objects, ID3D12Pageable *const *objects,
+        ID3D12Fence *fence_to_signal, UINT64 fence_value_to_signal)
+{
+    TRACE("iface %p, flags %#x, num_objects %u, objects %p, fence_to_signal %p, fence_value_to_signal %"PRIu64"\n",
+            iface, flags, num_objects, objects, fence_to_signal, fence_value_to_signal);
+
+    /* note: we ignore flags/D3D12_RESIDENCY_FLAG_DENY_OVERBUDGET; it involves
+       knowing if the app will be made over-budget.  We act as if it won't.  Could perhaps
+       use VK_EXT_memory_budget but don't have an app in-hand that clearly cares. */
+    d3d12_device_MakeResident(iface, num_objects, objects);
+
+    /* we don't block anyway - signal the fence immediately */
+    return ID3D12Fence_Signal(fence_to_signal, fence_value_to_signal);
 }
 
 static HRESULT STDMETHODCALLTYPE d3d12_device_Evict(d3d12_device_iface *iface,
         UINT object_count, ID3D12Pageable * const *objects)
 {
-    FIXME_ONCE("iface %p, object_count %u, objects %p stub!\n",
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+
+    TRACE("iface %p, object_count %u, objects %p\n",
             iface, object_count, objects);
+
+    if (device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory)
+    {
+        uint32_t i;
+
+        for (i = 0; i < object_count; i++)
+        {
+            VkDeviceMemory memory = VK_NULL_HANDLE;
+            ID3D12Resource *resource_iface;
+            bool now_evicted = false;
+            ID3D12Heap *heap_iface;
+
+            if (SUCCEEDED(ID3D12Pageable_QueryInterface(objects[i], &IID_ID3D12Heap, (void**)&heap_iface)))
+            {
+                struct d3d12_heap *heap_object = impl_from_ID3D12Heap(heap_iface);
+
+                if (heap_object->priority.allows_dynamic_residency)
+                {
+                    memory = heap_object->allocation.device_allocation.vk_memory;
+                    spinlock_acquire(&heap_object->priority.spinlock);
+                    now_evicted = (0 == --heap_object->priority.residency_count);
+                    spinlock_release(&heap_object->priority.spinlock);
+                }
+
+                ID3D12Heap_Release(heap_iface);
+            }
+            else if (SUCCEEDED(ID3D12Pageable_QueryInterface(objects[i], &IID_ID3D12Resource, (void**)&resource_iface)))
+            {
+                struct d3d12_resource *resource_object = impl_from_ID3D12Resource(resource_iface);
+
+                if (resource_object->priority.allows_dynamic_residency)
+                {
+                    memory = resource_object->mem.device_allocation.vk_memory;
+                    spinlock_acquire(&resource_object->priority.spinlock);
+                    now_evicted = (0 == --resource_object->priority.residency_count);
+                    spinlock_release(&resource_object->priority.spinlock);
+                }
+
+                ID3D12Resource_Release(resource_iface);
+            }
+
+            if (memory && now_evicted)
+            {
+                VK_CALL(vkSetDeviceMemoryPriorityEXT(device->vk_device, memory, 0.0f));
+            }
+        }
+    }
 
     return S_OK;
 }
@@ -5410,8 +5547,64 @@ fail:
 static HRESULT STDMETHODCALLTYPE d3d12_device_SetResidencyPriority(d3d12_device_iface *iface,
         UINT object_count, ID3D12Pageable *const *objects, const D3D12_RESIDENCY_PRIORITY *priorities)
 {
-    FIXME_ONCE("iface %p, object_count %u, objects %p, priorities %p stub!\n",
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+
+    TRACE("iface %p, object_count %u, objects %p, priorities %p\n",
             iface, object_count, objects, priorities);
+
+    if (device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory)
+    {
+        const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+        uint32_t i;
+
+        for (i = 0; i < object_count; i++)
+        {
+            D3D12_RESIDENCY_PRIORITY priority = priorities[i];
+            VkDeviceMemory memory = VK_NULL_HANDLE;
+            ID3D12Resource *resource_iface;
+            ID3D12Heap *heap_iface;
+
+            if (SUCCEEDED(ID3D12Pageable_QueryInterface(objects[i], &IID_ID3D12Heap, (void**)&heap_iface)))
+            {
+                struct d3d12_heap *heap_object = impl_from_ID3D12Heap(heap_iface);
+
+                if (heap_object->priority.allows_dynamic_residency)
+                {
+                    spinlock_acquire(&heap_object->priority.spinlock);
+                    heap_object->priority.d3d12priority = priority;
+                    if (heap_object->priority.residency_count)
+                    {
+                        memory = heap_object->allocation.device_allocation.vk_memory;
+                    }
+                    spinlock_release(&heap_object->priority.spinlock);
+                }
+
+                ID3D12Heap_Release(heap_iface);
+            }
+            else if (SUCCEEDED(ID3D12Pageable_QueryInterface(objects[i], &IID_ID3D12Resource, (void**)&resource_iface)))
+            {
+                struct d3d12_resource *resource_object = impl_from_ID3D12Resource(resource_iface);
+
+                if (resource_object->priority.allows_dynamic_residency)
+                {
+                    spinlock_acquire(&resource_object->priority.spinlock);
+                    resource_object->priority.d3d12priority = priority;
+                    if (resource_object->priority.residency_count)
+                    {
+                        memory = resource_object->mem.device_allocation.vk_memory;
+                    }
+                    spinlock_release(&resource_object->priority.spinlock);
+                }
+
+                ID3D12Resource_Release(resource_iface);
+            }
+
+            if (memory)
+            {
+                VK_CALL(vkSetDeviceMemoryPriorityEXT(device->vk_device, memory, vkd3d_convert_to_vk_prio(priority)));
+            }
+        }
+    }
 
     return S_OK;
 }
@@ -5525,16 +5718,6 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_OpenExistingHeapFromFileMapping(d3
     FIXME("OpenExistingHeapFromFileMapping can only be implemented in native Win32.\n");
     return E_NOTIMPL;
 #endif
-}
-
-static HRESULT STDMETHODCALLTYPE d3d12_device_EnqueueMakeResident(d3d12_device_iface *iface,
-        D3D12_RESIDENCY_FLAGS flags, UINT num_objects, ID3D12Pageable *const *objects,
-        ID3D12Fence *fence_to_signal, UINT64 fence_value_to_signal)
-{
-    FIXME_ONCE("iface %p, flags %#x, num_objects %u, objects %p, fence_to_signal %p, fence_value_to_signal %"PRIu64" stub!\n",
-            iface, flags, num_objects, objects, fence_to_signal, fence_value_to_signal);
-
-    return ID3D12Fence_Signal(fence_to_signal, fence_value_to_signal);
 }
 
 static HRESULT STDMETHODCALLTYPE d3d12_device_CreateCommandList1(d3d12_device_iface *iface,

--- a/libs/vkd3d/heap.c
+++ b/libs/vkd3d/heap.c
@@ -259,6 +259,10 @@ static HRESULT d3d12_heap_init(struct d3d12_heap *heap, struct d3d12_device *dev
     heap->refcount = 1;
     heap->desc = *desc;
     heap->device = device;
+    heap->priority.allows_dynamic_residency = false;
+    spinlock_init(&heap->priority.spinlock);
+    heap->priority.d3d12priority = D3D12_RESIDENCY_PRIORITY_NORMAL;
+    heap->priority.residency_count = 1;
 
     if (!heap->desc.Properties.CreationNodeMask)
         heap->desc.Properties.CreationNodeMask = 1;
@@ -277,12 +281,38 @@ static HRESULT d3d12_heap_init(struct d3d12_heap *heap, struct d3d12_device *dev
     if (FAILED(hr = vkd3d_private_store_init(&heap->private_store)))
         return hr;
 
+    if (device->device_info.memory_priority_features.memoryPriority)
+    {
+        /* this clause isn't trying to reproduce some precise d3d12 behavior,
+           though it's hinted in the public docs that a similar prioritization
+           is done there... and it seems like a good idea anyway. :) */
+        if (heap->desc.Flags & D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES)
+        {
+            uint32_t adjust = vkd3d_get_priority_adjust(heap->desc.SizeInBytes);
+            heap->priority.d3d12priority = D3D12_RESIDENCY_PRIORITY_HIGH | adjust;
+        }
+
+        if (device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory)
+        {
+            if (heap->desc.Flags & D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT)
+                heap->priority.residency_count = 0;
+        }
+    }
+
+    alloc_info.vk_memory_priority = heap->priority.residency_count ?
+        vkd3d_convert_to_vk_prio(heap->priority.d3d12priority) : 0.f;
+
     if (FAILED(hr = vkd3d_allocate_heap_memory(device,
             &device->memory_allocator, &alloc_info, &heap->allocation)))
     {
         vkd3d_private_store_destroy(&heap->private_store);
         return hr;
     }
+
+    heap->priority.allows_dynamic_residency = 
+        device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory &&
+        heap->allocation.chunk == NULL /* not suballocated */ &&
+        (device->memory_properties.memoryTypes[heap->allocation.device_allocation.vk_memory_type].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     d3d12_device_add_ref(heap->device);
     return S_OK;

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -1056,6 +1056,7 @@ static HRESULT vkd3d_memory_allocation_init(struct vkd3d_memory_allocation *allo
         struct vkd3d_memory_allocator *allocator, const struct vkd3d_allocate_memory_info *info)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    VkMemoryPriorityAllocateInfoEXT priority_info;
     VkMemoryRequirements memory_requirements;
     VkMemoryAllocateFlagsInfo flags_info;
     VkMemoryPropertyFlags type_flags;
@@ -1154,6 +1155,15 @@ static HRESULT vkd3d_memory_allocation_init(struct vkd3d_memory_allocation *allo
             VK_CALL(vkDestroyBuffer(device->vk_device, allocation->resource.vk_buffer, NULL));
             return E_INVALIDARG;
         }
+    }
+
+    if (device->device_info.memory_priority_features.memoryPriority &&
+        (type_flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+    {
+        priority_info.sType = VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT;
+        priority_info.pNext = NULL;
+        priority_info.priority = info->vk_memory_priority;
+        vk_prepend_struct(&flags_info, &priority_info);
     }
 
     if (host_ptr)
@@ -1530,6 +1540,7 @@ static HRESULT vkd3d_memory_allocator_try_add_chunk(struct vkd3d_memory_allocato
     alloc_info.heap_flags = heap_flags;
     alloc_info.flags = VKD3D_ALLOCATION_FLAG_NO_FALLBACK;
     alloc_info.optional_memory_properties = optional_properties;
+    alloc_info.vk_memory_priority = vkd3d_convert_to_vk_prio(D3D12_RESIDENCY_PRIORITY_NORMAL);
 
     if (!(heap_flags & D3D12_HEAP_FLAG_DENY_BUFFERS))
     {
@@ -1753,6 +1764,7 @@ HRESULT vkd3d_allocate_heap_memory(struct d3d12_device *device, struct vkd3d_mem
     alloc_info.heap_properties = info->heap_desc.Properties;
     alloc_info.heap_flags = info->heap_desc.Flags;
     alloc_info.host_ptr = info->host_ptr;
+    alloc_info.vk_memory_priority = info->vk_memory_priority;
 
     alloc_info.flags |= info->extra_allocation_flags;
     if (!(info->heap_desc.Flags & D3D12_HEAP_FLAG_DENY_BUFFERS))

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -331,6 +331,9 @@ VK_DEVICE_EXT_PFN(vkCmdSetDescriptorBufferOffsetsEXT)
 VK_DEVICE_EXT_PFN(vkGetDescriptorSetLayoutSizeEXT)
 VK_DEVICE_EXT_PFN(vkGetDescriptorSetLayoutBindingOffsetEXT)
 
+/* VK_EXT_pageable_device_local_memory */
+VK_DEVICE_EXT_PFN(vkSetDeviceMemoryPriorityEXT)
+
 #undef VK_INSTANCE_PFN
 #undef VK_INSTANCE_EXT_PFN
 #undef VK_DEVICE_PFN


### PR DESCRIPTION
The goal is to:

- Enable pageable memory, a.k.a. heap migration (VK_EXT_pageable_device_local_memory)
- Implement explicit D3D12 API residency+prioritization hints on top of VK_EXT_memory_priority
- Closely match the implicit D3D12 prioritization given to resources by default based on usage etc, insofar as publicly documented

**Notes**:
Practically speaking, it's not a panacea for when you're chronically oversubscribed (it may be a better experience... or it may not); the main win is that it recovers a lot more gracefully from transitory oversubscription.

Without VK_EXT_pageable_device_local_memory you can end up with rendertargets (or anything else vital) spilled to a system heap and stay there forever.  That can drive an app off an invisible performance cliff from which it's hard to recover (short of restarting).  With VK_EXT_pageable_device_local_memory and some half-decent priority hints, at least important stuff can make it back to a device-local heap once there's room again and perf gets back to a decent steady-state.
