### PR TITLE
vkd3d: Print build commit using a fixed width format.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -976,6 +976,7 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     const char **extensions;
     uint32_t layer_count, i;
     VkInstance vk_instance;
+    bool dirty_tree_build;
     VkResult vr;
     HRESULT hr;
     uint32_t loader_version = VK_API_VERSION_1_0;
@@ -1029,7 +1030,12 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     application_info.engineVersion = vkd3d_get_vk_version();
     application_info.apiVersion = loader_version;
 
-    INFO("vkd3d-proton - build: %"PRIx64".\n", vkd3d_build);
+    /* Builds from dirty trees generate vkd3d_version ending with a '+'. */
+    dirty_tree_build = sizeof(vkd3d_version) >= 2 && vkd3d_version[sizeof(vkd3d_version) - 2] == '+';
+    if (dirty_tree_build)
+        INFO("vkd3d-proton - build: %015"PRIx64"+.\n", vkd3d_build >> 4);
+    else
+        INFO("vkd3d-proton - build: %015"PRIx64".\n", vkd3d_build);
 
     if (vkd3d_get_program_name(application_name))
         application_info.pApplicationName = application_name;


### PR DESCRIPTION
Continuing https://github.com/HansKristian-Work/vkd3d-proton/pull/2017#discussion_r1642580774:

We indeed can't detect if the build was from a dirty tree based on `vkd3d_build` alone so check `vkd3d_version` for that instead. With this, we will always print 15 digits but with a `+` appended on dirty trees.

```
info:vkd3d_instance_init: vkd3d-proton - build: e20011164ce2450.
```
or
```
info:vkd3d_instance_init: vkd3d-proton - build: e20011164ce2450+.
```