### PR TITLE
Always enable storage image usage for non-RTV 2D images

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8464,7 +8464,7 @@ enum vkd3d_resolve_image_path d3d12_command_list_select_resolve_path(struct d3d1
         }
     }
 
-    if (dst_resource->desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
+    if (dst_resource->flags & VKD3D_RESOURCE_STORAGE_IMAGE)
     {
         /* Use the compute path if we need to use a pipeline anyway, or if
          * the destination image does not support render target usage. */

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -877,6 +877,7 @@ enum vkd3d_resource_flag
     VKD3D_RESOURCE_EXTERNAL               = (1u << 5),
     VKD3D_RESOURCE_ACCELERATION_STRUCTURE = (1u << 6),
     VKD3D_RESOURCE_GENERAL_LAYOUT         = (1u << 7),
+    VKD3D_RESOURCE_STORAGE_IMAGE          = (1u << 8),
 };
 
 struct d3d12_sparse_image_region


### PR DESCRIPTION
Needed for multisample resolve in some cases, but this is scary and needs testing on a wide range of hardware.

Builds on #1805.