### PR TITLE
vkd3d: Fix min luminance of HDR Metadata

### DIFF
--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -648,7 +648,7 @@ static float convert_max_luminance(UINT dxgi_luminance)
 
 static float convert_min_luminance(UINT dxgi_luminance)
 {
-    return dxgi_luminance / 0.0001f;
+    return dxgi_luminance * 0.0001f;
 }
 
 static float convert_level(UINT16 dxgi_level)


### PR DESCRIPTION
This should be a multiply instead of a divide. Values are 1/10000th of a nit (0.0001 nit).