### PR TITLE
Adding support for ASTC extension formats

### DIFF
--- a/include/vkd3d_dxgiformat.idl
+++ b/include/vkd3d_dxgiformat.idl
@@ -139,6 +139,10 @@ typedef enum DXGI_FORMAT
     DXGI_FORMAT_V208                        = 0x83,
     DXGI_FORMAT_V408                        = 0x84,
 
+    /* https://gli.g-truc.net/0.6.1/api/a00001.html */
+    DXGI_FORMAT_UNDOCUMENTED_ASTC_FIRST     = 0x85,
+    DXGI_FORMAT_UNDOCUMENTED_ASTC_LAST      = 0xbc,
+
     DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE         = 0xbd,
     DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE = 0xbe,
 

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -920,9 +920,7 @@ bool is_valid_format(DXGI_FORMAT dxgi_format)
 {
     if (dxgi_format >= DXGI_FORMAT_UNKNOWN && dxgi_format <= DXGI_FORMAT_B4G4R4A4_UNORM)
         return true;
-    if (dxgi_format >= DXGI_FORMAT_P208 && dxgi_format <= DXGI_FORMAT_V408)
-        return true;
-    if (dxgi_format >= DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE && dxgi_format <= DXGI_FORMAT_A4B4G4R4_UNORM)
+    if (dxgi_format >= DXGI_FORMAT_P208 && dxgi_format <= DXGI_FORMAT_A4B4G4R4_UNORM)
         return true;
     return false;
 }
@@ -1077,6 +1075,8 @@ const char *debug_dxgi_format(DXGI_FORMAT format)
         ENUM_NAME(DXGI_FORMAT_P208)
         ENUM_NAME(DXGI_FORMAT_V208)
         ENUM_NAME(DXGI_FORMAT_V408)
+        ENUM_NAME(DXGI_FORMAT_UNDOCUMENTED_ASTC_FIRST)
+        ENUM_NAME(DXGI_FORMAT_UNDOCUMENTED_ASTC_LAST)
         ENUM_NAME(DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE)
         ENUM_NAME(DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE)
         ENUM_NAME(DXGI_FORMAT_A4B4G4R4_UNORM)

--- a/tests/d3d12_device.c
+++ b/tests/d3d12_device.c
@@ -462,8 +462,7 @@ void test_format_support(void)
     for (format = 0; format <= DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE; ++format)
     {
         /* Undefined range, skip */
-        if ((format > DXGI_FORMAT_B4G4R4A4_UNORM && format < DXGI_FORMAT_P208) ||
-            (format > DXGI_FORMAT_V408 && format < DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE))
+        if (format > DXGI_FORMAT_B4G4R4A4_UNORM && format < DXGI_FORMAT_P208)
             continue;
 
         vkd3d_test_set_context("format %#x", format);
@@ -483,30 +482,39 @@ void test_format_support(void)
 
         if (!required_but_fails)
         {
-            /* Check if the format is unspecified or optional */
-            for (i = 0; i < ARRAY_SIZE(dxgi_format->unspecified_formats); ++i)
+            /* ASTC format are unspecified */
+            if (format >= /* DXGI_FORMAT_UNDOCUMENTED_ASTC_FIRST */ (DXGI_FORMAT)0x85 && 
+                format <= /* DXGI_FORMAT_UNDOCUMENTED_ASTC_LAST */  (DXGI_FORMAT)0xbc)
             {
-                /* Fixed size list with only part of the list filled */
-                if (dxgi_format->unspecified_formats[i] == DXGI_FORMAT_UNKNOWN)
-                    break;
-                if (dxgi_format->unspecified_formats[i] == format)
-                {
-                    unspecified_format = true;
-                    break;
-                }
+                unspecified_format = true;
             }
-
-            if (!unspecified_format)
+            else
             {
-                for (i = 0; i < ARRAY_SIZE(dxgi_format->optional_formats); ++i)
+                /* Check if the format is unspecified or optional */
+                for (i = 0; i < ARRAY_SIZE(dxgi_format->unspecified_formats); ++i)
                 {
                     /* Fixed size list with only part of the list filled */
-                    if (dxgi_format->optional_formats[i] == DXGI_FORMAT_UNKNOWN)
+                    if (dxgi_format->unspecified_formats[i] == DXGI_FORMAT_UNKNOWN)
                         break;
-                    if (dxgi_format->optional_formats[i] == format)
+                    if (dxgi_format->unspecified_formats[i] == format)
                     {
-                        optional_format = true;
+                        unspecified_format = true;
                         break;
+                    }
+                }
+
+                if (!unspecified_format)
+                {
+                    for (i = 0; i < ARRAY_SIZE(dxgi_format->optional_formats); ++i)
+                    {
+                        /* Fixed size list with only part of the list filled */
+                        if (dxgi_format->optional_formats[i] == DXGI_FORMAT_UNKNOWN)
+                            break;
+                        if (dxgi_format->optional_formats[i] == format)
+                        {
+                            optional_format = true;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
A game engine is relying on these returning S_OK or E_FAIL and not E_INVALIDARG.

This builds on #1906.