### PR TITLE
Workaround RADV hangs in Lords of the Fallen

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -416,6 +416,9 @@ enum vkd3d_shader_quirk
 
     /* Driver workaround hackery. Try to rewrite weird Grads to plain Bias. */
     VKD3D_SHADER_QUIRK_REWRITE_GRAD_TO_BIAS = (1 << 12),
+
+    /* Driver workarounds. Force loops to not be unrolled with SPIR-V control masks. */
+    VKD3D_SHADER_QUIRK_FORCE_LOOP = (1 << 13),
 };
 
 struct vkd3d_shader_quirk_hash

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -776,6 +776,18 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
         }
     }
 
+    if (quirks & VKD3D_SHADER_QUIRK_FORCE_LOOP)
+    {
+        struct dxil_spv_option_branch_control helper = { { DXIL_SPV_OPTION_BRANCH_CONTROL } };
+        helper.force_loop = DXIL_SPV_TRUE;
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            WARN("dxil-spirv does not support BRANCH_CONTROL.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
     if (compiler_args)
     {
         for (i = 0; i < compiler_args->target_extension_count; i++)
@@ -1365,6 +1377,18 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
         if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
         {
             WARN("dxil-spirv does not support PRECISE_CONTROL.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
+    if (quirks & VKD3D_SHADER_QUIRK_FORCE_LOOP)
+    {
+        struct dxil_spv_option_branch_control helper = { { DXIL_SPV_OPTION_BRANCH_CONTROL } };
+        helper.force_loop = DXIL_SPV_TRUE;
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            WARN("dxil-spirv does not support BRANCH_CONTROL.\n");
             ret = VKD3D_ERROR_NOT_IMPLEMENTED;
             goto end;
         }

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -619,9 +619,19 @@ static const struct vkd3d_shader_quirk_info mhr_quirks = {
     mhr_hashes, ARRAY_SIZE(mhr_hashes), 0,
 };
 
+static const struct vkd3d_shader_quirk_hash lotf_hashes[] = {
+    /* Temporarily works around RADV bug. GPU will hang on these
+     * due to a miscompilation of some loops. */
+    { 0x99d322acc782d539, VKD3D_SHADER_QUIRK_FORCE_LOOP },
+    { 0x21456c748ae88ea9, VKD3D_SHADER_QUIRK_FORCE_LOOP },
+    { 0x710945244ce6ac3e, VKD3D_SHADER_QUIRK_FORCE_LOOP },
+};
+
+static const struct vkd3d_shader_quirk_info lotf_quirks = {
+    lotf_hashes, ARRAY_SIZE(lotf_hashes), 0,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
-    /* Unreal Engine 4 */
-    { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
     /* F1 2019 (928600) */
@@ -638,6 +648,10 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "re4.exe", &re4_quirks },
     /* Monster Hunter Rise (1446780) */
     { VKD3D_STRING_COMPARE_EXACT, "MonsterHunterRise.exe", &mhr_quirks },
+    /* Lords of the Fallen (1501750) */
+    { VKD3D_STRING_COMPARE_EXACT, "LOTF2-Win64-Shipping.exe", &lotf_quirks },
+    /* Unreal Engine 4 */
+    { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* MSVC fails to compile empty array. */
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };


### PR DESCRIPTION
dxil-spirv now has support for forced control flow hints, and not unrolling some chungus loops works around a hang in short term.