### PR TITLE
build: Use new glslang name with fallback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,7 @@ idl_generator = generator(idl_compiler,
   output    : [ '@BASENAME@.h' ],
   arguments : [ '-h', '-o', '@OUTPUT@', '@INPUT@' ])
 
-glsl_compiler  = find_program('glslangValidator')
+glsl_compiler  = find_program('glslang', 'glslangValidator')
 glsl_args = [ '-V', '--target-env', 'vulkan1.1', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@' ]
 if run_command(glsl_compiler, [ '--quiet', '--version' ], check : false).returncode() == 0
     glsl_args += [ '--quiet' ]


### PR DESCRIPTION
Fixes the CI failing with the name change.
https://github.com/KhronosGroup/glslang/releases/tag/12.3.0
Even though that is a bug, since a symlink is supposed to be created, it seems fine to change the name anyway and have a fallback.

Edit: Symlink now fixed on Arch with glslang 12.3.1-2