### PR TITLE
Implement DXR local -> external dependencies

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -966,14 +966,17 @@ enum vkd3d_shader_subobject_kind
 struct vkd3d_shader_library_subobject
 {
     enum vkd3d_shader_subobject_kind kind;
-    unsigned int dxil_identifier;
 
     /* All const pointers here point directly to the DXBC blob,
      * so they do not need to be freed.
      * Fortunately for us, the C strings are zero-terminated in the blob itself. */
 
-    /* In the blob, ASCII is used as identifier, where API uses wide strings, sigh ... */
-    const char *name;
+    /* In the blob, ASCII is used as identifier, where API uses wide strings, sigh ...
+     * We need to dup this name for deferred COLLECTIONS, so use wchar instead. */
+    WCHAR *name;
+
+    /* If true, any pointers below are just borrowed. */
+    bool borrowed_payloads;
 
     union
     {
@@ -987,7 +990,8 @@ struct vkd3d_shader_library_subobject
 
         struct
         {
-            const void *data;
+            /* Duped because of deferred COLLECTIONS. */
+            void *data;
             size_t size;
         } payload;
     } data;

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -972,6 +972,7 @@ static HRESULT d3d12_state_object_parse_subobject(struct d3d12_state_object *obj
              * but STATE_OBJECT_CONFIG doesn't change any functionality or compatibility rules really,
              * so just append flags. */
             const uint32_t supported_flags =
+                    D3D12_STATE_OBJECT_FLAG_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITIONS |
                     D3D12_STATE_OBJECT_FLAG_ALLOW_EXTERNAL_DEPENDENCIES_ON_LOCAL_DEFINITIONS |
                     D3D12_STATE_OBJECT_FLAG_ALLOW_STATE_OBJECT_ADDITIONS;
             const D3D12_STATE_OBJECT_CONFIG *object_config = obj->pDesc;
@@ -980,6 +981,13 @@ static HRESULT d3d12_state_object_parse_subobject(struct d3d12_state_object *obj
             {
                 FIXME("Object config flag #%x is not supported.\n", object->flags);
                 return E_INVALIDARG;
+            }
+
+            /* Need to ignore these flags on RTPSOs to avoid us doing funny things. */
+            if (object->type == D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE)
+            {
+                object->flags &= ~(D3D12_STATE_OBJECT_FLAG_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITIONS |
+                        D3D12_STATE_OBJECT_FLAG_ALLOW_EXTERNAL_DEPENDENCIES_ON_LOCAL_DEFINITIONS);
             }
 
             RT_TRACE("%p || STATE_OBJECT_CONFIG: #%x.\n", obj->pDesc, object_config->Flags);

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -653,7 +653,7 @@ static HRESULT d3d12_state_object_add_collection(
         return E_OUTOFMEMORY;
 
     if (!vkd3d_array_reserve((void **)&data->associations, &data->associations_size,
-            data->associations_count + 3, sizeof(*data->associations)))
+            data->associations_count + 2, sizeof(*data->associations)))
         return E_OUTOFMEMORY;
 
     RT_TRACE("EXISTING_COLLECTION:\n");

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -778,7 +778,7 @@ static HRESULT d3d12_state_object_parse_subobject(struct d3d12_state_object *obj
 
             for (i = 0; i < data->subobjects_count; i++)
             {
-                if (vkd3d_export_strequal_mixed(association->SubobjectToAssociate, data->subobjects[i].name))
+                if (vkd3d_export_strequal(association->SubobjectToAssociate, data->subobjects[i].name))
                     break;
 
                 if (data->subobjects[i].kind == VKD3D_SHADER_SUBOBJECT_KIND_GLOBAL_ROOT_SIGNATURE ||

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4678,6 +4678,8 @@ struct d3d12_state_object_variant
     } local_static_sampler;
 };
 
+struct d3d12_state_object_pipeline_data;
+
 struct d3d12_state_object
 {
     d3d12_state_object_iface ID3D12StateObject_iface;
@@ -4709,6 +4711,8 @@ struct d3d12_state_object
 
     struct d3d12_state_object **collections;
     size_t collections_count;
+
+    struct d3d12_state_object_pipeline_data *deferred_data;
 
 #ifdef VKD3D_ENABLE_BREADCRUMBS
     /* For breadcrumbs. */

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -333,6 +333,7 @@ decl_test(test_raytracing_embedded_subobjects);
 decl_test(test_raytracing_default_association_tiebreak);
 decl_test(test_raytracing_collection_identifiers);
 decl_test(test_raytracing_root_signature_from_subobject);
+decl_test(test_raytracing_deferred_compilation);
 decl_test(test_fence_wait_robustness);
 decl_test(test_fence_wait_robustness_shared);
 decl_test(test_fence_wait_multiple);


### PR DESCRIPTION
Forgot about this cursed RTPSO flag. Warhammer: Darktide uses this.

Works now on RADV (but Xid 109 on NV, but probably not our bug).