### PR TITLE
Implement missing functions for bundles

### DIFF
--- a/libs/vkd3d/bundle.c
+++ b/libs/vkd3d/bundle.c
@@ -1662,9 +1662,31 @@ static void STDMETHODCALLTYPE d3d12_bundle_Barrier(d3d12_command_list_iface *ifa
     WARN("iface %p, NumBarrierGroups %u, D3D12_BARRIER_GROUP %p ignored!\n", iface, NumBarrierGroups, pBarrierGroups);
 }
 
+struct d3d12_om_set_front_and_back_stencil_ref_command
+{
+    struct d3d12_bundle_command command;
+    UINT stencil_ref_front;
+    UINT stencil_ref_back;
+};
+
+static void d3d12_bundle_exec_om_set_front_and_back_stencil_ref(d3d12_command_list_iface *list, const void *args_v)
+{
+    const struct d3d12_om_set_front_and_back_stencil_ref_command *args = args_v;
+
+    ID3D12GraphicsCommandList9_OMSetFrontAndBackStencilRef(list,
+            args->stencil_ref_front, args->stencil_ref_back);
+}
+
 static void STDMETHODCALLTYPE d3d12_bundle_OMSetFrontAndBackStencilRef(d3d12_command_list_iface *iface, UINT FrontStencilRef, UINT BackStencilRef)
 {
-    WARN("iface %p, FrontStencilRef %u, BackStencilRef %u ignored!\n", iface, FrontStencilRef, BackStencilRef);
+    struct d3d12_bundle *bundle = impl_from_ID3D12GraphicsCommandList(iface);
+    struct d3d12_om_set_front_and_back_stencil_ref_command *args;
+
+    TRACE("iface %p, FrontStencilRef %u, BackStencilRef %u.\n", iface, FrontStencilRef, BackStencilRef);
+
+    args = d3d12_bundle_add_command(bundle, &d3d12_bundle_exec_om_set_front_and_back_stencil_ref, sizeof(*args));
+    args->stencil_ref_front = FrontStencilRef;
+    args->stencil_ref_back = BackStencilRef;
 }
 
 static void STDMETHODCALLTYPE d3d12_bundle_RSSetDepthBias(d3d12_command_list_iface *iface, FLOAT DepthBias, FLOAT DepthBiasClamp, FLOAT SlopeScaledDepthBias)

--- a/libs/vkd3d/bundle.c
+++ b/libs/vkd3d/bundle.c
@@ -1718,9 +1718,28 @@ static void STDMETHODCALLTYPE d3d12_bundle_RSSetDepthBias(d3d12_command_list_ifa
     args->slope_factor = SlopeScaledDepthBias;
 }
 
+struct d3d12_ia_set_index_buffer_strip_cut_value_command
+{
+    struct d3d12_bundle_command command;
+    D3D12_INDEX_BUFFER_STRIP_CUT_VALUE strip_cut_value;
+};
+
+static void d3d12_bundle_exec_ia_set_index_buffer_strip_cut_value(d3d12_command_list_iface *list, const void *args_v)
+{
+    const struct d3d12_ia_set_index_buffer_strip_cut_value_command *args = args_v;
+
+    ID3D12GraphicsCommandList9_IASetIndexBufferStripCutValue(list, args->strip_cut_value);
+}
+
 static void STDMETHODCALLTYPE d3d12_bundle_IASetIndexBufferStripCutValue(d3d12_command_list_iface *iface, D3D12_INDEX_BUFFER_STRIP_CUT_VALUE IBStripCutValue)
 {
-    WARN("iface %p, IBStripCutValue %u ignored!\n", iface, IBStripCutValue);
+    struct d3d12_bundle *bundle = impl_from_ID3D12GraphicsCommandList(iface);
+    struct d3d12_ia_set_index_buffer_strip_cut_value_command *args;
+
+    TRACE("iface %p, IBStripCutValue %u.\n", iface, IBStripCutValue);
+
+    args = d3d12_bundle_add_command(bundle, &d3d12_bundle_exec_ia_set_index_buffer_strip_cut_value, sizeof(*args));
+    args->strip_cut_value = IBStripCutValue;
 }
 
 static CONST_VTBL struct ID3D12GraphicsCommandList9Vtbl d3d12_bundle_vtbl =

--- a/libs/vkd3d/bundle.c
+++ b/libs/vkd3d/bundle.c
@@ -1689,9 +1689,33 @@ static void STDMETHODCALLTYPE d3d12_bundle_OMSetFrontAndBackStencilRef(d3d12_com
     args->stencil_ref_back = BackStencilRef;
 }
 
