### PR TITLE
RFC: Add application to compile batches of HLSL shaders

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -2,6 +2,7 @@ vkd3d_idl = [
   'vkd3d_d3d12.idl',
   'vkd3d_d3d12sdklayers.idl',
   'vkd3d_d3dcommon.idl',
+  'vkd3d_dxcapi.idl',
   'vkd3d_dxgi.idl',
   'vkd3d_dxgi1_2.idl',
   'vkd3d_dxgi1_3.idl',

--- a/include/vkd3d_dxcapi.idl
+++ b/include/vkd3d_dxcapi.idl
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2024 Philip Rebohle for Valve Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+import "vkd3d_windows.h";
+
+#include "vkd3d_unknown.idl"
+
+typedef HRESULT (__stdcall *DxcCreateInstanceProc)(
+    REFCLSID clsid, REFIID iid, void **object);
+
+[local] HRESULT __stdcall DxcCreateInstance(
+    REFCLSID clsid, REFIID iid, void **object);
+
+cpp_quote("DEFINE_GUID(CLSID_DxcCompiler, 0x73e22d93, 0xe6ce, 0x47f3, 0xb5, 0xbf, 0xf0, 0x66, 0x4f, 0x39, 0xc1, 0xb0);")
+cpp_quote("DEFINE_GUID(CLSID_DxcUtils, 0x6245d6af, 0x66e0, 0x48fd, 0x80, 0xb4, 0x4d, 0x27, 0x17, 0x96, 0x74, 0x8c);")
+
+cpp_quote("#define DXC_CP_UTF8 65001")
+cpp_quote("#define DXC_CP_UTF16 1200")
+cpp_quote("#define DXC_CP_UTF32 12000")
+
+struct IMalloc;
+typedef struct IMalloc IMalloc;
+struct IStream;
+typedef struct IStream IStream;
+
+typedef enum DXC_OUT_KIND
+{
+    DXC_OUT_NONE = 0,
+    DXC_OUT_OBJECT = 1,
+    DXC_OUT_ERRORS = 2,
+    DXC_OUT_PDB = 3,
+    DXC_OUT_SHADER_HASH = 4,
+    DXC_OUT_DISASSEMBLY = 5,
+    DXC_OUT_HLSL = 6,
+    DXC_OUT_TEXT = 7,
+    DXC_OUT_REFLECTION = 8,
+    DXC_OUT_ROOT_SIGNATURE = 9,
+    DXC_OUT_EXTRA_OUTPUTS = 10,
+    DXC_OUT_REMARKS = 11,
+    DXC_OUT_TIME_REPORT = 12,
+    DXC_OUT_TIME_TRACE = 13,
+    DXC_OUT_FORCE_DWORD = 0xffffffff,
+} DXC_OUT_KIND;
+
+typedef struct DxcBuffer
+{
+    const void *Ptr;
+    SIZE_T Size;
+    UINT Encoding;
+} DxcBuffer;
+
+typedef struct DxcDefine
+{
+    LPCWSTR Name;
+    LPCWSTR Value;
+} DxcDefine;
+
+[
+    local,
+    object,
+    uuid(8Ba5fb08-5195-40e2-ac58-0d989c3a0102),
+    pointer_default(unique)
+]
+interface IDxcBlob : IUnknown
+{
+    void *GetBufferPointer(void);
+    SIZE_T GetBufferSize(void);
+}
+
+[
+    local,
+    object,
+    uuid(7241d424-2646-4191-97c0-98e96e42fc68),
+    pointer_default(unique)
+]
+interface IDxcBlobEncoding : IDxcBlob
+{
+    HRESULT GetEncoding(BOOL *known, UINT32 *code_page);
+}
+
+[
+    local,
+    object,
+    uuid(3da636c9-ba71-4024-a301-30cbf125305b),
+    pointer_default(unique)
+]
+interface IDxcBlobUtf8 : IDxcBlobEncoding
+{
+    LPCSTR GetStringPointer(void);
+    SIZE_T GetStringLength(void);
+}
+
+[
+    local,
+    object,
+    uuid(a3f84eab-0faa-497e-a39c-ee6ed60b2d84),
+    pointer_default(unique)
+]
+interface IDxcBlobWide : IDxcBlobEncoding
+{
+    LPCWSTR GetStringPointer(void);
+    SIZE_T GetStringLength(void);
+}
+
+[
+    local,
+    object,
+    uuid(7f61fc7d-950d-467f-b3e3-3c02fb49187c),
+    pointer_default(unique)
+]
+interface IDxcIncludeHandler : IUnknown
+{
+    HRESULT LoadSource(LPCWSTR file_name, IDxcBlob **include_source);
+}
+
+[
+    local,
+    object,
+    uuid(cedb484a-d4e9-445a-b991-ca21ca157dc2),
+    pointer_default(unique)
+]
+interface IDxcOperationResult : IUnknown
+{
+    HRESULT GetStatus(HRESULT *status);
+    HRESULT GetResult(IDxcBlob **result);
+    HRESULT GetErrorBuffer(IDxcBlobEncoding **errors);
+}
+
+[
+    local,
+    object,
+    uuid(58346cda-dde7-4497-9461-6f87af5e0659),
+    pointer_default(unique)
+]
+interface IDxcResult : IDxcOperationResult
+{
+    BOOL HasOutput(DXC_OUT_KIND dxc_out_kind);
+    HRESULT GetOutput(DXC_OUT_KIND dxc_out_kind, REFIID iid, void **object,
+            IDxcBlobWide **output_name);
+    UINT32 GetNumOutputs(void);
+    DXC_OUT_KIND GetOutputByIndex(UINT32 Index);
+    DXC_OUT_KIND PrimaryOutput(void);
+}
+
+[
+    local,
+    object,
+    uuid(73effe2a-70dc-45f8-9690-eff64c02429d),
+    pointer_default(unique)
+]
+interface IDxcCompilerArgs : IUnknown
+{
+    LPCWSTR *GetArguments(void);
+    UINT32 GetCount(void);
+    HRESULT AddArguments(LPCWSTR arguments, UINT32 arg_count);
+    HRESULT AddArgumentsUTF8(LPCSTR arguments, UINT32 arg_count);
+    HRESULT AddDefines(const DxcDefine *defines, UINT32 define_count);
+}
+
+[
+    local,
+    object,
+    uuid(8c210bf3-011f-4422-8d70-6f9acb8db617),
+    pointer_default(unique)
+]
+interface IDxcCompiler : IUnknown
+{
+    HRESULT Compile(IDxcBlob *source, LPCWSTR source_name, LPCWSTR entry_point, LPCWSTR target_profile,
+            LPCWSTR arguments, UINT32 arg_count, const DxcDefine *defines, UINT32 define_count,
+            IDxcIncludeHandler *include_handler, IDxcOperationResult **result);
+    HRESULT Preprocess(IDxcBlob *source, LPCWSTR source_name, LPCWSTR arguments, UINT32 arg_count,
+            const DxcDefine *defines, UINT32 define_count, IDxcIncludeHandler *include_handler,
+            IDxcOperationResult **result);
+    HRESULT Disassemble(IDxcBlob *source, IDxcBlobEncoding **disassembly);
+}
+
+[
+    local,
+    object,
+    uuid(228b4687-5a6a-4730-900c-9702b2203f54),
+    pointer_default(unique)
+]
+interface IDxcCompiler3 : IUnknown
+{
+    HRESULT Compile(const DxcBuffer *source, LPCWSTR *arguments, UINT32 arg_count,
+            IDxcIncludeHandler *include_handler, REFIID iid, void **result);
+    HRESULT Disassemble(const DxcBuffer *object, REFIID iid, void **result);
+}
+
+[
+    local,
+    object,
+    uuid(4605c4cb-2019-492a-ada4-65f20bb7d67f),
+    pointer_default(unique)
+]
+interface IDxcUtils : IUnknown
+{
+    HRESULT CreateBlobFromBlob(IDxcBlob *blob, UINT32 offset, UINT32 length,
+            IDxcBlob **result);
+    HRESULT CreateBlobFromPinned(const void *data, UINT32 size, UINT32 code_page,
+            IDxcBlobEncoding **result);
+    HRESULT MoveToBlob(const void *data, IMalloc *alloc, UINT32 size,
+            UINT32 code_page, IDxcBlobEncoding **result);
+    HRESULT CreateBlob(const void *data, UINT32 size, UINT32 code_page,
+            IDxcBlobEncoding **result);
+    HRESULT LoadFile(LPCWSTR file_name, UINT32 code_page, IDxcBlobEncoding **result);
+    HRESULT CreateReadOnlyStreamFromBlob(IDxcBlob *blob, IStream **stream);
+    HRESULT CreateDefaultIncludeHandler(IDxcIncludeHandler **result);
+    HRESULT GetBlobAsUtf8(IDxcBlob *blob, IDxcBlobUtf8 **result);
+    HRESULT GetBlobAsWide(IDxcBlob *blob, IDxcBlobWide **result);
+    HRESULT GetDxilContainerPart(const DxcBuffer *shader, UINT32 dxc_part,
+            void **part_data, UINT32 *part_size);
+    HRESULT CreateReflection(const DxcBuffer *data, REFIID iid, void **reflection);
+    HRESULT BuildArguments(LPCWSTR source_name, LPCWSTR entry_point, LPCWSTR target_profile,
+            LPCWSTR *arguments, UINT32 arg_count, const DxcDefine *defines, UINT32 define_count,
+            IDxcCompilerArgs **args);
+    HRESULT GetPDBContents(IDxcBlob *pdb_blob, IDxcBlob **hash, IDxcBlob **container);
+}

--- a/include/vkd3d_windows.h
+++ b/include/vkd3d_windows.h
@@ -85,9 +85,11 @@ typedef unsigned long ULONG_PTR;
 
 typedef ULONG_PTR SIZE_T;
 
+typedef char CHAR;
 typedef unsigned short WCHAR;
 typedef void *HANDLE;
 
+typedef const CHAR* LPCSTR;
 typedef const WCHAR* LPCWSTR;
 
 #define _fseeki64(a, b, c) fseeko64(a, b, c)

--- a/programs/meson.build
+++ b/programs/meson.build
@@ -1,1 +1,2 @@
 subdir('vkd3d-compiler')
+subdir('vkd3d-hlsl-build')

--- a/programs/vkd3d-hlsl-build/dxbc_library.cpp
+++ b/programs/vkd3d-hlsl-build/dxbc_library.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Philip Rebohle for Valve Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+#include <cstring>
+#include <iostream>
+#include <unordered_map>
+
+#include "dxbc_library.h"
+
+d3dcompiler_library::d3dcompiler_library()
+{
+    m_d3dcompiler = LoadLibraryA("d3dcompiler_47.dll");
+
+    if (!m_d3dcompiler)
+    {
+        std::cerr << "Failed to load d3dcompiler_47.dll." << std::endl;
+        return;
+    }
+
+    m_d3d_compile_proc = reinterpret_cast<pfn_d3d_compile>(
+        GetProcAddress(m_d3dcompiler, "D3DCompile"));
+    m_d3d_strip_shader_proc = reinterpret_cast<pfn_d3d_strip_shader_proc>(
+        GetProcAddress(m_d3dcompiler, "D3DStripShader"));
+
+    if (!m_d3d_compile_proc || !m_d3d_strip_shader_proc)
+    {
+        std::cerr << "Failed to locate D3DCompile and D3DStripShader functions." << std::endl;
+        FreeLibrary(m_d3dcompiler);
+        m_d3dcompiler = nullptr;
+    }
+}
+
+
+d3dcompiler_library::~d3dcompiler_library()
+{
+    FreeLibrary(m_d3dcompiler);
+}
+
+
+bool d3dcompiler_library::compile(const std::vector<char> &code, LPCSTR source_name, LPCSTR target,
+        LPCSTR entry_point, const std::vector<std::wstring> &arguments, std::vector<char> &binary) const
+{
+    static const std::unordered_map<std::wstring, UINT> argument_map = {{
+        { L"-Vd",                     D3DCOMPILE_SKIP_VALIDATION                },
+        { L"-Od",                     D3DCOMPILE_SKIP_OPTIMIZATION              },
+        { L"-Zpr",                    D3DCOMPILE_PACK_MATRIX_ROW_MAJOR          },
+        { L"-Zpc",                    D3DCOMPILE_PACK_MATRIX_COLUMN_MAJOR       },
+        { L"-Gpp",                    D3DCOMPILE_PARTIAL_PRECISION              },
+        { L"-Gfa",                    D3DCOMPILE_AVOID_FLOW_CONTROL             },
+        { L"-Ges",                    D3DCOMPILE_ENABLE_STRICTNESS              },
+        { L"-Gis",                    D3DCOMPILE_IEEE_STRICTNESS                },
+        { L"-Gec",                    D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY },
+        { L"-O0",                     D3DCOMPILE_OPTIMIZATION_LEVEL0            },
+        { L"-O1",                     D3DCOMPILE_OPTIMIZATION_LEVEL1            },
+        { L"-O2",                     D3DCOMPILE_OPTIMIZATION_LEVEL2            },
+        { L"-O3",                     D3DCOMPILE_OPTIMIZATION_LEVEL3            },
+        { L"-WX",                     D3DCOMPILE_WARNINGS_ARE_ERRORS            },
+        { L"-res_may_alias",          D3DCOMPILE_RESOURCES_MAY_ALIAS            },
+        { L"-enable_unbounded_descriptor_tables",
+                                      D3DCOMPILE_ENABLE_UNBOUNDED_DESCRIPTOR_TABLES },
+        { L"-all_resources_bound",    D3DCOMPILE_ALL_RESOURCES_BOUND            },
+    }};
+
+    if (!m_d3dcompiler)
+        return false;
+
+    ID3DBlob *blob = nullptr;
+    ID3DBlob *errors = nullptr;
+
+    /* Always enable unbounded descriptor tables for convenience, but
+     * recognize the fxc argument anyway instead of erroring out. */
+    UINT flags = D3DCOMPILE_ENABLE_UNBOUNDED_DESCRIPTOR_TABLES;
+
+    for (const auto &arg : arguments) {
+        auto entry = argument_map.find(arg);
+
+        if (entry == argument_map.end())
+        {
+            std::wcerr << "Unknown argument: '" << arg << "'" << std::endl;
+            return false;
+        }
+
+        flags |= entry->second;
+    }
+
+    /* Default to full optimization */
+    if (!(flags & (D3DCOMPILE_OPTIMIZATION_LEVEL0 |
+            D3DCOMPILE_OPTIMIZATION_LEVEL1 |
+            D3DCOMPILE_OPTIMIZATION_LEVEL2 |
+            D3DCOMPILE_OPTIMIZATION_LEVEL3 |
+            D3DCOMPILE_SKIP_OPTIMIZATION)))
+        flags |= D3DCOMPILE_OPTIMIZATION_LEVEL3;
+
+    HRESULT hr = m_d3d_compile_proc(code.data(), code.size(), source_name,
+        nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, entry_point, target,
+        flags, 0, &blob, &errors);
+
+    if (errors)
+    {
+        std::wcerr << reinterpret_cast<const char*>(
+          errors->GetBufferPointer()) << std::endl;
+        errors->Release();
+    }
+
+    if (FAILED(hr))
+        return false;
+
+    ID3DBlob *stripped_blob = nullptr;
+
+    hr = m_d3d_strip_shader_proc(blob->GetBufferPointer(), blob->GetBufferSize(),
+      D3DCOMPILER_STRIP_REFLECTION_DATA | D3DCOMPILER_STRIP_DEBUG_INFO, &stripped_blob);
+
+    blob->Release();
+
+    if (FAILED(hr))
+        return false;
+
+    binary.resize(stripped_blob->GetBufferSize());
+    std::memcpy(binary.data(), stripped_blob->GetBufferPointer(), binary.size());
+
+    stripped_blob->Release();
+    return true;
+}

--- a/programs/vkd3d-hlsl-build/dxbc_library.h
+++ b/programs/vkd3d-hlsl-build/dxbc_library.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Philip Rebohle for Valve Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+#pragma once
+
+#include <vector>
+
+#include <d3dcompiler.h>
+
+using pfn_d3d_compile = HRESULT (STDMETHODCALLTYPE *) (LPCVOID src_data,
+    SIZE_T src_data_size, LPCSTR source_name, const D3D_SHADER_MACRO *defines,
+    ID3DInclude *includes, LPCSTR entry_point, LPCSTR target, UINT flags1,
+    UINT flags2, ID3DBlob **code, ID3DBlob **error_msgs);
+
+using pfn_d3d_strip_shader_proc = HRESULT (STDMETHODCALLTYPE *) (LPCVOID shader_bytecode,
+    SIZE_T bytecode_length, UINT strip_flags, ID3DBlob **stripped_blob);
+
+class d3dcompiler_library
+{
+public:
+
+    d3dcompiler_library();
+
+    d3dcompiler_library(const d3dcompiler_library&) = delete;
+    d3dcompiler_library &operator = (const d3dcompiler_library&) = delete;
+
+    ~d3dcompiler_library();
+
+    bool compile(const std::vector<char> &code, LPCSTR source_name, LPCSTR target,
+            LPCSTR entry_point, const std::vector<std::wstring> &arguments, std::vector<char> &binary) const;
+
+private:
+
+    HMODULE m_d3dcompiler = nullptr;
+
+    pfn_d3d_compile m_d3d_compile_proc = nullptr;
+    pfn_d3d_strip_shader_proc m_d3d_strip_shader_proc = nullptr;
+
+};

--- a/programs/vkd3d-hlsl-build/dxil_library.cpp
+++ b/programs/vkd3d-hlsl-build/dxil_library.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2024 Philip Rebohle for Valve Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+#define INITGUID
+
+#include <array>
+#include <cstring>
+#include <iostream>
+
+#include "dxil_library.h"
+
+dxc_library dxc_library::instance;
+
+
+dxc_library::dxc_library()
+{
+    m_dxcompiler = LoadLibraryA("dxcompiler.dll");
+
+    if (!m_dxcompiler)
+    {
+        std::wcerr << "Failed to load dxcompiler.dll." << std::endl;
+        return;
+    }
+
+    m_dxc_create_instance = reinterpret_cast<DxcCreateInstanceProc>(
+        GetProcAddress(m_dxcompiler, "DxcCreateInstance"));
+
+    if (!m_dxc_create_instance)
+    {
+        std::wcerr << "DxcCreateInstance not found in dxcompiler.dll." << std::endl;
+        FreeLibrary(m_dxcompiler);
+        m_dxcompiler = nullptr;
+    }
+}
+
+
+dxc_library::~dxc_library()
+{
+    FreeLibrary(m_dxcompiler);
+}
+
+
+bool dxc_library::compile(const std::vector<char> &code, LPCWSTR source_name, LPCWSTR target,
+        LPCWSTR entry_point, const std::vector<std::wstring> &arguments, std::vector<char> &binary) const
+{
+    if (!m_dxcompiler)
+        return false;
+
+    /* These are not thread-safe, just create new instances each time */
+    IDxcUtils *utils = nullptr;
+    HRESULT hr = m_dxc_create_instance(CLSID_DxcUtils, IID_PPV_ARGS(&utils));
+
+    if (FAILED(hr))
+    {
+        std::wcerr << "Failed to create IDxcUtils instance." << std::endl;
+        return false;
+    }
+
+    IDxcCompiler3 *compiler = nullptr;
+    hr = m_dxc_create_instance(CLSID_DxcCompiler, IID_PPV_ARGS(&compiler));
+
+    if (FAILED(hr))
+    {
+        std::wcerr << "Failed to create IDxcCompiler3 instance." << std::endl;
+        utils->Release();
+        return false;
+    }
+
+    IDxcIncludeHandler *include_handler = nullptr;
+    hr = utils->CreateDefaultIncludeHandler(&include_handler);
+
+    if (FAILED(hr))
+    {
+        std::wcerr << "Failed to create include handler." << std::endl;
+        utils->Release();
+        compiler->Release();
+        return false;
+    }
+
+    /* Set up parameters that minimize the generated binary size */
+    IDxcCompilerArgs *args = nullptr;
+
+    std::vector<LPCWSTR> argument_list = {
+        L"-Qstrip_debug",
+        L"-Qstrip_reflect",
+    };
+
+    for (const auto &arg : arguments)
+        argument_list.push_back(arg.c_str());
+
+    hr = utils->BuildArguments(source_name, entry_point, target,
+            argument_list.data(), argument_list.size(), nullptr, 0, &args);
+
+    if (FAILED(hr))
+    {
+        std::wcerr << "Failed to build compiler arguments." << std::endl;
+        include_handler->Release();
+        utils->Release();
+        compiler->Release();
+        return false;
+    }
+
+    IDxcResult *result = nullptr;
+
+    /* Assume that shader code is some sort of single-byte encoding */
+    DxcBuffer source_buffer = { };
+    source_buffer.Ptr = code.data();
+    source_buffer.Size = code.size();
+    source_buffer.Encoding = DXC_CP_UTF8;
+
+    hr = compiler->Compile(&source_buffer,
+        args->GetArguments(), args->GetCount(),
+        include_handler, IID_PPV_ARGS(&result));
+
+    /* Compile will still return S_OK if compilation failed, we need to ask
+     * the result object for the status of the operation, and for some bizarre
+     * reason that call returns a HRESULT itself, so we have three layers of
+     * error checking here. Just make sure we end up with an error status at
+     * the end if anything fails here. */
+    if (SUCCEEDED(hr))
+    {
+        HRESULT status = S_OK;
+        hr = result->GetStatus(&status);
+
+        if (SUCCEEDED(hr))
+            hr = status;
+    }
+
+    bool status = SUCCEEDED(hr);
+
+    if (status)
+    {
+        /* Compilation successful, just retrieve the binary blob and return it. */
+        IDxcBlob *binary_blob = nullptr;
+
+        if (result && result->HasOutput(DXC_OUT_OBJECT))
+        {
+            hr = result->GetOutput(DXC_OUT_OBJECT, IID_PPV_ARGS(&binary_blob), nullptr);
+
+            if (SUCCEEDED(hr))
+            {
+                binary.resize(binary_blob->GetBufferSize());
+                std::memcpy(binary.data(), binary_blob->GetBufferPointer(), binary.size());
+            }
+        }
+
+        if (binary_blob)
+            binary_blob->Release();
+        else
+            std::wcerr << "Failed to retrieve shader binary." << std::endl;
+    }
+    else if (result)
+    {
+        /* Try to print, retrieve and convert error messages to a format that we
+         * can print to the console. More nested error checking madness here. */
+        std::wcerr << "Failed to compile DXIL shader '" << source_name << "':" << std::endl;
+
+        if (result->HasOutput(DXC_OUT_ERRORS))
+        {
+            IDxcBlobEncoding *error_blob = nullptr;
+            IDxcBlobWide *error_blob_wide = nullptr;
+
+            hr = result->GetOutput(DXC_OUT_ERRORS, IID_PPV_ARGS(&error_blob), nullptr);
+
+            if (SUCCEEDED(hr) && SUCCEEDED(utils->GetBlobAsWide(error_blob, &error_blob_wide)))
+            {
+                std::wcerr << error_blob_wide->GetStringPointer() << std::endl;
+                error_blob_wide->Release();
+            }
+            else
+            {
+                std::wcerr << "Failed to get errors." << std::endl;
+            }
+
+            if (error_blob)
+                error_blob->Release();
+        }
+    }
+
+    if (result)
+        result->Release();
+
+    args->Release();
+    include_handler->Release();
+    compiler->Release();
+    utils->Release();
+    return status;
+}

--- a/programs/vkd3d-hlsl-build/dxil_library.h
+++ b/programs/vkd3d-hlsl-build/dxil_library.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Philip Rebohle for Valve Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <vkd3d_dxcapi.h>
+
+class dxc_library
+{
+public:
+
+    static dxc_library instance;
+
+    dxc_library();
+
+    dxc_library(const dxc_library&) = delete;
+    dxc_library &operator = (const dxc_library&) = delete;
+
+    ~dxc_library();
+
+    bool compile(const std::vector<char> &code, LPCWSTR source_name, LPCWSTR target,
+            LPCWSTR entry_point, const std::vector<std::wstring> &arguments, std::vector<char> &binary) const;
+
+private:
+
+    HMODULE m_dxcompiler = nullptr;
+
+    DxcCreateInstanceProc m_dxc_create_instance = nullptr;
+
+};

--- a/programs/vkd3d-hlsl-build/main.cpp
+++ b/programs/vkd3d-hlsl-build/main.cpp
@@ -1,0 +1,521 @@
+/*
+ * Copyright 2024 Philip Rebohle for Valve Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <queue>
+#include <mutex>
+#include <string>
+#include <sstream>
+#include <thread>
+#include <utility>
+
+#include "dxbc_library.h"
+#include "dxil_library.h"
+
+template<typename T>
+std::string from_wide_string(const T &str)
+{
+    std::string result;
+    result.reserve(str.size());
+
+    for (size_t i = 0; i < str.size(); i++)
+        result += char(str[i]);
+
+    return result;
+}
+
+
+bool create_output_directory(const std::filesystem::path &path)
+{
+  return std::filesystem::is_directory(path) ||
+          std::filesystem::create_directory(path);
+}
+
+
+/* Structure that stores compiler instances */
+struct compiler_instances
+{
+    dxc_library dxc;
+    d3dcompiler_library d3dcompiler;
+};
+
+
+struct shader_profile
+{
+    /* Full target name for DXC */
+    std::wstring wide_name;
+    /* Full target name for d3dcompiler */
+    std::string name;
+    /* Compiler arguments. For DXIL, these are passed directly to
+     * dxcapi, for d3dcompiler these match fxc arguments. */
+    std::vector<std::wstring> arguments;
+    /* Whether or not the shader targets Shader Model 6 or above */
+    bool is_dxil = false;
+
+    template<typename string_type>
+    static std::optional<shader_profile> parse(const string_type &str)
+    {
+        using char_type = typename string_type::value_type;
+
+        shader_profile result;
+        uint32_t idx = 0;
+
+        /* Validate profile name until delimiter. Only ASCII
+         * characters are allowed. */
+        while (str[idx] && str[idx] != char_type('_'))
+        {
+            if (str[idx++] > char_type('\x7f'))
+                return std::nullopt;
+        }
+
+        if (str[idx++] != char_type('_'))
+            return std::nullopt;
+
+        /* Valicate major version and check whether the profile is
+         * DXIL (6_x) or DXBC (5_x) */
+        if (str[idx] < char_type('0') || str[idx] > char_type('9'))
+            return std::nullopt;
+
+        uint8_t hi_ver = uint8_t(str[idx++] - char_type('0'));
+
+        if (str[idx++] != char_type('_'))
+            return std::nullopt;
+
+        result.is_dxil = hi_ver >= 6;
+
+        /* Validate minor version number */
+        while (str[idx])
+        {
+            if (str[idx] < char_type('0') || str[idx] > char_type('9'))
+                return std::nullopt;
+            idx++;
+        }
+
+        if (result.is_dxil)
+            result.wide_name.reserve(idx);
+        else
+            result.name.reserve(idx);
+
+        /* Copy profile name to relevant string */
+        for (uint32_t i = 0; i < idx; i++)
+        {
+            if (result.is_dxil)
+              result.wide_name.push_back(str[i]);
+            else
+              result.name.push_back(char(str[i]));
+        }
+
+        return std::make_optional(std::move(result));
+    }
+
+
+    template<typename string_type>
+    void add_argument(const string_type &str)
+    {
+        /* Handle spaces as delimiters within compiler arguments */
+        using char_type = typename string_type::value_type;
+
+        string_type prefix;
+        prefix = char_type('-');
+
+        auto delim = str.find(' ');
+        arguments.push_back(prefix + str.substr(0, delim));
+
+        while (delim != string_type::npos)
+        {
+            auto next = str.find(' ', delim + 1);
+            arguments.push_back(str.substr(delim + 1, next - delim - 1));
+            delim = next;
+        }
+    }
+};
+
+
+struct work_item
+{
+    std::filesystem::path in_file;
+    std::filesystem::path out_file;
+
+    /* Support one DXIL profile and one DXBC one */
+    std::array<shader_profile, 2> profiles;
+    uint32_t profile_count = 0;
+
+
+    static std::optional<work_item> parse(std::filesystem::path file,
+            const std::filesystem::path &dst_dir)
+    {
+        work_item result;
+
+        /* Get rid of .hlsl extension right away */
+        auto file_name = file.filename().stem().native();
+
+        /* File names are formatted as:
+         *    frog.vs_6_6.enable-16-bit-types.vs_5_1.hlsl.Gis.hlsl
+         *
+         * where 'frog' is used as the output file name, vs_x_y are the shader
+         * profiles to compile the shader for, and all other parts are interpreted
+         * as compiler options for the previously specified profile. */
+        auto delim = file_name.find('.');
+        result.out_file = dst_dir / file_name.substr(0, delim);
+        result.out_file += ".h";
+
+        /* Parse the file name as a sequence of shader targets delimited
+         * by dots, e.g. frog.vs_6_6.vs_5_1.hlsl */
+        while (delim != std::filesystem::path::string_type::npos)
+        {
+            auto next = file_name.find('.', delim + 1);
+            auto substr = file_name.substr(delim + 1, next - delim - 1);
+
+            auto profile = shader_profile::parse(substr);
+
+            if (profile)
+            {
+                if (result.profile_count == result.profiles.size())
+                {
+                    std::wcerr << file << ": Too many profiles specified." << std::endl;
+                    return std::nullopt;
+                }
+
+                result.profiles[result.profile_count++] = std::move(*profile);
+            }
+            else
+            {
+                if (!result.profile_count)
+                {
+                    std::wcerr << file << ": Found option " << substr << ", but no profile specified." << std::endl;
+                    return std::nullopt;
+                }
+
+                result.profiles[result.profile_count - 1].add_argument(substr);
+            }
+
+            delim = next;
+        }
+
+        if (!result.profile_count)
+        {
+            std::wcerr << file << ": No profiles specified." << std::endl;
+            return std::nullopt;
+        }
+
+        result.in_file = std::move(file);
+        return std::make_optional(std::move(result));
+    }
+
+
+    bool needs_update() const
+    {
+        /* Check if the output file exists first, then compare access dates */
+        if (!std::filesystem::is_regular_file(out_file))
+            return true;
+
+        auto in_time = std::filesystem::last_write_time(in_file);
+        auto out_time = std::filesystem::last_write_time(out_file);
+
+        return in_time > out_time;
+    }
+
+
+    bool compile(const compiler_instances &compilers) const
+    {
+        if (!create_output_directory(out_file.parent_path()))
+            return false;
+
+        /* Read entire source file into a character array */
+        std::ifstream in_stream(in_file, std::ios::binary | std::ios::ate);
+
+        if (!in_stream.is_open())
+        {
+            std::wcerr << in_file << ": Failed to open file." << std::endl;
+            return false;
+        }
+
+        std::vector<char> code(in_stream.tellg());
+        in_stream.seekg(0, std::ios::beg);
+
+        if (!in_stream.read(code.data(), code.size()))
+        {
+            std::wcerr << in_file << ": Failed to read file." << std::endl;
+            return false;
+        }
+
+        /* Source file name, used by both DXC and d3dcompiler for
+         * error reporting, but in different character encodings */
+        auto source_name_wide = in_file.filename().native();
+        auto source_name = from_wide_string(source_name_wide);
+
+        /* Accumulate data in a string stream first, so that we can
+         * discard it and not alter the output file's time stamp in
+         * case any profile fails to compile. */
+        std::stringstream header_stream;
+
+        for (uint32_t i = 0; i < profile_count; i++)
+        {
+            std::vector<char> binary;
+            bool status;
+
+            if (profiles[i].is_dxil)
+                status = compilers.dxc.compile(code, in_file.filename().c_str(),
+                        profiles[i].wide_name.data(), L"main", profiles[i].arguments, binary);
+            else
+                status = compilers.d3dcompiler.compile(code, source_name.c_str(),
+                        profiles[i].name.data(), "main", profiles[i].arguments, binary);
+
+            if (!status)
+                return false;
+
+            emit_binary(header_stream, binary, profiles[i].is_dxil);
+        }
+
+        /* Compiling will have succeeded at this point, write the output. */
+        std::ofstream out_stream(out_file, std::ios::trunc | std::ios::binary);
+
+        if (!out_stream.is_open())
+        {
+            std::wcerr << out_file << ": Failed to create file." << std::endl;
+            return false;
+        }
+
+        if (!(out_stream << header_stream.str()))
+        {
+            std::wcerr << out_file << ": Failed to write file." << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+private:
+
+    void emit_binary(std::ostream &out_stream, const std::vector<char> &binary, bool is_dxil) const
+    {
+        const char *var_suffix = is_dxil ? "dxil" : "dxbc";
+        std::string var_name = from_wide_string(out_file.stem().native());
+
+        out_stream << "static const " << (is_dxil ? "BYTE" : "DWORD")
+                   << " " << var_name << "_code_" << var_suffix << "[] =\n{\n";
+
+        /* Stick to the usual formatting */
+        size_t unit_size = is_dxil ? 1 : 4;
+        size_t row_length = 32;
+
+        for (size_t i = 0; i < binary.size(); i += row_length)
+        {
+            out_stream << "   ";
+
+            for (size_t j = 0; j < row_length / unit_size; j++)
+            {
+                size_t offset = i + j * unit_size;
+
+                /* Handle lines that are less than the maximum length */
+                if (offset >= binary.size())
+                    break;
+
+                uint32_t unit = 0u;
+                std::memcpy(&unit, &binary[offset], unit_size);
+                out_stream << " 0x" << std::hex << std::setfill('0') << std::setw(2 * unit_size) << unit << ",";
+            }
+
+            out_stream << "\n";
+        }
+
+        out_stream << "};\n";
+        out_stream << "static const D3D12_SHADER_BYTECODE " << var_name << "_" << var_suffix
+                   << " = { " << var_name << "_code_" << var_suffix << ", "
+                   << "sizeof(" << var_name << "_code_" << var_suffix << ") };\n";
+    }
+
+};
+
+
+/* Simple worker thread system that spawns up to one thread
+ * per available CPU core on demand in case a large number
+ * of files needs updating. */
+class thread_manager
+{
+public:
+
+    thread_manager()
+    : m_max_threads(std::thread::hardware_concurrency())
+    {
+        m_threads.reserve(m_max_threads);
+    }
+
+    /* Queues up work item and spawns a thread if necessary */
+    void add_item(work_item &&item)
+    {
+        if (m_threads.size() < m_max_threads)
+            m_threads.emplace_back([this] { run(); });
+
+        std::lock_guard lock(m_mutex);
+        m_work_items.push(std::move(item));
+        m_cond.notify_one();
+    }
+
+    /* Waits for all threads to finish and returns false
+     * if any queued up compile job has failed. */
+    bool stop()
+    {
+        {
+            std::lock_guard lock(m_mutex);
+            m_stop = true;
+            m_cond.notify_all();
+        }
+
+        for (auto &t : m_threads)
+            t.join();
+
+        m_threads.clear();
+        return m_status.load();
+    }
+
+private:
+
+    compiler_instances        m_compilers;
+
+    std::atomic<bool>         m_status = { true };
+
+    std::mutex                m_mutex;
+    std::condition_variable   m_cond;
+    std::queue<work_item>     m_work_items;
+    std::vector<std::thread>  m_threads;
+    bool                      m_stop = false;
+
+    uint32_t                  m_max_threads = 0;
+
+    void run()
+    {
+        while (true)
+        {
+            std::unique_lock lock(m_mutex);
+
+            m_cond.wait(lock, [this]
+            {
+                return m_stop || !m_work_items.empty();
+            });
+
+            /* Ensure queue is drained before exiting */
+            if (m_work_items.empty())
+                return;
+
+            work_item item = std::move(m_work_items.front());
+            m_work_items.pop();
+
+            lock.unlock();
+
+            if (!item.compile(m_compilers))
+                m_status.store(false);
+        }
+    }
+
+};
+
+
+/* Scans shader files in the given source directory and queues up any
+ * file for compiling if it has been updated more recently than its
+ * corresponding output file. */
+bool build_shader_files(const std::filesystem::path &src_dir,
+        const std::filesystem::path &dst_dir, bool rebuild_all)
+{
+    thread_manager threads;
+    bool error = false;
+
+    for (const auto &file : std::filesystem::directory_iterator(src_dir))
+    {
+        if (!file.is_regular_file())
+            continue;
+
+        const auto &file_path = file.path();
+
+        if (file_path.extension() != ".hlsl")
+            continue;
+
+        auto item = work_item::parse(file_path, dst_dir);
+
+        if (!item)
+        {
+            error = true;
+            continue;
+        }
+
+        if (rebuild_all || item->needs_update())
+            threads.add_item(std::move(*item));
+    }
+
+    return threads.stop() && !error;
+}
+
+
+int main(int argc, char **argv)
+{
+    std::filesystem::path src_dir = std::filesystem::current_path();
+    std::filesystem::path dst_dir;
+    bool rebuild_all = false;
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (!std::strcmp(argv[i], "-a"))
+        {
+            rebuild_all = true;
+        }
+        else if (!std::strcmp(argv[i], "-t"))
+        {
+            if (i + 1 >= argc)
+            {
+                std::wcerr << "-t: No target directory specified." << std::endl;
+                return 1;
+            }
+
+            dst_dir = argv[++i];
+        }
+        else if (!std::strcmp(argv[i], "--help"))
+        {
+            std::wcout << "Usage: " << argv[0] << " [-a] [-t output_dir] [input_dir]" << std::endl;
+            return 0;
+        }
+        else if (argv[i][0] != '-')
+        {
+            src_dir = argv[i];
+        }
+    }
+
+    if (dst_dir.empty())
+        dst_dir = src_dir / "headers";
+
+    if (!std::filesystem::is_directory(src_dir))
+    {
+        std::wcerr << "Input directory '" << src_dir << "' does not exist." << std::endl;
+        return 1;
+    }
+
+    if (!create_output_directory(dst_dir))
+    {
+        std::wcerr << "Failed to create target directory '" << dst_dir << "'." << std::endl;
+        return 1;
+    }
+
+    return build_shader_files(src_dir, dst_dir, rebuild_all) ? 0 : 1;
+}

--- a/programs/vkd3d-hlsl-build/meson.build
+++ b/programs/vkd3d-hlsl-build/meson.build
@@ -1,0 +1,19 @@
+vkd3d_hlsl_build_files = files(
+  'dxbc_library.cpp',
+  'dxil_library.cpp',
+  'main.cpp',
+)
+
+hlsl_build_cpp_args = []
+
+if not vkd3d_is_msvc
+  hlsl_build_cpp_args += ['-Wno-cast-function-type']
+endif
+
+if vkd3d_platform == 'windows'
+  add_languages('cpp', native : false, required : true)
+  executable('vkd3d-hlsl-build', vkd3d_hlsl_build_files, vkd3d_header_files,
+    include_directories : vkd3d_private_includes,
+    cpp_args : hlsl_build_cpp_args,
+    override_options: ['cpp_std=c++17'])
+endif


### PR DESCRIPTION
As discussed on Discord, this could be used to make writing tests less painful by allowing us to simply run the exe within a directory that contains HLSL shaders and spits out plain C headers. Draft for now to gauge whether this is going in the right direction.

Currently, this works as follows:
- For DXIL, `dxcompiler.dll` must be in the search path (either next to the exe or in the wine prefix). As for headers, I added a new IDL with the necessary interfaces, but it does not cover the entire DXC API.
- For DXBC, we require `d3dcompiler_47.dll` as the latest version. I haven't added a custom IDL for the d3dcompiler APIs since MinGW ships the necessary headers anyway, but I can add a minimal IDL here as well if we want to go that route.
- Input directory defaults to CWD, can be changed via command line. This currently does not scan directories recursively.
- Output directory defaults to `headers` within the source directory.
- Input files must named something like `frog.vs_6_0.vs_5_0.hlsl`, with support for up to one DXIL target and up to one DXBC target (of course, specifying only one also works). The output file name would be `frog.h`, and names of the corresponding `D3D12_SHADER_BYTECODE` constants are `frog_dxil` and `frog_dxbc`.
- The entry point **must** be called `main`. When porting our existing shaders, this would to be adjusted in some places.
- Debug and reflection info are currently always stripped out of the binaries to keep the size small.
- In terms of naming, we assume ASCII characters for everything excluding directory paths. This is kind of necessary anyway since C wouldn't be overly happy about having 🐸 as a variable name, but also simplifies string conversions in various places because *of course* the shader compiler APIs are inconsistent about requiring wide strings vs utf-8 strings.

All of this could be changed or expanded if necessary (e.g. to allow for changing entry point names, or supporting multiple entry points per file), but for now I went with a fairly minimal approach. I haven't really looked into whether special options are necessary when compiling raytracing/workgraph shaders or shaders with embedded root signatures.