### PR TITLE
vkd3d: Implement fallback when 2D sparse is not supported.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -16833,6 +16833,13 @@ static void STDMETHODCALLTYPE d3d12_command_queue_UpdateTileMappings(ID3D12Comma
             iface, resource, region_count, region_coords, region_sizes, heap,
             range_count, range_flags, heap_range_offsets, range_tile_counts, flags);
 
+    /* This can be a fallback sparse resource, just ignore any UpdateTileMapping calls on this. */
+    if (!(res->flags & VKD3D_RESOURCE_RESERVED))
+    {
+        WARN("Ignoring UpdateTileMapping calls on fallback reserved resource.\n");
+        return;
+    }
+
     if (!region_count || !range_count)
         return;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5237,6 +5237,7 @@ struct vkd3d_format
     VkFormatFeatureFlags2 vk_format_features_castable;
     /* Includes only buffer view features. */
     VkFormatFeatureFlags2 vk_format_features_buffer;
+    VkSampleCountFlags supported_sparse_sample_counts;
 };
 
 static inline size_t vkd3d_format_get_data_offset(const struct vkd3d_format *format,

--- a/tests/d3d12_sparse.c
+++ b/tests/d3d12_sparse.c
@@ -2263,6 +2263,9 @@ void test_sparse_depth_stencil_rendering(void)
 
                 /* For mapped pages, we cleared to 0.5, so we don't expect to see FB write. */
                 expected = y * 2 + x <= iter ? 0 : 150;
+
+                /* We work around lack of sparse support currently. */
+                todo_if(is_radv_device(context.device))
                 ok(value == expected, "Iter %u, tile %u, %u: expected %u, got %u.\n", iter, x, y, expected, value);
             }
         }


### PR DESCRIPTION
Relevant for DS sparse on RADV. Convert to a committed resource and pretend all pages are mapped at all times.
Technically out of spec, but should be good enough to work around games until we have proper support.

Fixes #1924.