### PR TITLE
Add NV low latency support

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -13,6 +13,7 @@ vkd3d_idl = [
   'vkd3d_dxgitype.idl',
   'vkd3d_swapchain_factory.idl',
   'vkd3d_command_list_vkd3d_ext.idl',
+  'vkd3d_command_queue_vkd3d_ext.idl',
   'vkd3d_device_vkd3d_ext.idl',
   'vkd3d_core_interface.idl',
 ]

--- a/include/vkd3d_command_queue_vkd3d_ext.idl
+++ b/include/vkd3d_command_queue_vkd3d_ext.idl
@@ -1,0 +1,30 @@
+/*
+ * * Copyright 2023 NVIDIA Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+import "vkd3d_d3d12.idl";
+import "vkd3d_vk_includes.h";
+
+[
+    uuid(40ed3f96-e773-e9bc-fc0c-e95560c99ad6),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12CommandQueueExt : IUnknown
+{
+    HRESULT NotifyOutOfBandCommandQueue(D3D12_OUT_OF_BAND_CQ_TYPE type);
+}

--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -54,3 +54,18 @@ interface ID3D12DXVKInteropDevice : IUnknown
     HRESULT LockCommandQueue(ID3D12CommandQueue *queue);
     HRESULT UnlockCommandQueue(ID3D12CommandQueue *queue);
 }
+
+[
+    uuid(f3112584-41f9-348d-a59b-00b7e1d285d6),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3DLowLatencyDevice : IUnknown
+{
+    BOOL SupportsLowLatency();
+    HRESULT LatencySleep();
+    HRESULT SetLatencySleepMode(BOOL low_latency_mode, BOOL low_latency_boost, UINT32 minimum_interval_us);
+    HRESULT SetLatencyMarker(UINT64 frameID, UINT32 markerType);
+    HRESULT GetLatencyInfo(D3D12_LATENCY_RESULTS *latency_results);
+}

--- a/include/vkd3d_vk_includes.h
+++ b/include/vkd3d_vk_includes.h
@@ -41,8 +41,15 @@ typedef enum VkImageLayout VkImageLayout;
 typedef enum D3D12_VK_EXTENSION
 {
     D3D12_VK_NVX_BINARY_IMPORT      = 0x1,
-    D3D12_VK_NVX_IMAGE_VIEW_HANDLE  = 0x2
+    D3D12_VK_NVX_IMAGE_VIEW_HANDLE  = 0x2,
+    D3D12_VK_NV_LOW_LATENCY_2       = 0x3
 } D3D12_VK_EXTENSION;
+
+typedef enum D3D12_OUT_OF_BAND_CQ_TYPE
+{
+    OUT_OF_BAND_RENDER  = 0,
+    OUT_OF_BAND_PRESENT = 1
+} D3D12_OUT_OF_BAND_CQ_TYPE;
 
 typedef struct D3D12_CUBIN_DATA_HANDLE
 {
@@ -60,6 +67,31 @@ typedef struct D3D12_UAV_INFO
     UINT64 gpuVAStart;
     UINT64 gpuVASize;  
 } D3D12_UAV_INFO;
+
+typedef struct D3D12_LATENCY_RESULTS
+{
+    UINT32 version;
+    struct D3D12_FRAME_REPORT {
+        UINT64 frameID;
+        UINT64 inputSampleTime;
+        UINT64 simStartTime;
+        UINT64 simEndTime;
+        UINT64 renderSubmitStartTime;
+        UINT64 renderSubmitEndTime;
+        UINT64 presentStartTime;
+        UINT64 presentEndTime;
+        UINT64 driverStartTime;
+        UINT64 driverEndTime;
+        UINT64 osRenderQueueStartTime;
+        UINT64 osRenderQueueEndTime;
+        UINT64 gpuRenderStartTime;
+        UINT64 gpuRenderEndTime;
+        UINT32 gpuActiveRenderTimeUs;
+        UINT32 gpuFrameTimeUs;
+        UINT8 rsvd[120];
+    } frame_reports[64];
+    UINT8 rsvd[32];
+} D3D12_LATENCY_RESULTS;
 
 #endif  // __VKD3D_VK_INCLUDES_H
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -219,7 +219,7 @@ fail_destroy_mutex:
     return hr;
 }
 
-void vkd3d_set_queue_out_of_band(struct d3d12_device *device, struct vkd3d_queue *queue)
+void vkd3d_set_queue_out_of_band(struct d3d12_device *device, struct vkd3d_queue *queue, VkOutOfBandQueueTypeNV type)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkOutOfBandQueueTypeInfoNV queue_info;
@@ -230,11 +230,7 @@ void vkd3d_set_queue_out_of_band(struct d3d12_device *device, struct vkd3d_queue
     memset(&queue_info, 0, sizeof(queue_info));
     queue_info.sType = VK_STRUCTURE_TYPE_OUT_OF_BAND_QUEUE_TYPE_INFO_NV;
     queue_info.pNext = NULL;
-    queue_info.queueType = VK_OUT_OF_BAND_QUEUE_TYPE_RENDER_NV;
-
-    VK_CALL(vkQueueNotifyOutOfBandNV(queue->vk_queue, &queue_info));
-
-    queue_info.queueType = VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV;
+    queue_info.queueType = type;
 
     VK_CALL(vkQueueNotifyOutOfBandNV(queue->vk_queue, &queue_info));
 }

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -219,6 +219,26 @@ fail_destroy_mutex:
     return hr;
 }
 
+void vkd3d_set_queue_out_of_band(struct d3d12_device *device, struct vkd3d_queue *queue)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    VkOutOfBandQueueTypeInfoNV queue_info;
+
+    if (!device->vk_info.NV_low_latency2)
+        return;
+
+    memset(&queue_info, 0, sizeof(queue_info));
+    queue_info.sType = VK_STRUCTURE_TYPE_OUT_OF_BAND_QUEUE_TYPE_INFO_NV;
+    queue_info.pNext = NULL;
+    queue_info.queueType = VK_OUT_OF_BAND_QUEUE_TYPE_RENDER_NV;
+
+    VK_CALL(vkQueueNotifyOutOfBandNV(queue->vk_queue, &queue_info));
+
+    queue_info.queueType = VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV;
+
+    VK_CALL(vkQueueNotifyOutOfBandNV(queue->vk_queue, &queue_info));
+}
+
 static void vkd3d_queue_flush_waiters(struct vkd3d_queue *vkd3d_queue,
         struct vkd3d_fence_worker *worker,
         const struct vkd3d_vk_device_procs *vk_procs);
@@ -16591,12 +16611,14 @@ static struct d3d12_command_list *d3d12_command_list_from_iface(ID3D12CommandLis
 }
 
 /* ID3D12CommandQueue */
