### PR TITLE
vkd3d: proper return values for formats that are valid but not supported.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3731,6 +3731,12 @@ static HRESULT d3d12_device_get_format_support(struct d3d12_device *device, D3D1
     data->Support1 = D3D12_FORMAT_SUPPORT1_NONE;
     data->Support2 = D3D12_FORMAT_SUPPORT2_NONE;
 
+    if (!is_valid_format(data->Format))
+    {
+        WARN("Invalid format %d.\n", data->Format);
+        return E_INVALIDARG;
+    }
+
     if (!data->Format)
     {
         data->Support1 = D3D12_FORMAT_SUPPORT1_BUFFER;
@@ -3743,10 +3749,7 @@ static HRESULT d3d12_device_get_format_support(struct d3d12_device *device, D3D1
     if (!(format = vkd3d_get_format(device, data->Format, false)))
         format = vkd3d_get_format(device, data->Format, true);
     if (!format)
-    {
-        FIXME("Unhandled format %#x.\n", data->Format);
-        return E_INVALIDARG;
-    }
+        return E_FAIL;
 
     /* Special opaque formats. */
     if (data->Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ||

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -674,8 +674,11 @@ const struct vkd3d_format *vkd3d_get_format(const struct d3d12_device *device,
 {
     const struct vkd3d_format *format;
 
-    if (dxgi_format > VKD3D_MAX_DXGI_FORMAT)
+    if (!is_valid_format(dxgi_format))
+    {
+        ERR("Invalid format %d.\n", dxgi_format);
         return NULL;
+    }
 
     /* If we request a depth-stencil format (or typeless variant) that is planar,
      * there cannot be any ambiguity which format to select, we must choose a depth-stencil format.
@@ -911,6 +914,17 @@ bool is_valid_resource_state(D3D12_RESOURCE_STATES state)
     }
 
     return true;
+}
+
+bool is_valid_format(DXGI_FORMAT dxgi_format)
+{
+    if (dxgi_format >= DXGI_FORMAT_UNKNOWN && dxgi_format <= DXGI_FORMAT_B4G4R4A4_UNORM)
+        return true;
+    if (dxgi_format >= DXGI_FORMAT_P208 && dxgi_format <= DXGI_FORMAT_V408)
+        return true;
+    if (dxgi_format >= DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE && dxgi_format <= DXGI_FORMAT_A4B4G4R4_UNORM)
+        return true;
+    return false;
 }
 
 HRESULT return_interface(void *iface, REFIID iface_iid,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5338,6 +5338,8 @@ bool is_valid_feature_level(D3D_FEATURE_LEVEL feature_level);
 bool is_valid_resource_state(D3D12_RESOURCE_STATES state);
 bool is_write_resource_state(D3D12_RESOURCE_STATES state);
 
+bool is_valid_format(DXGI_FORMAT format);
+
 HRESULT return_interface(void *iface, REFIID iface_iid,
         REFIID requested_iid, void **object);
 


### PR DESCRIPTION
Found a game engine that was doing it's initial checking of formats fail because E_INVALIDARG was returned for DXGI_FORMAT_R1_UNORM. This format is unspecified in the required and optional format list in msdn but D3D12 returns E_FAIL instead of E_INVALIDARG.

This diff returns E_INVALIDARG if the format is not a valid DXGI_FORMAT but E_FAIL if vkd3d does not support it.

Updating test_format_support to check all formats for valid HR results.