### PR TITLE
vkd3d: Ensure monotonic frame ID order for Reflex.

### DIFF
--- a/include/vkd3d_vk_includes.h
+++ b/include/vkd3d_vk_includes.h
@@ -68,28 +68,31 @@ typedef struct D3D12_UAV_INFO
     UINT64 gpuVASize;  
 } D3D12_UAV_INFO;
 
+typedef struct D3D12_FRAME_REPORT
+{
+    UINT64 frameID;
+    UINT64 inputSampleTime;
+    UINT64 simStartTime;
+    UINT64 simEndTime;
+    UINT64 renderSubmitStartTime;
+    UINT64 renderSubmitEndTime;
+    UINT64 presentStartTime;
+    UINT64 presentEndTime;
+    UINT64 driverStartTime;
+    UINT64 driverEndTime;
+    UINT64 osRenderQueueStartTime;
+    UINT64 osRenderQueueEndTime;
+    UINT64 gpuRenderStartTime;
+    UINT64 gpuRenderEndTime;
+    UINT32 gpuActiveRenderTimeUs;
+    UINT32 gpuFrameTimeUs;
+    UINT8 rsvd[120];
+} D3D12_FRAME_REPORT;
+
 typedef struct D3D12_LATENCY_RESULTS
 {
     UINT32 version;
-    struct D3D12_FRAME_REPORT {
-        UINT64 frameID;
-        UINT64 inputSampleTime;
-        UINT64 simStartTime;
-        UINT64 simEndTime;
-        UINT64 renderSubmitStartTime;
-        UINT64 renderSubmitEndTime;
-        UINT64 presentStartTime;
-        UINT64 presentEndTime;
-        UINT64 driverStartTime;
-        UINT64 driverEndTime;
-        UINT64 osRenderQueueStartTime;
-        UINT64 osRenderQueueEndTime;
-        UINT64 gpuRenderStartTime;
-        UINT64 gpuRenderEndTime;
-        UINT32 gpuActiveRenderTimeUs;
-        UINT32 gpuFrameTimeUs;
-        UINT8 rsvd[120];
-    } frame_reports[64];
+    D3D12_FRAME_REPORT frame_reports[64];
     UINT8 rsvd[32];
 } D3D12_LATENCY_RESULTS;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4497,11 +4497,13 @@ struct vkd3d_device_swapchain_info
     uint32_t minimum_us;
 };
 
+#define VKD3D_LOW_LATENCY_FRAME_ID_STRIDE 10000
 struct vkd3d_device_frame_markers
 {
     uint64_t simulation;
     uint64_t render;
     uint64_t present;
+    uint64_t consumed_present_id;
 };
 
 /* ID3D12Device */


### PR DESCRIPTION
Some applications use app IDs in "random" order which completely breaks the existing implementation.