### PR TITLE
vkd3d: Support indexed draws with NULL index buffer.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -76,6 +76,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_PRESENT_ID, KHR_present_id),
     VK_EXTENSION(KHR_PRESENT_WAIT, KHR_present_wait),
     VK_EXTENSION(KHR_MAINTENANCE_5, KHR_maintenance5),
+    VK_EXTENSION(KHR_MAINTENANCE_6, KHR_maintenance6),
     VK_EXTENSION(KHR_SHADER_MAXIMAL_RECONVERGENCE, KHR_shader_maximal_reconvergence),
     VK_EXTENSION(KHR_SHADER_QUAD_CONTROL, KHR_shader_quad_control),
 #ifdef _WIN32
@@ -1773,6 +1774,14 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         info->maintenance_5_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR;
         vk_prepend_struct(&info->features2, &info->maintenance_5_features);
         vk_prepend_struct(&info->properties2, &info->maintenance_5_properties);
+    }
+
+    if (vulkan_info->KHR_maintenance6)
+    {
+        info->maintenance_6_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR;
+        info->maintenance_6_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR;
+        vk_prepend_struct(&info->features2, &info->maintenance_6_features);
+        vk_prepend_struct(&info->properties2, &info->maintenance_6_properties);
     }
 
     if (vulkan_info->KHR_shader_maximal_reconvergence)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -126,6 +126,7 @@ struct vkd3d_vulkan_info
     bool KHR_present_wait;
     bool KHR_present_id;
     bool KHR_maintenance5;
+    bool KHR_maintenance6;
     bool KHR_shader_maximal_reconvergence;
     bool KHR_shader_quad_control;
     /* EXT device extensions */
@@ -4375,6 +4376,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT graphics_pipeline_library_properties;
     VkPhysicalDeviceMemoryDecompressionPropertiesNV memory_decompression_properties;
     VkPhysicalDeviceMaintenance5PropertiesKHR maintenance_5_properties;
+    VkPhysicalDeviceMaintenance6PropertiesKHR maintenance_6_properties;
     VkPhysicalDeviceLineRasterizationPropertiesEXT line_rasterization_properties;
 
     VkPhysicalDeviceProperties2KHR properties2;
@@ -4420,6 +4422,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceMemoryDecompressionFeaturesNV memory_decompression_features;
     VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV device_generated_commands_compute_features_nv;
     VkPhysicalDeviceMaintenance5FeaturesKHR maintenance_5_features;
+    VkPhysicalDeviceMaintenance6FeaturesKHR maintenance_6_features;
     VkPhysicalDeviceLineRasterizationFeaturesEXT line_rasterization_features;
     VkPhysicalDeviceImageCompressionControlFeaturesEXT image_compression_control_features;
     VkPhysicalDeviceFaultFeaturesEXT fault_features;

--- a/tests/d3d12_streamout.c
+++ b/tests/d3d12_streamout.c
@@ -422,7 +422,7 @@ void test_index_buffer_edge_case_stream_output(void)
 
     get_buffer_readback_with_command_list(counter_buffer, DXGI_FORMAT_R32_UINT, &rb, queue, command_list);
     counter = get_readback_uint(&rb, 0, 0, 0);
-    todo ok(counter == 15 * sizeof(struct vec4), "Got unexpected counter %u.\n", counter);
+    ok(counter == 15 * sizeof(struct vec4), "Got unexpected counter %u.\n", counter);
     release_resource_readback(&rb);
     reset_command_list(command_list, context.allocator);
     get_buffer_readback_with_command_list(so_buffer, DXGI_FORMAT_UNKNOWN, &rb, queue, command_list);
@@ -430,7 +430,7 @@ void test_index_buffer_edge_case_stream_output(void)
     {
         const struct vec4 *expected = &expected_output[i];
         data = get_readback_vec4(&rb, i, 0);
-        todo_if(i >= 4 && i != 7) ok(compare_vec4(data, expected, 1),
+        ok(compare_vec4(data, expected, 1),
                 "Got {%.8e, %.8e, %.8e, %.8e}, expected {%.8e, %.8e, %.8e, %.8e}.\n",
                 data->x, data->y, data->z, data->w, expected->x, expected->y, expected->z, expected->w);
     }


### PR DESCRIPTION
Brought up by @rlocatti-nv . `KHR_maintenance6` doesn't seem overly interesting for us, but it does allow us to handle this edge case properly. Tested on both RADV and Nvidia.