### PR TITLE
build: Replace stdcall-alias with kill-at, remove __declspec(dllexport)

### DIFF
--- a/libs/d3d12/main.c
+++ b/libs/d3d12/main.c
@@ -40,17 +40,11 @@
 #include "vkd3d_string.h"
 #include "vkd3d_platform.h"
 
-/* We need to specify the __declspec(dllexport) attribute
- * on MinGW because otherwise the stdcall aliases/fixups
- * don't get exported.
- */
-#if defined(_MSC_VER)
-  #define DLLEXPORT
-#elif defined(__MINGW32__)
-  #define DLLEXPORT __declspec(dllexport)
+#if defined(__WINE__) || !defined(_WIN32)
+#define DLLEXPORT __attribute__((visibility("default")))
+#include <dlfcn.h>
 #else
-  #define DLLEXPORT __attribute__((visibility("default")))
-  #include <dlfcn.h>
+#define DLLEXPORT
 #endif
 
 static pthread_once_t library_once = PTHREAD_ONCE_INIT;

--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -34,17 +34,11 @@
 
 #include "debug.h"
 
-/* We need to specify the __declspec(dllexport) attribute
- * on MinGW because otherwise the stdcall aliases/fixups
- * don't get exported.
- */
-#if defined(_MSC_VER)
-  #define DLLEXPORT
-#elif defined(__MINGW32__)
-  #define DLLEXPORT __declspec(dllexport)
+#if defined(__WINE__) || !defined(_WIN32)
+#define DLLEXPORT __attribute__((visibility("default")))
+#include <dlfcn.h>
 #else
-  #define DLLEXPORT __attribute__((visibility("default")))
-  #include <dlfcn.h>
+#define DLLEXPORT
 #endif
 
 typedef IVKD3DCoreInterface d3d12core_interface;

--- a/meson.build
+++ b/meson.build
@@ -116,7 +116,7 @@ add_project_arguments(vkd3d_compiler.get_supported_arguments([
 
 if cpu_family == 'x86'
   add_global_link_arguments(vkd3d_compiler.get_supported_link_arguments([
-      '-Wl,--add-stdcall-alias',
+      '-Wl,--kill-at',
       '-Wl,--enable-stdcall-fixup']),
     language : [ 'c', 'cpp' ])
 
@@ -164,7 +164,13 @@ dxil_spirv_dep = dxil_spirv.get_variable('dxil_spirv_dep')
 subdir('include')
 subdir('libs')
 
-lib_d3d12 = d3d12_dep
+if vkd3d_platform == 'windows'
+  # MinGW LD on x86 emits incorrect implib with ordinal suffixes.
+  # As a workaround, just link to the system D3D12.
+  lib_d3d12 = vkd3d_compiler.find_library('d3d12')
+else
+  lib_d3d12 = d3d12_dep
+endif
 
 if vkd3d_platform == 'linux'
   pkg = import('pkgconfig')


### PR DESCRIPTION
This mirrors changes at DXVK [1], [2].

The intent in [1] was to prevent 32-bit export function names from containing @Ordinals at the end.

This also turns out to be useful for compatibility with LLVM-based toolchain, in particular when using LLD, because LLD does not recognize --add-stdcall-alias but does recognize --kill-at.

As in [1], we use the system-provided d3d12 dependency instead of the
implib we generated, because MinGW LD insists on emitting implib with
ordinal suffixes (LLD does the correct thing here).

Another part of the change is to remove __declspec(dllexport). The .def
files we use specify the linkage already, so the attributes are obsolete.
This fixes LLD warnings like:

    ld.lld: warning: duplicate /export option: D3D12CreateDevice

There is another LLD compatibility issue here: while MSVC and MinGW will
give priority to the .def definitions, older versions of LLD would end up
honoring the attribute instead, resulting in default ordinals to be
exported instead of the specified one [3]. Not specifying dllexport in the
source fixes this.

This probably needs more testing. I'm primarily doing this since I use the LLVM toolchain for development ([like this cross file](https://github.com/ishitatsuyuki/dxvk/blob/clang/build-clang-win64.txt)), and I don't have 32-bit D3D12 games at hand to test. I did test that the 64-bit binaries produced by Clang/LLD runs correctly, unlike before where ordinals were messed up.

cc @Joshua-Ashton 

[1]: https://github.com/doitsujin/dxvk/commit/a62117cd13618f98e5c0f0da27de9193cbc6dae2
[2]: https://github.com/doitsujin/dxvk/commit/904d3e6c9014bff7aa0843630b009c51879a1d06
[3]: https://github.com/llvm/llvm-project/issues/62329