### PR TITLE
debug: Make FIXME_ONCE fallback to TRACE after first message.

### DIFF
--- a/include/private/vkd3d_debug.h
+++ b/include/private/vkd3d_debug.h
@@ -113,7 +113,7 @@ const char *debugstr_w(const WCHAR *wstr);
 #define TRACE_ON() (vkd3d_dbg_get_level(VKD3D_DBG_CHANNEL) == VKD3D_DBG_LEVEL_TRACE)
 #endif
 
-#define FIXME_ONCE VKD3D_DBG_LOG_ONCE(FIXME, WARN)
+#define FIXME_ONCE VKD3D_DBG_LOG_ONCE(FIXME, TRACE)
 
 static inline const char *debugstr_guid(const GUID *guid)
 {


### PR DESCRIPTION
WARN is a bit too spammy for this.