### PR TITLE
Sampler feedback implementation - Phase 8

### DIFF
--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -34,6 +34,13 @@ vkd3d_shaders =[
   'shaders/cs_execute_indirect_patch_debug_ring.comp',
   'shaders/cs_execute_indirect_multi_dispatch.comp',
   'shaders/cs_execute_indirect_multi_dispatch_state.comp',
+
+  'shaders/cs_sampler_feedback_decode_buffer_min_mip.comp',
+  'shaders/fs_sampler_feedback_decode_image_min_mip.frag',
+  'shaders/fs_sampler_feedback_decode_image_mip_used.frag',
+  'shaders/cs_sampler_feedback_encode_buffer_min_mip.comp',
+  'shaders/cs_sampler_feedback_encode_image_min_mip.comp',
+  'shaders/cs_sampler_feedback_encode_image_mip_used.comp'
 ]
 
 vkd3d_src = [

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -1468,6 +1468,207 @@ static void vkd3d_dstorage_ops_cleanup(struct vkd3d_dstorage_ops *dstorage_ops, 
     VK_CALL(vkDestroyPipelineLayout(device->vk_device, dstorage_ops->vk_emit_nv_memory_decompression_regions_layout, NULL));
 }
 
+static HRESULT vkd3d_sampler_feedback_ops_init(struct vkd3d_sampler_feedback_resolve_ops *sampler_feedback_ops,
+        struct d3d12_device *device)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    VkDescriptorSetLayoutBinding decode_bindings[2];
+    VkDescriptorSetLayoutBinding encode_bindings[3];
+    VkPushConstantRange push_range;
+    VkPipelineLayout vk_layout;
+    VkShaderModule vk_module;
+    VkSampler vk_sampler;
+    unsigned int i;
+    VkResult vr;
+
+    static const struct pipeline
+    {
+        enum vkd3d_sampler_feedback_resolve_type type;
+        const uint32_t *code;
+        size_t code_size;
+        bool is_encode;
+        bool is_compute;
+    } pipelines[] = {
+        {
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER,
+            cs_sampler_feedback_decode_buffer_min_mip,
+            sizeof(cs_sampler_feedback_decode_buffer_min_mip),
+            false, true,
+        },
+        {
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE,
+            fs_sampler_feedback_decode_image_min_mip,
+            sizeof(fs_sampler_feedback_decode_image_min_mip),
+            false, false,
+        },
+        {
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE,
+            fs_sampler_feedback_decode_image_mip_used,
+            sizeof(fs_sampler_feedback_decode_image_mip_used),
+            false, false,
+        },
+        {
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_BUFFER_TO_MIN_MIP,
+            cs_sampler_feedback_encode_buffer_min_mip,
+            sizeof(cs_sampler_feedback_encode_buffer_min_mip),
+            true, true,
+        },
+        {
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIN_MIP,
+            cs_sampler_feedback_encode_image_min_mip,
+            sizeof(cs_sampler_feedback_encode_image_min_mip),
+            true, true,
+        },
+        {
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIP_USED,
+            cs_sampler_feedback_encode_image_mip_used,
+            sizeof(cs_sampler_feedback_encode_image_mip_used),
+            true, true,
+        },
+    };
+
+    memset(decode_bindings, 0, sizeof(decode_bindings));
+    memset(encode_bindings, 0, sizeof(encode_bindings));
+
+    if ((vr = vkd3d_meta_create_sampler(device, VK_FILTER_NEAREST, &vk_sampler)))
+        return hresult_from_vk_result(vr);
+
+    decode_bindings[0].binding = 0;
+    decode_bindings[0].descriptorCount = 1;
+    decode_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+    decode_bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+    decode_bindings[1].binding = 1;
+    decode_bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_COMPUTE_BIT;
+    decode_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    decode_bindings[1].descriptorCount = 1;
+    decode_bindings[1].pImmutableSamplers = &vk_sampler;
+
+    encode_bindings[0].binding = 0;
+    encode_bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    encode_bindings[0].descriptorCount = 1;
+    encode_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+
+    encode_bindings[1].binding = 1;
+    encode_bindings[1].descriptorCount = 1;
+    encode_bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    encode_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    encode_bindings[1].pImmutableSamplers = &vk_sampler;
+
+    encode_bindings[2].binding = 2;
+    encode_bindings[2].descriptorCount = 1;
+    encode_bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    encode_bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+
+    if ((vr = vkd3d_meta_create_descriptor_set_layout(device,
+            ARRAY_SIZE(decode_bindings), decode_bindings,
+            true, &sampler_feedback_ops->vk_decode_set_layout)))
+        return hresult_from_vk_result(vr);
+
+    if ((vr = vkd3d_meta_create_descriptor_set_layout(device,
+            ARRAY_SIZE(encode_bindings), encode_bindings,
+            true, &sampler_feedback_ops->vk_encode_set_layout)))
+        return hresult_from_vk_result(vr);
+
+    push_range.offset = 0;
+
+    push_range.size = sizeof(struct vkd3d_sampler_feedback_resolve_encode_args);
+    push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    if ((vr = vkd3d_meta_create_pipeline_layout(device,
+            1, &sampler_feedback_ops->vk_encode_set_layout,
+            1, &push_range,
+            &sampler_feedback_ops->vk_compute_encode_layout)))
+        return hresult_from_vk_result(vr);
+
+    push_range.size = sizeof(struct vkd3d_sampler_feedback_resolve_decode_args);
+    push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    if ((vr = vkd3d_meta_create_pipeline_layout(device,
+            1, &sampler_feedback_ops->vk_decode_set_layout,
+            1, &push_range,
+            &sampler_feedback_ops->vk_compute_decode_layout)))
+        return hresult_from_vk_result(vr);
+
+    push_range.size = sizeof(struct vkd3d_sampler_feedback_resolve_decode_args);
+    push_range.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    if ((vr = vkd3d_meta_create_pipeline_layout(device,
+            1, &sampler_feedback_ops->vk_decode_set_layout,
+            1, &push_range,
+            &sampler_feedback_ops->vk_graphics_decode_layout)))
+        return hresult_from_vk_result(vr);
+
+    for (i = 0; i < ARRAY_SIZE(pipelines); i++)
+    {
+        if (pipelines[i].is_compute)
+        {
+            vk_layout = pipelines[i].is_encode ?
+                    sampler_feedback_ops->vk_compute_encode_layout :
+                    sampler_feedback_ops->vk_compute_decode_layout;
+
+            if ((vr = vkd3d_meta_create_compute_pipeline(device, pipelines[i].code_size,
+                    pipelines[i].code, vk_layout,
+                    NULL, true, &sampler_feedback_ops->vk_pipelines[pipelines[i].type])))
+                return hresult_from_vk_result(vr);
+        }
+        else
+        {
+            if ((vr = vkd3d_meta_create_shader_module(device, pipelines[i].code, pipelines[i].code_size, &vk_module)))
+                return hresult_from_vk_result(vr);
+
+            if ((vr = vkd3d_meta_create_graphics_pipeline(&device->meta_ops,
+                    sampler_feedback_ops->vk_graphics_decode_layout,
+                    VK_FORMAT_R8_UINT, VK_FORMAT_UNDEFINED, VK_IMAGE_ASPECT_COLOR_BIT, VK_NULL_HANDLE, vk_module,
+                    VK_SAMPLE_COUNT_1_BIT, NULL, NULL, true,
+                    &sampler_feedback_ops->vk_pipelines[pipelines[i].type])))
+            {
+                VK_CALL(vkDestroyShaderModule(device->vk_device, vk_module, NULL));
+                return hresult_from_vk_result(vr);
+            }
+
+            VK_CALL(vkDestroyShaderModule(device->vk_device, vk_module, NULL));
+        }
+    }
+
+    return S_OK;
+}
+
+void vkd3d_meta_get_sampler_feedback_resolve_pipeline(struct vkd3d_meta_ops *meta_ops,
+        enum vkd3d_sampler_feedback_resolve_type type, struct vkd3d_sampler_feedback_resolve_info *info)
+{
+    info->vk_pipeline = meta_ops->sampler_feedback.vk_pipelines[type];
+
+    switch (type)
+    {
+        case VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE:
+        case VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE:
+            info->vk_layout = meta_ops->sampler_feedback.vk_graphics_decode_layout;
+            break;
+
+        case VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER:
+            info->vk_layout = meta_ops->sampler_feedback.vk_compute_decode_layout;
+            break;
+
+        default:
+            info->vk_layout = meta_ops->sampler_feedback.vk_compute_encode_layout;
+            break;
+    }
+}
+
+static void vkd3d_sampler_feedback_ops_cleanup(struct vkd3d_sampler_feedback_resolve_ops *sampler_feedback_ops,
+        struct d3d12_device *device)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    unsigned int i;
+
+    VK_CALL(vkDestroyPipelineLayout(device->vk_device, sampler_feedback_ops->vk_compute_decode_layout, NULL));
+    VK_CALL(vkDestroyPipelineLayout(device->vk_device, sampler_feedback_ops->vk_compute_encode_layout, NULL));
+    VK_CALL(vkDestroyPipelineLayout(device->vk_device, sampler_feedback_ops->vk_graphics_decode_layout, NULL));
+    VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, sampler_feedback_ops->vk_encode_set_layout, NULL));
+    VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, sampler_feedback_ops->vk_decode_set_layout, NULL));
+
+    for (i = 0; i < ARRAY_SIZE(sampler_feedback_ops->vk_pipelines); i++)
+        VK_CALL(vkDestroyPipeline(device->vk_device, sampler_feedback_ops->vk_pipelines[i], NULL));
+}
+
 HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device *device)
 {
     HRESULT hr;
@@ -1502,8 +1703,13 @@ HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device
     if (FAILED(hr = vkd3d_dstorage_ops_init(&meta_ops->dstorage, device)))
         goto fail_dstorage_ops;
 
+    if (FAILED(hr = vkd3d_sampler_feedback_ops_init(&meta_ops->sampler_feedback, device)))
+        goto fail_sampler_feedback;
+
     return S_OK;
 
+fail_sampler_feedback:
+    vkd3d_dstorage_ops_cleanup(&meta_ops->dstorage, device);
 fail_dstorage_ops:
     vkd3d_multi_dispatch_indirect_ops_cleanup(&meta_ops->multi_dispatch_indirect, device);
 fail_multi_dispatch_indirect_ops:
@@ -1526,6 +1732,7 @@ fail_common:
 
 HRESULT vkd3d_meta_ops_cleanup(struct vkd3d_meta_ops *meta_ops, struct d3d12_device *device)
 {
+    vkd3d_sampler_feedback_ops_cleanup(&meta_ops->sampler_feedback, device);
     vkd3d_dstorage_ops_cleanup(&meta_ops->dstorage, device);
     vkd3d_multi_dispatch_indirect_ops_cleanup(&meta_ops->multi_dispatch_indirect, device);
     vkd3d_execute_indirect_ops_cleanup(&meta_ops->execute_indirect, device);

--- a/libs/vkd3d/shaders/cs_sampler_feedback_decode_buffer_min_mip.comp
+++ b/libs/vkd3d/shaders/cs_sampler_feedback_decode_buffer_min_mip.comp
@@ -1,0 +1,18 @@
+#version 450
+layout(local_size_x = 8, local_size_y = 8) in;
+
+#extension GL_GOOGLE_include_directive : require
+#include "sampler_feedback_decode.h"
+
+layout(set = 0, binding = 0, r8ui) uniform writeonly uimageBuffer OutputBuffer;
+
+void main()
+{
+	ivec2 icoord = ivec2(gl_GlobalInvocationID.xy);
+
+	if (any(greaterThanEqual(icoord, resolution)))
+		return;
+
+	int result = sampler_feedback_decode_min_mip(icoord, 0.0);
+	imageStore(OutputBuffer, icoord.y * resolution.x + icoord.x, uvec4(result));
+}

--- a/libs/vkd3d/shaders/cs_sampler_feedback_encode_buffer_min_mip.comp
+++ b/libs/vkd3d/shaders/cs_sampler_feedback_encode_buffer_min_mip.comp
@@ -1,0 +1,18 @@
+#version 450
+layout(local_size_x = 8, local_size_y = 8) in;
+
+#extension GL_GOOGLE_include_directive : require
+#include "sampler_feedback_encode.h"
+
+layout(set = 0, binding = 2) uniform utextureBuffer InputBuffer;
+
+void main()
+{
+	ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+	if (all(lessThan(coord, resolution)))
+	{
+		uint value = texelFetch(InputBuffer, int(coord.y * resolution.x + coord.x)).x;
+		sampler_feedback_encode_min_mip(coord, 0, value);
+	}
+}
+

--- a/libs/vkd3d/shaders/cs_sampler_feedback_encode_image_min_mip.comp
+++ b/libs/vkd3d/shaders/cs_sampler_feedback_encode_image_min_mip.comp
@@ -1,0 +1,19 @@
+#version 450
+layout(local_size_x = 8, local_size_y = 8) in;
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_samplerless_texture_functions : require
+#include "sampler_feedback_encode.h"
+
+layout(set = 0, binding = 1) uniform utexture2DArray InputBuffer;
+
+void main()
+{
+	ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+	if (all(lessThan(coord, resolution)))
+	{
+		uint value = texelFetch(InputBuffer, ivec3(coord + src_offset, gl_WorkGroupID.z), src_mip).x;
+		sampler_feedback_encode_min_mip(coord, int(gl_WorkGroupID.z), value);
+	}
+}
+

--- a/libs/vkd3d/shaders/cs_sampler_feedback_encode_image_mip_used.comp
+++ b/libs/vkd3d/shaders/cs_sampler_feedback_encode_image_mip_used.comp
@@ -1,0 +1,19 @@
+#version 450
+layout(local_size_x = 8, local_size_y = 8) in;
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_samplerless_texture_functions : require
+#include "sampler_feedback_encode.h"
+
+layout(set = 0, binding = 1) uniform utexture2DArray InputBuffer;
+
+void main()
+{
+	ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+	if (all(lessThan(coord, resolution)))
+	{
+		uint value = texelFetch(InputBuffer, ivec3(coord + src_offset, gl_WorkGroupID.z), src_mip).x;
+		sampler_feedback_encode_mip_used(coord, int(gl_WorkGroupID.z), value != 0);
+	}
+}
+

--- a/libs/vkd3d/shaders/fs_sampler_feedback_decode_image_min_mip.frag
+++ b/libs/vkd3d/shaders/fs_sampler_feedback_decode_image_min_mip.frag
@@ -1,0 +1,14 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+#define ARRAY
+#include "sampler_feedback_decode.h"
+
+layout(location = 0) out uint Output;
+
+void main()
+{
+	ivec2 icoord = ivec2(gl_FragCoord.xy) - dst_offset; // Compensate for viewport offset.
+	int result = sampler_feedback_decode_min_mip(icoord, float(gl_Layer));
+	Output = uint(result);
+}

--- a/libs/vkd3d/shaders/fs_sampler_feedback_decode_image_mip_used.frag
+++ b/libs/vkd3d/shaders/fs_sampler_feedback_decode_image_mip_used.frag
@@ -1,0 +1,14 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+#define ARRAY
+#include "sampler_feedback_decode.h"
+
+layout(location = 0) out uint Output;
+
+void main()
+{
+	ivec2 icoord = ivec2(gl_FragCoord.xy) - dst_offset; // Compensate for viewport offset.
+	bool result = sampler_feedback_decode_mip_used(icoord, mip_level, float(gl_Layer));
+	Output = result ? 0xffu : 0u;
+}

--- a/libs/vkd3d/shaders/sampler_feedback_decode.h
+++ b/libs/vkd3d/shaders/sampler_feedback_decode.h
@@ -1,0 +1,148 @@
+#ifndef SAMPLER_FEEDBACK_DECODE_MIN_MIP_H_
+#define SAMPLER_FEEDBACK_DECODE_MIN_MIP_H_
+
+layout(push_constant, std430) uniform Registers
+{
+	ivec2 src_offset;
+	ivec2 dst_offset;
+	ivec2 resolution;
+	ivec2 paired_resolution;
+	vec2 inv_paired_resolution;
+	vec2 inv_feedback_resolution;
+	int mip_levels;
+	int mip_level;
+};
+
+#ifdef ARRAY
+layout(set = 0, binding = 1) uniform usampler2DArray Input;
+#else
+layout(set = 0, binding = 1) uniform usampler2D Input;
+#endif
+
+bool fetch_mip(vec2 unnormalized_feedback_coord, int mip, float layer)
+{
+	// Sample such that we get bottom-right (Y) as target region,
+	// and the potential neighbors in top-left (W), left (X) and up (Z).
+	// If we detect any writes in those neighbors, propagate them to the bottom-right.
+	// By flooring the integer coordinate, we get the behavior we want.
+
+#ifdef ARRAY
+	vec3 fcoord = vec3(unnormalized_feedback_coord * inv_feedback_resolution, layer);
+#else
+	vec2 fcoord = unnormalized_feedback_coord * inv_feedback_resolution;
+#endif
+
+	uvec4 values;
+	if (mip >= 8)
+	{
+		values = textureGather(Input, fcoord, 1);
+		mip -= 8;
+	}
+	else
+	{
+		values = textureGather(Input, fcoord, 0);
+	}
+
+	// Shift down to get the mip level we care about. Every mip gets 4 bits of data.
+	// This is enough for 16 mips.
+	uvec4 per_mip_bits = bitfieldExtract(values, 4 * mip, 4);
+
+	// Check self-access and neighbor access.
+	// Clamp behavior is okay here. If we intend sample region (0, 0)
+	// there cannot be neighbor access unless we also have self-access,
+	// so false positive is not possible here.
+
+	const uint HORIZ = 2;
+	const uint VERT = 4;
+	const uint DIAG = 8;
+	const uint SELF = 1;
+	return any(notEqual(per_mip_bits & uvec4(HORIZ, SELF, VERT, DIAG), uvec4(0)));
+}
+
+int sampler_feedback_decode_min_mip(ivec2 icoord, float layer)
+{
+	// Use a small epsilon here so that POT scaling does not add false positives, or we get funny rounding errors.
+	// Aim to sample at corners, but not *exactly* at corners to avoid straddling into regions we don't really care about.
+	// This epsilon is computed in FP32, *not* in subtexels.
+	const float EPSILON = 1.0 / (256.0 * 256.0);
+	vec2 top_left_coord = vec2(icoord) + EPSILON;
+	vec2 bottom_right_coord = top_left_coord + (1.0 - 2.0 * EPSILON);
+
+	// Compute the relevant footprint.
+	vec2 top_left_coord_normalized = top_left_coord * inv_paired_resolution;
+	vec2 bottom_right_coord_normalized = bottom_right_coord * inv_paired_resolution;
+
+	// Flooring gets us the behavior we want.
+	// We'll sample exactly in-between 4 texel centers such that coordiate we floor becomes the bottom-right texel.
+
+	if (fetch_mip(vec2(icoord), 0, layer))
+		return 0;
+
+#ifdef ARRAY
+	ivec3 fetch_coord = ivec3(icoord, layer);
+#else
+	ivec2 fetch_coord = icoord;
+#endif
+
+	// Extract encoded min-mip. This serves as our starting min-bound.
+	int result = 0xff;
+	uint high_bits = texelFetch(Input, fetch_coord, 0).y >> 28;
+	if (high_bits > 0)
+		result = int(high_bits - 1);
+
+	int scan_mip_levels = min(mip_levels, result);
+
+	for (int i = 1; i < scan_mip_levels; i++)
+	{
+		// We need to intersect the LOD 0 region with the used region in a coarse LOD.
+		// For simple POT, this is a trivial 2x2 expansion.
+		// However, for NPOT, this gets ... hairy very quickly.
+		// It's possible that a lower LOD access can cause a 3x3 access in the higher LOD.
+		// Sample the lower LOD at each (approximate) corner to get a conservative estimate of access.
+		// This is intended to match NV behavior.
+
+		// Rescale the coordinates into coordinates matching lower resolution.
+		vec2 mip_resolution = vec2(max(paired_resolution >> i, ivec2(1)));
+		vec2 c0 = floor(mip_resolution * top_left_coord_normalized);
+		vec2 c1 = floor(mip_resolution * bottom_right_coord_normalized);
+
+		if (fetch_mip(c0, i, layer))
+		{
+			result = i;
+			break;
+		}
+
+		if (any(notEqual(c0, c1)))
+		{
+			// Should only trigger for NPOT.
+			if (fetch_mip(vec2(c1.x, c0.y), i, layer))
+			{
+				result = i;
+				break;
+			}
+
+			if (fetch_mip(vec2(c0.x, c1.y), i, layer))
+			{
+				result = i;
+				break;
+			}
+
+			if (fetch_mip(vec2(c1.x, c1.y), i, layer))
+			{
+				result = i;
+				break;
+			}
+		}
+	}
+
+	return result;
+}
+
+bool sampler_feedback_decode_mip_used(ivec2 icoord, int mip, float layer)
+{
+	// This is much simpler.
+	return fetch_mip(vec2(icoord + src_offset), mip, layer);
+}
+
+#endif
+

--- a/libs/vkd3d/shaders/sampler_feedback_encode.h
+++ b/libs/vkd3d/shaders/sampler_feedback_encode.h
@@ -1,0 +1,103 @@
+#ifndef SAMPLER_FEEDBACK_ENCODE_MIN_MIP_H_
+#define SAMPLER_FEEDBACK_ENCODE_MIN_MIP_H_
+
+layout(push_constant, std430) uniform Registers
+{
+	ivec2 src_offset;
+	ivec2 dst_offset;
+	ivec2 resolution;
+	int src_mip;
+	int dst_mip;
+};
+
+layout(set = 0, binding = 0, rg32ui) uniform uimage2DArray Output;
+
+void sampler_feedback_encode_min_mip(ivec2 coord, int layer, uint value)
+{
+	// Fixup bogus inputs.
+	// Since max resource size in D3D12 is 16k, we have a maximum number of 15 mips.
+	// This leaves 4 bits to store encoded min-mip in the 64-bit MSB.
+	// When we roundtrip with a decode we can get proper behavior (invariant),
+	// unlike NV which is completely broken here on native drivers.
+	// If we're given bogus input, like mip levels above a certain limit,
+	// AMD native will clip if given bogus inputs, so we try to match AMD behavior here.
+
+	if (value > 14u)
+		value = 0xff;
+
+	uvec2 encoded_value = uvec2(0u, value == 0xff ? 0 : ((value + 1) << 28));
+	imageStore(Output, ivec3(coord + dst_offset, layer), encoded_value.xyxy);
+}
+
+void clear_bit(inout uvec2 v, int bit)
+{
+	// Could bitcast to 64-bit, but, eeeeh.
+	if (bit >= 32)
+		v.y &= ~(1u << (bit - 32));
+	else
+		v.x &= ~(1u << bit);
+}
+
+void set_bit(inout uvec2 v, int bit)
+{
+	if (bit >= 32)
+		v.y |= 1u << (bit - 32);
+	else
+		v.x |= 1u << bit;
+}
+
+// When resolving back-to-back mips, we'll need barriers. Could in theory use 64-bit atomics here,
+// but we'll have to refactor a bunch of stuff to be able to use 64-bit atomics, and feels kinda overkill
+// to hammer a ton of atomics here ...
+void sampler_feedback_encode_mip_used(ivec2 coord, int layer, bool accessed)
+{
+	// This gets awkward.
+	uvec2 value = imageLoad(Output, ivec3(coord + dst_offset, layer)).xy;
+	int bit_offset = dst_mip * 4;
+
+	if (accessed)
+		set_bit(value, bit_offset);
+	else
+		clear_bit(value, bit_offset);
+
+	// Clear out any neighbor bits. After an encode we only want the "self" bits to remain.
+
+	// If we're encoding the adjacent horizontal value, clear that bit too.
+	if (coord.x + 1 < resolution.x)
+		clear_bit(value, bit_offset + 1);
+	// If we're encoding the adjacent vertical value, clear that bit too.
+	if (coord.y + 1 < resolution.y)
+		clear_bit(value, bit_offset + 2);
+	// If we're encoding the adjacent diagonal value, clear that bit too.
+	if (all(lessThan(coord + 1, resolution)))
+		clear_bit(value, bit_offset + 3);
+
+	imageStore(Output, ivec3(coord + dst_offset, layer), value.xyxy);
+
+	if (coord.x > 0 && dst_offset.x > 0)
+	{
+		// Clear out usage from left neighbor.
+		value = imageLoad(Output, ivec3(coord + dst_offset - ivec2(1, 0), layer)).xy;
+		clear_bit(value, bit_offset + 1);
+		imageStore(Output, ivec3(coord + dst_offset - ivec2(1, 0), layer), value.xyxy);
+	}
+
+	if (coord.y > 0 && dst_offset.y > 0)
+	{
+		// Clear out usage from top neighbor.
+		value = imageLoad(Output, ivec3(coord + dst_offset - ivec2(0, 1), layer)).xy;
+		clear_bit(value, bit_offset + 2);
+		imageStore(Output, ivec3(coord + dst_offset - ivec2(0, 1), layer), value.xyxy);
+	}
+
+	if (all(greaterThan(uvec4(coord, dst_offset), uvec4(0))))
+	{
+		// Clear out usage from top-left neighbor.
+		value = imageLoad(Output, ivec3(coord + dst_offset - ivec2(1), layer)).xy;
+		clear_bit(value, bit_offset + 3);
+		imageStore(Output, ivec3(coord + dst_offset - ivec2(1), layer), value.xyxy);
+	}
+}
+
+#endif
+

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3894,6 +3894,17 @@ enum vkd3d_predicate_command_type
     VKD3D_PREDICATE_COMMAND_COUNT
 };
 
+enum vkd3d_sampler_feedback_resolve_type
+{
+    VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER,
+    VKD3D_SAMPLER_FEEDBACK_RESOLVE_BUFFER_TO_MIN_MIP,
+    VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE,
+    VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIN_MIP,
+    VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE,
+    VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIP_USED,
+    VKD3D_SAMPLER_FEEDBACK_RESOLVE_COUNT
+};
+
 struct vkd3d_predicate_command_info
 {
     VkPipelineLayout vk_pipeline_layout;
@@ -4004,6 +4015,43 @@ struct vkd3d_meta_ops_common
     VkShaderModule vk_module_fullscreen_gs;
 };
 
+struct vkd3d_sampler_feedback_resolve_info
+{
+    VkPipelineLayout vk_layout;
+    VkPipeline vk_pipeline;
+};
+
+struct vkd3d_sampler_feedback_resolve_decode_args
+{
+    uint32_t src_x, src_y;
+    uint32_t dst_x, dst_y;
+    uint32_t resolve_width, resolve_height;
+    uint32_t paired_width, paired_height;
+    float inv_paired_width, inv_paired_height;
+    float inv_feedback_width, inv_feedback_height;
+    uint32_t num_mip_levels;
+    uint32_t mip_level;
+};
+
+struct vkd3d_sampler_feedback_resolve_encode_args
+{
+    uint32_t src_x, src_y;
+    uint32_t dst_x, dst_y;
+    uint32_t resolve_width, resolve_height;
+    uint32_t src_mip;
+    uint32_t dst_mip;
+};
+
+struct vkd3d_sampler_feedback_resolve_ops
+{
+    VkPipelineLayout vk_compute_encode_layout;
+    VkPipelineLayout vk_compute_decode_layout;
+    VkPipelineLayout vk_graphics_decode_layout;
+    VkDescriptorSetLayout vk_decode_set_layout;
+    VkDescriptorSetLayout vk_encode_set_layout;
+    VkPipeline vk_pipelines[VKD3D_SAMPLER_FEEDBACK_RESOLVE_COUNT];
+};
+
 struct vkd3d_meta_ops
 {
     struct d3d12_device *device;
@@ -4016,6 +4064,7 @@ struct vkd3d_meta_ops
     struct vkd3d_execute_indirect_ops execute_indirect;
     struct vkd3d_multi_dispatch_indirect_ops multi_dispatch_indirect;
     struct vkd3d_dstorage_ops dstorage;
+    struct vkd3d_sampler_feedback_resolve_ops sampler_feedback;
 };
 
 HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device *device);
