### PR TITLE
vkd3d: Close memory handle in d3d12_device_CreateSharedHandle().

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -5022,6 +5022,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateSharedHandle(d3d12_device_if
                 if (!vkd3d_set_shared_metadata(*handle, &metadata, sizeof(metadata)))
                     ERR("Failed to set metadata for shared resource, importing created handle will fail.\n");
             }
+            CloseHandle(*handle);
         }
 
         ID3D12Resource_Release(resource_iface);


### PR DESCRIPTION
vkGetMemoryWin32HandleKHR with VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT returns a duplicated handle which needs to be closed by the caller (otherwise leaking shared resource memory).