### PR TITLE
Handle dynamic depth-stencil write masks based on DSV descriptor

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -6034,6 +6034,7 @@ void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_dev
     rtv_desc->layer_count = key.u.texture.layer_count;
     rtv_desc->view = view;
     rtv_desc->resource = resource;
+    rtv_desc->plane_write_enable = 1u << 0;
 }
 
 void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_device *device,
@@ -6124,6 +6125,9 @@ void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_dev
     dsv_desc->layer_count = key.u.texture.layer_count;
     dsv_desc->view = view;
     dsv_desc->resource = resource;
+    dsv_desc->plane_write_enable =
+            (desc && (desc->Flags & D3D12_DSV_FLAG_READ_ONLY_DEPTH) ? 0 : (1u << 0)) |
+            (desc && (desc->Flags & D3D12_DSV_FLAG_READ_ONLY_STENCIL) ? 0 : (1u << 1));
 }
 
 /* ID3D12DescriptorHeap */

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3500,6 +3500,8 @@ vkd3d_dynamic_state_list[] =
     { VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE, VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR },
     { VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART,     VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT },
     { VKD3D_DYNAMIC_STATE_PATCH_CONTROL_POINTS,  VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT },
+    { VKD3D_DYNAMIC_STATE_DEPTH_WRITE_ENABLE,    VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE },
+    { VKD3D_DYNAMIC_STATE_STENCIL_WRITE_MASK,    VK_DYNAMIC_STATE_STENCIL_WRITE_MASK },
 };
 
 uint32_t vkd3d_init_dynamic_state_array(VkDynamicState *dynamic_states, uint32_t dynamic_state_flags)
@@ -3776,6 +3778,13 @@ uint32_t d3d12_graphics_pipeline_state_get_dynamic_state_flags(struct d3d12_pipe
 
     if (graphics->ds_desc.depthBoundsTestEnable)
         dynamic_state_flags |= VKD3D_DYNAMIC_STATE_DEPTH_BOUNDS;
+
+    /* If the DSV is read-only for a plane, writes are dynamically disabled. */
+    if (graphics->ds_desc.depthTestEnable && graphics->ds_desc.depthWriteEnable)
+        dynamic_state_flags |= VKD3D_DYNAMIC_STATE_DEPTH_WRITE_ENABLE;
+
+    if (graphics->ds_desc.stencilTestEnable && graphics->ds_desc.front.writeMask)
+        dynamic_state_flags |= VKD3D_DYNAMIC_STATE_STENCIL_WRITE_MASK;
 
     for (i = 0; i < graphics->rt_count; i++)
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1237,6 +1237,7 @@ struct d3d12_rtv_desc
     unsigned int width;
     unsigned int height;
     unsigned int layer_count;
+    unsigned int plane_write_enable;
     struct vkd3d_view *view;
     struct d3d12_resource *resource;
 };
@@ -1770,6 +1771,8 @@ enum vkd3d_dynamic_state_flag
     VKD3D_DYNAMIC_STATE_FRAGMENT_SHADING_RATE = (1 << 7),
     VKD3D_DYNAMIC_STATE_PRIMITIVE_RESTART     = (1 << 8),
     VKD3D_DYNAMIC_STATE_PATCH_CONTROL_POINTS  = (1 << 9),
+    VKD3D_DYNAMIC_STATE_DEPTH_WRITE_ENABLE    = (1 << 10),
+    VKD3D_DYNAMIC_STATE_STENCIL_WRITE_MASK    = (1 << 11),
 };
 
 struct vkd3d_shader_debug_ring_spec_constants
@@ -2371,6 +2374,8 @@ struct vkd3d_dynamic_state
 
     float blend_constants[4];
     uint32_t stencil_reference;
+    uint32_t stencil_write_mask;
+    uint32_t dsv_plane_write_enable;
 
     float min_depth_bounds;
     float max_depth_bounds;

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -192,6 +192,7 @@ VK_DEVICE_PFN(vkUnmapMemory)
 VK_DEVICE_PFN(vkUpdateDescriptorSets)
 VK_DEVICE_PFN(vkWaitForFences)
 VK_DEVICE_PFN(vkWaitSemaphores)
+VK_DEVICE_PFN(vkCmdSetDepthWriteEnable)
 
 /* VK_KHR_push_descriptor */
 VK_DEVICE_EXT_PFN(vkCmdPushDescriptorSetKHR)

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -339,3 +339,4 @@ decl_test(test_uav_robustness_oob_structure_element_dxbc);
 decl_test(test_uav_robustness_oob_structure_element_dxil);
 decl_test(test_denorm_behavior_dxbc);
 decl_test(test_denorm_behavior_dxil);
+decl_test(test_dynamic_depth_stencil_write);


### PR DESCRIPTION
We are apparently required to handle this. Fixes #1547.