### PR TITLE
ci: Workaround choco breaking vulkan-sdk package.

### DIFF
--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -16,10 +16,9 @@ jobs:
     - name: Setup widl and glslangValidator
       shell: pwsh
       run: |
-        choco install strawberryperl vulkan-sdk -y
+        choco install strawberryperl curl -y
+        curl "https://raw.githubusercontent.com/HansKristian-Work/vkd3d-proton-ci/main/glslangValidator.exe" -o "C:\Strawberry\c\bin\glslangValidator.exe"
         Write-Output "C:\Strawberry\c\bin" | Out-File -FilePath "${Env:GITHUB_PATH}" -Append
-        Write-Output "$([System.Environment]::GetEnvironmentVariable('VULKAN_SDK', 'Machine'))\Bin" `
-          | Out-File -FilePath "${Env:GITHUB_PATH}" -Append
 
     - name: Setup Meson
       shell: pwsh


### PR DESCRIPTION
vulkan-sdk is over 2 years old, and breaks now. We only need glslangValidator.exe, so just download a .exe we have handy. KISS.