### PR TITLE
vkd3d: Also enable AC Mirage shader quirk for ACMirage_plus.exe.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -724,6 +724,7 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "Pioneers of Pagonia.exe", &pagonia_quirks },
     /* AC: Mirage */
     { VKD3D_STRING_COMPARE_EXACT, "ACMirage.exe", &ac_mirage_quirks },
+    { VKD3D_STRING_COMPARE_EXACT, "ACMirage_plus.exe", &ac_mirage_quirks },
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* MSVC fails to compile empty array. */


### PR DESCRIPTION
To handle the trend of Ubisoft games shipping separate executables for subscribers of their Ubisoft+ thingy.

Although I can't verify this myself because I'm playing via `ACMirage.exe`, this is how the binary is called exactly:

```
$ ls -1 *.exe
ACMirage.exe
ACMirage_plus.exe
```