### PR TITLE
vkd3d-shader: Fix maximum ICB size.

### DIFF
--- a/libs/vkd3d-shader/dxbc.c
+++ b/libs/vkd3d-shader/dxbc.c
@@ -628,7 +628,7 @@ static void shader_sm4_read_shader_data(struct vkd3d_shader_instruction *ins,
 
     ++tokens;
     icb_size = token_count - 1;
-    if (icb_size % 4 || icb_size > MAX_IMMEDIATE_CONSTANT_BUFFER_SIZE)
+    if (icb_size % 4 || icb_size > MAX_IMMEDIATE_CONSTANT_BUFFER_DWORDS)
     {
         FIXME("Unexpected immediate constant buffer size %u.\n", icb_size);
         ins->handler_idx = VKD3DSIH_INVALID;

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -492,7 +492,7 @@ enum vkd3d_shader_conditional_op
 #define VKD3D_SM5_DS  0x0004u
 #define VKD3D_SM5_CS  0x0005u
 
-#define MAX_IMMEDIATE_CONSTANT_BUFFER_SIZE 4096
+#define MAX_IMMEDIATE_CONSTANT_BUFFER_DWORDS 16384
 #define MAX_REG_OUTPUT 32
 
 enum vkd3d_shader_type
@@ -518,7 +518,7 @@ struct vkd3d_shader_version
 struct vkd3d_shader_immediate_constant_buffer
 {
     unsigned int vec4_count;
-    uint32_t data[MAX_IMMEDIATE_CONSTANT_BUFFER_SIZE];
+    uint32_t data[MAX_IMMEDIATE_CONSTANT_BUFFER_DWORDS];
 };
 
 struct vkd3d_shader_indexable_temp


### PR DESCRIPTION
The limit is 4096 four-component vectors, but the size is given in dwords. Rename the constant to make this more clear.