+struct d3d12_rs_set_depth_bias_command
+{
+    struct d3d12_bundle_command command;
+    float constant_factor;
+    float clamp;
+    float slope_factor;
+};
+
+static void d3d12_bundle_exec_rs_set_depth_bias(d3d12_command_list_iface *list, const void *args_v)
+{
+    const struct d3d12_rs_set_depth_bias_command *args = args_v;
+
+    ID3D12GraphicsCommandList9_RSSetDepthBias(list,
+            args->constant_factor, args->clamp, args->slope_factor);
+}
+
 static void STDMETHODCALLTYPE d3d12_bundle_RSSetDepthBias(d3d12_command_list_iface *iface, FLOAT DepthBias, FLOAT DepthBiasClamp, FLOAT SlopeScaledDepthBias)
 {
-    WARN("iface %p, DepthBias %f, DepthBiasClamp %f, SlopeScaledDepthBias %f ignored!\n", iface, DepthBias, DepthBiasClamp, SlopeScaledDepthBias);
+    struct d3d12_bundle *bundle = impl_from_ID3D12GraphicsCommandList(iface);
+    struct d3d12_rs_set_depth_bias_command *args;
+
+    TRACE("iface %p, DepthBias %f, DepthBiasClamp %f, SlopeScaledDepthBias %f.\n", iface, DepthBias, DepthBiasClamp, SlopeScaledDepthBias);
+
+    args = d3d12_bundle_add_command(bundle, &d3d12_bundle_exec_rs_set_depth_bias, sizeof(*args));
+    args->constant_factor = DepthBias;
+    args->clamp = DepthBiasClamp;
+    args->slope_factor = SlopeScaledDepthBias;
 }
 
 static void STDMETHODCALLTYPE d3d12_bundle_IASetIndexBufferStripCutValue(d3d12_command_list_iface *iface, D3D12_INDEX_BUFFER_STRIP_CUT_VALUE IBStripCutValue)

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3081,7 +3081,7 @@ static enum VkBlendFactor vk_blend_factor_from_d3d12_a8(D3D12_BLEND blend)
     }
 }
 
-static enum VkBlendFactor vk_blend_factor_from_d3d12(D3D12_BLEND blend, bool alpha)
+static enum VkBlendFactor vk_blend_factor_from_d3d12(D3D12_BLEND blend)
 {
     switch (blend)
     {
@@ -3108,12 +3108,8 @@ static enum VkBlendFactor vk_blend_factor_from_d3d12(D3D12_BLEND blend, bool alp
         case D3D12_BLEND_SRC_ALPHA_SAT:
             return VK_BLEND_FACTOR_SRC_ALPHA_SATURATE;
         case D3D12_BLEND_BLEND_FACTOR:
-            if (alpha)
-                return VK_BLEND_FACTOR_CONSTANT_ALPHA;
             return VK_BLEND_FACTOR_CONSTANT_COLOR;
         case D3D12_BLEND_INV_BLEND_FACTOR:
-            if (alpha)
-                return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
             return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR;
         case D3D12_BLEND_SRC1_COLOR:
             return VK_BLEND_FACTOR_SRC1_COLOR;
@@ -3155,11 +3151,11 @@ static void blend_attachment_from_d3d12(struct VkPipelineColorBlendAttachmentSta
     if (d3d12_desc->BlendEnable && d3d12_desc->RenderTargetWriteMask)
     {
         vk_desc->blendEnable = VK_TRUE;
-        vk_desc->srcColorBlendFactor = vk_blend_factor_from_d3d12(d3d12_desc->SrcBlend, false);
-        vk_desc->dstColorBlendFactor = vk_blend_factor_from_d3d12(d3d12_desc->DestBlend, false);
+        vk_desc->srcColorBlendFactor = vk_blend_factor_from_d3d12(d3d12_desc->SrcBlend);
+        vk_desc->dstColorBlendFactor = vk_blend_factor_from_d3d12(d3d12_desc->DestBlend);
         vk_desc->colorBlendOp = vk_blend_op_from_d3d12(d3d12_desc->BlendOp);
-        vk_desc->srcAlphaBlendFactor = vk_blend_factor_from_d3d12(d3d12_desc->SrcBlendAlpha, true);
-        vk_desc->dstAlphaBlendFactor = vk_blend_factor_from_d3d12(d3d12_desc->DestBlendAlpha, true);
+        vk_desc->srcAlphaBlendFactor = vk_blend_factor_from_d3d12(d3d12_desc->SrcBlendAlpha);
+        vk_desc->dstAlphaBlendFactor = vk_blend_factor_from_d3d12(d3d12_desc->DestBlendAlpha);
         vk_desc->alphaBlendOp = vk_blend_op_from_d3d12(d3d12_desc->BlendOpAlpha);
 
         if (format && format->dxgi_format == DXGI_FORMAT_A8_UNORM && format->vk_format != VK_FORMAT_A8_UNORM_KHR)


### PR DESCRIPTION
Some trivial boilerplate code for now, we should probably make it a habit to do this right away when bumping interface versions since this is otherwise easily forgotten about.

Barrier() remains unsupported on bundles.