### PR TITLE
Add tar.gz as an option archive for the release

### DIFF
--- a/package-release.sh
+++ b/package-release.sh
@@ -13,6 +13,7 @@ VKD3D_VERSION="$1"
 VKD3D_SRC_DIR=$(dirname "$(readlink -f "$0")")
 VKD3D_BUILD_DIR=$(realpath "$2")"/vkd3d-proton-$VKD3D_VERSION"
 VKD3D_ARCHIVE_PATH=$(realpath "$2")"/vkd3d-proton-$VKD3D_VERSION.tar.zst"
+VKD3D_ARCHIVE_PATH_ALT=$(realpath "$2")"/vkd3d-proton-$VKD3D_VERSION.tar.gz"
 
 if [ -e "$VKD3D_BUILD_DIR" ]; then
   echo "Build directory $VKD3D_BUILD_DIR already exists"
@@ -84,6 +85,7 @@ function build_script {
 function package {
   cd "$VKD3D_BUILD_DIR/.."
   tar -caf "$VKD3D_ARCHIVE_PATH" "vkd3d-proton-$VKD3D_VERSION"
+  tar -caf "$VKD3D_ARCHIVE_PATH_ALT" "vkd3d-proton-$VKD3D_VERSION"
   rm -R "vkd3d-proton-$VKD3D_VERSION"
 }
 


### PR DESCRIPTION
I am using a tool (CrossOver) that doesn't recognize the tar.zst archive type. 

Another alternative archive type can be added?