### PR TITLE
Fix multiple issues and inconsistencies in log message formats

### DIFF
--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -69,12 +69,12 @@ static BOOL wait_vr_key(HKEY vr_key)
     size = sizeof(value);
     if ((status = RegQueryValueExA(vr_key, "state", NULL, &type, (BYTE *)&value, &size)))
     {
-        ERR("OpenVR: could not query value, status %d", status);
+        ERR("OpenVR: could not query value, status %d.\n", status);
         return false;
     }
     if (type != REG_DWORD)
     {
-        ERR("OpenVR: unexpected value type %d", type);
+        ERR("OpenVR: unexpected value type %d.\n", type);
         return false;
     }
 
@@ -84,7 +84,7 @@ static BOOL wait_vr_key(HKEY vr_key)
     event = CreateEventA(NULL, FALSE, FALSE, NULL);
     if (event == NULL)
     {
-        ERR("Cannot create event");
+        ERR("Cannot create event.\n");
         return false;
     }
 
@@ -92,13 +92,13 @@ static BOOL wait_vr_key(HKEY vr_key)
     {
         if (RegNotifyChangeKeyValue(vr_key, FALSE, REG_NOTIFY_CHANGE_LAST_SET, event, TRUE))
         {
-            ERR("Error registering registry change notification");
+            ERR("Error registering registry change notification.\n");
             break;
         }
         size = sizeof(value);
         if ((status = RegQueryValueExA(vr_key, "state", NULL, &type, (BYTE *)&value, &size)))
         {
-            ERR("OpenVR: could not query value, status %d", status);
+            ERR("OpenVR: could not query value, status %d.\n", status);
             break;
         }
         if (value)
@@ -107,13 +107,13 @@ static BOOL wait_vr_key(HKEY vr_key)
 
         while ((wait_status = WaitForSingleObject(event, 1000)) == WAIT_TIMEOUT && max_retry)
         {
-            WARN("VR state wait timeout (retries left %u)", max_retry);
+            WARN("VR state wait timeout (retries left %u).\n", max_retry);
             max_retry--;
         }
 
         if (wait_status != WAIT_OBJECT_0 && wait_status != WAIT_TIMEOUT)
         {
-            ERR("Got unexpected wait status ", wait_status);
+            ERR("Got unexpected wait status %u.\n", wait_status);
             break;
         }
     }
@@ -225,20 +225,20 @@ static char *openxr_vulkan_extensions(bool device_extensions)
                                        : p___wineopenxr_GetVulkanInstanceExtensions;
     if (!get_extensions)
     {
-        WARN("wineopenxr.dll is missing required symbols");
+        WARN("wineopenxr.dll is missing required symbols.\n");
         return NULL;
     }
 
     if (get_extensions(0, &len, NULL))
     {
-        WARN("Failed to get OpenXR extensions size from wineopenxr");
+        WARN("Failed to get OpenXR extensions size from wineopenxr.\n");
         return NULL;
     }
 
     ret = vkd3d_malloc(len);
     if (get_extensions(len, &len, ret))
     {
-        WARN("Failed to get OpenXR extensions from wineopenxr");
+        WARN("Failed to get OpenXR extensions from wineopenxr.\n");
         return NULL;
     }
     return ret;
