### PR TITLE
Sampler feedback implementation - Phase 6

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3630,6 +3630,15 @@ static HRESULT d3d12_device_get_format_support(struct d3d12_device *device, D3D1
         return E_INVALIDARG;
     }
 
+    /* Special opaque formats. */
+    if (data->Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ||
+            data->Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE)
+    {
+        data->Support1 = D3D12_FORMAT_SUPPORT1_TEXTURE2D | D3D12_FORMAT_SUPPORT1_MIP;
+        data->Support2 = D3D12_FORMAT_SUPPORT2_SAMPLER_FEEDBACK;
+        return S_OK;
+    }
+
     image_features = format->vk_format_features;
 
     if (format->vk_format_features_buffer)

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2464,6 +2464,54 @@ HRESULT d3d12_resource_validate_desc(const D3D12_RESOURCE_DESC1 *desc,
         return E_INVALIDARG;
     }
 
+    /* There are special validation rules for sampler feedback. */
+    if (d3d12_resource_desc_is_sampler_feedback(desc))
+    {
+        if (device->d3d12_caps.options7.SamplerFeedbackTier == D3D12_SAMPLER_FEEDBACK_TIER_NOT_SUPPORTED)
+        {
+            WARN("Sampler feedback not supported.\n");
+            return E_INVALIDARG;
+        }
+
+        if (desc->SamplerFeedbackMipRegion.Width < 4 || desc->SamplerFeedbackMipRegion.Height < 4)
+        {
+            WARN("Sampler feedback mip region must be at least 4x4.\n");
+            return E_INVALIDARG;
+        }
+
+        if (desc->SamplerFeedbackMipRegion.Depth > 1)
+        {
+            WARN("Sampler feedback mip region depth must be 0 or 1.\n");
+            return E_INVALIDARG;
+        }
+
+        if (desc->SamplerFeedbackMipRegion.Width * 2 > desc->Width ||
+                desc->SamplerFeedbackMipRegion.Height * 2 > desc->Height)
+        {
+            WARN("Sampler feedback mip region must not be larger than half the texture size.\n");
+            return E_INVALIDARG;
+        }
+
+        if ((desc->SamplerFeedbackMipRegion.Width & (desc->SamplerFeedbackMipRegion.Width - 1)) ||
+                (desc->SamplerFeedbackMipRegion.Height & (desc->SamplerFeedbackMipRegion.Height - 1)))
+        {
+            WARN("Sampler feedback mip region must be POT.\n");
+            return E_INVALIDARG;
+        }
+
+        if (desc->Flags & (D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL | D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET))
+        {
+            WARN("Sampler feedback image cannot declare RTV/DSV usage.\n");
+            return E_INVALIDARG;
+        }
+
+        if (desc->Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D)
+        {
+            WARN("Sampler feedback image must be 2D.\n");
+            return E_INVALIDARG;
+        }
+    }
+
     switch (desc->Dimension)
     {
         case D3D12_RESOURCE_DIMENSION_BUFFER:

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -122,6 +122,9 @@ static const struct vkd3d_format vkd3d_formats[] =
     {DXGI_FORMAT_BC7_UNORM_SRGB,        VK_FORMAT_BC7_SRGB_BLOCK,           1,  4, 4, 16, COLOR, 1},
     {DXGI_FORMAT_B4G4R4A4_UNORM,        VK_FORMAT_A4R4G4B4_UNORM_PACK16,    2,  1, 1,  1, COLOR, 1},
     {DXGI_FORMAT_A4B4G4R4_UNORM,        VK_FORMAT_R4G4B4A4_UNORM_PACK16,    2,  1, 1,  1, COLOR, 1},
+
+    {DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE, VK_FORMAT_R32G32_UINT, 8,  1, 1,  1, COLOR, 1},
+    {DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE, VK_FORMAT_R32G32_UINT, 8,  1, 1,  1, COLOR, 1},
 };
 
 static const struct vkd3d_format_footprint depth_stencil_copy_footprints[] =
@@ -384,6 +387,13 @@ dxgi_format_compatibility_list[] =
             {DXGI_FORMAT_BC7_UNORM_SRGB}},
     {DXGI_FORMAT_BC7_UNORM_SRGB,
             {DXGI_FORMAT_BC7_UNORM}},
+
+    /* Internal implementation detail. We desire 64-bit atomics and R32G32 UAV will trigger that compat
+     * similar to other 64-bit images. */
+    {DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE,
+            {DXGI_FORMAT_R32G32_UINT}},
+    {DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE,
+            {DXGI_FORMAT_R32G32_UINT}},
 };
 
 void vkd3d_format_compatibility_list_add_format(struct vkd3d_format_compatibility_list *list, VkFormat vk_format)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4890,6 +4890,17 @@ static inline unsigned int d3d12_resource_desc_get_layer_count(const D3D12_RESOU
     return desc->Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D ? desc->DepthOrArraySize : 1;
 }
 
+static inline bool d3d12_resource_desc_is_sampler_feedback(const D3D12_RESOURCE_DESC1 *desc)
+{
+    return desc->Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ||
+            desc->Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE;
+}
+
+static inline unsigned int d3d12_resource_desc_get_active_level_count(const D3D12_RESOURCE_DESC1 *desc)
+{
+    return d3d12_resource_desc_is_sampler_feedback(desc) ? 1 : desc->MipLevels;
+}
+
 static inline unsigned int d3d12_resource_desc_get_sub_resource_count_per_plane(const D3D12_RESOURCE_DESC1 *desc)
 {
     return d3d12_resource_desc_get_layer_count(desc) * desc->MipLevels;


### PR DESCRIPTION
Start adding some simple implementation details:

- Some helper functions to deduce information from a resource desc.
- Format compat info. A sampler feedback instruction is a 64-bit UAV for us (via a R32G32_UINT, just like normal 64-bit UAV).
- Add format feature query.
- Add resource desc validation.