### PR TITLE
vkd3d: Don't update low latency state if it isn't going to change

### DIFF
--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -1564,7 +1564,8 @@ static void dxgi_vk_swap_chain_low_latency_state_update(struct dxgi_vk_swap_chai
         if (chain->present.low_latency_state.mode != chain->request.requested_low_latency_state.mode)
             chain->present.previous_application_frame_id = 0;
 
-        dxgi_vk_swap_chain_set_low_latency_state(chain, &chain->request.requested_low_latency_state);
+        if (memcmp(&chain->present.low_latency_state, &chain->request.requested_low_latency_state, sizeof(chain->present.low_latency_state)))
+            dxgi_vk_swap_chain_set_low_latency_state(chain, &chain->request.requested_low_latency_state);
     }
 
     /* Transitioning from using the id maintained by the present task to the application frame id, and


### PR DESCRIPTION
This should workaround the problems discovered in https://github.com/HansKristian-Work/vkd3d-proton/issues/1929. The root cause of the issue is most likely a driver synchronization bug that we will have to fix on our end.