@@ -417,7 +417,7 @@ static VkPhysicalDevice d3d12_find_physical_device(struct vkd3d_instance *instan
         /* Skip over physical devices below our minimum API version */
         if (properties2.properties.apiVersion < VKD3D_MIN_API_VERSION)
         {
-            WARN("Skipped adapter %s as it is below our minimum API version.", properties2.properties.deviceName);
+            WARN("Skipped adapter %s as it is below our minimum API version.\n", properties2.properties.deviceName);
             continue;
         }
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1725,7 +1725,7 @@ static HRESULT d3d12_shared_fence_set_native_sync_handle_on_completion_explicit(
 
             if (!(waiting_event = vkd3d_malloc(sizeof(*waiting_event))))
             {
-                ERR("Failed to register device singleton for adapter.");
+                ERR("Failed to register device singleton for adapter.\n");
                 return E_OUTOFMEMORY;
             }
 
@@ -12940,7 +12940,7 @@ static char *decode_pix_blob(const void *data, size_t size)
        String fromatting will overcomplicate things and skipped for now */
     if ((type != ePIXEvent_BeginEvent_NoArgs) && (type != ePIXEvent_BeginEvent_VarArgs))
     {
-        WARN("Unexpected/unsupported PIX3Event");
+        WARN("Unexpected/unsupported PIX3Event: %#"PRIx64".\n", type);
         return NULL;
     }
 
@@ -15517,7 +15517,7 @@ static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
     if (!rtas_batch->build_info_count)
         return;
 
-    TRACE("list %p, build_info_count %u.\n", list, rtas_batch->build_info_count);
+    TRACE("list %p, build_info_count %zu.\n", list, rtas_batch->build_info_count);
 
     if (!vkd3d_array_reserve((void **)&rtas_batch->range_ptrs, &rtas_batch->range_ptr_size,
             rtas_batch->build_info_count, sizeof(*rtas_batch->range_ptrs)))

--- a/libs/vkd3d/command_list_vkd3d_ext.c
+++ b/libs/vkd3d/command_list_vkd3d_ext.c
@@ -82,7 +82,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_vkd3d_ext_LaunchCubinShaderE
     };
 
     struct d3d12_command_list *command_list = d3d12_command_list_from_ID3D12GraphicsCommandListExt(iface);
-    TRACE("iface %p, handle %p, block_x %u,  block_y %u, block_z %u, smem_size %u, params %p, param_size %u, raw_params %p, raw_params_count %u \n",
+    TRACE("iface %p, handle %p, block_x %u, block_y %u, block_z %u, smem_size %u, params %p, param_size %u, raw_params %p, raw_params_count %u\n",
            iface, handle, block_x, block_y, block_z, smem_size, params, param_size, raw_params, raw_params_count);
 
     if (!handle || !block_x || !block_y || !block_z || !params || !param_size)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3064,7 +3064,7 @@ static void d3d12_add_device_singleton(struct d3d12_device *device, LUID luid)
 
     if (!(e = vkd3d_malloc(sizeof(*e))))
     {
-        ERR("Failed to register device singleton for adapter.");
+        ERR("Failed to register device singleton for adapter.\n");
         return;
     }
     e->adapter_luid = luid;
@@ -3175,7 +3175,7 @@ HRESULT d3d12_device_get_scratch_buffer(struct d3d12_device *device, enum vkd3d_
 
     if (min_size > pool->block_size)
     {
-        FIXME("Requesting scratch buffer kind %u larger than limit (%"PRIu64" > %u). Expect bad performance.\n",
+        FIXME("Requesting scratch buffer kind %u larger than limit (%"PRIu64" > %"PRIu64"). Expect bad performance.\n",
                 kind, min_size, pool->block_size);
         return d3d12_device_create_scratch_buffer(device, kind, min_size, memory_types, scratch);
     }
@@ -4223,7 +4223,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
             }
 
             data->Support = D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAG_NONE;
-            TRACE("Protected resource session support %#x.", data->Support);
+            TRACE("Protected resource session support %#x.\n", data->Support);
             return S_OK;
         }
 
@@ -4314,7 +4314,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
                     D3D12_SHADER_CACHE_SUPPORT_AUTOMATIC_INPROC_CACHE |
                     D3D12_SHADER_CACHE_SUPPORT_AUTOMATIC_DISK_CACHE;
 
-            TRACE("Shader cache support flags %#x.", data->SupportFlags);
+            TRACE("Shader cache support flags %#x.\n", data->SupportFlags);
             return S_OK;
         }
 
@@ -4331,7 +4331,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
             /* FIXME We ignore priorities since Vulkan queues are created up-front */
             data->PriorityForTypeIsSupported = data->Priority <= D3D12_COMMAND_QUEUE_PRIORITY_HIGH;
 
-            TRACE("Command list type %u supports priority %u: %#x.",
+            TRACE("Command list type %u supports priority %u: %#x.\n",
                     data->CommandListType, data->Priority, data->PriorityForTypeIsSupported);
             return S_OK;
         }
@@ -4348,11 +4348,11 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
 
             *data = device->d3d12_caps.options3;
 
-            TRACE("Copy queue timestamp queries %#x.", data->CopyQueueTimestampQueriesSupported);
-            TRACE("Casting fully typed formats %#x.", data->CastingFullyTypedFormatSupported);
-            TRACE("Write buffer immediate support flags %#x.", data->WriteBufferImmediateSupportFlags);
-            TRACE("View instancing tier %u.", data->ViewInstancingTier);
-            TRACE("Barycentrics %#x.", data->BarycentricsSupported);
+            TRACE("Copy queue timestamp queries %#x.\n", data->CopyQueueTimestampQueriesSupported);
+            TRACE("Casting fully typed formats %#x.\n", data->CastingFullyTypedFormatSupported);
+            TRACE("Write buffer immediate support flags %#x.\n", data->WriteBufferImmediateSupportFlags);
+            TRACE("View instancing tier %u.\n", data->ViewInstancingTier);
+            TRACE("Barycentrics %#x.\n", data->BarycentricsSupported);
             return S_OK;
         }
 
