### PR TITLE
vkd3d: Fix stray invalid SSBO being generated.

### DIFF
--- a/libs/vkd3d/shaders/cs_resolve_query.comp
+++ b/libs/vkd3d/shaders/cs_resolve_query.comp
@@ -25,7 +25,7 @@ struct query_map_entry_t {
 layout(std430, buffer_reference, buffer_reference_align = 4)
 readonly buffer query_map_t {
   query_map_entry_t entries[];
-} map;
+};
 
 layout(push_constant)
 uniform u_info_t {


### PR DESCRIPTION
RenderDoc ran into a crash here since the SSBO is part of OpEntryPoint in SPIR-V 1.6 and thus static use.