### PR TITLE
d3d12: Pick the adapter chosen by the app when duplicate LUIDs are present

### DIFF
--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -199,7 +199,9 @@ static VkPhysicalDevice d3d12_find_physical_device(struct vkd3d_instance *instan
         if (id_properties.deviceLUIDValid && !memcmp(id_properties.deviceLUID, &adapter_desc->AdapterLuid, VK_LUID_SIZE))
         {
             vk_physical_device = vk_physical_devices[i];
-            break;
+            /* Workaround for systems where multiple devices have the same LUID */
+            if (properties2.properties.deviceID == adapter_desc->DeviceId && properties2.properties.vendorID == adapter_desc->VendorId)
+                break;
         }
     }
 


### PR DESCRIPTION
Add a heuristic when initializing a d3d12 physical device to take the discrete GPU if available, and fall back to the integrated GPU. This mirrors the device selection code in vkd3d_select_physical_device. Previously, the first available device was selected without checking for others, which would lead to the wrong device being selected on hybrid graphics systems.

Fixes #1809