### PR TITLE
vkd3d: Introduce interface for creating d3d12 resources from VkImages

### DIFF
--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -69,3 +69,14 @@ interface ID3DLowLatencyDevice : IUnknown
     HRESULT SetLatencyMarker(UINT64 frameID, UINT32 markerType);
     HRESULT GetLatencyInfo(D3D12_LATENCY_RESULTS *latency_results);
 }
+
+[
+    uuid(e1da3c4a-bf21-4f48-a7d6-e444dba9ad7e),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12DeviceExt1 : ID3D12DeviceExt
+{
+    HRESULT CreateResourceFromBorrowedHandle(const D3D12_RESOURCE_DESC1 *desc, UINT64 vk_handle, ID3D12Resource **resource);
+}

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3401,7 +3401,8 @@ HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
         return S_OK;
     }
 
-    if (IsEqualGUID(riid, &IID_ID3D12DeviceExt))
+    if (IsEqualGUID(riid, &IID_ID3D12DeviceExt)
+            || IsEqualGUID(riid, &IID_ID3D12DeviceExt1))
     {
         struct d3d12_device *device = impl_from_ID3D12Device(iface);
         d3d12_device_vkd3d_ext_AddRef(&device->ID3D12DeviceExt_iface);
@@ -8563,7 +8564,7 @@ static void d3d12_device_replace_vtable(struct d3d12_device *device)
     }
 }
 
-extern CONST_VTBL struct ID3D12DeviceExtVtbl d3d12_device_vkd3d_ext_vtbl;
+extern CONST_VTBL struct ID3D12DeviceExt1Vtbl d3d12_device_vkd3d_ext_vtbl;
 extern CONST_VTBL struct ID3D12DXVKInteropDeviceVtbl d3d12_dxvk_interop_device_vtbl;
 extern CONST_VTBL struct ID3DLowLatencyDeviceVtbl d3d_low_latency_device_vtbl;
 

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -218,7 +218,20 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CaptureUAVInfo(d3d12_dev
     return S_OK;
 }
 
-CONST_VTBL struct ID3D12DeviceExtVtbl d3d12_device_vkd3d_ext_vtbl =
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CreateResourceFromBorrowedHandle(d3d12_device_vkd3d_ext_iface *iface,
+       const D3D12_RESOURCE_DESC1 *desc, UINT64 vk_handle, ID3D12Resource **ppResource)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
+    struct d3d12_resource *object;
+    HRESULT hr = d3d12_resource_create_committed_borrowed(device, desc, vk_handle, &object);
+    if (FAILED(hr))
+        return hr;
+
+    *ppResource = (ID3D12Resource *)&object->ID3D12Resource_iface;
+    return S_OK;
+}
+
+CONST_VTBL struct ID3D12DeviceExt1Vtbl d3d12_device_vkd3d_ext_vtbl =
 {
     /* IUnknown methods */
     d3d12_device_vkd3d_ext_QueryInterface,
@@ -232,7 +245,10 @@ CONST_VTBL struct ID3D12DeviceExtVtbl d3d12_device_vkd3d_ext_vtbl =
     d3d12_device_vkd3d_ext_DestroyCubinComputeShader,
     d3d12_device_vkd3d_ext_GetCudaTextureObject,
     d3d12_device_vkd3d_ext_GetCudaSurfaceObject,
-    d3d12_device_vkd3d_ext_CaptureUAVInfo
+    d3d12_device_vkd3d_ext_CaptureUAVInfo,
+
+    /* ID3D12DeviceExt1 methods */
+    d3d12_device_vkd3d_ext_CreateResourceFromBorrowedHandle,
 };
 
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1070,6 +1070,8 @@ VkImageLayout vk_image_layout_from_d3d12_resource_state(
         struct d3d12_command_list *list, const struct d3d12_resource *resource, D3D12_RESOURCE_STATES state);
 UINT d3d12_plane_index_from_vk_aspect(VkImageAspectFlagBits aspect);
 
+HRESULT d3d12_resource_create_committed_borrowed(struct d3d12_device *device, const D3D12_RESOURCE_DESC1 *desc,
+        UINT64 vk_handle, struct d3d12_resource **resource);
 HRESULT d3d12_resource_create_committed(struct d3d12_device *device, const D3D12_RESOURCE_DESC1 *desc,
         const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags, D3D12_RESOURCE_STATES initial_state,
         const D3D12_CLEAR_VALUE *optimized_clear_value,
@@ -4518,7 +4520,7 @@ struct vkd3d_descriptor_qa_global_info;
 struct vkd3d_descriptor_qa_heap_buffer_data;
 
 /* ID3D12DeviceExt */
-typedef ID3D12DeviceExt d3d12_device_vkd3d_ext_iface;
+typedef ID3D12DeviceExt1 d3d12_device_vkd3d_ext_iface;
 
 /* ID3D12DXVKInteropDevice */
 typedef ID3D12DXVKInteropDevice d3d12_dxvk_interop_device_iface;


### PR DESCRIPTION
Motivation for adding this is to support OpenXR extension XR_KHR_D3D12_enable.

The way OpenXR is designed, the application gets an array of swapchain images from the runtime, and renders into them. (Unlike OpenVR, with which the application will submit textures to be displayed in the VR environment). This means we need to convert the VkImages we get on the unix side to ID3D12Resources on the PE side.

* * *

I hope I am doing this correctly. I tried the `hello_xr` demo on D3D12 which works, and I didn't see any warnings from the validation layer. 