### PR TITLE
Fix root signature feature check

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3652,6 +3652,12 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
                 return E_INVALIDARG;
             }
 
+            if (!data->HighestVersion || data->HighestVersion > D3D_ROOT_SIGNATURE_VERSION_1_1)
+            {
+                WARN("Unrecognized root signature version %#x.\n", data->HighestVersion);
+                return E_INVALIDARG;
+            }
+
             TRACE("Root signature requested %#x.\n", data->HighestVersion);
             data->HighestVersion = min(data->HighestVersion, D3D_ROOT_SIGNATURE_VERSION_1_1);
 

--- a/tests/d3d12_device.c
+++ b/tests/d3d12_device.c
@@ -299,6 +299,20 @@ void test_check_feature_support(void)
             || root_signature.HighestVersion == D3D_ROOT_SIGNATURE_VERSION_1_1,
             "Got unexpected root signature feature version %#x.\n", root_signature.HighestVersion);
 
+    root_signature.HighestVersion = 0;
+    hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ROOT_SIGNATURE,
+            &root_signature, sizeof(root_signature));
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(root_signature.HighestVersion == 0, "Got unexpected root signature feature version %#x.\n",
+            root_signature.HighestVersion);
+
+    root_signature.HighestVersion = 0xdeadbeef;
+    hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ROOT_SIGNATURE,
+            &root_signature, sizeof(root_signature));
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(root_signature.HighestVersion == 0xdeadbeef, "Got unexpected root signature feature version %#x.\n",
+            root_signature.HighestVersion);
+
     refcount = ID3D12Device_Release(device);
     ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
 }


### PR DESCRIPTION
Turns out that the runtime will return `E_INVALIDARG` when the app passes in an unrecognized or unsupported root signature version, which makes this whole function a bit... weird.

Fixes #1548.