+extern ULONG STDMETHODCALLTYPE d3d12_command_queue_vkd3d_ext_AddRef(d3d12_command_queue_vkd3d_ext_iface *iface);
+
 static inline struct d3d12_command_queue *impl_from_ID3D12CommandQueue(ID3D12CommandQueue *iface)
 {
     return CONTAINING_RECORD(iface, struct d3d12_command_queue, ID3D12CommandQueue_iface);
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_command_queue_QueryInterface(ID3D12CommandQueue *iface,
+HRESULT STDMETHODCALLTYPE d3d12_command_queue_QueryInterface(ID3D12CommandQueue *iface,
         REFIID riid, void **object)
 {
     TRACE("iface %p, riid %s, object %p.\n", iface, debugstr_guid(riid), object);
@@ -16615,6 +16637,14 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_queue_QueryInterface(ID3D12Comman
         return S_OK;
     }
 
+    if (IsEqualGUID(riid, &IID_ID3D12CommandQueueExt))
+    {
+        struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
+        d3d12_command_queue_vkd3d_ext_AddRef(&command_queue->ID3D12CommandQueueExt_iface);
+        *object = &command_queue->ID3D12CommandQueueExt_iface;
+        return S_OK;
+    }
+
     if (IsEqualGUID(riid, &IID_IDXGIVkSwapChainFactory))
     {
         struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
@@ -16629,7 +16659,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_queue_QueryInterface(ID3D12Comman
     return E_NOINTERFACE;
 }
 
-static ULONG STDMETHODCALLTYPE d3d12_command_queue_AddRef(ID3D12CommandQueue *iface)
+ULONG STDMETHODCALLTYPE d3d12_command_queue_AddRef(ID3D12CommandQueue *iface)
 {
     struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
     ULONG refcount = InterlockedIncrement(&command_queue->refcount);
@@ -16639,7 +16669,7 @@ static ULONG STDMETHODCALLTYPE d3d12_command_queue_AddRef(ID3D12CommandQueue *if
     return refcount;
 }
 
-static ULONG STDMETHODCALLTYPE d3d12_command_queue_Release(ID3D12CommandQueue *iface)
+ULONG STDMETHODCALLTYPE d3d12_command_queue_Release(ID3D12CommandQueue *iface)
 {
     struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
     ULONG refcount = InterlockedDecrement(&command_queue->refcount);
@@ -17132,6 +17162,7 @@ static void STDMETHODCALLTYPE d3d12_command_queue_ExecuteCommandLists(ID3D12Comm
     sub.execute.cmd_count = num_command_buffers;
     sub.execute.command_allocators = allocators;
     sub.execute.num_command_allocators = command_list_count;
+    sub.execute.low_latency_frame_id = command_queue->device->frame_markers.render;
 #ifdef VKD3D_ENABLE_BREADCRUMBS
     sub.execute.breadcrumb_indices = breadcrumb_indices;
     sub.execute.breadcrumb_indices_count = breadcrumb_indices ? command_list_count : 0;
@@ -17294,6 +17325,8 @@ static D3D12_COMMAND_QUEUE_DESC * STDMETHODCALLTYPE d3d12_command_queue_GetDesc(
     *desc = command_queue->desc;
     return desc;
 }
+
+extern CONST_VTBL struct ID3D12CommandQueueExtVtbl d3d12_command_queue_vkd3d_ext_vtbl;
 
 static CONST_VTBL struct ID3D12CommandQueueVtbl d3d12_command_queue_vtbl =
 {
@@ -17807,10 +17840,12 @@ static void d3d12_command_queue_execute(struct d3d12_command_queue *command_queu
         const VkSemaphoreSubmitInfo *transition_semaphore,
         struct d3d12_command_allocator **command_allocators, size_t num_command_allocators,
         struct vkd3d_queue_timeline_trace_cookie timeline_cookie,
-        bool debug_capture, bool split_submissions)
+        uint64_t low_latency_frame_id, bool debug_capture, bool split_submissions)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &command_queue->device->vk_procs;
     struct vkd3d_queue *vkd3d_queue = command_queue->vkd3d_queue;
+    VkLatencySubmissionPresentIdNV latency_submit_present_info;
+    struct dxgi_vk_swap_chain *low_latency_swapchain;
     VkSemaphoreSubmitInfo signal_semaphore_info;
     VkSemaphoreSubmitInfo binary_semaphore_info;
     VkSubmitInfo2 submit_desc[4];
@@ -17893,6 +17928,27 @@ static void d3d12_command_queue_execute(struct d3d12_command_queue *command_queu
         submit_desc[num_submits + 1].waitSemaphoreInfoCount = 1;
         submit_desc[num_submits + 1].pWaitSemaphoreInfos = &binary_semaphore_info;
         num_submits += 2;
+    }
+
+    if (command_queue->device->vk_info.NV_low_latency2)
+    {
+        spinlock_acquire(&command_queue->device->low_latency_swapchain_spinlock);
+        if ((low_latency_swapchain = command_queue->device->swapchain_info.low_latency_swapchain))
+            dxgi_vk_swap_chain_incref(low_latency_swapchain);
+        spinlock_release(&command_queue->device->low_latency_swapchain_spinlock);
+
+        if (low_latency_swapchain && dxgi_vk_swap_chain_low_latency_enabled(low_latency_swapchain))
+        {
+            latency_submit_present_info.sType = VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV;
+            latency_submit_present_info.pNext = NULL;
+            latency_submit_present_info.presentID = low_latency_frame_id;
+
+            for (i = 0; i < num_submits; i++)
+                submit_desc[i].pNext = &latency_submit_present_info;
+        }
+
+        if (low_latency_swapchain)
+            dxgi_vk_swap_chain_decref(low_latency_swapchain);
     }
 
 #ifdef VKD3D_ENABLE_RENDERDOC
@@ -18397,7 +18453,9 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
                     submission.execute.command_allocators,
                     submission.execute.num_command_allocators,
                     submission.execute.timeline_cookie,
-                    submission.execute.debug_capture, submission.execute.split_submission);
+                    submission.execute.low_latency_frame_id,
+                    submission.execute.debug_capture,
+                    submission.execute.split_submission);
 
             /* command_queue_execute takes ownership of the
              * outstanding_submission_counters and queue_timeline_indices allocations.
@@ -18460,6 +18518,7 @@ static HRESULT d3d12_command_queue_init(struct d3d12_command_queue *queue,
     int rc;
 
     queue->ID3D12CommandQueue_iface.lpVtbl = &d3d12_command_queue_vtbl;
+    queue->ID3D12CommandQueueExt_iface.lpVtbl = &d3d12_command_queue_vkd3d_ext_vtbl;
     queue->refcount = 1;
 
     queue->desc = *desc;
@@ -18588,6 +18647,7 @@ void vkd3d_enqueue_initial_transition(ID3D12CommandQueue *queue, ID3D12Resource 
 
     memset(&sub, 0, sizeof(sub));
     sub.type = VKD3D_SUBMISSION_EXECUTE;
+    sub.execute.low_latency_frame_id = d3d12_queue->device->frame_markers.render;
     sub.execute.transition_count = 1;
     sub.execute.transitions = vkd3d_malloc(sizeof(*sub.execute.transitions));
     sub.execute.transitions[0].type = VKD3D_INITIAL_TRANSITION_TYPE_RESOURCE;

--- a/libs/vkd3d/command_queue_vkd3d_ext.c
+++ b/libs/vkd3d/command_queue_vkd3d_ext.c
@@ -1,0 +1,91 @@
+/*
+ * * Copyright 2023 NVIDIA Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+
+#include "vkd3d_private.h"
+
+static inline struct d3d12_command_queue *d3d12_command_queue_from_ID3D12CommandQueueExt(d3d12_command_queue_vkd3d_ext_iface *iface)
+{
+    return CONTAINING_RECORD(iface, struct d3d12_command_queue, ID3D12CommandQueueExt_iface);
+}
+
+extern ULONG STDMETHODCALLTYPE d3d12_command_queue_AddRef(d3d12_command_queue_iface *iface);
+
+ULONG STDMETHODCALLTYPE d3d12_command_queue_vkd3d_ext_AddRef(d3d12_command_queue_vkd3d_ext_iface *iface)
+{
+    struct d3d12_command_queue *command_queue = d3d12_command_queue_from_ID3D12CommandQueueExt(iface);
+    return d3d12_command_queue_AddRef(&command_queue->ID3D12CommandQueue_iface);
+}
+
+extern ULONG STDMETHODCALLTYPE d3d12_command_queue_Release(d3d12_command_queue_iface *iface);
+
+static ULONG STDMETHODCALLTYPE d3d12_command_queue_vkd3d_ext_Release(d3d12_command_queue_vkd3d_ext_iface *iface)
+{
+    struct d3d12_command_queue *command_queue = d3d12_command_queue_from_ID3D12CommandQueueExt(iface);
+    return d3d12_command_queue_Release(&command_queue->ID3D12CommandQueue_iface);
+}
+
+extern HRESULT STDMETHODCALLTYPE d3d12_command_queue_QueryInterface(d3d12_command_queue_iface *iface,
+        REFIID iid, void **object);
+
+static HRESULT STDMETHODCALLTYPE d3d12_command_queue_vkd3d_ext_QueryInterface(d3d12_command_queue_vkd3d_ext_iface *iface,
+        REFIID iid, void **out)
+{
+    struct d3d12_command_queue *command_queue = d3d12_command_queue_from_ID3D12CommandQueueExt(iface);
+    TRACE("iface %p, iid %s, out %p.\n", iface, debugstr_guid(iid), out);
+    return d3d12_command_queue_QueryInterface(&command_queue->ID3D12CommandQueue_iface, iid, out);
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_command_queue_vkd3d_ext_NotifyOutOfBandCommandQueue(d3d12_command_queue_vkd3d_ext_iface *iface, D3D12_OUT_OF_BAND_CQ_TYPE type)
+{
+    struct d3d12_command_queue *command_queue;
+    int i;
+
+    command_queue = d3d12_command_queue_from_ID3D12CommandQueueExt(iface);
+
+    if (!command_queue->device->vk_info.NV_low_latency2)
+        return E_NOTIMPL;
+
+    if (type != OUT_OF_BAND_RENDER && type != OUT_OF_BAND_PRESENT)
+        return E_INVALIDARG;
+
+    for (i = 0; i < VKD3D_QUEUE_FAMILY_COUNT; i++)
+    {
+        if (command_queue->device->queue_families[i]->vk_family_index == command_queue->vkd3d_queue->vk_family_index &&
+                command_queue->device->queue_families[i]->out_of_band_queue)
+        {
+            command_queue->vkd3d_queue = command_queue->device->queue_families[i]->out_of_band_queue;
+            break;
+        }
+    }
+
+    return S_OK;
+}
+
+CONST_VTBL struct ID3D12CommandQueueExtVtbl d3d12_command_queue_vkd3d_ext_vtbl =
+{
+    /* IUnknown methods */
+    d3d12_command_queue_vkd3d_ext_QueryInterface,
+    d3d12_command_queue_vkd3d_ext_AddRef,
+    d3d12_command_queue_vkd3d_ext_Release,
+
+    /* ID3D12CommandQueueExt methods */
+    d3d12_command_queue_vkd3d_ext_NotifyOutOfBandCommandQueue
+};
+

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -127,6 +127,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(NV_SHADER_SUBGROUP_PARTITIONED, NV_shader_subgroup_partitioned),
     VK_EXTENSION(NV_MEMORY_DECOMPRESSION, NV_memory_decompression),
     VK_EXTENSION(NV_DEVICE_GENERATED_COMMANDS_COMPUTE, NV_device_generated_commands_compute),
+    VK_EXTENSION_VERSION(NV_LOW_LATENCY_2, NV_low_latency2, 2),
     /* VALVE extensions */
     VK_EXTENSION(VALVE_MUTABLE_DESCRIPTOR_TYPE, VALVE_mutable_descriptor_type),
     VK_EXTENSION(VALVE_DESCRIPTOR_SET_HOST_MAPPING, VALVE_descriptor_set_host_mapping),
@@ -2588,6 +2589,12 @@ struct vkd3d_device_queue_info
     VkDeviceQueueCreateInfo vk_queue_create_info[VKD3D_QUEUE_FAMILY_COUNT];
 };
 
+static bool vkd3d_queue_family_needs_out_of_band_queue(unsigned int vkd3d_queue_family)
+{
+    return vkd3d_queue_family == VKD3D_QUEUE_FAMILY_GRAPHICS ||
+        vkd3d_queue_family == VKD3D_QUEUE_FAMILY_COMPUTE;
+}
+
 static void d3d12_device_destroy_vkd3d_queues(struct d3d12_device *device)
 {
     unsigned int i, j;
@@ -2611,6 +2618,9 @@ static void d3d12_device_destroy_vkd3d_queues(struct d3d12_device *device)
             if (queue_family->queues[j])
                 vkd3d_queue_destroy(queue_family->queues[j], device);
         }
+
+        if (queue_family->out_of_band_queue)
+            vkd3d_queue_destroy(queue_family->out_of_band_queue, device);
 
         vkd3d_free(queue_family->queues);
         vkd3d_free(queue_family);
@@ -2652,6 +2662,12 @@ static HRESULT d3d12_device_create_vkd3d_queues(struct d3d12_device *device,
 
         info->queue_count = queue_info->vk_queue_create_info[k++].queueCount;
 
+        /* Unless the queue family only has a single queue to allocate, when NV_low_latency2
+         * is enabled one queue is reserved for out of band work */
+        if (device->vk_info.NV_low_latency2 && vkd3d_queue_family_needs_out_of_band_queue(i) &&
+                queue_info->vk_properties[i].queueCount > 1)
+            info->queue_count--;
+
         if (!(info->queues = vkd3d_calloc(info->queue_count, sizeof(*info->queues))))
         {
             hr = E_OUTOFMEMORY;
@@ -2664,6 +2680,19 @@ static HRESULT d3d12_device_create_vkd3d_queues(struct d3d12_device *device,
                     j, &queue_info->vk_properties[i], &info->queues[j]))))
                 goto out_destroy_queues;
         }
+
+        if (device->vk_info.NV_low_latency2 && vkd3d_queue_family_needs_out_of_band_queue(i) &&
+                queue_info->vk_properties[i].queueCount > 1)
+        {
+            /* The low latency out of band queue is always the last queue for the family */
+            if (FAILED((hr = vkd3d_queue_create(device, queue_info->family_index[i],
+                    info->queue_count, &queue_info->vk_properties[i], &info->out_of_band_queue))))
+                goto out_destroy_queues;
+
+            vkd3d_set_queue_out_of_band(device, info->out_of_band_queue);
+        }
+        else
+            WARN("Could not allocate an out of band queue for queue family %u. All out of band work will happen on the in band queue.\n", i);
 
         info->vk_family_index = queue_info->family_index[i];
         info->vk_queue_flags = queue_info->vk_properties[i].queueFlags;
@@ -2684,7 +2713,11 @@ out_destroy_queues:
 }
 
 #define VKD3D_MAX_QUEUE_COUNT_PER_FAMILY (4u)
