### PR TITLE
Add special game perf workaround for Starfield and other DGC junkies

### DIFF
--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -269,7 +269,7 @@ static void vkd3d_acceleration_structure_end_barrier(struct d3d12_command_list *
     dep_info.memoryBarrierCount = 1;
     dep_info.pMemoryBarriers = &barrier;
 
-    VK_CALL(vkCmdPipelineBarrier2(list->vk_command_buffer, &dep_info));
+    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
 }
 
 static void vkd3d_acceleration_structure_write_postbuild_info(
@@ -324,7 +324,7 @@ static void vkd3d_acceleration_structure_write_postbuild_info(
         /* TODO: CURRENT_SIZE is something we cannot query in Vulkan, so
          * we'll need to keep around a buffer to handle this.
          * For now, just clear to 0. */
-        VK_CALL(vkCmdFillBuffer(list->vk_command_buffer, vk_buffer, offset,
+        VK_CALL(vkCmdFillBuffer(list->cmd.vk_command_buffer, vk_buffer, offset,
                 sizeof(uint64_t), 0));
         return;
     }
@@ -338,9 +338,9 @@ static void vkd3d_acceleration_structure_write_postbuild_info(
 
     d3d12_command_list_reset_query(list, vk_query_pool, vk_query_index);
 
-    VK_CALL(vkCmdWriteAccelerationStructuresPropertiesKHR(list->vk_command_buffer,
+    VK_CALL(vkCmdWriteAccelerationStructuresPropertiesKHR(list->cmd.vk_command_buffer,
             1, &vk_acceleration_structure, vk_query_type, vk_query_pool, vk_query_index));
-    VK_CALL(vkCmdCopyQueryPoolResults(list->vk_command_buffer,
+    VK_CALL(vkCmdCopyQueryPoolResults(list->cmd.vk_command_buffer,
             vk_query_pool, vk_query_index, 1,
             vk_buffer, offset, stride,
             VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT));
@@ -359,10 +359,10 @@ static void vkd3d_acceleration_structure_write_postbuild_info(
 
             d3d12_command_list_reset_query(list, vk_query_pool, vk_query_index);
 
-            VK_CALL(vkCmdWriteAccelerationStructuresPropertiesKHR(list->vk_command_buffer,
+            VK_CALL(vkCmdWriteAccelerationStructuresPropertiesKHR(list->cmd.vk_command_buffer,
                     1, &vk_acceleration_structure, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR,
                     vk_query_pool, vk_query_index));
-            VK_CALL(vkCmdCopyQueryPoolResults(list->vk_command_buffer,
+            VK_CALL(vkCmdCopyQueryPoolResults(list->cmd.vk_command_buffer,
                     vk_query_pool, vk_query_index, 1,
                     vk_buffer, offset + sizeof(uint64_t), stride,
                     VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT));
@@ -370,7 +370,7 @@ static void vkd3d_acceleration_structure_write_postbuild_info(
         else
         {
             FIXME("NumBottomLevelPointers will always return 0.\n");
-            VK_CALL(vkCmdFillBuffer(list->vk_command_buffer, vk_buffer, offset + sizeof(uint64_t),
+            VK_CALL(vkCmdFillBuffer(list->cmd.vk_command_buffer, vk_buffer, offset + sizeof(uint64_t),
                     sizeof(uint64_t), 0));
         }
     }
@@ -401,7 +401,7 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
     dep_info.memoryBarrierCount = 1;
     dep_info.pMemoryBarriers = &barrier;
 
-    VK_CALL(vkCmdPipelineBarrier2(list->vk_command_buffer, &dep_info));
+    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
 
     stride = desc->InfoType == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION ?
             2 * sizeof(uint64_t) : sizeof(uint64_t);
@@ -448,7 +448,7 @@ void vkd3d_acceleration_structure_emit_immediate_postbuild_info(
     dep_info.memoryBarrierCount = 1;
     dep_info.pMemoryBarriers = &barrier;
 
-    VK_CALL(vkCmdPipelineBarrier2(list->vk_command_buffer, &dep_info));
+    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
 
     /* Could optimize a bit by batching more aggressively, but no idea if it's going to help in practice. */
     for (i = 0; i < count; i++)
@@ -503,5 +503,5 @@ void vkd3d_acceleration_structure_copy(
     info.dst = dst_as;
     info.src = src_as;
     if (convert_copy_mode(mode, &info.mode))
-        VK_CALL(vkCmdCopyAccelerationStructureKHR(list->vk_command_buffer, &info));
+        VK_CALL(vkCmdCopyAccelerationStructureKHR(list->cmd.vk_command_buffer, &info));
 }

--- a/libs/vkd3d/breadcrumbs.c
+++ b/libs/vkd3d/breadcrumbs.c
@@ -601,11 +601,11 @@ void vkd3d_breadcrumb_tracer_begin_command_list(struct d3d12_command_list *list)
         cmd.type = VKD3D_BREADCRUMB_COMMAND_SET_BOTTOM_MARKER;
         vkd3d_breadcrumb_tracer_add_command(list, &cmd);
 
-        VK_CALL(vkCmdSetCheckpointNV(list->vk_command_buffer, NV_ENCODE_CHECKPOINT(context, trace->counter)));
+        VK_CALL(vkCmdSetCheckpointNV(list->cmd.vk_command_buffer, NV_ENCODE_CHECKPOINT(context, trace->counter)));
     }
     else if (list->device->vk_info.AMD_buffer_marker)
     {
-        VK_CALL(vkCmdWriteBufferMarkerAMD(list->vk_command_buffer,
+        VK_CALL(vkCmdWriteBufferMarkerAMD(list->cmd.vk_command_buffer,
                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                 breadcrumb_tracer->host_buffer,
                 context * sizeof(struct vkd3d_breadcrumb_counter) +
@@ -661,7 +661,7 @@ void vkd3d_breadcrumb_tracer_signal(struct d3d12_command_list *list)
         vkd3d_breadcrumb_tracer_add_command(list, &cmd);
         TRACE("Breadcrumb signal bottom-of-pipe context %u -> %u\n", context, cmd.count);
 
-        VK_CALL(vkCmdSetCheckpointNV(list->vk_command_buffer, NV_ENCODE_CHECKPOINT(context, trace->counter)));
+        VK_CALL(vkCmdSetCheckpointNV(list->cmd.vk_command_buffer, NV_ENCODE_CHECKPOINT(context, trace->counter)));
     }
     else if (list->device->vk_info.AMD_buffer_marker)
     {
@@ -670,7 +670,7 @@ void vkd3d_breadcrumb_tracer_signal(struct d3d12_command_list *list)
         vkd3d_breadcrumb_tracer_add_command(list, &cmd);
         TRACE("Breadcrumb signal bottom-of-pipe context %u -> %u\n", context, cmd.count);
 
-        VK_CALL(vkCmdWriteBufferMarkerAMD(list->vk_command_buffer,
+        VK_CALL(vkCmdWriteBufferMarkerAMD(list->cmd.vk_command_buffer,
                 VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                 breadcrumb_tracer->host_buffer,
                 context * sizeof(struct vkd3d_breadcrumb_counter) +
@@ -684,7 +684,7 @@ void vkd3d_breadcrumb_tracer_signal(struct d3d12_command_list *list)
         vkd3d_breadcrumb_tracer_add_command(list, &cmd);
         TRACE("Breadcrumb signal top-of-pipe context %u -> %u\n", context, cmd.count);
 
-        VK_CALL(vkCmdWriteBufferMarkerAMD(list->vk_command_buffer,
+        VK_CALL(vkCmdWriteBufferMarkerAMD(list->cmd.vk_command_buffer,
                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                 breadcrumb_tracer->host_buffer,
                 context * sizeof(struct vkd3d_breadcrumb_counter) +
@@ -723,18 +723,18 @@ void vkd3d_breadcrumb_tracer_end_command_list(struct d3d12_command_list *list)
 
     if (list->device->vk_info.NV_device_diagnostic_checkpoints)
     {
-        VK_CALL(vkCmdSetCheckpointNV(list->vk_command_buffer, NV_ENCODE_CHECKPOINT(context, trace->counter)));
+        VK_CALL(vkCmdSetCheckpointNV(list->cmd.vk_command_buffer, NV_ENCODE_CHECKPOINT(context, trace->counter)));
     }
     else if (list->device->vk_info.AMD_buffer_marker)
     {
-        VK_CALL(vkCmdWriteBufferMarkerAMD(list->vk_command_buffer,
+        VK_CALL(vkCmdWriteBufferMarkerAMD(list->cmd.vk_command_buffer,
                 VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                 breadcrumb_tracer->host_buffer,
                 context * sizeof(struct vkd3d_breadcrumb_counter) +
                         offsetof(struct vkd3d_breadcrumb_counter, begin_marker),
                 trace->counter));
 
-        VK_CALL(vkCmdWriteBufferMarkerAMD(list->vk_command_buffer,
+        VK_CALL(vkCmdWriteBufferMarkerAMD(list->cmd.vk_command_buffer,
                 VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                 breadcrumb_tracer->host_buffer,
                 context * sizeof(struct vkd3d_breadcrumb_counter) +
@@ -751,7 +751,7 @@ void vkd3d_breadcrumb_tracer_end_command_list(struct d3d12_command_list *list)
     dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
     dep_info.memoryBarrierCount = 1;
     dep_info.pMemoryBarriers = &vk_barrier;
-    VK_CALL(vkCmdPipelineBarrier2(list->vk_command_buffer, &dep_info));
+    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
 
     cmd.count = trace->counter;
     cmd.type = VKD3D_BREADCRUMB_COMMAND_SET_TOP_MARKER;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6672,6 +6672,7 @@ static bool d3d12_command_list_emit_predicated_command(struct d3d12_command_list
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     struct vkd3d_predicate_command_info pipeline_info;
     struct vkd3d_predicate_command_args args;
+    VkCommandBuffer vk_patch_cmd_buffer;
     VkMemoryBarrier2 vk_barrier;
     VkDependencyInfo dep_info;
 
@@ -6682,36 +6683,46 @@ static bool d3d12_command_list_emit_predicated_command(struct d3d12_command_list
             pipeline_info.data_size, sizeof(uint32_t), ~0u, scratch))
         return false;
 
-    d3d12_command_list_end_current_render_pass(list, true);
+    d3d12_command_allocator_allocate_init_post_indirect_command_buffer(list->allocator, list);
+    vk_patch_cmd_buffer = list->cmd.vk_init_commands_post_indirect_barrier;
 
-    d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
+    if (vk_patch_cmd_buffer == list->cmd.vk_command_buffer)
+        d3d12_command_list_end_current_render_pass(list, true);
 
     args.predicate_va = list->predication.va;
     args.dst_arg_va = scratch->va;
     args.src_arg_va = indirect_args;
     args.args = *direct_args;
 
-    VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+    VK_CALL(vkCmdBindPipeline(vk_patch_cmd_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
             pipeline_info.vk_pipeline));
-    VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
+    VK_CALL(vkCmdPushConstants(vk_patch_cmd_buffer,
             pipeline_info.vk_pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT,
             0, sizeof(args), &args));
-    VK_CALL(vkCmdDispatch(list->cmd.vk_command_buffer, 1, 1, 1));
+    VK_CALL(vkCmdDispatch(vk_patch_cmd_buffer, 1, 1, 1));
 
-    memset(&vk_barrier, 0, sizeof(vk_barrier));
-    vk_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
-    vk_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
-    vk_barrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
-    vk_barrier.dstStageMask = VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT;
-    vk_barrier.dstAccessMask = VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT;
+    if (vk_patch_cmd_buffer == list->cmd.vk_command_buffer)
+    {
+        memset(&vk_barrier, 0, sizeof(vk_barrier));
+        vk_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
+        vk_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+        vk_barrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
+        vk_barrier.dstStageMask = VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT;
+        vk_barrier.dstAccessMask = VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT;
 
-    memset(&dep_info, 0, sizeof(dep_info));
-    dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
-    dep_info.memoryBarrierCount = 1;
-    dep_info.pMemoryBarriers = &vk_barrier;
+        memset(&dep_info, 0, sizeof(dep_info));
+        dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        dep_info.memoryBarrierCount = 1;
+        dep_info.pMemoryBarriers = &vk_barrier;
 
-    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
+        VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
+
+        d3d12_command_list_invalidate_current_pipeline(list, true);
+        d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
+    }
+    else
+        list->cmd.indirect_meta->need_compute_to_indirect_barrier = true;
+
     return true;
 }
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -12084,6 +12084,10 @@ static void d3d12_command_list_execute_indirect_state_template_dgc(
     {
         if (!d3d12_command_list_update_compute_pipeline(list))
             return;
+
+        /* Needed for workarounds later. */
+        if (!(list->vk_queue_flags & VK_QUEUE_GRAPHICS_BIT))
+            list->cmd.uses_dgc_compute_in_async_compute = true;
     }
     else
     {
@@ -14611,6 +14615,7 @@ static void STDMETHODCALLTYPE d3d12_command_queue_ExecuteCommandLists(ID3D12Comm
 #endif
 
     sub.execute.debug_capture = false;
+    sub.execute.split_submission = false;
 
     num_transitions = 0;
 
@@ -14651,6 +14656,14 @@ static void STDMETHODCALLTYPE d3d12_command_queue_ExecuteCommandLists(ID3D12Comm
 
         if (cmd_list->debug_capture)
             sub.execute.debug_capture = true;
+
+        /* Submission logic for IB fallbacks seems to have exposed something ... very dodgy in RADV. */
+        if (cmd_list->cmd.uses_dgc_compute_in_async_compute &&
+                !(vkd3d_config_flags & VKD3D_CONFIG_FLAG_SKIP_DRIVER_WORKAROUNDS) &&
+                command_queue->device->device_info.vulkan_1_2_properties.driverID == VK_DRIVER_ID_MESA_RADV)
+        {
+            sub.execute.split_submission = true;
+        }
 
 #ifdef VKD3D_ENABLE_BREADCRUMBS
         if (breadcrumb_indices)
@@ -15321,12 +15334,64 @@ static void d3d12_command_queue_transition_pool_build(struct d3d12_command_queue
     *timeline_value = pool->timeline_value;
 }
 
+static VkResult d3d12_command_queue_submit_split_locked(struct d3d12_device *device,
+        VkQueue vk_queue, uint32_t num_submits, const VkSubmitInfo2 *submits)
+{
+    /* Ugly workaround when needed. Never submit more than one command buffer at a time. */
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    const VkSubmitInfo2 *input_submission;
+    VkSubmitInfo2 split_submission;
+    uint32_t submit_index;
+    uint32_t cmd_index;
+    uint32_t num_cmds;
+    VkResult vr;
+
+    memset(&split_submission, 0, sizeof(split_submission));
+    split_submission.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+
+    for (submit_index = 0; submit_index < num_submits; submit_index++)
+    {
+        input_submission = &submits[submit_index];
+
+        if (input_submission->commandBufferInfoCount > 1)
+        {
+            num_cmds = input_submission->commandBufferInfoCount;
+            split_submission.pSignalSemaphoreInfos = input_submission->pSignalSemaphoreInfos;
+            split_submission.pWaitSemaphoreInfos = input_submission->pWaitSemaphoreInfos;
+            split_submission.commandBufferInfoCount = 1;
+
+            for (cmd_index = 0; cmd_index < num_cmds; cmd_index++)
+            {
+                split_submission.pCommandBufferInfos =
+                        &input_submission->pCommandBufferInfos[cmd_index];
+                split_submission.signalSemaphoreInfoCount =
+                        cmd_index + 1 == num_cmds ? input_submission->signalSemaphoreInfoCount : 0;
+                split_submission.waitSemaphoreInfoCount =
+                        cmd_index == 0 ? input_submission->waitSemaphoreInfoCount : 0;
+
+                if ((vr = VK_CALL(vkQueueSubmit2(vk_queue, 1, &split_submission, VK_NULL_HANDLE))) < 0)
+                {
+                    ERR("Failed to submit queue(s), vr %d.\n", vr);
+                    return vr;
+                }
+            }
+        }
+        else if ((vr = VK_CALL(vkQueueSubmit2(vk_queue, 1, input_submission, VK_NULL_HANDLE))) < 0)
+        {
+            ERR("Failed to submit queue(s), vr %d.\n", vr);
+            return vr;
+        }
+    }
+
+	return VK_SUCCESS;
+}
+
 static void d3d12_command_queue_execute(struct d3d12_command_queue *command_queue,
         const VkCommandBufferSubmitInfo *cmd, UINT count,
         const VkCommandBufferSubmitInfo *transition_cmd,
         const VkSemaphoreSubmitInfo *transition_semaphore,
         LONG **submission_counters, size_t num_submission_counters,
-        bool debug_capture)
+        bool debug_capture, bool split_submissions)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &command_queue->device->vk_procs;
     struct vkd3d_queue *vkd3d_queue = command_queue->vkd3d_queue;
@@ -15402,7 +15467,9 @@ static void d3d12_command_queue_execute(struct d3d12_command_queue *command_queu
     (void)debug_capture;
 #endif
 
-    if ((vr = VK_CALL(vkQueueSubmit2(vk_queue, num_submits, submit_desc, VK_NULL_HANDLE))) < 0)
+    if (split_submissions)
+        vr = d3d12_command_queue_submit_split_locked(command_queue->device, vk_queue, num_submits, submit_desc);
+    else if ((vr = VK_CALL(vkQueueSubmit2(vk_queue, num_submits, submit_desc, VK_NULL_HANDLE))) < 0)
         ERR("Failed to submit queue(s), vr %d.\n", vr);
 
     VKD3D_DEVICE_REPORT_BREADCRUMB_IF(command_queue->device, vr == VK_ERROR_DEVICE_LOST);
@@ -15888,7 +15955,7 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
                     &transition_cmd, &transition_semaphore,
                     submission.execute.outstanding_submissions_counters,
                     submission.execute.outstanding_submissions_counter_count,
-                    submission.execute.debug_capture);
+                    submission.execute.debug_capture, submission.execute.split_submission);
 
             /* command_queue_execute takes ownership of the outstanding_submission_counters allocation.
              * The atomic counters are decremented when the submission is observed to be freed.

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1918,6 +1918,78 @@ static HRESULT d3d12_command_allocator_allocate_command_buffer(struct d3d12_comm
     return S_OK;
 }
 
+static void d3d12_command_list_invalidate_all_state(struct d3d12_command_list *list);
+static void d3d12_command_list_end_current_render_pass(struct d3d12_command_list *list, bool suspend);
+
+static void d3d12_command_list_begin_new_sequence(struct d3d12_command_list *list)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    VkConditionalRenderingBeginInfoEXT conditional_begin_info;
+    VkCommandBufferAllocateInfo command_buffer_info;
+    struct d3d12_command_list_iteration *iteration;
+    VkCommandBufferBeginInfo begin_info;
+    VkResult vr;
+
+    if (list->cmd.iteration_count >= VKD3D_MAX_COMMAND_LIST_SEQUENCES)
+        return;
+
+    iteration = &list->cmd.iterations[list->cmd.iteration_count];
+    command_buffer_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    command_buffer_info.pNext = NULL;
+    command_buffer_info.commandPool = list->allocator->vk_command_pool;
+    command_buffer_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    command_buffer_info.commandBufferCount = 1;
+
+    if ((vr = VK_CALL(vkAllocateCommandBuffers(list->device->vk_device,
+            &command_buffer_info, &iteration->vk_command_buffer))) < 0)
+    {
+        ERR("Failed to allocate Vulkan command buffer, vr %d.\n", vr);
+        /* Not fatal, but we don't get to split. */
+        return;
+    }
+
+    begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    begin_info.pNext = NULL;
+    begin_info.flags = 0;
+    begin_info.pInheritanceInfo = NULL;
+    if ((vr = VK_CALL(vkBeginCommandBuffer(iteration->vk_command_buffer, &begin_info))) < 0)
+    {
+        VK_CALL(vkFreeCommandBuffers(list->device->vk_device, list->allocator->vk_command_pool,
+                1, &iteration->vk_command_buffer));
+        ERR("Failed to begin Vulkan command buffer, vr %d.\n", vr);
+        return;
+    }
+
+    /* Some things we *have* to end now because API says so.
+     * Most cleanup can be deferred to Close(). */
+    d3d12_command_list_end_current_render_pass(list, true);
+    if (list->predicate_enabled)
+        VK_CALL(vkCmdEndConditionalRenderingEXT(list->cmd.vk_command_buffer));
+
+    if ((vr = VK_CALL(vkEndCommandBuffer(list->cmd.vk_command_buffer)) < 0))
+        ERR("Failed to end command buffer, vr %d.\n", vr);
+
+    list->cmd.vk_command_buffer = iteration->vk_command_buffer;
+    list->cmd.vk_init_commands_post_indirect_barrier = VK_NULL_HANDLE;
+    list->cmd.indirect_meta = &list->cmd.iterations[list->cmd.iteration_count].indirect_meta;
+    list->cmd.iteration_count++;
+
+    if (list->predicate_enabled)
+    {
+        /* Rearm the conditional rendering. */
+        conditional_begin_info.sType = VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT;
+        conditional_begin_info.pNext = NULL;
+        conditional_begin_info.buffer = list->predicate_vk_buffer;
+        conditional_begin_info.offset = list->predicate_vk_buffer_offset;
+        conditional_begin_info.flags = 0;
+        VK_CALL(vkCmdBeginConditionalRenderingEXT(list->cmd.vk_command_buffer, &conditional_begin_info));
+    }
+
+    d3d12_command_list_invalidate_all_state(list);
+    /* Extra special consideration since we're starting a fresh command buffer. */
+    list->descriptor_heap.buffers.heap_dirty = true;
+}
+
 static HRESULT d3d12_command_allocator_allocate_init_command_buffer(struct d3d12_command_allocator *allocator,
         struct d3d12_command_list *list)
 {
@@ -5322,7 +5394,7 @@ static void d3d12_command_list_reset_state(struct d3d12_command_list *list,
     d3d12_command_list_reset_internal_state(list);
 }
 
-static inline void d3d12_command_list_invalidate_all_state(struct d3d12_command_list *list)
+static void d3d12_command_list_invalidate_all_state(struct d3d12_command_list *list)
 {
     d3d12_command_list_invalidate_current_pipeline(list, true);
     d3d12_command_list_invalidate_root_parameters(list, &list->graphics_bindings, true, NULL);

--- a/libs/vkd3d/command_list_vkd3d_ext.c
+++ b/libs/vkd3d/command_list_vkd3d_ext.c
@@ -60,7 +60,9 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_vkd3d_ext_GetVulkanHandle(d3
     if (!pVkCommandBuffer)
         return E_INVALIDARG;
 
-    *pVkCommandBuffer = command_list->vk_command_buffer;
+    *pVkCommandBuffer = command_list->cmd.vk_command_buffer;
+    /* TODO: Do we need to block any attempt to split command buffers here?
+     * Might be a problem if DLSS implementation caches the VkCommandBuffer across DLSS invocations. */
     return S_OK;
 }
 
@@ -100,7 +102,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_vkd3d_ext_LaunchCubinShaderE
     launchInfo.pExtras = config;
     
     vk_procs = &command_list->device->vk_procs;
-    VK_CALL(vkCmdCuLaunchKernelNVX(command_list->vk_command_buffer, &launchInfo));
+    VK_CALL(vkCmdCuLaunchKernelNVX(command_list->cmd.vk_command_buffer, &launchInfo));
     return S_OK;
 }
 

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -15,6 +15,7 @@ vkd3d_shaders =[
   'shaders/cs_emit_nv_memory_decompression_regions.comp',
   'shaders/cs_emit_nv_memory_decompression_workgroups.comp',
   'shaders/cs_predicate_command.comp',
+  'shaders/cs_predicate_command_execute_indirect.comp',
   'shaders/cs_resolve_binary_queries.comp',
   'shaders/cs_resolve_predicate.comp',
   'shaders/cs_resolve_query.comp',

--- a/libs/vkd3d/shaders/cs_predicate_command_execute_indirect.comp
+++ b/libs/vkd3d/shaders/cs_predicate_command_execute_indirect.comp
@@ -1,0 +1,65 @@
+#version 450
+
+#extension GL_EXT_buffer_reference : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_vote : require
+
+layout(local_size_x = 32) in;
+
+layout(constant_id = 0) const uint c_words = 0;
+
+layout(std430, buffer_reference, buffer_reference_align = 4)
+readonly buffer src_args_t
+{
+    uint data[];
+};
+
+layout(std430, buffer_reference, buffer_reference_align = 4)
+writeonly buffer dst_count_t { uint data; };
+
+layout(push_constant)
+uniform u_info_t
+{
+    // Common header for predicate shaders
+    uvec2 dummy_predicate;
+    src_args_t arg_buffer;
+    dst_count_t dst_count;
+    // direct_args_execute_indirect
+    uint max_commands;
+    uint stride_words;
+};
+
+void main()
+{
+	// Could get fancy with spec constant workgroup size
+	// and subgroup_size_control, but that's somewhat overkill here.
+	if (gl_SubgroupID != 0)
+		return;
+
+	uvec4 ballot = subgroupBallot(true);
+	uint id = subgroupBallotExclusiveBitCount(ballot);
+	uint lane_count = subgroupBallotBitCount(ballot);
+
+	bool has_active_command = false;
+	for (uint i = 0; !has_active_command && i < max_commands; i += lane_count)
+	{
+		uint local_id = i + id;
+		bool is_active;
+
+		if (local_id < max_commands)
+		{
+			is_active = true;
+			for (uint j = 0; j < c_words && is_active; j++)
+				if (arg_buffer.data[local_id * stride_words + j] == 0)
+					is_active = false;
+		}
+		else
+			is_active = false;
+
+		has_active_command = subgroupAny(is_active);
+	}
+
+	if (subgroupElect())
+		dst_count.data = has_active_command ? max_commands : 0;
+}

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2723,7 +2723,9 @@ struct d3d12_command_list
     bool xfb_enabled;
 
     bool predicate_enabled;
-    VkDeviceAddress predicate_va;
+    VkDeviceAddress predicate_fallback_va;
+    VkBuffer predicate_vk_buffer;
+    VkDeviceSize predicate_vk_buffer_offset;
 
     /* This is VK_NULL_HANDLE when we are no longer sure which pipeline to bind,
      * if this is NULL, we might need to lookup a pipeline key in order to bind the correct pipeline. */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2674,8 +2674,8 @@ struct d3d12_command_list
     struct
     {
         bool has_observed_transition_to_indirect;
-        bool has_emitted_indirect_to_compute_barrier;
-        bool has_emitted_indirect_to_compute_cbv_barrier;
+        bool need_compute_to_indirect_barrier;
+        bool need_compute_to_cbv_barrier;
     } execute_indirect;
 
     VkCommandBuffer vk_command_buffer;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2660,7 +2660,7 @@ struct d3d12_command_list_iteration
     struct d3d12_command_list_iteration_indirect_meta indirect_meta;
 };
 
-#define VKD3D_MAX_COMMAND_LIST_SEQUENCES 4
+#define VKD3D_MAX_COMMAND_LIST_SEQUENCES 2
 
 struct d3d12_command_list_sequence
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2749,6 +2749,9 @@ struct d3d12_command_list
     struct d3d12_command_allocator *allocator;
     struct d3d12_device *device;
 
+    VkBuffer so_buffers[D3D12_SO_BUFFER_SLOT_COUNT];
+    VkDeviceSize so_buffer_offsets[D3D12_SO_BUFFER_SLOT_COUNT];
+    VkDeviceSize so_buffer_sizes[D3D12_SO_BUFFER_SLOT_COUNT];
     VkBuffer so_counter_buffers[D3D12_SO_BUFFER_SLOT_COUNT];
     VkDeviceSize so_counter_buffer_offsets[D3D12_SO_BUFFER_SLOT_COUNT];
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3095,7 +3095,7 @@ struct d3d12_command_signature
     LONG refcount;
 
     D3D12_COMMAND_SIGNATURE_DESC desc;
-    uint32_t argument_buffer_offset;
+    uint32_t argument_buffer_offset_for_command;
 
     /* Complex command signatures require some work to stamp out device generated commands. */
     union
@@ -3819,11 +3819,18 @@ HRESULT vkd3d_query_ops_init(struct vkd3d_query_ops *meta_query_ops,
 void vkd3d_query_ops_cleanup(struct vkd3d_query_ops *meta_query_ops,
         struct d3d12_device *device);
 
+struct vkd3d_predicate_command_direct_args_execute_indirect
+{
+    uint32_t max_commands;
+    uint32_t stride_words;
+};
+
 union vkd3d_predicate_command_direct_args
 {
     VkDispatchIndirectCommand dispatch;
     VkDrawIndirectCommand draw;
     VkDrawIndexedIndirectCommand draw_indexed;
+    struct vkd3d_predicate_command_direct_args_execute_indirect execute_indirect;
     uint32_t draw_count;
 };
 
@@ -3843,6 +3850,8 @@ enum vkd3d_predicate_command_type
     VKD3D_PREDICATE_COMMAND_DRAW_INDIRECT_COUNT,
     VKD3D_PREDICATE_COMMAND_DISPATCH,
     VKD3D_PREDICATE_COMMAND_DISPATCH_INDIRECT,
+    VKD3D_PREDICATE_COMMAND_EXECUTE_INDIRECT_GRAPHICS,
+    VKD3D_PREDICATE_COMMAND_EXECUTE_INDIRECT_COMPUTE,
     VKD3D_PREDICATE_COMMAND_COUNT
 };
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2673,6 +2673,7 @@ struct d3d12_command_list_sequence
      * where INDIRECT_ARGUMENT barriers appear in the stream. */
     struct d3d12_command_list_iteration iterations[VKD3D_MAX_COMMAND_LIST_SEQUENCES];
     unsigned int iteration_count;
+    unsigned int active_non_inline_running_queries;
     bool uses_dgc_compute_in_async_compute;
 
     /* Emit normal commands here. */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2722,10 +2722,14 @@ struct d3d12_command_list
 
     bool xfb_enabled;
 
-    bool predicate_enabled;
-    VkDeviceAddress predicate_fallback_va;
-    VkBuffer predicate_vk_buffer;
-    VkDeviceSize predicate_vk_buffer_offset;
+    struct
+    {
+        VkDeviceAddress va;
+        VkBuffer vk_buffer;
+        VkDeviceSize vk_buffer_offset;
+        bool enabled_on_command_buffer;
+        bool fallback_enabled;
+    } predication;
 
     /* This is VK_NULL_HANDLE when we are no longer sure which pipeline to bind,
      * if this is NULL, we might need to lookup a pipeline key in order to bind the correct pipeline. */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2660,8 +2660,7 @@ struct d3d12_command_list_iteration
     struct d3d12_command_list_iteration_indirect_meta indirect_meta;
 };
 
-/* TODO: increase. */
-#define VKD3D_MAX_COMMAND_LIST_SEQUENCES 1
+#define VKD3D_MAX_COMMAND_LIST_SEQUENCES 4
 
 struct d3d12_command_list_sequence
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2673,6 +2673,7 @@ struct d3d12_command_list_sequence
      * where INDIRECT_ARGUMENT barriers appear in the stream. */
     struct d3d12_command_list_iteration iterations[VKD3D_MAX_COMMAND_LIST_SEQUENCES];
     unsigned int iteration_count;
+    bool uses_dgc_compute_in_async_compute;
 
     /* Emit normal commands here. */
     VkCommandBuffer vk_command_buffer;
@@ -2981,6 +2982,7 @@ struct d3d12_command_queue_submission_execute
 #endif
 
     bool debug_capture;
+    bool split_submission;
 };
 
 struct d3d12_command_queue_submission_bind_sparse

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4255,6 +4255,7 @@ struct d3d12_device
     struct vkd3d_descriptor_qa_global_info *descriptor_qa_global_info;
 #endif
     uint64_t shader_interface_key;
+    uint32_t device_has_dgc_templates;
 };
 
 HRESULT d3d12_device_create(struct vkd3d_instance *instance,

--- a/libs/vkd3d/vkd3d_shaders.h
+++ b/libs/vkd3d/vkd3d_shaders.h
@@ -42,6 +42,7 @@ enum vkd3d_meta_copy_mode
 #include <cs_clear_uav_image_3d_float.h>
 #include <cs_clear_uav_image_3d_uint.h>
 #include <cs_predicate_command.h>
+#include <cs_predicate_command_execute_indirect.h>
 #include <cs_resolve_binary_queries.h>
 #include <cs_resolve_predicate.h>
 #include <cs_resolve_query.h>

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -144,6 +144,7 @@ decl_test(test_resolve_query_data_in_different_command_list);
 decl_test(test_resolve_query_data_in_reordered_command_list);
 decl_test(test_execute_indirect);
 decl_test(test_execute_indirect_state);
+decl_test(test_execute_indirect_state_predication);
 decl_test(test_execute_indirect_multi_dispatch);
 decl_test(test_execute_indirect_multi_dispatch_root_constants);
 decl_test(test_execute_indirect_multi_dispatch_root_descriptors);


### PR DESCRIPTION
**NOTE: The meaning of this PR, potential perf impact and the problem it tries to solve is being grossly misrepresented on other sites.**


The goal of this refactor is to optimize for cases where games (Starfield in particular) uses advanced ExecuteIndirect in very inefficient ways.

- Indirect count, but indirect count ends up being 0.
- Non-indirect count, but none of the active draws inside the multi-draw indirect actually result in a draw. Multiple back-to-back ExecuteIndirects are called like this, causing big bubbles on the GPU.

In RADV, a special optimization was added which uses indirectCount in DGC as a predicate when possible. This lets us skip over the prepare cmdbuffer as well as the INDIRECT_BUFFER execution which is about 10x faster than spawning a small CS, adding extra sync and then executing a NOP-ed out indirect buffer.

We can take advantage of this by doing our own prologue which scans through the ExecuteIndirect buffer in the scenario where non-indirect count is used. Using indirect count is not slower than direct count at all.

To make this efficient, this PR refactors the command buffer emit system so that instead of having one init command buffer and one "real" command buffer, we have N sequences of this pattern. This allows us to split a command stream when observing an INDIRECT_ARGUMENT barrier, and we can batch up any patch CS easily. For example, given a D3D12 command stream like:

- CS to generate indirect arguments
- ResourceBarrier(UAV -> INDIRECT_ARGUMENT)
- ExecuteIndirect (arg0, command_count = 16)
- ExecuteIndirect (arg1, command_count = 16)
- ExecuteIndirect (arg2, command_count = 16)
- ExecuteIndirect (arg3, command_count = 16)

we can now transform this into:

iteration[0].vk_cmd_buffer:
- CS to generate
- UAV -> INDIRECT_ARGUMENT
- Begin new sequence

iteration[1].vk_init_buffer:
- Scan arg0 (emit count 0 if all empty draws)
- Scan arg1 (emit count 0 if all empty draws)
- Scan arg2 (emit count 0 if all empty draws)
- Scan arg3 (emit count 0 if all empty draws)
- CS -> INDIRECT_ARGUMENT

iteration[1].vk_cmd_buffer:
- ExecuteIndirect(arg0, count0) (over 10x faster throughput if we can predicate out work)
- ExecuteIndirect(arg0, count0)
- ExecuteIndirect(arg0, count0)
- ExecuteIndirect(arg0, count0)

This kind of command reordering can be extended later to whatever use case we have in mind, but reordering indirect work is the main important case I think. 

As a heuristic, splitting command buffers isn't ideal, so we only consider a split if a device ever created a fancy execute indirect command signature and existing content outside Halo and Starfield should not observe any difference in behavior here.
