### PR TITLE
Update upstream git URL to WineHQ GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The project serves as the development effort for Direct3D 12 support in [Proton]
 
 ## Upstream
 
-The original project is available at [WineHQ](https://source.winehq.org/git/vkd3d.git/).
+The original project is available at [WineHQ](https://gitlab.winehq.org/wine/vkd3d).
 
 ## Priorities
 


### PR DESCRIPTION
WineHQ has started using GitLab. Update the upstream git URL in README.md to use the link to their GitLab project.