@@ -4060,6 +4109,15 @@ static inline uint32_t vkd3d_meta_get_multi_dispatch_indirect_workgroup_size(voi
 
 HRESULT vkd3d_meta_get_execute_indirect_pipeline(struct vkd3d_meta_ops *meta_ops,
         uint32_t patch_command_count, struct vkd3d_execute_indirect_info *info);
+
+void vkd3d_meta_get_sampler_feedback_resolve_pipeline(struct vkd3d_meta_ops *meta_ops,
+        enum vkd3d_sampler_feedback_resolve_type type, struct vkd3d_sampler_feedback_resolve_info *info);
+
+static inline VkExtent3D vkd3d_meta_get_sampler_feedback_workgroup_size(void)
+{
+    VkExtent3D result = { 8, 8, 1 };
+    return result;
+}
 
 enum vkd3d_time_domain_flag
 {

--- a/libs/vkd3d/vkd3d_shaders.h
+++ b/libs/vkd3d/vkd3d_shaders.h
@@ -60,5 +60,11 @@ enum vkd3d_meta_copy_mode
 #include <fs_copy_image_stencil.h>
 #include <vs_swapchain_fullscreen.h>
 #include <fs_swapchain_fullscreen.h>
+#include <cs_sampler_feedback_decode_buffer_min_mip.h>
+#include <fs_sampler_feedback_decode_image_min_mip.h>
+#include <fs_sampler_feedback_decode_image_mip_used.h>
+#include <cs_sampler_feedback_encode_buffer_min_mip.h>
+#include <cs_sampler_feedback_encode_image_min_mip.h>
+#include <cs_sampler_feedback_encode_image_mip_used.h>
 
 #endif  /* __VKD3D_SPV_SHADERS_H */


### PR DESCRIPTION
Contains the meta implementation for resolve.

There are 6 shader variants here:

Buffer decode/encode is only supported for MIN_MIP under restricted circumstances. No arrays, etc.

For decode, I went with fragment shaders, since we already add COLOR_ATTACHMENT for R8_UINT for stencil -> color copies anyways. ResolveSubresourceRange also only works in DIRECT queue, so there's no worry about having to support compute paths.

For encode, it's all compute, since there was no need to avoid it.