### PR TITLE
Add NOCONTRACT quirk path to DXIL as well.

### DIFF
--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -763,6 +763,19 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
             WARN("dxil-spirv does not support SHADER_SOURCE_FILE.\n");
     }
 
+    {
+        const struct dxil_spv_option_precise_control helper =
+                { { DXIL_SPV_OPTION_PRECISE_CONTROL },
+                        (quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH) ? DXIL_SPV_TRUE : DXIL_SPV_FALSE,
+                        DXIL_SPV_FALSE };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            WARN("dxil-spirv does not support PRECISE_CONTROL.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
     if (compiler_args)
     {
         for (i = 0; i < compiler_args->target_extension_count; i++)
@@ -1330,6 +1343,19 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
         snprintf(buffer, sizeof(buffer), "%016"PRIx64".%s.dxil", spirv->meta.hash, export);
         if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
             WARN("dxil-spirv does not support SHADER_SOURCE_FILE.\n");
+    }
+
+    {
+        const struct dxil_spv_option_precise_control helper =
+                { { DXIL_SPV_OPTION_PRECISE_CONTROL },
+                        (quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH) ? DXIL_SPV_TRUE : DXIL_SPV_FALSE,
+                        DXIL_SPV_FALSE };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            WARN("dxil-spirv does not support PRECISE_CONTROL.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
     }
 
     if (compiler_args)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -592,6 +592,17 @@ static const struct vkd3d_shader_quirk_info re4_quirks = {
     re_hashes, ARRAY_SIZE(re_hashes), VKD3D_SHADER_QUIRK_FORCE_MIN16_AS_32BIT,
 };
 
+static const struct vkd3d_shader_quirk_hash mhr_hashes[] = {
+    /* Shader is extremely sensitive to nocontract behavior.
+     * There some places where catastrophic cancellation occurs
+     * and one ULP difference is the difference between blown out bloom and not. */
+    { 0xd892f8024f52d3ca, VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH },
+};
+
+static const struct vkd3d_shader_quirk_info mhr_quirks = {
+    mhr_hashes, ARRAY_SIZE(mhr_hashes), 0,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
@@ -609,6 +620,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "re7.exe", &re_quirks },
     /* Resident Evil 4 (2050650) */
     { VKD3D_STRING_COMPARE_EXACT, "re4.exe", &re4_quirks },
+    /* Monster Hunter Rise (1446780) */
+    { VKD3D_STRING_COMPARE_EXACT, "MonsterHunterRise.exe", &mhr_quirks },
     /* MSVC fails to compile empty array. */
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -708,7 +708,9 @@ static void vkd3d_instance_deduce_config_flags_from_environment(void)
         /* Disable caching so we can get full debug information when emitting labels. */
         vkd3d_config_flags |= VKD3D_CONFIG_FLAG_DEBUG_UTILS |
                 VKD3D_CONFIG_FLAG_GLOBAL_PIPELINE_CACHE |
-                VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_APP_CACHE_ONLY;
+                VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_APP_CACHE_ONLY |
+                VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_NO_SERIALIZE_SPIRV |
+                VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_IGNORE_SPIRV;
     }
 }
 


### PR DESCRIPTION
Finally resolves the bizarre rendering glitches in MHR in certain scenes.

Game bug, and practically relies on full NoContract math to work as expected.