### PR TITLE
Implement frame statistics

### DIFF
--- a/include/vkd3d_swapchain_factory.idl
+++ b/include/vkd3d_swapchain_factory.idl
@@ -31,6 +31,12 @@ typedef struct DXGI_VK_HDR_METADATA
     };
 } DXGI_VK_HDR_METADATA;
 
+typedef struct DXGI_VK_FRAME_STATISTICS
+{
+    UINT64 PresentCount;
+    UINT64 PresentQPCTime;
+} DXGI_VK_FRAME_STATISTICS;
+
 [
     object,
     local,
@@ -99,6 +105,31 @@ interface IDXGIVkSwapChain : IUnknown {
 
     HRESULT SetHDRMetaData(
       const DXGI_VK_HDR_METADATA*     pMetaData);
+}
+
+[
+    object,
+    local,
+    uuid(785326d4-b77b-4826-ae70-8d08308ee6d1)
+]
+interface IDXGIVkSwapChain1 : IDXGIVkSwapChain
+{
+    void GetLastPresentCount(
+        UINT64*                   pLastPresentCount);
+
+    void GetFrameStatistics(
+        DXGI_VK_FRAME_STATISTICS* pFrameStatistics);
+}
+
+[
+    object,
+    local,
+    uuid(aed91093-e02e-458c-bdef-a97da1a7e6d2)
+]
+interface IDXGIVkSwapChain2 : IDXGIVkSwapChain1
+{
+    void SetTargetFrameRate(
+        double                    FrameRate);
 }
 
 [


### PR DESCRIPTION
Implements necessary functionality for `IDXGISwapChain::GetFrameStatistics` to return somewhat meaningful data. Without it, we pretend that a present operation completes immediately, which is bad in case the app uses this for frame pacing purposes, and worse if it makes assumptions on whether or not it is safe to free GPU resources. There are a couple of games using this (albeit for unknown purposes), most notably Nixxes ports.

TL;DR is that the API quite literally counts successful presents, and we happen to have an internal timeline doing exactly that in a robust manner already so we can just expose that to the app. Some refactoring was needed since this requires us to always have the waiter thread active, even if present wait is not used for a given present.

Additionally, this adds a frame rate limiter. The main motivation for this interface on the DXVK side of things was to support games that disable their own built-in limiter when running in full-screen with a 60 Hz display mode, but we can do the same here. This is less important for D3D12, but works in games that allow changing the refresh rate, e.g. Horizon Zero Dawn. If this functionality isn't desired, I can drop the commit.

Currently untested on environments where present wait is unsupported. There's no rush to land this either, it's probably a good idea to tackle this after 2.13 and do some broad testing on whether it affects (or breaks) any existing games.