### PR TITLE
Implement stencil copies without stencil export

### DIFF
--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -23,6 +23,7 @@ vkd3d_shaders =[
   'shaders/fs_copy_image_float.frag',
   'shaders/fs_copy_image_uint.frag',
   'shaders/fs_copy_image_stencil.frag',
+  'shaders/fs_copy_image_stencil_no_export.frag',
 
   'shaders/gs_fullscreen.geom',
   'shaders/vs_fullscreen.vert',

--- a/libs/vkd3d/shaders/fs_copy_image_stencil_no_export.frag
+++ b/libs/vkd3d/shaders/fs_copy_image_stencil_no_export.frag
@@ -1,0 +1,29 @@
+#version 450
+
+#extension GL_EXT_samplerless_texture_functions : enable
+
+#define MODE_1D 0
+#define MODE_2D 1
+#define MODE_MS 2
+
+layout(constant_id = 0) const uint c_mode = MODE_2D;
+
+layout(binding = 0) uniform utexture1DArray tex_1d;
+layout(binding = 0) uniform utexture2DArray tex_2d;
+layout(binding = 0) uniform utexture2DMSArray tex_ms;
+
+layout(push_constant)
+uniform u_info_t {
+  ivec2 offset;
+  uint bit_mask;
+} u_info;
+
+void main() {
+  ivec3 coord = ivec3(u_info.offset + ivec2(gl_FragCoord.xy), gl_Layer);
+  uint value;
+  if (c_mode == MODE_1D) value = texelFetch(tex_1d, coord.xz, 0).r;
+  if (c_mode == MODE_2D) value = texelFetch(tex_2d, coord, 0).r;
+  if (c_mode == MODE_MS) value = texelFetch(tex_ms, coord, gl_SampleID).r;
+  if ((value & u_info.bit_mask) == 0)
+    discard;
+}

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3752,6 +3752,7 @@ struct vkd3d_clear_uav_pipeline
 struct vkd3d_copy_image_args
 {
     VkOffset2D offset;
+    uint32_t bit_mask;
 };
 
 struct vkd3d_copy_image_info
@@ -3759,6 +3760,7 @@ struct vkd3d_copy_image_info
     VkDescriptorSetLayout vk_set_layout;
     VkPipelineLayout vk_pipeline_layout;
     VkPipeline vk_pipeline;
+    bool needs_stencil_mask;
 };
 
 struct vkd3d_copy_image_pipeline_key

--- a/libs/vkd3d/vkd3d_shaders.h
+++ b/libs/vkd3d/vkd3d_shaders.h
@@ -58,6 +58,7 @@ enum vkd3d_meta_copy_mode
 #include <fs_copy_image_float.h>
 #include <fs_copy_image_uint.h>
 #include <fs_copy_image_stencil.h>
+#include <fs_copy_image_stencil_no_export.h>
 #include <vs_swapchain_fullscreen.h>
 #include <fs_swapchain_fullscreen.h>
 #include <cs_sampler_feedback_decode_buffer_min_mip.h>

--- a/tests/d3d12_copy.c
+++ b/tests/d3d12_copy.c
@@ -119,7 +119,6 @@ void test_copy_texture(void)
         DXGI_FORMAT readback_format;
         bool stencil;
         bool roundtrip;
-        bool requires_stencil_export;
     };
     static const struct depth_copy_test depth_copy_tests[] = {
         { 0.0f, 0, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_R32_FLOAT, false, false },
@@ -141,7 +140,7 @@ void test_copy_texture(void)
 
         /* Test color <-> stencil copies. */
         { 1.0f, 44, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R8_UINT, true, false },
-        { 1.0f, 45, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R8_UINT, true, true, true },
+        { 1.0f, 45, DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R8_UINT, true, true },
     };
 
     static const D3D12_RESOURCE_STATES resource_states[] =
@@ -352,15 +351,9 @@ void test_copy_texture(void)
                 D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE);
 
         if (depth_copy_tests[i].stencil)
-        {
-            /* Supported on AMD, but not NV. Need buffer copy roundtrip workaround for that to work. */
-            todo_if(depth_copy_tests[i].requires_stencil_export)
             check_sub_resource_float(context.render_target, 0, queue, command_list, (float)depth_copy_tests[i].stencil_value, 0);
-        }
         else
-        {
             check_sub_resource_float(context.render_target, 0, queue, command_list, depth_copy_tests[i].depth_value, 2);
-        }
 
         destroy_depth_stencil(&ds);
         ID3D12Resource_Release(dst_texture);


### PR DESCRIPTION
Unblocks R8->stencil copies on NV. We'll need the same trickery for stencil resolves anyway, so might as well support this as well.