### PR TITLE
Add compute shader fallback for multisample resolves

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8751,9 +8751,10 @@ static void d3d12_command_list_execute_resolve(struct d3d12_command_list *list,
             else
             {
                 memset(&resolve_pipeline_key, 0, sizeof(resolve_pipeline_key));
-                resolve_pipeline_key.format = vk_format;
-                resolve_pipeline_key.dst_aspect = (VkImageAspectFlagBits)region->dstSubresource.aspectMask;
-                resolve_pipeline_key.mode = mode;
+                resolve_pipeline_key.path = path;
+                resolve_pipeline_key.graphics.format = vk_format;
+                resolve_pipeline_key.graphics.dst_aspect = (VkImageAspectFlagBits)region->dstSubresource.aspectMask;
+                resolve_pipeline_key.graphics.mode = mode;
 
                 if (FAILED(vkd3d_meta_get_resolve_image_pipeline(&list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info)))
                 {

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -49,6 +49,10 @@ vkd3d_shaders =[
   'shaders/fs_resolve_depth.frag',
   'shaders/fs_resolve_stencil.frag',
   'shaders/fs_resolve_stencil_no_export.frag',
+
+  'shaders/cs_resolve_color_float.comp',
+  'shaders/cs_resolve_color_uint.comp',
+  'shaders/cs_resolve_color_sint.comp',
 ]
 
 vkd3d_src = [

--- a/libs/vkd3d/shaders/cs_resolve_color_float.comp
+++ b/libs/vkd3d/shaders/cs_resolve_color_float.comp
@@ -1,0 +1,48 @@
+#version 450
+
+layout(local_size_x = 8, local_size_y = 8) in;
+
+#extension GL_EXT_samplerless_texture_functions : enable
+
+#define MODE_MIN 1
+#define MODE_MAX 2
+#define MODE_AVERAGE 3
+
+layout(constant_id = 0) const uint c_mode = 0;
+
+layout(binding = 0) uniform texture2DMSArray tex_ms;
+layout(binding = 1) uniform writeonly image2DArray dst;
+
+layout(push_constant)
+uniform u_info_t {
+  ivec2 dst_offset;
+  ivec2 src_offset;
+  uvec2 extent;
+} u_info;
+
+void main() {
+  ivec3 src_coord = ivec3(gl_GlobalInvocationID) + ivec3(u_info.src_offset, 0);
+  ivec3 dst_coord = ivec3(gl_GlobalInvocationID) + ivec3(u_info.dst_offset, 0);
+
+  uint samples = textureSamples(tex_ms);
+
+  if (any(greaterThanEqual(gl_GlobalInvocationID.xy, u_info.extent)))
+    return;
+
+  vec4 color = texelFetch(tex_ms, src_coord, 0);
+
+  for (uint i = 1; i < samples; i++) {
+    vec4 sample_value = texelFetch(tex_ms, src_coord, int(i));
+
+    switch (c_mode) {
+      case MODE_MIN: color = min(color, sample_value); break;
+      case MODE_MAX: color = max(color, sample_value); break;
+      case MODE_AVERAGE: color += sample_value; break;
+    }
+  }
+
+  if (c_mode == MODE_AVERAGE)
+    color /= float(samples);
+
+  imageStore(dst, dst_coord, color);
+}

--- a/libs/vkd3d/shaders/cs_resolve_color_sint.comp
+++ b/libs/vkd3d/shaders/cs_resolve_color_sint.comp
@@ -1,0 +1,43 @@
+#version 450
+
+layout(local_size_x = 8, local_size_y = 8) in;
+
+#extension GL_EXT_samplerless_texture_functions : enable
+
+#define MODE_MIN 1
+#define MODE_MAX 2
+
+layout(constant_id = 0) const uint c_mode = 0;
+
+layout(binding = 0) uniform itexture2DMSArray tex_ms;
+layout(binding = 1) uniform writeonly iimage2DArray dst;
+
+layout(push_constant)
+uniform u_info_t {
+  ivec2 dst_offset;
+  ivec2 src_offset;
+  uvec2 extent;
+} u_info;
+
+void main() {
+  ivec3 src_coord = ivec3(gl_GlobalInvocationID) + ivec3(u_info.src_offset, 0);
+  ivec3 dst_coord = ivec3(gl_GlobalInvocationID) + ivec3(u_info.dst_offset, 0);
+
+  uint samples = textureSamples(tex_ms);
+
+  if (any(greaterThanEqual(gl_GlobalInvocationID.xy, u_info.extent)))
+    return;
+
+  ivec4 color = texelFetch(tex_ms, src_coord, 0);
+
+  for (uint i = 1; i < samples; i++) {
+    ivec4 sample_value = texelFetch(tex_ms, src_coord, int(i));
+
+    switch (c_mode) {
+      case MODE_MIN: color = min(color, sample_value); break;
+      case MODE_MAX: color = max(color, sample_value); break;
+    }
+  }
+
+  imageStore(dst, dst_coord, color);
+}

--- a/libs/vkd3d/shaders/cs_resolve_color_uint.comp
+++ b/libs/vkd3d/shaders/cs_resolve_color_uint.comp
@@ -1,0 +1,43 @@
+#version 450
+
+layout(local_size_x = 8, local_size_y = 8) in;
+
+#extension GL_EXT_samplerless_texture_functions : enable
+
+#define MODE_MIN 1
+#define MODE_MAX 2
+
+layout(constant_id = 0) const uint c_mode = 0;
+
+layout(binding = 0) uniform utexture2DMSArray tex_ms;
+layout(binding = 1) uniform writeonly uimage2DArray dst;
+
+layout(push_constant)
+uniform u_info_t {
+  ivec2 dst_offset;
+  ivec2 src_offset;
+  uvec2 extent;
+} u_info;
+
+void main() {
+  ivec3 src_coord = ivec3(gl_GlobalInvocationID) + ivec3(u_info.src_offset, 0);
+  ivec3 dst_coord = ivec3(gl_GlobalInvocationID) + ivec3(u_info.dst_offset, 0);
+
+  uint samples = textureSamples(tex_ms);
+
+  if (any(greaterThanEqual(gl_GlobalInvocationID.xy, u_info.extent)))
+    return;
+
+  uvec4 color = texelFetch(tex_ms, src_coord, 0);
+
+  for (uint i = 1; i < samples; i++) {
+    uvec4 sample_value = texelFetch(tex_ms, src_coord, int(i));
+
+    switch (c_mode) {
+      case MODE_MIN: color = min(color, sample_value); break;
+      case MODE_MAX: color = max(color, sample_value); break;
+    }
+  }
+
+  imageStore(dst, dst_coord, color);
+}

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3804,6 +3804,14 @@ struct vkd3d_copy_image_ops
     size_t pipeline_count;
 };
 
+enum vkd3d_resolve_image_path
+{
+    VKD3D_RESOLVE_IMAGE_PATH_UNSUPPORTED,
+    VKD3D_RESOLVE_IMAGE_PATH_DIRECT,
+    VKD3D_RESOLVE_IMAGE_PATH_RENDER_PASS_ATTACHMENT,
+    VKD3D_RESOLVE_IMAGE_PATH_RENDER_PASS_PIPELINE,
+};
+
 struct vkd3d_resolve_image_args
 {
     VkOffset2D offset;

--- a/libs/vkd3d/vkd3d_shaders.h
+++ b/libs/vkd3d/vkd3d_shaders.h
@@ -73,5 +73,8 @@ enum vkd3d_meta_copy_mode
 #include <fs_resolve_depth.h>
 #include <fs_resolve_stencil.h>
 #include <fs_resolve_stencil_no_export.h>
+#include <cs_resolve_color_float.h>
+#include <cs_resolve_color_sint.h>
+#include <cs_resolve_color_uint.h>
 
 #endif  /* __VKD3D_SPV_SHADERS_H */


### PR DESCRIPTION
Extends the extsiting resolve implementation by *yet another* code path, so that we no longer require render target usage for the destination image.

~~Draft becasue always enabling `STORAGE_IMAGE_BIT` for non-render target images seems a bit scary, this should probably be tested somewhat extensively on Nvidia.~~