### PR TITLE
Workaround glitched mesh shader output in Remnant II

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -411,6 +411,10 @@ enum vkd3d_shader_quirk
 
     /* For shaders which are bugged when you opt-in to 16-bit. */
     VKD3D_SHADER_QUIRK_FORCE_MIN16_AS_32BIT = (1 << 11),
+
+    /* Ensure that unwritten mesh output indices generate no garbage primitives.
+     * Only applies to shaders where this can be trivially done. */
+    VKD3D_SHADER_QUIRK_MESH_INDEX_OUTPUT_WORKAROUND = (1 << 12),
 };
 
 struct vkd3d_shader_quirk_hash

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -952,6 +952,18 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
         }
     }
 
+    if (quirks & VKD3D_SHADER_QUIRK_MESH_INDEX_OUTPUT_WORKAROUND)
+    {
+        const dxil_spv_option_mesh_index_output_workaround helper =
+                { { DXIL_SPV_OPTION_MESH_INDEX_OUTPUT_WORKAROUND }, DXIL_SPV_TRUE };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            ERR("dxil-spirv does not support MESH_INDEX_OUTPUT_WORKAROUND.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
     remap_userdata.shader_interface_info = shader_interface_info;
     remap_userdata.shader_interface_local_info = NULL;
     remap_userdata.num_root_descriptors = num_root_descriptors;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -603,9 +603,11 @@ static const struct vkd3d_shader_quirk_info mhr_quirks = {
     mhr_hashes, ARRAY_SIZE(mhr_hashes), 0,
 };
 
+static const struct vkd3d_shader_quirk_info remnant2_quirks = {
+    NULL, 0, VKD3D_SHADER_QUIRK_MESH_INDEX_OUTPUT_WORKAROUND,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
-    /* Unreal Engine 4 */
-    { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
     /* F1 2019 (928600) */
@@ -622,6 +624,10 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "re4.exe", &re4_quirks },
     /* Monster Hunter Rise (1446780) */
     { VKD3D_STRING_COMPARE_EXACT, "MonsterHunterRise.exe", &mhr_quirks },
+    /* Remnant II (1282100) */
+    { VKD3D_STRING_COMPARE_EXACT, "Remnant2-Win64-Shipping.exe", &remnant2_quirks },
+    /* Unreal Engine 4 */
+    { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* MSVC fails to compile empty array. */
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };


### PR DESCRIPTION
Some of the mesh shaders are bugged where it allocates mesh output, but doesn't write to it. This causes weird glitches on RTX 4xxx at least.

Fix #1664.