### PR TITLE
d3d12: Add D3D12PIXEventsReplaceBlock and D3D12PIXGetThreadInfo stub …

### DIFF
--- a/libs/d3d12/d3d12.def
+++ b/libs/d3d12/d3d12.def
@@ -9,3 +9,6 @@ EXPORTS
     D3D12EnableExperimentalFeatures
     D3D12SerializeRootSignature
     D3D12SerializeVersionedRootSignature
+
+    D3D12PIXEventsReplaceBlock
+    D3D12PIXGetThreadInfo

--- a/libs/d3d12/main.c
+++ b/libs/d3d12/main.c
@@ -206,3 +206,15 @@ HRESULT WINAPI DLLEXPORT D3D12GetInterface(REFCLSID rcslid, REFIID iid, void **d
         return E_NOINTERFACE;
     return IVKD3DCoreInterface_GetInterface(core, rcslid, iid, debug);
 }
+
+HRESULT WINAPI DLLEXPORT D3D12PIXEventsReplaceBlock()
+{
+    FIXME("stub!\n");
+    return E_NOTIMPL;
+}
+
+HRESULT WINAPI DLLEXPORT D3D12PIXGetThreadInfo()
+{
+    FIXME("stub!\n");
+    return E_NOTIMPL;
+}


### PR DESCRIPTION
…to fix failing to load DirectML.dll

If we use vkd3d-proton in an application with DirectML enabled. The program will error out Entry Point Not Found.

The procedure entry point D3D12PIXEventsReplaceBlock/D3D12PIXGetThreadInfo could not be located in the dynamic link library C:\Windows\SYSTEM32\DirectML.dll

And the DirectML.dll will be unloaded.