### PR TITLE
Add vkd3d_counted_by

### DIFF
--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -66,6 +66,12 @@ static inline size_t align(size_t addr, size_t alignment)
 # define VKD3D_UNUSED
 #endif  /* __GNUC__ */
 
+#if __has_attribute(__counted_by__)
+# define vkd3d_counted_by(member) __attribute__((__counted_by__(member)))
+#else
+# define vkd3d_counted_by(member)
+#endif
+
 static inline unsigned int vkd3d_popcount(unsigned int v)
 {
 #ifdef _MSC_VER

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -130,7 +130,7 @@ struct vkd3d_spirv_chunk
     struct list entry;
     size_t location;
     size_t word_count;
-    uint32_t words[];
+    uint32_t words[] vkd3d_counted_by(word_count);
 };
 
 static void vkd3d_spirv_stream_clear(struct vkd3d_spirv_stream *stream)

--- a/libs/vkd3d/bundle.c
+++ b/libs/vkd3d/bundle.c
@@ -854,7 +854,7 @@ struct d3d12_set_root_32bit_constants_command
     UINT parameter_index;
     UINT constant_count;
     UINT offset;
-    UINT data[];
+    UINT data[] vkd3d_counted_by(constant_count);
 };
 
 static void d3d12_bundle_exec_set_compute_root_32bit_constants(d3d12_command_list_iface *list, const void *args_v)
@@ -1089,7 +1089,7 @@ struct d3d12_ia_set_vertex_buffers_command
     struct d3d12_bundle_command command;
     UINT start_slot;
     UINT view_count;
-    D3D12_VERTEX_BUFFER_VIEW views[];
+    D3D12_VERTEX_BUFFER_VIEW views[] vkd3d_counted_by(view_count);
 };
 
 static void d3d12_bundle_exec_ia_set_vertex_buffers(d3d12_command_list_iface *list, const void *args_v)
@@ -1204,7 +1204,7 @@ struct d3d12_debug_marker_command
     struct d3d12_bundle_command command;
     UINT metadata;
     UINT data_size;
-    char data[];
+    char data[] vkd3d_counted_by(data_size);
 };
 
 static void d3d12_bundle_exec_set_marker(d3d12_command_list_iface *list, const void *args_v)
@@ -1361,7 +1361,7 @@ struct d3d12_set_sample_positions_command
     struct d3d12_bundle_command command;
     UINT sample_count;
     UINT pixel_count;
-    D3D12_SAMPLE_POSITION positions[];
+    D3D12_SAMPLE_POSITION positions[]; /* vkd3d_counted_by(sample_count * pixel_count) -> Unfortunately this isn't supported yet, sad. */
 };
 
 static void d3d12_bundle_exec_set_sample_positions(d3d12_command_list_iface *list, const void *args_v)

--- a/libs/vkd3d/cache.c
+++ b/libs/vkd3d/cache.c
@@ -208,14 +208,14 @@ struct vkd3d_pipeline_blob_chunk
 {
     uint32_t type; /* vkd3d_pipeline_blob_chunk_type with extra data in upper bits. */
     uint32_t size; /* size of data. Does not include size of header. */
-    uint8_t data[]; /* struct vkd3d_pipeline_blob_chunk_*. */
+    uint8_t data[] vkd3d_counted_by(size); /* struct vkd3d_pipeline_blob_chunk_*. */
 };
 
 struct vkd3d_pipeline_blob_chunk_spirv
 {
     uint32_t decompressed_spirv_size;
     uint32_t compressed_spirv_size; /* Size of data[]. */
-    uint8_t data[];
+    uint8_t data[] vkd3d_counted_by(compressed_spirv_size);
 };
 
 struct vkd3d_pipeline_blob_chunk_link


### PR DESCRIPTION
Probably not too helpful right now, but probably good to do going forward.

Added it to the flexi-array members I found that had a member associated with their size, and checked the size was set before their use.