### PR TITLE
vkd3d: Fix flags used to create resources from borrowed handles.

### DIFF
--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -223,7 +223,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CreateResourceFromBorrow
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     struct d3d12_resource *object;
-    HRESULT hr = d3d12_resource_create_committed_borrowed(device, desc, vk_handle, &object);
+    HRESULT hr = d3d12_resource_create_borrowed(device, desc, vk_handle, &object);
     if (FAILED(hr))
         return hr;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3405,7 +3405,7 @@ static void d3d12_resource_tag_debug_name(struct d3d12_resource *resource,
         vkd3d_set_vk_object_name(device, (uint64_t)resource->res.vk_buffer, VK_OBJECT_TYPE_BUFFER, name_buffer);
 }
 
-HRESULT d3d12_resource_create_committed_borrowed(struct d3d12_device *device, const D3D12_RESOURCE_DESC1 *desc,
+HRESULT d3d12_resource_create_borrowed(struct d3d12_device *device, const D3D12_RESOURCE_DESC1 *desc,
         UINT64 vk_handle, struct d3d12_resource **resource)
 {
     D3D12_HEAP_PROPERTIES heap_props;
@@ -3423,7 +3423,7 @@ HRESULT d3d12_resource_create_committed_borrowed(struct d3d12_device *device, co
     heap_props.CreationNodeMask = 0;
     heap_props.VisibleNodeMask = 0;
 
-    hr = d3d12_resource_create(device, VKD3D_RESOURCE_COMMITTED | VKD3D_RESOURCE_EXTERNAL,
+    hr = d3d12_resource_create(device, VKD3D_RESOURCE_PLACED | VKD3D_RESOURCE_EXTERNAL,
             desc, &heap_props, D3D12_HEAP_FLAG_SHARED, D3D12_RESOURCE_STATE_COMMON, NULL, 0, NULL, &object);
     if (FAILED(hr))
         return hr;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1070,7 +1070,7 @@ VkImageLayout vk_image_layout_from_d3d12_resource_state(
         struct d3d12_command_list *list, const struct d3d12_resource *resource, D3D12_RESOURCE_STATES state);
 UINT d3d12_plane_index_from_vk_aspect(VkImageAspectFlagBits aspect);
 
-HRESULT d3d12_resource_create_committed_borrowed(struct d3d12_device *device, const D3D12_RESOURCE_DESC1 *desc,
+HRESULT d3d12_resource_create_borrowed(struct d3d12_device *device, const D3D12_RESOURCE_DESC1 *desc,
         UINT64 vk_handle, struct d3d12_resource **resource);
 HRESULT d3d12_resource_create_committed(struct d3d12_device *device, const D3D12_RESOURCE_DESC1 *desc,
         const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags, D3D12_RESOURCE_STATES initial_state,


### PR DESCRIPTION
I am so sorry! When addressing the review comment I changed the function names but forgot to actually change the flags...

Fixes #1972 