### PR TITLE
vkd3d: Falsely report RADV doesn't implicitly clear

### DIFF
--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -1668,7 +1668,6 @@ static inline bool vkd3d_driver_implicitly_clears(VkDriverId driver_id)
     switch (driver_id)
     {
         /* Known to pass test_stress_suballocation which hits this path. */
-        case VK_DRIVER_ID_MESA_RADV:
         case VK_DRIVER_ID_NVIDIA_PROPRIETARY:
         case VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA:
             return true;


### PR DESCRIPTION
radv_zero_vram=true is causing performance problems for many people after some kernel commits, so just workaround the problem for now. (To be clear: at this point in time this is not intended to get merged, only meant for testing purposes)