### PR TITLE
vkd3d: Extend CP2077 workaround to shaders from 2.1

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -640,6 +640,7 @@ static const struct vkd3d_shader_quirk_info witcher3_quirks = {
 static const struct vkd3d_shader_quirk_hash cp77_hashes[] = {
     /* Shader accesses descriptor heap out of bounds spuriously, causing GPU hang on RADV. */
     { 0x55540466536c9e11, VKD3D_SHADER_QUIRK_DESCRIPTOR_HEAP_ROBUSTNESS },
+    { 0x0c3defbf58c47055, VKD3D_SHADER_QUIRK_DESCRIPTOR_HEAP_ROBUSTNESS },
 };
 
 static const struct vkd3d_shader_quirk_info cp77_quirks = {


### PR DESCRIPTION
The shader hash changed in Update 2.1. The bug remains, so add it to the quirk table.