### PR TITLE
Fix various problems with the resinfo instruction

### DIFF
--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -10739,13 +10739,15 @@ static void vkd3d_dxbc_compiler_emit_bufinfo(struct vkd3d_dxbc_compiler *compile
 static void vkd3d_dxbc_compiler_emit_resinfo(struct vkd3d_dxbc_compiler *compiler,
         const struct vkd3d_shader_instruction *instruction)
 {
+    uint32_t type_id, lod_id, val_id, one_id, rcp_id, cond_id, rcp_type_id, miplevel_count_id;
     struct vkd3d_spirv_builder *builder = &compiler->spirv_builder;
     const struct vkd3d_shader_dst_param *dst = instruction->dst;
     const struct vkd3d_shader_src_param *src = instruction->src;
-    uint32_t type_id, lod_id, val_id, miplevel_count_id;
     uint32_t constituents[VKD3D_VEC4_SIZE];
     unsigned int i, size_component_count;
+    uint32_t indices[VKD3D_VEC4_SIZE];
     struct vkd3d_shader_image image;
+    uint32_t resinfo_type;
     bool supports_mipmaps;
 
     vkd3d_spirv_enable_capability(builder, SpvCapabilityImageQuery);
@@ -10761,8 +10763,16 @@ static void vkd3d_dxbc_compiler_emit_resinfo(struct vkd3d_dxbc_compiler *compile
     {
         lod_id = vkd3d_dxbc_compiler_emit_load_src(compiler, &src[0], VKD3DSP_WRITEMASK_0);
         val_id = vkd3d_spirv_build_op_image_query_size_lod(builder, type_id, image.image_id, lod_id);
-        type_id = vkd3d_spirv_get_type_id(builder, VKD3D_TYPE_UINT, 1);
-        miplevel_count_id = vkd3d_spirv_build_op_image_query_levels(builder, type_id, image.image_id);
+
+        miplevel_count_id = vkd3d_spirv_build_op_image_query_levels(builder,
+                vkd3d_spirv_get_type_id(builder, VKD3D_TYPE_UINT, 1), image.image_id);
+
+        cond_id = vkd3d_spirv_build_op_uless_than(builder,
+                vkd3d_spirv_get_type_id(builder, VKD3D_TYPE_BOOL, 1),
+                lod_id, miplevel_count_id);
+
+        val_id = vkd3d_spirv_build_op_select(builder, type_id, cond_id, val_id,
+                vkd3d_dxbc_compiler_get_constant_uint_vector(compiler, 0, size_component_count));
     }
     else
     {
@@ -10779,16 +10789,41 @@ static void vkd3d_dxbc_compiler_emit_resinfo(struct vkd3d_dxbc_compiler *compile
     val_id = vkd3d_spirv_build_op_composite_construct(builder,
             type_id, constituents, i + 2);
 
+    resinfo_type = instruction->flags & VKD3DSI_RESINFO_MASK;
+
     type_id = vkd3d_spirv_get_type_id(builder, VKD3D_TYPE_FLOAT, VKD3D_VEC4_SIZE);
-    if (instruction->flags == VKD3DSI_RESINFO_UINT)
+    if (resinfo_type == VKD3DSI_RESINFO_UINT)
     {
         val_id = vkd3d_spirv_build_op_bitcast(builder, type_id, val_id);
     }
     else
     {
-        if (instruction->flags)
-            FIXME("Unhandled flags %#x.\n", instruction->flags);
         val_id = vkd3d_spirv_build_op_convert_utof(builder, type_id, val_id);
+
+        if (resinfo_type == VKD3DSI_RESINFO_RCP_FLOAT)
+        {
+            /* The rcp_float flag only applies to the width, height and
+             * depth, but not to the array size or any zeroed component. */
+            if (image.resource_type_info->arrayed)
+                size_component_count -= 1;
+
+            rcp_type_id = vkd3d_spirv_get_type_id(builder, VKD3D_TYPE_FLOAT, size_component_count);
+
+            for (i = 0; i < size_component_count; i++)
+                indices[i] = i;
+
+            rcp_id = vkd3d_spirv_build_op_vector_shuffle(builder, rcp_type_id,
+                    val_id, val_id, indices, size_component_count);
+
+            one_id = vkd3d_dxbc_compiler_get_constant_float_vector(compiler, 1.0f, size_component_count);
+            rcp_id = vkd3d_spirv_build_op_fdiv(builder, rcp_type_id, one_id, rcp_id);
+
+            for (i = 0; i < VKD3D_VEC4_SIZE; i++)
+                indices[i] = (i < size_component_count ? VKD3D_VEC4_SIZE : 0) + i;
+
+            val_id = vkd3d_spirv_build_op_vector_shuffle(builder, type_id,
+                    val_id, rcp_id, indices, VKD3D_VEC4_SIZE);
+        }
     }
     val_id = vkd3d_dxbc_compiler_emit_swizzle(compiler,
             val_id, VKD3DSP_WRITEMASK_ALL, VKD3D_TYPE_FLOAT, src[1].swizzle, dst->write_mask);

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -457,6 +457,7 @@ enum vkd3d_tessellator_domain
 #define VKD3DSI_INDEXED_DYNAMIC         0x4
 #define VKD3DSI_RESINFO_RCP_FLOAT       0x1
 #define VKD3DSI_RESINFO_UINT            0x2
+#define VKD3DSI_RESINFO_MASK            0x3
 #define VKD3DSI_SAMPLE_INFO_UINT        0x1
 #define VKD3DSI_SAMPLER_COMPARISON_MODE 0x1
 

--- a/tests/d3d12_shaders.c
+++ b/tests/d3d12_shaders.c
@@ -6892,11 +6892,13 @@ void test_resinfo(void)
         {&ps_2d, {32, 16, 1, 3, 1, 0}, 0, {32.0f, 16.0f, 3.0f, 0.0f}},
         {&ps_2d, {32, 16, 1, 3, 1, 0}, 1, {16.0f,  8.0f, 3.0f, 0.0f}},
         {&ps_2d, {32, 16, 1, 3, 1, 0}, 2, { 8.0f,  4.0f, 3.0f, 0.0f}},
+        {&ps_2d, {32, 16, 1, 1, 1, 0}, 2, { 0.0f,  0.0f, 1.0f, 0.0f}},
 
         {&ps_2d_array, {64, 64, 1, 1, 6, 0}, 0, {64.0f, 64.0f, 6.0f, 1.0f}},
         {&ps_2d_array, {32, 16, 1, 3, 9, 0}, 0, {32.0f, 16.0f, 9.0f, 3.0f}},
         {&ps_2d_array, {32, 16, 1, 3, 7, 0}, 1, {16.0f,  8.0f, 7.0f, 3.0f}},
         {&ps_2d_array, {32, 16, 1, 3, 3, 0}, 2, { 8.0f,  4.0f, 3.0f, 3.0f}},
+        {&ps_2d_array, {16, 16, 1, 1, 1, 0}, 1, { 0.0f,  0.0f, 0.0f, 1.0f}},
 
         {&ps_3d, {64, 64, 2, 1, 1, 0}, 0, {64.0f, 64.0f, 2.0f, 1.0f}},
         {&ps_3d, {64, 64, 2, 2, 1, 0}, 1, {32.0f, 32.0f, 1.0f, 2.0f}},
@@ -6907,16 +6909,19 @@ void test_resinfo(void)
         {&ps_3d, { 8,  8, 8, 4, 1, 0}, 1, { 4.0f,  4.0f, 4.0f, 4.0f}},
         {&ps_3d, { 8,  8, 8, 4, 1, 0}, 2, { 2.0f,  2.0f, 2.0f, 4.0f}},
         {&ps_3d, { 8,  8, 8, 4, 1, 0}, 3, { 1.0f,  1.0f, 1.0f, 4.0f}},
+        {&ps_3d, {16, 16, 16, 2, 1, 0}, 3, { 0.0f,  0.0f, 0.0f, 2.0f}},
 
         {&ps_cube, { 4,  4, 1, 1, 6, 1}, 0, { 4.0f,  4.0f, 1.0f, 0.0f}},
         {&ps_cube, {32, 32, 1, 1, 6, 1}, 0, {32.0f, 32.0f, 1.0f, 0.0f}},
         {&ps_cube, {32, 32, 1, 3, 6, 1}, 0, {32.0f, 32.0f, 3.0f, 0.0f}},
         {&ps_cube, {32, 32, 1, 3, 6, 1}, 1, {16.0f, 16.0f, 3.0f, 0.0f}},
         {&ps_cube, {32, 32, 1, 3, 6, 1}, 2, { 8.0f,  8.0f, 3.0f, 0.0f}},
+        {&ps_cube, {16, 16, 1, 1, 6, 1}, 6, { 0.0f,  0.0f, 1.0f, 0.0f}},
 
         {&ps_cube_array, { 4,  4, 1, 1, 12, 2}, 0, { 4.0f,  4.0f, 1.0f, 0.0f}},
         {&ps_cube_array, {32, 32, 1, 1, 12, 2}, 0, {32.0f, 32.0f, 1.0f, 0.0f}},
         {&ps_cube_array, {32, 32, 1, 3, 12, 2}, 0, {32.0f, 32.0f, 3.0f, 0.0f}},
+        {&ps_cube_array, {32, 32, 1, 3, 12, 2}, 4, { 0.0f,  0.0f, 3.0f, 0.0f}},
     };
 
     memset(&desc, 0, sizeof(desc));
@@ -7022,6 +7027,7 @@ void test_resinfo(void)
             transition_resource_state(command_list, context.render_target,
                     D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE);
 
+            bug_if(test->miplevel >= test->texture_desc.miplevel_count && is_amd_windows_device(context.device))
             check_sub_resource_vec4(context.render_target, 0, queue, command_list, &test->expected_result, 0);
 
             reset_command_list(command_list, context.allocator);


### PR DESCRIPTION
Addresses the following issues:
- `precise` flags can be set on this instruction, but this would lead to the uint path not working properly.
- if the queried mip level is out of bounds, the returned width, height and array size is specified to be 0. AMD Windows drivers do not seem to implement this, but Nvidia passes the relevant test.
- `_rcpfloat` was not supported. FXC never seems to emit this, but I've seen this in the wild with DXVK, probably from custom DXBC emitters.

The first issue was encountered in Avatar Frontiers of Pandora.