### PR TITLE
vkd3d: Add an interface for getting all information about a VkQueue

### DIFF
--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -159,6 +159,8 @@ VkPhysicalDevice vkd3d_get_vk_physical_device(ID3D12Device *device);
 struct vkd3d_instance *vkd3d_instance_from_device(ID3D12Device *device);
 
 uint32_t vkd3d_get_vk_queue_family_index(ID3D12CommandQueue *queue);
+uint32_t vkd3d_get_vk_queue_index(ID3D12CommandQueue *queue);
+uint32_t vkd3d_get_vk_queue_flags(ID3D12CommandQueue *queue);
 VkQueue vkd3d_acquire_vk_queue(ID3D12CommandQueue *queue);
 void vkd3d_release_vk_queue(ID3D12CommandQueue *queue);
 void vkd3d_enqueue_initial_transition(ID3D12CommandQueue *queue, ID3D12Resource *resource);

--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -71,7 +71,7 @@ interface ID3DLowLatencyDevice : IUnknown
 }
 
 [
-    uuid(e1da3c4a-bf21-4f48-a7d6-e444dba9ad7e),
+    uuid(099a73fd-2199-4f45-bf48-0eb86f6fdb65),
     object,
     local,
     pointer_default(unique)
@@ -79,4 +79,5 @@ interface ID3DLowLatencyDevice : IUnknown
 interface ID3D12DeviceExt1 : ID3D12DeviceExt
 {
     HRESULT CreateResourceFromBorrowedHandle(const D3D12_RESOURCE_DESC1 *desc, UINT64 vk_handle, ID3D12Resource **resource);
+    HRESULT GetVulkanQueueInfoEx(ID3D12CommandQueue *queue, VkQueue *vk_queue, UINT32 *vk_queue_index, UINT32 *vk_queue_flags, UINT32 *vk_queue_family);
 }

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -144,6 +144,7 @@ HRESULT vkd3d_queue_create(struct d3d12_device *device, uint32_t family_index, u
     }
 
     object->vk_family_index = family_index;
+    object->vk_queue_index = queue_index;
     object->vk_queue_flags = properties->queueFlags;
     object->timestamp_bits = properties->timestampValidBits;
 
@@ -18726,6 +18727,20 @@ uint32_t vkd3d_get_vk_queue_family_index(ID3D12CommandQueue *queue)
     struct d3d12_command_queue *d3d12_queue = impl_from_ID3D12CommandQueue(queue);
 
     return d3d12_queue->vkd3d_queue->vk_family_index;
+}
+
+uint32_t vkd3d_get_vk_queue_index(ID3D12CommandQueue *queue)
+{
+    struct d3d12_command_queue *d3d12_queue = impl_from_ID3D12CommandQueue(queue);
+
+    return d3d12_queue->vkd3d_queue->vk_queue_index;
+}
+
+uint32_t vkd3d_get_vk_queue_flags(ID3D12CommandQueue *queue)
+{
+    struct d3d12_command_queue *d3d12_queue = impl_from_ID3D12CommandQueue(queue);
+
+    return d3d12_queue->vkd3d_queue->vk_queue_flags;
 }
 
 VkQueue vkd3d_acquire_vk_queue(ID3D12CommandQueue *queue)

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -231,6 +231,22 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CreateResourceFromBorrow
     return S_OK;
 }
 
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetVulkanQueueInfoEx(d3d12_device_vkd3d_ext_iface *iface,
+       ID3D12CommandQueue *queue, VkQueue *vk_queue, UINT32 *vk_queue_index, UINT32 *vk_queue_flags, UINT32 *vk_queue_family)
+{
+    TRACE("iface %p, queue %p, vk_queue %p, vk_queue_index %p, vk_queue_flags %p vk_queue_family %p.\n",
+            iface, queue, vk_queue, vk_queue_index, vk_queue_flags, vk_queue_family);
+
+    /* This only gets called during D3D11 device creation */
+    *vk_queue = vkd3d_acquire_vk_queue(queue);
+    vkd3d_release_vk_queue(queue);
+
+    *vk_queue_index = vkd3d_get_vk_queue_index(queue);
+    *vk_queue_flags = vkd3d_get_vk_queue_flags(queue);
+    *vk_queue_family = vkd3d_get_vk_queue_family_index(queue);
+    return S_OK;
+}
+
 CONST_VTBL struct ID3D12DeviceExt1Vtbl d3d12_device_vkd3d_ext_vtbl =
 {
     /* IUnknown methods */
@@ -249,6 +265,7 @@ CONST_VTBL struct ID3D12DeviceExt1Vtbl d3d12_device_vkd3d_ext_vtbl =
 
     /* ID3D12DeviceExt1 methods */
     d3d12_device_vkd3d_ext_CreateResourceFromBorrowedHandle,
+    d3d12_device_vkd3d_ext_GetVulkanQueueInfoEx,
 };
 
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3024,6 +3024,7 @@ struct vkd3d_queue
     uint64_t submission_timeline_count;
 
     uint32_t vk_family_index;
+    uint32_t vk_queue_index;
     VkQueueFlags vk_queue_flags;
     uint32_t timestamp_bits;
     uint32_t virtual_queue_count;


### PR DESCRIPTION
OpenXR's vulkan extension expects a queue index instead of a VkQueue handle directly, so we need to expose this information from vkd3d-proton to support that.