### PR TITLE
Use EXT_host_image_copy if supported

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2960,6 +2960,29 @@ uint64_t d3d12_device_get_descriptor_heap_gpu_va(struct d3d12_device *device, D3
     return va;
 }
 
+bool d3d12_device_supports_host_image_copy(struct d3d12_device *device, VkImageLayout layout)
+{
+    bool supports_layout_src = false;
+    bool supports_layout_dst = false;
+
+    if (!device->device_info.host_image_copy_features.hostImageCopy)
+        return false;
+
+    for (uint32_t i = 0; i < device->device_info.host_image_copy_properties.copySrcLayoutCount; i++)
+    {
+        if ((supports_layout_src = (device->device_info.host_image_copy_properties.pCopySrcLayouts[i] == layout)))
+            break;
+    }
+
+    for (uint32_t i = 0; i < device->device_info.host_image_copy_properties.copyDstLayoutCount; i++)
+    {
+        if ((supports_layout_dst = (device->device_info.host_image_copy_properties.pCopyDstLayouts[i] == layout)))
+            break;
+    }
+
+    return supports_layout_src && supports_layout_dst;
+}
+
 void d3d12_device_return_descriptor_heap_gpu_va(struct d3d12_device *device, uint64_t va)
 {
     /* Fixup the magic shift we used when allocating. */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4267,6 +4267,7 @@ HRESULT d3d12_device_get_query_pool(struct d3d12_device *device, uint32_t type_i
 void d3d12_device_return_query_pool(struct d3d12_device *device, const struct vkd3d_query_pool *pool);
 
 uint64_t d3d12_device_get_descriptor_heap_gpu_va(struct d3d12_device *device, D3D12_DESCRIPTOR_HEAP_TYPE type);
+bool d3d12_device_supports_host_image_copy(struct d3d12_device *device, VkImageLayout layout);
 void d3d12_device_return_descriptor_heap_gpu_va(struct d3d12_device *device, uint64_t va);
 
 static inline bool d3d12_device_uses_descriptor_buffers(const struct d3d12_device *device)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -150,6 +150,7 @@ struct vkd3d_vulkan_info
     bool EXT_pageable_device_local_memory;
     bool EXT_memory_priority;
     bool EXT_dynamic_rendering_unused_attachments;
+    bool EXT_host_image_copy;
     /* AMD device extensions */
     bool AMD_buffer_marker;
     bool AMD_device_coherent_memory;
@@ -4020,6 +4021,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT graphics_pipeline_library_properties;
     VkPhysicalDeviceMemoryDecompressionPropertiesNV memory_decompression_properties;
     VkPhysicalDeviceMaintenance5PropertiesKHR maintenance_5_properties;
+    VkPhysicalDeviceHostImageCopyPropertiesEXT host_image_copy_properties;
 
     VkPhysicalDeviceProperties2KHR properties2;
 
@@ -4063,6 +4065,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceMemoryDecompressionFeaturesNV memory_decompression_features;
     VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV device_generated_commands_compute_features_nv;
     VkPhysicalDeviceMaintenance5FeaturesKHR maintenance_5_features;
+    VkPhysicalDeviceHostImageCopyFeaturesEXT host_image_copy_features;
 
     VkPhysicalDeviceFeatures2 features2;
 

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -265,6 +265,13 @@ VK_DEVICE_EXT_PFN(vkCmdDrawMeshTasksIndirectCountEXT)
 /* VK_EXT_hdr_metadata */
 VK_DEVICE_EXT_PFN(vkSetHdrMetadataEXT)
 
+/* VK_EXT_host_image_copy */
+VK_DEVICE_EXT_PFN(vkCopyMemoryToImageEXT)
+VK_DEVICE_EXT_PFN(vkCopyImageToImageEXT)
+VK_DEVICE_EXT_PFN(vkCopyImageToMemoryEXT)
+VK_DEVICE_EXT_PFN(vkTransitionImageLayoutEXT)
+VK_DEVICE_EXT_PFN(vkGetImageSubresourceLayout2EXT)
+
 /* VK_KHR_surface */
 VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceSurfacePresentModesKHR)
 VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceSurfaceSupportKHR)


### PR DESCRIPTION
Currently, only Lavapipe supports this to a sufficient degree, hence the draft.

Unfortunately, we cannot really use the extension on Nvidia in any meaningful way because host-visible images are **only** exposed on HVV, so we just end up disabling it there and keep using the fallback path. `ReadFromSubresource` seems to be uncommon enough that the quirks of our current fallback implementation don't really seem to matter anyway.

Should definitely hold off landing this until we get RADV support.