### PR TITLE
vkd3d: Apply curb memory pso cache globally on Deck.

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -4832,11 +4832,7 @@ HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindP
 
     /* Mesa's internal cache can bloat indefinitely, so workaround it as needed for now.
      * TODO: Find a better solution. */
-    if (!object->vk_pso_cache &&
-            (vkd3d_config_flags & VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE) &&
-            (vkd3d_config_flags & VKD3D_CONFIG_FLAG_CURB_MEMORY_PSO_CACHE) &&
-            !(vkd3d_config_flags & VKD3D_CONFIG_FLAG_SKIP_DRIVER_WORKAROUNDS) &&
-            device->device_info.vulkan_1_2_properties.driverID == VK_DRIVER_ID_MESA_RADV)
+    if (!object->vk_pso_cache && device->device_info.workarounds.force_dummy_pipeline_cache)
     {
         if (vkd3d_create_pipeline_cache(device, 0, NULL, &object->vk_pso_cache) != VK_SUCCESS)
             object->vk_pso_cache = VK_NULL_HANDLE;
@@ -4927,10 +4923,7 @@ HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindP
         vkd3d_pipeline_library_store_pipeline_to_disk_cache(&device->disk_cache, object);
     }
 
-    if ((vkd3d_config_flags & VKD3D_CONFIG_FLAG_CURB_MEMORY_PSO_CACHE) &&
-            (vkd3d_config_flags & VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE) &&
-            !(vkd3d_config_flags & VKD3D_CONFIG_FLAG_SKIP_DRIVER_WORKAROUNDS) &&
-            device->device_info.vulkan_1_2_properties.driverID == VK_DRIVER_ID_MESA_RADV)
+    if (device->device_info.workarounds.force_dummy_pipeline_cache)
     {
         /* Throw the pipeline cache away immediately. Tricks drivers into not retaining the PSO in memory cache. */
         VK_CALL(vkDestroyPipelineCache(device->vk_device, object->vk_pso_cache, NULL));

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3974,6 +3974,11 @@ struct vkd3d_physical_device_info
     uint32_t time_domains;  /* vkd3d_time_domain_flag */
 
     bool additional_shading_rates_supported; /* d3d12 additional fragment shading rates cap */
+
+    struct
+    {
+        bool force_dummy_pipeline_cache;
+    } workarounds;
 };
 
 struct d3d12_caps


### PR DESCRIPTION
In a memory constrained environment this is a good idea, and Deck should have everything primed in disk$ either way, so the value of memory cache is greatly diminished.