### PR TITLE
Workaround games which forget to set SetRootDescriptorTable

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5523,7 +5523,7 @@ static void d3d12_command_list_update_descriptor_table_offsets(struct d3d12_comm
     uint64_t descriptor_table_mask;
 
     assert(root_signature->descriptor_table_count);
-    descriptor_table_mask = root_signature->descriptor_table_mask & bindings->descriptor_table_active_mask;
+    descriptor_table_mask = root_signature->descriptor_table_mask;
 
     while (descriptor_table_mask)
     {
@@ -5758,7 +5758,7 @@ static void d3d12_command_list_fetch_root_parameter_uniform_block_data(struct d3
     }
 
     first_table_offset = root_signature->descriptor_table_offset / sizeof(uint32_t);
-    descriptor_table_mask = root_signature->descriptor_table_mask & bindings->descriptor_table_active_mask;
+    descriptor_table_mask = root_signature->descriptor_table_mask;
 
     while (descriptor_table_mask)
     {
@@ -9027,7 +9027,6 @@ static inline void d3d12_command_list_set_descriptor_table_embedded(struct d3d12
     assert(index < ARRAY_SIZE(bindings->descriptor_tables));
     bindings->descriptor_tables[index] = d3d12_desc_heap_offset_from_embedded_gpu_handle(
             base_descriptor, cbv_srv_uav_size_log2, sampler_size_log2);
-    bindings->descriptor_table_active_mask |= (uint64_t)1 << index;
 
     if (root_signature)
     {
@@ -9045,7 +9044,6 @@ static inline void d3d12_command_list_set_descriptor_table(struct d3d12_command_
 
     assert(index < ARRAY_SIZE(bindings->descriptor_tables));
     bindings->descriptor_tables[index] = d3d12_desc_heap_offset_from_gpu_handle(base_descriptor);
-    bindings->descriptor_table_active_mask |= (uint64_t)1 << index;
 
     if (root_signature)
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2388,7 +2388,6 @@ struct vkd3d_pipeline_bindings
     uint32_t dirty_flags; /* vkd3d_pipeline_dirty_flags */
 
     uint32_t descriptor_tables[D3D12_MAX_ROOT_COST];
-    uint64_t descriptor_table_active_mask;
     uint64_t descriptor_heap_dirty_mask;
 
     /* Needed when VK_KHR_push_descriptor is not available. */

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -358,3 +358,4 @@ decl_test(test_enhanced_barrier_castable_formats_buffer);
 decl_test(test_enhanced_barrier_castable_formats_validation);
 decl_test(test_enhanced_barrier_castable_dsv);
 decl_test(test_dstorage_decompression);
+decl_test(test_uninit_root_parameters);


### PR DESCRIPTION
Gets rid of the "active" mask. It's vestigial and useless and only serves to push garbage data from stack to GPU.

Should fix spurious GPU hangs in SF6, which hits this scenario.