-static float queue_priorities[] = {1.0f, 1.0f, 1.0f, 1.0f};
+
+/* The queue priorities list contains VKD3D_MAX_QUEUE_COUNT_PER_FAMILY + 1 priorities
+ * because it is possible for low latency to add an additional queue for out of band work
+ * submission. */
+static float queue_priorities[] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
 
 static uint32_t vkd3d_find_queue(unsigned int count, const VkQueueFamilyProperties *properties,
         VkQueueFlags mask, VkQueueFlags flags)
@@ -2700,10 +2733,10 @@ static uint32_t vkd3d_find_queue(unsigned int count, const VkQueueFamilyProperti
     return VK_QUEUE_FAMILY_IGNORED;
 }
 
-static HRESULT vkd3d_select_queues(const struct vkd3d_instance *vkd3d_instance,
+static HRESULT vkd3d_select_queues(const struct d3d12_device *device,
         VkPhysicalDevice physical_device, struct vkd3d_device_queue_info *info)
 {
-    const struct vkd3d_vk_instance_procs *vk_procs = &vkd3d_instance->vk_procs;
+    const struct vkd3d_vk_instance_procs *vk_procs = &device->vkd3d_instance->vk_procs;
     VkQueueFamilyProperties *queue_properties = NULL;
     VkDeviceQueueCreateInfo *queue_info = NULL;
     bool duplicate, single_queue;
@@ -2766,6 +2799,10 @@ static HRESULT vkd3d_select_queues(const struct vkd3d_instance *vkd3d_instance,
 
         if (single_queue)
             queue_info->queueCount = 1;
+
+        if (device->vk_info.NV_low_latency2 && vkd3d_queue_family_needs_out_of_band_queue(i) &&
+                queue_info->queueCount < info->vk_properties[i].queueCount)
+            queue_info->queueCount++;
     }
 
     vkd3d_free(queue_properties);
@@ -2807,9 +2844,6 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
 
     VK_CALL(vkGetPhysicalDeviceProperties(device->vk_physical_device, &device_properties));
     device->api_version = min(device_properties.apiVersion, VKD3D_MAX_API_VERSION);
-
-    if (FAILED(hr = vkd3d_select_queues(device->vkd3d_instance, physical_device, &device_queue_info)))
-        return hr;
 
     TRACE("Using queue family %u for direct command queues.\n",
             device_queue_info.family_index[VKD3D_QUEUE_FAMILY_GRAPHICS]);
@@ -2855,6 +2889,13 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
     {
         vkd3d_free(user_extension_supported);
         return E_OUTOFMEMORY;
+    }
+
+    if (FAILED(hr = vkd3d_select_queues(device, physical_device, &device_queue_info)))
+    {
+        vkd3d_free(user_extension_supported);
+        vkd3d_free(extensions);
+        return hr;
     }
 
     /* Create device */
@@ -3285,8 +3326,9 @@ void d3d12_device_return_query_pool(struct d3d12_device *device, const struct vk
 }
 
 /* ID3D12Device */
-extern ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_AddRef(ID3D12DeviceExt *iface);
+extern ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_AddRef(d3d12_device_vkd3d_ext_iface *iface);
 extern ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_AddRef(ID3D12DXVKInteropDevice *iface);
+extern ULONG STDMETHODCALLTYPE d3d12_low_latency_device_AddRef(ID3DLowLatencyDevice *iface);
 
 HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
         REFIID riid, void **object)
@@ -3330,6 +3372,14 @@ HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
         struct d3d12_device *device = impl_from_ID3D12Device(iface);
         d3d12_dxvk_interop_device_AddRef(&device->ID3D12DXVKInteropDevice_iface);
         *object = &device->ID3D12DXVKInteropDevice_iface;
+        return S_OK;
+    }
+
+    if (IsEqualGUID(riid, &IID_ID3DLowLatencyDevice))
+    {
+        struct d3d12_device *device = impl_from_ID3D12Device(iface);
+        d3d12_low_latency_device_AddRef(&device->ID3DLowLatencyDevice_iface);
+        *object = &device->ID3DLowLatencyDevice_iface;
         return S_OK;
     }
 
