### PR TITLE
Add ID3D12DeviceRemovedExtendedDataSettings stub

### DIFF
--- a/include/vkd3d_d3d12.idl
+++ b/include/vkd3d_d3d12.idl
@@ -5072,6 +5072,19 @@ interface ID3D12VersionedRootSignatureDeserializer : IUnknown
     const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *GetUnconvertedRootSignatureDesc();
 };
 
+[
+    uuid(82bc481c-6b9b-4030-aedb-7ee3d1df1e63),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12DeviceRemovedExtendedDataSettings : IUnknown
+{
+    void SetAutoBreadcrumbsEnablement(D3D12_DRED_ENABLEMENT enablement);
+    void SetPageFaultEnablement(D3D12_DRED_ENABLEMENT enablement);
+    void SetWatsonDumpEnablement(D3D12_DRED_ENABLEMENT enablement);
+}
+
 [local] HRESULT __stdcall D3D12CreateRootSignatureDeserializer(
         const void *data, SIZE_T data_size, REFIID iid, void **deserializer);
 

--- a/libs/d3d12core/debug.c
+++ b/libs/d3d12core/debug.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Philip Rebohle for Valve Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+#define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+
+#include "vkd3d_debug.h"
+#include "vkd3d_threads.h"
+
+#include "debug.h"
+
+static struct d3d12_dred_settings *d3d12_dred_settings_instance;
+
+static pthread_mutex_t debug_singleton_lock = PTHREAD_MUTEX_INITIALIZER;
+
+
+static struct d3d12_dred_settings *impl_from_ID3D12DeviceRemovedExtendedDataSettings(ID3D12DeviceRemovedExtendedDataSettings *iface);
+
+static HRESULT STDMETHODCALLTYPE d3d12_dred_settings_QueryInterface(
+        d3d12_dred_settings_iface *iface, REFIID riid, void **object)
+{
+    TRACE("iface %p, riid %s, object %p.\n", iface, debugstr_guid(riid), object);
+
+    if (!object)
+        return E_POINTER;
+
+    if (IsEqualGUID(riid, &IID_IUnknown)
+            || IsEqualGUID(riid, &IID_ID3D12DeviceRemovedExtendedDataSettings))
+    {
+        ID3D12DeviceRemovedExtendedDataSettings_AddRef(iface);
+        *object = iface;
+        return S_OK;
+    }
+
+    WARN("%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid(riid));
+
+    *object = NULL;
+    return E_NOINTERFACE;
+}
+
+static ULONG STDMETHODCALLTYPE d3d12_dred_settings_AddRef(d3d12_dred_settings_iface *iface)
+{
+    struct d3d12_dred_settings *dred_settings = impl_from_ID3D12DeviceRemovedExtendedDataSettings(iface);
+    ULONG refcount = InterlockedIncrement(&dred_settings->refcount);
+
+    TRACE("%p increasing refcount to %u.\n", dred_settings, refcount);
+
+    return refcount;
+}
+
+static ULONG STDMETHODCALLTYPE d3d12_dred_settings_Release(d3d12_dred_settings_iface *iface)
+{
+    struct d3d12_dred_settings *dred_settings = impl_from_ID3D12DeviceRemovedExtendedDataSettings(iface);
+    ULONG refcount;
+
+    pthread_mutex_lock(&debug_singleton_lock);
+    refcount = InterlockedDecrement(&dred_settings->refcount);
+
+    TRACE("%p decreasing refcount to %u.\n", dred_settings, refcount);
+
+    if (!refcount)
+    {
+        assert(d3d12_dred_settings_instance == dred_settings);
+        vkd3d_free(dred_settings);
+        d3d12_dred_settings_instance = NULL;
+    }
+
+    pthread_mutex_unlock(&debug_singleton_lock);
+    return refcount;
+}
+
+static void STDMETHODCALLTYPE d3d12_dred_settings_SetAutoBreadcrumbsEnablement( 
+        d3d12_dred_settings_iface *iface, D3D12_DRED_ENABLEMENT enablement)
+{
+    FIXME_ONCE("iface %p, enablement %u stub!\n", iface, enablement);
+}
+
+static void STDMETHODCALLTYPE d3d12_dred_settings_SetPageFaultEnablement( 
+        d3d12_dred_settings_iface *iface, D3D12_DRED_ENABLEMENT enablement)
+{
+    FIXME_ONCE("iface %p, enablement %u stub!\n", iface, enablement);
+}
+
+static void STDMETHODCALLTYPE d3d12_dred_settings_SetWatsonDumpEnablement( 
+        d3d12_dred_settings_iface *iface, D3D12_DRED_ENABLEMENT enablement)
+{
+    FIXME_ONCE("iface %p, enablement %u stub!\n", iface, enablement);
+}
+
+CONST_VTBL struct ID3D12DeviceRemovedExtendedDataSettingsVtbl d3d12_dred_settings_vtbl =
+{
+    /* IUnknown methods */
+    d3d12_dred_settings_QueryInterface,
+    d3d12_dred_settings_AddRef,
+    d3d12_dred_settings_Release,
+    /* ID3D12DeviceRemovedExtendedDataSettings methods */
+    d3d12_dred_settings_SetAutoBreadcrumbsEnablement,
+    d3d12_dred_settings_SetPageFaultEnablement,
+    d3d12_dred_settings_SetWatsonDumpEnablement,
+};
+
+static void d3d12_dred_settings_init(struct d3d12_dred_settings *object)
+{
+    object->ID3D12DeviceRemovedExtendedDataSettings_iface.lpVtbl = &d3d12_dred_settings_vtbl;
+    object->refcount = 0; /* incremented on retrieval */
+}
+
+HRESULT d3d12_dred_settings_create(ID3D12DeviceRemovedExtendedDataSettings **object)
+{
+    ID3D12DeviceRemovedExtendedDataSettings *iface;
+    HRESULT hr = S_OK;
+
+    pthread_mutex_lock(&debug_singleton_lock);
+
+    if (!d3d12_dred_settings_instance)
+    {
+        d3d12_dred_settings_instance = vkd3d_malloc(sizeof(*d3d12_dred_settings_instance));
+        d3d12_dred_settings_init(d3d12_dred_settings_instance);
+    }
+
+    iface = &d3d12_dred_settings_instance->ID3D12DeviceRemovedExtendedDataSettings_iface;
+    ID3D12DeviceRemovedExtendedDataSettings_AddRef(iface);
+
+    pthread_mutex_unlock(&debug_singleton_lock);
+
+    *object = iface;
+    return hr;
+}
+
+static struct d3d12_dred_settings *impl_from_ID3D12DeviceRemovedExtendedDataSettings(ID3D12DeviceRemovedExtendedDataSettings *iface)
+{
+    if (!iface)
+        return NULL;
+    assert(iface->lpVtbl == &d3d12_dred_settings_vtbl);
+    return CONTAINING_RECORD(iface, struct d3d12_dred_settings, ID3D12DeviceRemovedExtendedDataSettings_iface);
+}

--- a/libs/d3d12core/debug.h
+++ b/libs/d3d12core/debug.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Philip Rebohle for Valve Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+#ifndef __VKD3D_CORE_DEBUG_H
+#define __VKD3D_CORE_DEBUG_H
+
+#include "vkd3d.h"
+
+typedef ID3D12DeviceRemovedExtendedDataSettings d3d12_dred_settings_iface;
+
+struct d3d12_dred_settings
+{
+    d3d12_dred_settings_iface ID3D12DeviceRemovedExtendedDataSettings_iface;
+    LONG refcount;
+};
+
+HRESULT d3d12_dred_settings_create(ID3D12DeviceRemovedExtendedDataSettings **dred_settings);
+
+#endif

--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -32,6 +32,8 @@
 #include "vkd3d_threads.h"
 #include "vkd3d_core_interface.h"
 
+#include "debug.h"
+
 /* We need to specify the __declspec(dllexport) attribute
  * on MinGW because otherwise the stdcall aliases/fixups
  * don't get exported.
@@ -396,10 +398,20 @@ HRESULT STDMETHODCALLTYPE d3d12core_SerializeVersionedRootSignature(d3d12core_in
 HRESULT STDMETHODCALLTYPE d3d12core_GetDebugInterface(d3d12core_interface *core,
         REFIID iid, void** debug)
 {
+    ID3D12DeviceRemovedExtendedDataSettings *dred_settings;
+    HRESULT hr;
+
     TRACE("iid %s, debug %p.\n", debugstr_guid(iid), debug);
 
     if (debug)
         *debug = NULL;
+
+    if (!memcmp(iid, &IID_ID3D12DeviceRemovedExtendedDataSettings, sizeof(*iid)))
+    {
+        hr = d3d12_dred_settings_create(&dred_settings);
+        *debug = dred_settings;
+        return hr;
+    }
 
     WARN("Returning DXGI_ERROR_SDK_COMPONENT_MISSING.\n");
     return DXGI_ERROR_SDK_COMPONENT_MISSING;

--- a/libs/d3d12core/meson.build
+++ b/libs/d3d12core/meson.build
@@ -1,4 +1,5 @@
 d3d12core_src = [
+  'debug.c',
   'main.c'
 ]
 


### PR DESCRIPTION
Fixes Atlas Fallen crashing on launch. Nothing too sophisticated.