### PR TITLE
vkd3d: Also enable VK_EXT_swapchain_maintenance1 on Nvidia R550 Vulkan beta/dev drivers.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1475,7 +1475,7 @@ static void vkd3d_physical_device_info_apply_workarounds(struct vkd3d_physical_d
          */
         if (info->vulkan_1_2_properties.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY &&
                 info->swapchain_maintenance1_features.swapchainMaintenance1 &&
-                info->properties2.properties.driverVersion < VKD3D_DRIVER_VERSION_MAKE_NV(550, 54, 14))
+                info->properties2.properties.driverVersion <= VKD3D_DRIVER_VERSION_MAKE_NV(550, 40, 7))
         {
             WARN("Disabling VK_EXT_swapchain_maintenance1 on NV due to driver bugs.\n");
             device->device_info.swapchain_maintenance1_features.swapchainMaintenance1 = VK_FALSE;


### PR DESCRIPTION
Seems to work with recent Vulkan dev driver (550.40.53) on my setup without issues (tested using Granite's `tests/latency-test` and resizing/fullscreening its window, KDE Plasma 6.0, Wayland, PRIME setup with Intel iGPU).

With this, the only 550 driver on which it will stay disabled should be initial R550 beta release (550.40.07).