@@ -4370,7 +4370,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
              * interop to support file handles */
             data->Supported = FALSE;
 
-            TRACE("Existing heaps %#x.", data->Supported);
+            TRACE("Existing heaps %#x.\n", data->Supported);
             return S_OK;
         }
 
@@ -4587,8 +4587,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
 
             *data = device->d3d12_caps.options13;
 
-            TRACE("Inverted viewport height flips Y supported %u.", data->InvertedViewportHeightFlipsYSupported);
-            TRACE("Inverted viewport deps flips Z supported %u.", data->InvertedViewportDepthFlipsZSupported);
+            TRACE("Inverted viewport height flips Y supported %u.\n", data->InvertedViewportHeightFlipsYSupported);
+            TRACE("Inverted viewport deps flips Z supported %u.\n", data->InvertedViewportDepthFlipsZSupported);
             return S_OK;
         }
 
@@ -4755,7 +4755,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
                 return E_INVALIDARG;
             }
 
-            TRACE("input_data_size = %u, input_data = %p, output_data_size = %u, output_data = %p.\n",
+            TRACE("input_data_size = %zu, input_data = %p, output_data_size = %zu, output_data = %p.\n",
                     data->QueryInputDataSizeInBytes, data->pQueryInputData, data->QueryOutputDataSizeInBytes,
                     data->pQueryOutputData);
 
@@ -4774,7 +4774,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
                  * is allowed but any excess bytes are not written. */
                 if (data->QueryInputDataSizeInBytes < sizeof(*in_args) || data->QueryOutputDataSizeInBytes < sizeof(*out_args))
                 {
-                    FIXME("Unexpected input/output sizes for DirectStorage meta command: %u, %u.\n",
+                    FIXME("Unexpected input/output sizes for DirectStorage meta command: %zu, %zu.\n",
                             data->QueryInputDataSizeInBytes, data->QueryOutputDataSizeInBytes);
                     return E_INVALIDARG;
                 }
@@ -5629,7 +5629,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateCommittedResource(d3d12_devi
         const D3D12_RESOURCE_DESC *desc, D3D12_RESOURCE_STATES initial_state,
         const D3D12_CLEAR_VALUE *optimized_clear_value, REFIID iid, void **resource)
 {
-    TRACE("iface %p, heap_properties %p, heap_flags %#x,  desc %p, initial_state %#x, "
+    TRACE("iface %p, heap_properties %p, heap_flags %#x, desc %p, initial_state %#x, "
             "optimized_clear_value %p, iid %s, resource %p.\n",
             iface, heap_properties, heap_flags, desc, initial_state,
             optimized_clear_value, debugstr_guid(iid), resource);
@@ -7004,7 +7004,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateCommittedResource2(d3d12_dev
     struct d3d12_resource *object;
     HRESULT hr;
 
-    TRACE("iface %p, heap_properties %p, heap_flags %#x,  desc %p, initial_state %#x, "
+    TRACE("iface %p, heap_properties %p, heap_flags %#x, desc %p, initial_state %#x, "
             "optimized_clear_value %p, protected_session %p, iid %s, resource %p.\n",
             iface, heap_properties, heap_flags, desc, initial_state,
             optimized_clear_value, protected_session, debugstr_guid(iid), resource);
@@ -7787,7 +7787,7 @@ static void d3d12_device_caps_init_feature_options1(struct d3d12_device *device)
     else
     {
         options1->TotalLaneCount = 32 * device->device_info.vulkan_1_1_properties.subgroupSize;
-        WARN("No device info available for TotalLaneCount = .\n");
+        WARN("No device info available for TotalLaneCount = %u.\n", options1->TotalLaneCount);
     }
 
     options1->ExpandedComputeResourceStates = TRUE;
@@ -8931,19 +8931,19 @@ bool d3d12_device_validate_shader_meta(struct d3d12_device *device, const struct
     if ((meta->flags & VKD3D_SHADER_META_FLAG_USES_NATIVE_16BIT_OPERATIONS) &&
             !device->d3d12_caps.options4.Native16BitShaderOpsSupported)
     {
-        WARN("Attempting to use 16-bit operations in shader %016"PRIx64", but this is not supported.", meta->hash);
+        WARN("Attempting to use 16-bit operations in shader %016"PRIx64", but this is not supported.\n", meta->hash);
         return false;
     }
 
     if ((meta->flags & VKD3D_SHADER_META_FLAG_USES_FP64) && !device->d3d12_caps.options.DoublePrecisionFloatShaderOps)
     {
-        WARN("Attempting to use FP64 operations in shader %016"PRIx64", but this is not supported.", meta->hash);
+        WARN("Attempting to use FP64 operations in shader %016"PRIx64", but this is not supported.\n", meta->hash);
         return false;
     }
 
     if ((meta->flags & VKD3D_SHADER_META_FLAG_USES_INT64) && !device->d3d12_caps.options1.Int64ShaderOps)
     {
-        WARN("Attempting to use Int64 operations in shader %016"PRIx64", but this is not supported.", meta->hash);
+        WARN("Attempting to use Int64 operations in shader %016"PRIx64", but this is not supported.\n", meta->hash);
         return false;
     }
 
@@ -8954,28 +8954,28 @@ bool d3d12_device_validate_shader_meta(struct d3d12_device *device, const struct
             !device->d3d12_caps.options11.AtomicInt64OnDescriptorHeapResourceSupported &&
             !device->d3d12_caps.options9.AtomicInt64OnTypedResourceSupported)
     {
-        WARN("Attempting to use Int64Atomic operations in shader %016"PRIx64", but this is not supported.", meta->hash);
+        WARN("Attempting to use Int64Atomic operations in shader %016"PRIx64", but this is not supported.\n", meta->hash);
         return false;
     }
 
     if ((meta->flags & VKD3D_SHADER_META_FLAG_USES_INT64_ATOMICS_IMAGE) &&
             !device->device_info.shader_image_atomic_int64_features.shaderImageInt64Atomics)
     {
-        WARN("Attempting to use typed Int64Atomic operations in shader %016"PRIx64", but this is not supported.", meta->hash);
+        WARN("Attempting to use typed Int64Atomic operations in shader %016"PRIx64", but this is not supported.\n", meta->hash);
         return false;
     }
 
     if ((meta->flags & VKD3D_SHADER_META_FLAG_USES_FRAGMENT_BARYCENTRIC) &&
             !device->d3d12_caps.options3.BarycentricsSupported)
     {
-        WARN("Attempting to use barycentrics in shader %016"PRIx64", but this is not supported.", meta->hash);
+        WARN("Attempting to use barycentrics in shader %016"PRIx64", but this is not supported.\n", meta->hash);
         return false;
     }
 
     if ((meta->flags & VKD3D_SHADER_META_FLAG_USES_STENCIL_EXPORT) &&
             !device->d3d12_caps.options.PSSpecifiedStencilRefSupported)
     {
-        WARN("Attempting to use stencil reference in shader %016"PRIx64", but this is not supported.", meta->hash);
+        WARN("Attempting to use stencil reference in shader %016"PRIx64", but this is not supported.\n", meta->hash);
         return false;
     }
 

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -326,7 +326,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetInstanceExtensions
 
     TRACE("iface %p, extension_count %p, extensions %p.\n", iface, extension_count, extensions);
 
-    if (extensions && (*extension_count < instance->vk_info.extension_count))
+    if (!extension_count || (extensions && (*extension_count < instance->vk_info.extension_count)))
         return E_INVALIDARG;
 
     *extension_count = instance->vk_info.extension_count;
@@ -345,7 +345,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceExtensions(I
 
     TRACE("iface %p, extension_count %p, extensions %p.\n", iface, extension_count, extensions);
 
-    if (extensions && (*extension_count < device->vk_info.extension_count))
+    if (!extension_count || (extensions && (*extension_count < device->vk_info.extension_count)))
         return E_INVALIDARG;
 
     *extension_count = device->vk_info.extension_count;

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -51,7 +51,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_QueryInterface(d3d12_dev
 static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetVulkanHandles(d3d12_device_vkd3d_ext_iface *iface, VkInstance *vk_instance, VkPhysicalDevice *vk_physical_device, VkDevice *vk_device)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
-    TRACE("iface %p, vk_instance %p, vk_physical_device %p, vk_device %p \n", iface, vk_instance, vk_physical_device, vk_device);
+    TRACE("iface %p, vk_instance %p, vk_physical_device %p, vk_device %p\n", iface, vk_instance, vk_physical_device, vk_device);
     if (!vk_device || !vk_instance || !vk_physical_device)
         return E_INVALIDARG;
         
@@ -66,7 +66,7 @@ static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetExtensionSupport(d3d12_d
     const struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     bool ret_val = false;
     
-    TRACE("iface %p, extension %u \n", iface, extension);
+    TRACE("iface %p, extension %u\n", iface, extension);
     switch (extension)
     {
         case D3D12_VK_NVX_BINARY_IMPORT:
@@ -79,7 +79,7 @@ static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetExtensionSupport(d3d12_d
             ret_val = device->vk_info.NV_low_latency2;
             break;
         default:
-            WARN("Invalid extension %x\n", extension);
+            WARN("Invalid extension %x.\n", extension);
     }
     
     return ret_val;
@@ -96,7 +96,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_CreateCubinComputeShader
     VkDevice vk_device;
     VkResult vr;
     
-    TRACE("iface %p, cubin_data %p, cubin_size %u, shader_name %s \n", iface, cubin_data, cubin_size, shader_name);
+    TRACE("iface %p, cubin_data %p, cubin_size %u, shader_name %s\n", iface, cubin_data, cubin_size, shader_name);
     if (!cubin_data || !cubin_size || !shader_name)
         return E_INVALIDARG;    
 
@@ -138,7 +138,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_DestroyCubinComputeShade
     struct d3d12_device *device;
     VkDevice vk_device;
 
-    TRACE("iface %p, handle %p \n", iface, handle);
+    TRACE("iface %p, handle %p\n", iface, handle);
     if (!iface || !handle)
         return E_INVALIDARG;
     
@@ -309,7 +309,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanHandles(ID3D
         VkInstance *vk_instance, VkPhysicalDevice *vk_physical_device, VkDevice *vk_device)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
-    TRACE("iface %p, vk_instance %p, vk_physical_device %p, vk_device %p \n", iface, vk_instance, vk_physical_device, vk_device);
+    TRACE("iface %p, vk_instance %p, vk_physical_device %p, vk_device %p\n", iface, vk_instance, vk_physical_device, vk_device);
     if (!vk_device || !vk_instance || !vk_physical_device)
         return E_INVALIDARG;
 
@@ -324,7 +324,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetInstanceExtensions
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
     struct vkd3d_instance *instance = device->vkd3d_instance;
 
-    TRACE("iface %p, extension_count %u, extensions %p.\n", iface, extension_count, extensions);
+    TRACE("iface %p, extension_count %p, extensions %p.\n", iface, extension_count, extensions);
 
     if (extensions && (*extension_count < instance->vk_info.extension_count))
         return E_INVALIDARG;
@@ -343,7 +343,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceExtensions(I
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
 
-    TRACE("iface %p, extension_count %u, extensions %p.\n", iface, extension_count, extensions);
+    TRACE("iface %p, extension_count %p, extensions %p.\n", iface, extension_count, extensions);
 
     if (extensions && (*extension_count < device->vk_info.extension_count))
         return E_INVALIDARG;

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -122,7 +122,7 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
 
     if ((vr = vkd3d_meta_create_shader_module(device, code, code_size, &module)) < 0)
     {
-        ERR("Failed to create shader module, vr %d.", vr);
+        ERR("Failed to create shader module, vr %d.\n", vr);
         return vr;
     }
 
@@ -420,7 +420,7 @@ static HRESULT vkd3d_clear_uav_ops_init(struct vkd3d_clear_uav_ops *meta_clear_u
 
         if (vr < 0)
         {
-            ERR("Failed to create descriptor set layout %u, vr %d.", i, vr);
+            ERR("Failed to create descriptor set layout %u, vr %d.\n", i, vr);
             goto fail;
         }
 
@@ -429,7 +429,7 @@ static HRESULT vkd3d_clear_uav_ops_init(struct vkd3d_clear_uav_ops *meta_clear_u
 
         if (vr < 0)
         {
-            ERR("Failed to create pipeline layout %u, vr %d.", i, vr);
+            ERR("Failed to create pipeline layout %u, vr %d.\n", i, vr);
             goto fail;
         }
     }
@@ -439,7 +439,7 @@ static HRESULT vkd3d_clear_uav_ops_init(struct vkd3d_clear_uav_ops *meta_clear_u
         if ((vr = vkd3d_meta_create_compute_pipeline(device, pipelines[i].code_size, pipelines[i].code,
                 *pipelines[i].pipeline_layout, NULL, true, pipelines[i].pipeline)) < 0)
         {
-            ERR("Failed to create compute pipeline %u, vr %d.", i, vr);
+            ERR("Failed to create compute pipeline %u, vr %d.\n", i, vr);
             goto fail;
         }
     }

--- a/libs/vkd3d/meta_commands.c
+++ b/libs/vkd3d/meta_commands.c
@@ -484,24 +484,24 @@ static HRESULT d3d12_meta_command_create_dstorage(struct d3d12_meta_command *met
 
     if (parameter_size < sizeof(*parameters) || !parameters)
     {
-        FIXME("Invalid parameter set (size = %u, ptr = %p) for DirectStorage meta command.\n", parameter_size, parameters);
+        FIXME("Invalid parameter set (size = %zu, ptr = %p) for DirectStorage meta command.\n", parameter_size, parameters);
         return E_INVALIDARG;
     }
 
     if (parameters->version != 1)
     {
-        ERR("Unsupported version %u for DirectStorage meta command.\n", parameters->version);
+        ERR("Unsupported version %"PRIu64" for DirectStorage meta command.\n", parameters->version);
         return DXGI_ERROR_UNSUPPORTED;
     }
 
     if (parameters->format != 1)
     {
-        ERR("Unsupported format %u for DirectStorage meta command.\n", parameters->format);
+        ERR("Unsupported format %"PRIu64" for DirectStorage meta command.\n", parameters->format);
         return DXGI_ERROR_UNSUPPORTED;
     }
 
     if (parameters->flags != 0)
-        FIXME("Unrecognized flags %#x for DirectStorage meta command.\n", parameters->flags);
+        FIXME("Unrecognized flags %#"PRIx64" for DirectStorage meta command.\n", parameters->flags);
 
     meta_command->exec_proc = &d3d12_meta_command_exec_dstorage;
     return S_OK;

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -1065,7 +1065,7 @@ static HRESULT d3d12_state_object_parse_subobject(struct d3d12_state_object *obj
             }
 
             for (j = old_obj_count; j < data->subobjects_count; j++)
-                RT_TRACE("  RDAT subobject: %s (type #%x).\n", data->subobjects[j].name, data->subobjects[j].kind);
+                RT_TRACE("  RDAT subobject: %s (type #%x).\n", debugstr_w(data->subobjects[j].name), data->subobjects[j].kind);
             break;
         }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5901,7 +5901,7 @@ void d3d12_desc_create_srv_embedded(vkd3d_cpu_descriptor_va_t desc_va,
     }
     else
     {
-        WARN("Description required for NULL SRV.");
+        WARN("Description required for NULL SRV.\n");
         return;
     }
 
@@ -5928,7 +5928,7 @@ void d3d12_desc_create_srv(vkd3d_cpu_descriptor_va_t desc_va,
     }
     else
     {
-        WARN("Description required for NULL SRV.");
+        WARN("Description required for NULL SRV.\n");
         return;
     }
 
@@ -6429,7 +6429,7 @@ void d3d12_desc_create_uav_embedded(vkd3d_cpu_descriptor_va_t desc_va, struct d3
     }
     else
     {
-        WARN("Description required for NULL UAV.");
+        WARN("Description required for NULL UAV.\n");
         return;
     }
 
@@ -6458,7 +6458,7 @@ void d3d12_desc_create_uav(vkd3d_cpu_descriptor_va_t desc_va, struct d3d12_devic
     }
     else
     {
-        WARN("Description required for NULL UAV.");
+        WARN("Description required for NULL UAV.\n");
         return;
     }
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2364,7 +2364,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_pipeline_state_GetCachedBlob(ID3D12Pipeli
 
     if (FAILED(hr = d3d_blob_create(cache_data, cache_size, &blob_object)))
     {
-        ERR("Failed to create blob, hr %#x.", hr);
+        ERR("Failed to create blob, hr %#x.\n", hr);
         vkd3d_free(cache_data);
         return hr;
     }
@@ -2915,7 +2915,7 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     VK_CALL(vkDestroyShaderModule(device->vk_device, pipeline_info.stage.module, NULL));
     if (vr < 0)
     {
-        ERR("Failed to create Vulkan compute pipeline, hr %#x.", hr);
+        ERR("Failed to create Vulkan compute pipeline, hr %#x.\n", hr);
         ERR("  Root signature: %"PRIx64"\n", state->root_signature->pso_compatibility_hash);
         ERR("  Shader: %"PRIx64".\n", state->compute.code.meta.hash);
         return hresult_from_vk_result(vr);
@@ -4539,7 +4539,7 @@ static HRESULT d3d12_pipeline_state_init_graphics_create_info(struct d3d12_pipel
         }
         if (rt_desc->BlendEnable && rt_desc->LogicOpEnable)
         {
-            WARN("Only one of BlendEnable or LogicOpEnable can be set to TRUE.");
+            WARN("Only one of BlendEnable or LogicOpEnable can be set to TRUE.\n");
             hr = E_INVALIDARG;
             goto fail;
         }
@@ -5345,7 +5345,7 @@ HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindP
                 break;
 
             default:
-                ERR("Invalid pipeline type %u.", bind_point);
+                ERR("Invalid pipeline type %u.\n", bind_point);
                 hr = E_INVALIDARG;
         }
     }
@@ -5491,14 +5491,14 @@ static void d3d12_pipeline_state_log_graphics_state(const struct d3d12_pipeline_
     if (graphics->stage_flags & VK_SHADER_STAGE_VERTEX_BIT)
     {
         ERR("Topology: %u (patch vertex count: %u)\n", graphics->primitive_topology_type, graphics->patch_vertex_count);
-        ERR("Vertex attributes: %u\n", graphics->attribute_count);
+        ERR("Vertex attributes: %zu\n", graphics->attribute_count);
         for (i = 0; i < graphics->attribute_count; i++)
         {
             const VkVertexInputAttributeDescription *attr = &graphics->attributes[i];
-            ERR("  %u: binding %u, format %u, location %u, offset %u\n", attr->binding, attr->format, attr->location, attr->offset);
+            ERR("  %u: binding %u, format %u, location %u, offset %u\n", i, attr->binding, attr->format, attr->location, attr->offset);
         }
 
-        ERR("Vertex bindings: %u.\n", graphics->attribute_binding_count);
+        ERR("Vertex bindings: %zu.\n", graphics->attribute_binding_count);
         for (i = 0; i < graphics->attribute_binding_count; i++)
         {
             const VkVertexInputBindingDescription *binding = &graphics->attribute_bindings[i];
@@ -5511,7 +5511,7 @@ static void d3d12_pipeline_state_log_graphics_state(const struct d3d12_pipeline_
                     divisor = graphics->instance_divisors[j].divisor;
             }
 
-            ERR("  %u: binding %u, input rate %u, stride %u, divisor %u\n", binding->binding, binding->inputRate, binding->stride, divisor);
+            ERR("  %u: binding %u, input rate %u, stride %u, divisor %u\n", i, binding->binding, binding->inputRate, binding->stride, divisor);
         }
     }
 
@@ -5548,7 +5548,7 @@ static void d3d12_pipeline_state_log_graphics_state(const struct d3d12_pipeline_
 
     if (graphics->dsv_format)
     {
-        ERR("DSV: %u\n", graphics->dsv_format);
+        ERR("DSV: #%x\n", graphics->dsv_format->dxgi_format);
         ERR("  Depth test: %u (write: %u)\n", graphics->ds_desc.depthTestEnable, graphics->ds_desc.depthWriteEnable);
         ERR("  Depth bounds test: %u\n", graphics->ds_desc.depthBoundsTestEnable);
 
@@ -7038,7 +7038,7 @@ struct vkd3d_descriptor_binding vkd3d_bindless_state_find_set(const struct vkd3d
         }
     }
 
-    ERR("No set found for flags %#x.", flags);
+    ERR("No set found for flags %#x.\n", flags);
     binding.set = 0;
     binding.binding = 0;
     return binding;
@@ -7060,6 +7060,6 @@ uint32_t vkd3d_bindless_state_find_set_info_index(const struct vkd3d_bindless_st
             return i;
     }
 
-    ERR("No set found for flags %#x.", flags);
+    ERR("No set found for flags %#x.\n", flags);
     return 0;
 }


### PR DESCRIPTION
:broom:, but I dumped most of it into a single commit so let me know if you want this stuff to be split differently.

* Adds missing newlines
* Adds some dots where appropriate
* Removes some stray spaces, in particular at the end of message just before newline and when there was more than one space in the middle of format string
* Changes some specifiers to better match argument types
* Fixes some conversion specifiers missing their arguments or arguments missing their conversion specifiers
* Adds extra arguments to log messages in two places where it would make sense to log them

Two places I'm not sure about are

* `ERR("DSV: %p\n", graphics->dsv_format);` where I don't know if there's any value in logging the pointer value and maybe we should log `graphics->dsv_format->dxgi_format` or `graphics->dsv_format->vk_format` here instead (or both?)
* `RT_TRACE(" RDAT subobject: %s (type #%x).\n", debugstr_w(data->subobjects[j].name), data->subobjects[j].kind);` where the comment suggests that the strings might actually be ASCII but IIUC `name` is actually already post-conversion to `WCHAR`.

There's also another commit with two `NULL` checks added (for `extension_count`) where I found it weird that they are not checked before dereferencing. Finally, last commit attempts to ensure leading zeros are always printed when formatting the build commit message.