### PR TITLE
Implement linear tiling fallback for weird image formats

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3522,11 +3522,8 @@ bool d3d12_device_is_uma(struct d3d12_device *device, bool *coherent)
 
 static HRESULT d3d12_device_get_format_support(struct d3d12_device *device, D3D12_FEATURE_DATA_FORMAT_SUPPORT *data)
 {
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkFormatFeatureFlags2 image_features;
-    VkFormatProperties3 properties3;
     const struct vkd3d_format *format;
-    VkFormatProperties2 properties;
 
     data->Support1 = D3D12_FORMAT_SUPPORT1_NONE;
     data->Support2 = D3D12_FORMAT_SUPPORT2_NONE;
@@ -3538,20 +3535,11 @@ static HRESULT d3d12_device_get_format_support(struct d3d12_device *device, D3D1
         return E_INVALIDARG;
     }
 
-    properties.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
-    properties.pNext = NULL;
+    image_features = format->vk_format_features;
 
-    properties3.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3;
-    properties3.pNext = NULL;
-    vk_prepend_struct(&properties, &properties3);
-
-    VK_CALL(vkGetPhysicalDeviceFormatProperties2(device->vk_physical_device, format->vk_format, &properties));
-
-    image_features = properties3.linearTilingFeatures | properties3.optimalTilingFeatures;
-
-    if (properties.formatProperties.bufferFeatures)
+    if (format->vk_format_features_buffer)
         data->Support1 |= D3D12_FORMAT_SUPPORT1_BUFFER;
-    if (properties.formatProperties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)
+    if (format->vk_format_features_buffer & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)
         data->Support1 |= D3D12_FORMAT_SUPPORT1_IA_VERTEX_BUFFER;
     if (data->Format == DXGI_FORMAT_R16_UINT || data->Format == DXGI_FORMAT_R32_UINT)
         data->Support1 |= D3D12_FORMAT_SUPPORT1_IA_INDEX_BUFFER;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -698,7 +698,7 @@ static HRESULT vkd3d_get_image_create_info(struct d3d12_device *device,
 
     image_info->mipLevels = min(desc->MipLevels, max_miplevel_count(desc));
     image_info->samples = vk_samples_from_dxgi_sample_desc(&desc->SampleDesc);
-    image_info->tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_info->tiling = format->vk_image_tiling;
     image_info->initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     if (sparse_resource)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4734,12 +4734,15 @@ struct vkd3d_format
     enum vkd3d_format_type type;
     bool is_emulated;
     const struct vkd3d_format_footprint *plane_footprints;
-    /* Only includes format features explicitly for vk_format. */
-    VkFormatFeatureFlags vk_format_features;
+    VkImageTiling vk_image_tiling;
+    /* Only includes image format features explicitly for vk_format. */
+    VkFormatFeatureFlags2 vk_format_features;
     /* If the format is TYPELESS or relaxed castable (e.g. sRGB to UNORM),
      * the feature list includes all potential format features.
      * This will hold either just depth features or color features depending on which format query is used. */
-    VkFormatFeatureFlags vk_format_features_castable;
+    VkFormatFeatureFlags2 vk_format_features_castable;
+    /* Includes only buffer view features. */
+    VkFormatFeatureFlags2 vk_format_features_buffer;
 };
 
 static inline size_t vkd3d_format_get_data_offset(const struct vkd3d_format *format,


### PR DESCRIPTION
Pioneers of Pagonia requires RGB32 texture support, which isn't supported with `OPTIMAL` tiling on AMD/NV.

This also reworks the way we deal with format features a bit to get rid of some unnecessary GetFormatProperties calls, and just to make reporting of format support more consistent with what can actually work.

This alone is not enough to fix the game since there is an unrelated crash somewhere, but it lets us actually test the thing without immediately running into some error pop-up.