### PR TITLE
Workaround GPU hangs in RE4 DLC on Mesa

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -411,6 +411,9 @@ enum vkd3d_shader_quirk
 
     /* For shaders which are bugged when you opt-in to 16-bit. */
     VKD3D_SHADER_QUIRK_FORCE_MIN16_AS_32BIT = (1 << 11),
+
+    /* Driver workaround hackery. Try to rewrite weird Grads to plain Bias. */
+    VKD3D_SHADER_QUIRK_REWRITE_GRAD_TO_BIAS = (1 << 12),
 };
 
 struct vkd3d_shader_quirk_hash

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -952,6 +952,18 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
         }
     }
 
+    if (quirks & VKD3D_SHADER_QUIRK_REWRITE_GRAD_TO_BIAS)
+    {
+        const dxil_spv_option_sample_grad_optimization_control helper =
+                { { DXIL_SPV_OPTION_SAMPLE_GRAD_OPTIMIZATION_CONTROL }, DXIL_SPV_TRUE, DXIL_SPV_TRUE };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            ERR("dxil-spirv does not support SAMPLE_GRAD_OPTIMIZATION_CONTROL.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
     remap_userdata.shader_interface_info = shader_interface_info;
     remap_userdata.shader_interface_local_info = NULL;
     remap_userdata.num_root_descriptors = num_root_descriptors;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -584,6 +584,11 @@ static const struct vkd3d_shader_quirk_hash re_hashes[] = {
     { 0xa100b53736f9c1bfull, VKD3D_SHADER_QUIRK_FORCE_SUBGROUP_SIZE_1 },
     /* RE2 and RE7 */
     { 0x1c4c8782b75c498bull, VKD3D_SHADER_QUIRK_FORCE_SUBGROUP_SIZE_1 },
+    /* Temporary driver workaround for RADV. See https://gitlab.freedesktop.org/mesa/mesa/-/issues/9852. */
+    /* This shader trips on Mesa 23.0.3. */
+    { 0xdb1593ced60da3f1ull, VKD3D_SHADER_QUIRK_REWRITE_GRAD_TO_BIAS },
+    /* This shader hangs on Mesa main. */
+    { 0x5784e9e2f7a76819ull, VKD3D_SHADER_QUIRK_REWRITE_GRAD_TO_BIAS },
 };
 
 static const struct vkd3d_shader_quirk_info re_quirks = {


### PR DESCRIPTION
Mesa issue: https://gitlab.freedesktop.org/mesa/mesa/-/issues/9852

The bug seems to be a subtle scheduling bug in ACO (ACO_DEBUG=nosched also works around it), and rewriting some Grad instructions to the equivalent Bias instruction also works around it.