### PR TITLE
vkd3d: Issue sfence on command list close as well.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4865,6 +4865,10 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_Close(d3d12_command_list_ifa
         return E_FAIL;
     }
 
+    /* Ensure that any non-temporal writes from CopyDescriptors are ordered properly. */
+    if (d3d12_device_use_embedded_mutable_descriptors(list->device))
+        vkd3d_memcpy_non_temporal_barrier();
+
     d3d12_command_list_end_current_render_pass(list, false);
     d3d12_command_list_end_transfer_batch(list);
 


### PR DESCRIPTION
There's a risk that if descriptors are copied in the thread that records commands (common case), if submission happens in a completely different thread, it's plausible that memory order does not hold.

This does not fix any known bug, so it's a hallucinated fix, but might as well be defensive about it for more peace of mind.