### PR TITLE
Pass down subgroupSizeMin/Max to dxil-spirv

### DIFF
--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -778,6 +778,19 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
         }
     }
 
+    {
+        const struct dxil_spv_option_subgroup_properties helper =
+                { { DXIL_SPV_OPTION_SUBGROUP_PROPERTIES },
+                        compiler_args->min_subgroup_size,
+                        compiler_args->max_subgroup_size };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            WARN("dxil-spirv does not support SUBGROUP_PROPERTIES.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
     if (quirks & VKD3D_SHADER_QUIRK_FORCE_LOOP)
     {
         struct dxil_spv_option_branch_control helper = { { DXIL_SPV_OPTION_BRANCH_CONTROL } };
@@ -1381,6 +1394,19 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
         if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
         {
             WARN("dxil-spirv does not support PRECISE_CONTROL.\n");
+            ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+            goto end;
+        }
+    }
+
+    {
+        const struct dxil_spv_option_subgroup_properties helper =
+                { { DXIL_SPV_OPTION_SUBGROUP_PROPERTIES },
+                        compiler_args->min_subgroup_size,
+                        compiler_args->max_subgroup_size };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            WARN("dxil-spirv does not support SUBGROUP_PROPERTIES.\n");
             ret = VKD3D_ERROR_NOT_IMPLEMENTED;
             goto end;
         }

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -8062,6 +8062,8 @@ static void vkd3d_compute_shader_interface_key(struct d3d12_device *device)
      * but it is useful to be able to modify the internal revision while developing since
      * we have no mechanism for emitting dirty Git revisions. */
     key = hash_fnv1_iterate_u64(key, vkd3d_shader_get_revision());
+    key = hash_fnv1_iterate_u32(key, device->device_info.vulkan_1_3_properties.minSubgroupSize);
+    key = hash_fnv1_iterate_u32(key, device->device_info.vulkan_1_3_properties.maxSubgroupSize);
     key = hash_fnv1_iterate_u32(key, device->bindless_state.flags);
     key = hash_fnv1_iterate_u32(key, device->bindless_state.cbv_srv_uav_count);
     key = hash_fnv1_iterate_u32(key, device->bindless_state.set_count);


### PR DESCRIPTION
Works around some horrible codegen in Jurassic World Evolution 2 that ends up generating statically invalid code.
Also gets rid of some horrible unrolls in Starfield.