### PR TITLE
Fix some nagging low_latency2 issues.

### DIFF
--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -482,7 +482,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_LatencySleep(d3d_low_l
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencySleepMode(d3d_low_latency_device_iface *iface, BOOL low_latency_mode, BOOL low_latency_boost,
+static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencySleepMode(d3d_low_latency_device_iface *iface,
+        BOOL low_latency_mode, BOOL low_latency_boost,
         UINT32 minimum_interval_us)
 {
     struct dxgi_vk_swap_chain *low_latency_swapchain;
@@ -494,6 +495,9 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencySleepMode(d3
         return E_NOTIMPL;
 
     spinlock_acquire(&device->low_latency_swapchain_spinlock);
+    device->swapchain_info.mode = low_latency_mode;
+    device->swapchain_info.boost = low_latency_boost;
+    device->swapchain_info.minimum_us = minimum_interval_us;
     if ((low_latency_swapchain = device->swapchain_info.low_latency_swapchain))
         dxgi_vk_swap_chain_incref(low_latency_swapchain);
     spinlock_release(&device->low_latency_swapchain_spinlock);

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -90,6 +90,7 @@ struct dxgi_vk_swap_chain
     vkd3d_native_sync_handle frame_latency_event_internal;
     vkd3d_native_sync_handle present_request_done_event;
     bool outstanding_present_request;
+    uint32_t frame_latency_event_internal_wait_counts;
 
     UINT frame_latency;
     UINT frame_latency_internal;
@@ -885,11 +886,81 @@ static bool dxgi_vk_swap_chain_present_is_occluded(struct dxgi_vk_swap_chain *ch
 
 static void dxgi_vk_swap_chain_present_callback(void *chain);
 
+static void dxgi_vk_swap_chain_wait_internal_handle(struct dxgi_vk_swap_chain *chain, bool low_latency_enable)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
+    bool non_blocking_internal_handle_wait = low_latency_enable;
+    uint64_t completed_submissions = 0;
+    uint64_t user_submissions = 0;
+
+    chain->frame_latency_event_internal_wait_counts++;
+
+    if (non_blocking_internal_handle_wait)
+    {
+        /* If we're using low latency mode, we expect that applications sleep on their own in LatencySleep.
+         * If we start sleeping ourselves here, we sometimes end up fighting with NV's LL2 implementation over
+         * which sleep cycle gets to dominate. This can manifest as a random pumping pattern.
+         *
+         * If our sleep dominates, we end up in an unstable situation where LL2 may think we're
+         * more CPU bound than we actually are.
+         *
+         * In a FIFO bound scenario however where GPU completes long before vblank hits,
+         * we should rely on frame latency sleeps.
+         *
+         * Use a very simple heuristic. If the blit timeline semaphore lags behind by 2+ frames, assume we're
+         * fully GPU bound and we should back off and let low latency deal with it more gracefully. */
+        user_submissions = chain->user.blit_count;
+
+        if (VK_CALL(vkGetSemaphoreCounterValue(chain->queue->device->vk_device,
+                chain->present.vk_complete_semaphore,
+                &completed_submissions)) == VK_SUCCESS)
+        {
+            /* We just submitted frame N. If N - 2 is already complete, it means there is <= 2 frames worth of GPU work
+             * queued up. For a FIFO bound or CPU bound game, this is the case we expect, so we should use latency fences here.
+             * If we're GPU bound with <= 2 frames queued up, we'll likely not block in our own latency handles anyway. */
+            if (completed_submissions + 2 >= user_submissions)
+            {
+                non_blocking_internal_handle_wait = false;
+            }
+            else if (chain->debug_latency)
+            {
+                INFO("Completed count: %"PRIu64", submitted count: %"PRIu64". GPU queue is too deep, deferring to low latency sleep.\n",
+                        completed_submissions, user_submissions);
+            }
+        }
+        else
+        {
+            ERR("Failed to query semaphore complete value.\n");
+            non_blocking_internal_handle_wait = false;
+        }
+    }
+
+    if (non_blocking_internal_handle_wait)
+    {
+        /* Just make sure the counter doesn't get unbounded. */
+        while (chain->frame_latency_event_internal_wait_counts &&
+                vkd3d_native_sync_handle_acquire_timeout(chain->frame_latency_event_internal, 0))
+        {
+            chain->frame_latency_event_internal_wait_counts--;
+        }
+    }
+    else
+    {
+        while (chain->frame_latency_event_internal_wait_counts)
+        {
+            vkd3d_native_sync_handle_acquire(chain->frame_latency_event_internal);
+            chain->frame_latency_event_internal_wait_counts--;
+        }
+    }
+}
+
 static HRESULT STDMETHODCALLTYPE dxgi_vk_swap_chain_Present(IDXGIVkSwapChain *iface, UINT SyncInterval, UINT PresentFlags, const DXGI_PRESENT_PARAMETERS *pPresentParameters)
 {
     struct dxgi_vk_swap_chain *chain = impl_from_IDXGIVkSwapChain(iface);
     struct dxgi_vk_swap_chain_present_request *request;
     struct vkd3d_queue_timeline_trace_cookie cookie;
+    bool low_latency_enable;
+
     TRACE("iface %p, SyncInterval %u, PresentFlags #%x, pPresentParameters %p.\n",
             iface, SyncInterval, PresentFlags, pPresentParameters);
     (void)pPresentParameters;
@@ -937,12 +1008,14 @@ static HRESULT STDMETHODCALLTYPE dxgi_vk_swap_chain_Present(IDXGIVkSwapChain *if
         request->requested_low_latency_state = chain->requested_low_latency_state;
         request->low_latency_update_requested = chain->low_latency_update_requested;
         chain->low_latency_update_requested = false;
+        low_latency_enable = chain->requested_low_latency_state.mode;
         pthread_mutex_unlock(&chain->present.low_latency_state_update_lock);
     }
     else
     {
         memset(&request->requested_low_latency_state, 0, sizeof(request->requested_low_latency_state));
         request->low_latency_update_requested = false;
+        low_latency_enable = false;
     }
 
     /* Need to process this task in queue thread to deal with wait-before-signal.
@@ -960,7 +1033,7 @@ static HRESULT STDMETHODCALLTYPE dxgi_vk_swap_chain_Present(IDXGIVkSwapChain *if
 
     /* Relevant if application does not use latency fence, or we force a lower latency through VKD3D_SWAPCHAIN_FRAME_LATENCY overrides. */
     if (vkd3d_native_sync_handle_is_valid(chain->frame_latency_event_internal))
-        vkd3d_native_sync_handle_acquire(chain->frame_latency_event_internal);
+        dxgi_vk_swap_chain_wait_internal_handle(chain, low_latency_enable);
 
     if (vkd3d_native_sync_handle_is_valid(chain->present_request_done_event))
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4492,6 +4492,9 @@ struct vkd3d_device_swapchain_info
 {
     struct dxgi_vk_swap_chain *low_latency_swapchain;
     uint32_t swapchain_count;
+    bool mode;
+    bool boost;
+    uint32_t minimum_us;
 };
 
 struct vkd3d_device_frame_markers
@@ -4954,6 +4957,8 @@ static inline void d3d12_device_register_swapchain(struct d3d12_device *device, 
     {
         dxgi_vk_swap_chain_incref(chain);
         device->swapchain_info.low_latency_swapchain = chain;
+        dxgi_vk_swap_chain_set_latency_sleep_mode(chain, device->swapchain_info.mode,
+                device->swapchain_info.boost, device->swapchain_info.minimum_us);
     }
     else
     {


### PR DESCRIPTION
- Missed case where a swapchain is recreated. If a new swapchain becomes the low latency chain, inherit the device-global mode.
- Add some extra debug logging when latency debug is enabled.
- Fix some odd scenarios with internal frame latency handle + low latency. If GPU queue is deemed to be too deep, and low latency is enabled, don't try to sleep ourselves, as it seems to throw LL2 off, where it starts thinking it shouldn't sleep.

The heuristic here is pretty simple, but works well in practice. Query the blit timeline semaphore if number of requested submits is significantly larger than the completed counter, it means the GPU queue is deep.

There are some scenarios where we trigger latency limiter ourselves:
- We are FIFO bound. Low latency (at least not NV's implementation of it) will generally not kick in here, so we should use latency fences. When GPU drains the queue faster than display can, complete counter will be pretty close to submitted counter. If drivers actually do FIFO aware low-latency at some point, then we'll never end up blocking in our internal wait handles anyway.
- We are CPU bound. Irrelevant what we do since we are implicitly low latency at this point.