@@ -8349,6 +8399,7 @@ static void d3d12_device_replace_vtable(struct d3d12_device *device)
 
 extern CONST_VTBL struct ID3D12DeviceExtVtbl d3d12_device_vkd3d_ext_vtbl;
 extern CONST_VTBL struct ID3D12DXVKInteropDeviceVtbl d3d12_dxvk_interop_device_vtbl;
+extern CONST_VTBL struct ID3DLowLatencyDeviceVtbl d3d_low_latency_device_vtbl;
 
 static void vkd3d_scratch_pool_init(struct d3d12_device *device)
 {
@@ -8417,8 +8468,11 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
         goto out_free_mutex;
     }
 
+    spinlock_init(&device->low_latency_swapchain_spinlock);
+
     device->ID3D12DeviceExt_iface.lpVtbl = &d3d12_device_vkd3d_ext_vtbl;
     device->ID3D12DXVKInteropDevice_iface.lpVtbl = &d3d12_dxvk_interop_device_vtbl;
+    device->ID3DLowLatencyDevice_iface.lpVtbl = &d3d_low_latency_device_vtbl;
 
     if ((rc = rwlock_init(&device->vertex_input_lock)))
     {

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2688,8 +2688,6 @@ static HRESULT d3d12_device_create_vkd3d_queues(struct d3d12_device *device,
             if (FAILED((hr = vkd3d_queue_create(device, queue_info->family_index[i],
                     info->queue_count, &queue_info->vk_properties[i], &info->out_of_band_queue))))
                 goto out_destroy_queues;
-
-            vkd3d_set_queue_out_of_band(device, info->out_of_band_queue);
         }
         else
             WARN("Could not allocate an out of band queue for queue family %u. All out of band work will happen on the in band queue.\n", i);

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -460,8 +460,8 @@ static BOOL STDMETHODCALLTYPE d3d12_low_latency_device_SupportsLowLatency(d3d_lo
 
 static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_LatencySleep(d3d_low_latency_device_iface *iface)
 {
-    struct d3d12_device *device;
     struct dxgi_vk_swap_chain *low_latency_swapchain;
+    struct d3d12_device *device;
 
     device = d3d12_device_from_ID3DLowLatencyDevice(iface);
 
@@ -485,8 +485,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_LatencySleep(d3d_low_l
 static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencySleepMode(d3d_low_latency_device_iface *iface, BOOL low_latency_mode, BOOL low_latency_boost,
         UINT32 minimum_interval_us)
 {
-    struct d3d12_device *device;
     struct dxgi_vk_swap_chain *low_latency_swapchain;
+    struct d3d12_device *device;
 
     device = d3d12_device_from_ID3DLowLatencyDevice(iface);
 
@@ -509,10 +509,10 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencySleepMode(d3
 
 static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_low_latency_device_iface *iface, UINT64 frameID, UINT32 markerType)
 {
-    uint64_t internal_frame_id;
-    struct d3d12_device *device;
-    VkLatencyMarkerNV vk_marker;
     struct dxgi_vk_swap_chain *low_latency_swapchain;
+    VkLatencyMarkerNV vk_marker;
+    struct d3d12_device *device;
+    uint64_t internal_frame_id;
 
     device = d3d12_device_from_ID3DLowLatencyDevice(iface);
     vk_marker = (VkLatencyMarkerNV)markerType;
@@ -555,8 +555,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_l
 
 static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_GetLatencyInfo(d3d_low_latency_device_iface *iface, D3D12_LATENCY_RESULTS *latency_results)
 {
-    struct d3d12_device *device;
     struct dxgi_vk_swap_chain *low_latency_swapchain;
+    struct d3d12_device *device;
 
     device = d3d12_device_from_ID3DLowLatencyDevice(iface);
 

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -20,18 +20,18 @@
 
 #include "vkd3d_private.h"
 
-static inline struct d3d12_device *d3d12_device_from_ID3D12DeviceExt(ID3D12DeviceExt *iface)
+static inline struct d3d12_device *d3d12_device_from_ID3D12DeviceExt(d3d12_device_vkd3d_ext_iface *iface)
 {
     return CONTAINING_RECORD(iface, struct d3d12_device, ID3D12DeviceExt_iface);
 }
 
-ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_AddRef(ID3D12DeviceExt *iface)
+ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_AddRef(d3d12_device_vkd3d_ext_iface *iface)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     return d3d12_device_add_ref(device);
 }
 
-static ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_Release(ID3D12DeviceExt *iface)
+static ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_Release(d3d12_device_vkd3d_ext_iface *iface)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     return d3d12_device_release(device);
@@ -40,7 +40,7 @@ static ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_Release(ID3D12DeviceExt *i
 extern HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
         REFIID riid, void **object);
 
-static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_QueryInterface(ID3D12DeviceExt *iface,
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_QueryInterface(d3d12_device_vkd3d_ext_iface *iface,
         REFIID iid, void **out)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
@@ -48,7 +48,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_QueryInterface(ID3D12Dev
     return d3d12_device_QueryInterface(&device->ID3D12Device_iface, iid, out);
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetVulkanHandles(ID3D12DeviceExt *iface, VkInstance *vk_instance, VkPhysicalDevice *vk_physical_device, VkDevice *vk_device)
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetVulkanHandles(d3d12_device_vkd3d_ext_iface *iface, VkInstance *vk_instance, VkPhysicalDevice *vk_physical_device, VkDevice *vk_device)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     TRACE("iface %p, vk_instance %p, vk_physical_device %p, vk_device %p \n", iface, vk_instance, vk_physical_device, vk_device);
@@ -61,7 +61,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetVulkanHandles(ID3D12D
     return S_OK;
 }
 
-static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetExtensionSupport(ID3D12DeviceExt *iface, D3D12_VK_EXTENSION extension)
+static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetExtensionSupport(d3d12_device_vkd3d_ext_iface *iface, D3D12_VK_EXTENSION extension)
 {
     const struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     bool ret_val = false;
@@ -75,6 +75,9 @@ static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetExtensionSupport(ID3D12D
         case D3D12_VK_NVX_IMAGE_VIEW_HANDLE:
             ret_val = device->vk_info.NVX_image_view_handle;
             break;
+        case D3D12_VK_NV_LOW_LATENCY_2:
+            ret_val = device->vk_info.NV_low_latency2;
+            break;
         default:
             WARN("Invalid extension %x\n", extension);
     }
@@ -82,7 +85,7 @@ static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetExtensionSupport(ID3D12D
     return ret_val;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CreateCubinComputeShaderWithName(ID3D12DeviceExt *iface, const void *cubin_data,
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CreateCubinComputeShaderWithName(d3d12_device_vkd3d_ext_iface *iface, const void *cubin_data,
        UINT32 cubin_size, UINT32 block_x, UINT32 block_y, UINT32 block_z, const char *shader_name, D3D12_CUBIN_DATA_HANDLE **out_handle)
 {
     VkCuFunctionCreateInfoNVX functionCreateInfo = { VK_STRUCTURE_TYPE_CU_FUNCTION_CREATE_INFO_NVX };
@@ -129,7 +132,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CreateCubinComputeShader
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_DestroyCubinComputeShader(ID3D12DeviceExt *iface, D3D12_CUBIN_DATA_HANDLE *handle)
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_DestroyCubinComputeShader(d3d12_device_vkd3d_ext_iface *iface, D3D12_CUBIN_DATA_HANDLE *handle)
 {   
     const struct vkd3d_vk_device_procs *vk_procs;
     struct d3d12_device *device;
@@ -149,7 +152,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_DestroyCubinComputeShade
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetCudaTextureObject(ID3D12DeviceExt *iface, D3D12_CPU_DESCRIPTOR_HANDLE srv_handle,
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetCudaTextureObject(d3d12_device_vkd3d_ext_iface *iface, D3D12_CPU_DESCRIPTOR_HANDLE srv_handle,
        D3D12_CPU_DESCRIPTOR_HANDLE sampler_handle, UINT32 *cuda_texture_handle)
 {
     VkImageViewHandleInfoNVX imageViewHandleInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX };
@@ -177,7 +180,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetCudaTextureObject(ID3
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetCudaSurfaceObject(ID3D12DeviceExt *iface, D3D12_CPU_DESCRIPTOR_HANDLE uav_handle, 
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetCudaSurfaceObject(d3d12_device_vkd3d_ext_iface *iface, D3D12_CPU_DESCRIPTOR_HANDLE uav_handle, 
         UINT32 *cuda_surface_handle)
 {
     VkImageViewHandleInfoNVX imageViewHandleInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX };
@@ -202,7 +205,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetCudaSurfaceObject(ID3
 
 extern VKD3D_THREAD_LOCAL struct D3D12_UAV_INFO *d3d12_uav_info;
 
-static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CaptureUAVInfo(ID3D12DeviceExt *iface, D3D12_UAV_INFO *uav_info)
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CaptureUAVInfo(d3d12_device_vkd3d_ext_iface *iface, D3D12_UAV_INFO *uav_info)
 {
     if (!uav_info)
        return E_INVALIDARG;
@@ -416,4 +419,175 @@ CONST_VTBL struct ID3D12DXVKInteropDeviceVtbl d3d12_dxvk_interop_device_vtbl =
     d3d12_dxvk_interop_device_GetVulkanResourceInfo,
     d3d12_dxvk_interop_device_LockCommandQueue,
     d3d12_dxvk_interop_device_UnlockCommandQueue,
+};
+
+static inline struct d3d12_device *d3d12_device_from_ID3DLowLatencyDevice(d3d_low_latency_device_iface *iface)
+{
+    return CONTAINING_RECORD(iface, struct d3d12_device, ID3DLowLatencyDevice_iface);
+}
+
+ULONG STDMETHODCALLTYPE d3d12_low_latency_device_AddRef(d3d_low_latency_device_iface *iface)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3DLowLatencyDevice(iface);
+    return d3d12_device_add_ref(device);
+}
+
+static ULONG STDMETHODCALLTYPE d3d12_low_latency_device_Release(d3d_low_latency_device_iface *iface)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3DLowLatencyDevice(iface);
+    return d3d12_device_release(device);
+}
+
+extern HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
+        REFIID riid, void **object);
+
+static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_QueryInterface(d3d_low_latency_device_iface *iface,
+        REFIID iid, void **out)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3DLowLatencyDevice(iface);
+    TRACE("iface %p, iid %s, out %p.\n", iface, debugstr_guid(iid), out);
+    return d3d12_device_QueryInterface(&device->ID3D12Device_iface, iid, out);
+}
+
+static BOOL STDMETHODCALLTYPE d3d12_low_latency_device_SupportsLowLatency(d3d_low_latency_device_iface *iface)
+{
+    struct d3d12_device *device;
+
+    device = d3d12_device_from_ID3DLowLatencyDevice(iface);
+
+    return device->vk_info.NV_low_latency2;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_LatencySleep(d3d_low_latency_device_iface *iface)
+{
+    struct d3d12_device *device;
+    struct dxgi_vk_swap_chain *low_latency_swapchain;
+
+    device = d3d12_device_from_ID3DLowLatencyDevice(iface);
+
+    if (!device->vk_info.NV_low_latency2)
+        return E_NOTIMPL;
+
+    spinlock_acquire(&device->low_latency_swapchain_spinlock);
+    if ((low_latency_swapchain = device->swapchain_info.low_latency_swapchain))
+        dxgi_vk_swap_chain_incref(low_latency_swapchain);
+    spinlock_release(&device->low_latency_swapchain_spinlock);
+
+    if (low_latency_swapchain)
+    {
+        dxgi_vk_swap_chain_latency_sleep(low_latency_swapchain);
+        dxgi_vk_swap_chain_decref(low_latency_swapchain);
+    }
+
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencySleepMode(d3d_low_latency_device_iface *iface, BOOL low_latency_mode, BOOL low_latency_boost,
+        UINT32 minimum_interval_us)
+{
+    struct d3d12_device *device;
+    struct dxgi_vk_swap_chain *low_latency_swapchain;
+
+    device = d3d12_device_from_ID3DLowLatencyDevice(iface);
+
+    if (!device->vk_info.NV_low_latency2)
+        return E_NOTIMPL;
+
+    spinlock_acquire(&device->low_latency_swapchain_spinlock);
+    if ((low_latency_swapchain = device->swapchain_info.low_latency_swapchain))
+        dxgi_vk_swap_chain_incref(low_latency_swapchain);
+    spinlock_release(&device->low_latency_swapchain_spinlock);
+
+    if (low_latency_swapchain)
+    {
+        dxgi_vk_swap_chain_set_latency_sleep_mode(low_latency_swapchain, low_latency_mode, low_latency_boost, minimum_interval_us);
+        dxgi_vk_swap_chain_decref(low_latency_swapchain);
+    }
+
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_low_latency_device_iface *iface, UINT64 frameID, UINT32 markerType)
+{
+    uint64_t internal_frame_id;
+    struct d3d12_device *device;
+    VkLatencyMarkerNV vk_marker;
+    struct dxgi_vk_swap_chain *low_latency_swapchain;
+
+    device = d3d12_device_from_ID3DLowLatencyDevice(iface);
+    vk_marker = (VkLatencyMarkerNV)markerType;
+
+    if (!device->vk_info.NV_low_latency2)
+        return E_NOTIMPL;
+
+    /* Offset the frameID by one to ensure it will always
+     * be a valid presentID */
+    internal_frame_id = frameID + 1;
+
+    switch (vk_marker)
+    {
+        case VK_LATENCY_MARKER_SIMULATION_START_NV:
+            device->frame_markers.simulation = internal_frame_id;
+            break;
+        case VK_LATENCY_MARKER_RENDERSUBMIT_START_NV:
+            device->frame_markers.render = internal_frame_id;
+            break;
+        case VK_LATENCY_MARKER_PRESENT_START_NV:
+            device->frame_markers.present = internal_frame_id;
+            break;
+        default:
+            break;
+    }
+
+    spinlock_acquire(&device->low_latency_swapchain_spinlock);
+    if ((low_latency_swapchain = device->swapchain_info.low_latency_swapchain))
+        dxgi_vk_swap_chain_incref(low_latency_swapchain);
+    spinlock_release(&device->low_latency_swapchain_spinlock);
+
+    if (low_latency_swapchain)
+    {
+        dxgi_vk_swap_chain_set_latency_marker(low_latency_swapchain, internal_frame_id, vk_marker);
+        dxgi_vk_swap_chain_decref(low_latency_swapchain);
+    }
+
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_GetLatencyInfo(d3d_low_latency_device_iface *iface, D3D12_LATENCY_RESULTS *latency_results)
+{
+    struct d3d12_device *device;
+    struct dxgi_vk_swap_chain *low_latency_swapchain;
+
+    device = d3d12_device_from_ID3DLowLatencyDevice(iface);
+
+    if (!device->vk_info.NV_low_latency2)
+        return E_NOTIMPL;
+
+    spinlock_acquire(&device->low_latency_swapchain_spinlock);
+    if ((low_latency_swapchain = device->swapchain_info.low_latency_swapchain))
+        dxgi_vk_swap_chain_incref(low_latency_swapchain);
+    spinlock_release(&device->low_latency_swapchain_spinlock);
+
+    if (low_latency_swapchain)
+    {
+        dxgi_vk_swap_chain_get_latency_info(low_latency_swapchain, latency_results);
+        dxgi_vk_swap_chain_decref(low_latency_swapchain);
+    }
+
+    return S_OK;
+}
+
+CONST_VTBL struct ID3DLowLatencyDeviceVtbl d3d_low_latency_device_vtbl =
+{
+    /* IUnknown methods */
+    d3d12_low_latency_device_QueryInterface,
+    d3d12_low_latency_device_AddRef,
+    d3d12_low_latency_device_Release,
+
+    /* ID3DLowLatencyDevice methods */
+    d3d12_low_latency_device_SupportsLowLatency,
+    d3d12_low_latency_device_LatencySleep,
+    d3d12_low_latency_device_SetLatencySleepMode,
+    d3d12_low_latency_device_SetLatencyMarker,
+    d3d12_low_latency_device_GetLatencyInfo
 };

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -60,6 +60,7 @@ vkd3d_src = [
   'cache.c',
   'command.c',
   'command_list_vkd3d_ext.c',
+  'command_queue_vkd3d_ext.c',
   'device.c',
   'device_vkd3d_ext.c',
   'heap.c',

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -481,8 +481,8 @@ static ULONG STDMETHODCALLTYPE dxgi_vk_swap_chain_Release(IDXGIVkSwapChain *ifac
         if (device->vk_info.NV_low_latency2)
             d3d12_device_remove_swapchain(device, chain);
 
-        dxgi_vk_swap_chain_decref(chain);
         ID3D12CommandQueue_Release(&chain->queue->ID3D12CommandQueue_iface);
+        dxgi_vk_swap_chain_decref(chain);
     }
 
     return refcount;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3031,7 +3031,7 @@ struct vkd3d_queue
 VkQueue vkd3d_queue_acquire(struct vkd3d_queue *queue);
 HRESULT vkd3d_queue_create(struct d3d12_device *device, uint32_t family_index, uint32_t queue_index,
         const VkQueueFamilyProperties *properties, struct vkd3d_queue **queue);
-void vkd3d_set_queue_out_of_band(struct d3d12_device *device, struct vkd3d_queue *queue);
+void vkd3d_set_queue_out_of_band(struct d3d12_device *device, struct vkd3d_queue *queue, VkOutOfBandQueueTypeNV type);
 void vkd3d_queue_destroy(struct vkd3d_queue *queue, struct d3d12_device *device);
 void vkd3d_queue_release(struct vkd3d_queue *queue);
 void vkd3d_queue_add_wait(struct vkd3d_queue *queue, d3d12_fence_iface *waiter,

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -354,6 +354,13 @@ VK_DEVICE_EXT_PFN(vkCmdDecompressMemoryIndirectCountNV)
 /* VK_EXT_device_fault */
 VK_DEVICE_EXT_PFN(vkGetDeviceFaultInfoEXT)
 
+/* VK_NV_low_latency2 */
+VK_DEVICE_EXT_PFN(vkSetLatencySleepModeNV)
+VK_DEVICE_EXT_PFN(vkLatencySleepNV)
+VK_DEVICE_EXT_PFN(vkSetLatencyMarkerNV)
+VK_DEVICE_EXT_PFN(vkGetLatencyTimingsNV)
+VK_DEVICE_EXT_PFN(vkQueueNotifyOutOfBandNV)
+
 #undef VK_INSTANCE_PFN
 #undef VK_INSTANCE_EXT_PFN
 #undef VK_DEVICE_PFN


### PR DESCRIPTION
This pull request implements a new device interface called ID3DLowLatencyDevice, and ID3D12CommandQueueExt using the VK_NV_low_latency2 extension. The purpose of these interfaces, is to give dxvk-nvapi a way to implement the nvapi Reflex interface.