### PR TITLE
Planar formats, part 2: Handle subsampled planes and plane view aspects

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -11472,14 +11472,14 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
         const VkClearColorValue *clear_color, UINT rect_count, const D3D12_RECT *rects)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
-    VkExtent3D workgroup_size, workgroup_count;
-    unsigned int i, j, miplevel_idx, layer_count;
+    VkExtent3D workgroup_size, workgroup_count, view_extent;
     struct vkd3d_clear_uav_pipeline pipeline;
     struct vkd3d_clear_uav_args clear_args;
     VkDescriptorBufferInfo buffer_info;
     VkDescriptorImageInfo image_info;
     D3D12_RECT full_rect, curr_rect;
     VkWriteDescriptorSet write_set;
+    unsigned int i, j, layer_count;
     uint32_t max_workgroup_count;
     bool sampler_feedback_clear;
 
@@ -11506,12 +11506,11 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
     else
         clear_args.clear_color = *clear_color;
 
+    memset(&write_set, 0, sizeof(write_set));
     write_set.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write_set.pNext = NULL;
-    write_set.dstBinding = 0;
-    write_set.dstArrayElement = 0;
     write_set.descriptorCount = 1;
-    write_set.dstSet = VK_NULL_HANDLE;
+
+    memset(&full_rect, 0, sizeof(full_rect));
 
     if (d3d12_resource_is_texture(resource))
     {
@@ -11523,13 +11522,21 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
         write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
         write_set.pImageInfo = &image_info;
-        write_set.pBufferInfo = NULL;
-        write_set.pTexelBufferView = NULL;
 
-        miplevel_idx = args->u.view->info.texture.miplevel_idx;
+        view_extent = d3d12_resource_get_view_subresource_extent(resource, args->u.view);
+
+        full_rect.right = view_extent.width;
+        full_rect.bottom = view_extent.height;
+
         layer_count = args->u.view->info.texture.vk_view_type == VK_IMAGE_VIEW_TYPE_3D
-                ? d3d12_resource_desc_get_depth(&resource->desc, miplevel_idx)
-                : args->u.view->info.texture.layer_count;
+                ? view_extent.depth : args->u.view->info.texture.layer_count;
+
+        if (sampler_feedback_clear)
+        {
+            VkExtent3D padded = d3d12_resource_desc_get_padded_feedback_extent(&resource->desc);
+            full_rect.right = padded.width;
+            full_rect.bottom = padded.height;
+        }
 
         /* Robustness would take care of it, but no reason to spam more threads than needed. */
         if (args->u.view->info.texture.vk_view_type == VK_IMAGE_VIEW_TYPE_3D)
@@ -11549,17 +11556,20 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
     }
     else
     {
-        write_set.pImageInfo = NULL;
-        write_set.pBufferInfo = NULL;
-        write_set.pTexelBufferView = NULL;
+        full_rect.bottom = 1;
 
         if (args->has_view)
         {
+            VkDeviceSize byte_count = args->u.view->format->byte_count;
+            full_rect.right = args->u.view->info.buffer.size / byte_count;
+
             write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
             write_set.pTexelBufferView = &args->u.view->vk_buffer_view;
         }
         else
         {
+            full_rect.right = args->u.buffer.range / sizeof(uint32_t);
+
             write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             write_set.pBufferInfo = &buffer_info;
             /* resource heap offset is already in descriptor */
@@ -11568,35 +11578,11 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
             buffer_info.range = args->u.buffer.range;
         }
 
-        miplevel_idx = 0;
         layer_count = 1;
         pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops,
                 !args->has_view || args->u.view->format->type == VKD3D_FORMAT_TYPE_UINT,
                 !args->has_view);
         workgroup_size = vkd3d_meta_get_clear_buffer_uav_workgroup_size();
-    }
-
-    full_rect.left = 0;
-    full_rect.right = d3d12_resource_desc_get_width(&resource->desc, miplevel_idx);
-    full_rect.top = 0;
-    full_rect.bottom = d3d12_resource_desc_get_height(&resource->desc, miplevel_idx);
-
-    if (sampler_feedback_clear)
-    {
-        VkExtent3D padded = d3d12_resource_desc_get_padded_feedback_extent(&resource->desc);
-        full_rect.right = padded.width;
-        full_rect.bottom = padded.height;
-    }
-
-    if (d3d12_resource_is_buffer(resource))
-    {
-        if (args->has_view)
-        {
-            VkDeviceSize byte_count = args->u.view->format->byte_count;
-            full_rect.right = args->u.view->info.buffer.size / byte_count;
-        }
-        else
-            full_rect.right = args->u.buffer.range / sizeof(uint32_t);
     }
 
     /* clear full resource if no rects are specified */
@@ -11654,7 +11640,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
         const struct vkd3d_format *format, UINT rect_count, const D3D12_RECT *rects)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
-    unsigned int miplevel_idx, base_layer, layer_count, i, j;
+    unsigned int base_layer, layer_count, i, j;
     struct vkd3d_clear_uav_pipeline pipeline;
     struct vkd3d_scratch_allocation scratch;
     struct vkd3d_clear_uav_args clear_args;
@@ -11667,6 +11653,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     VkExtent3D workgroup_size;
     VkDependencyInfo dep_info;
     VkMemoryBarrier2 barrier;
+    VkExtent3D view_extent;
     uint32_t element_count;
 
     d3d12_command_list_track_resource_usage(list, resource, true);
@@ -11680,12 +11667,12 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     assert(args->has_view);
     assert(d3d12_resource_is_texture(resource));
 
-    miplevel_idx = args->u.view->info.texture.miplevel_idx;
+    view_extent = d3d12_resource_get_view_subresource_extent(resource, args->u.view);
 
     full_rect.left = 0;
-    full_rect.right = d3d12_resource_desc_get_width(&resource->desc, miplevel_idx);
+    full_rect.right = view_extent.width;
     full_rect.top = 0;
-    full_rect.bottom = d3d12_resource_desc_get_height(&resource->desc, miplevel_idx);
+    full_rect.bottom = view_extent.height;
 
     if (rect_count)
     {
@@ -11706,7 +11693,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
         element_count = full_rect.right * full_rect.bottom;
     }
 
-    element_count *= d3d12_resource_desc_get_depth(&resource->desc, miplevel_idx);
+    element_count *= view_extent.depth;
     scratch_buffer_size = element_count * format->byte_count;
 
     if (!d3d12_command_allocator_allocate_scratch_memory(list->allocator,
@@ -11785,7 +11772,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     if (args->u.view->info.texture.vk_view_type == VK_IMAGE_VIEW_TYPE_3D)
     {
         base_layer = args->u.view->info.texture.w_offset;
-        layer_count = d3d12_resource_desc_get_depth(&resource->desc, miplevel_idx);
+        layer_count = view_extent.depth;
         layer_count = min(layer_count - args->u.view->info.texture.w_offset, args->u.view->info.texture.w_size);
         if (layer_count >= 0x80000000u)
         {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2953,24 +2953,23 @@ static void d3d12_command_list_invalidate_current_pipeline(struct d3d12_command_
     }
 }
 
-static D3D12_RECT d3d12_get_image_rect(struct d3d12_resource *resource, unsigned int mip_level)
+static D3D12_RECT d3d12_get_image_rect(struct d3d12_resource *resource, const VkImageSubresourceLayers *subresource)
 {
+    VkExtent3D mip_extent = d3d12_resource_desc_get_vk_subresource_extent(&resource->desc, resource->format, subresource);
+
     D3D12_RECT rect;
     rect.left = 0;
     rect.top = 0;
-    rect.right = d3d12_resource_desc_get_width(&resource->desc, mip_level);
-    rect.bottom = d3d12_resource_desc_get_height(&resource->desc, mip_level);
+    rect.right = mip_extent.width;
+    rect.bottom = mip_extent.height;
     return rect;
 }
 
 static bool d3d12_image_copy_writes_full_subresource(struct d3d12_resource *resource,
         const VkExtent3D *extent, const VkImageSubresourceLayers *subresource)
 {
-    unsigned int width, height, depth;
-    width = d3d12_resource_desc_get_width(&resource->desc, subresource->mipLevel);
-    height = d3d12_resource_desc_get_height(&resource->desc, subresource->mipLevel);
-    depth = d3d12_resource_desc_get_depth(&resource->desc, subresource->mipLevel);
-    return width == extent->width && height == extent->height && depth == extent->depth;
+    VkExtent3D mip_extent = d3d12_resource_desc_get_vk_subresource_extent(&resource->desc, resource->format, subresource);
+    return mip_extent.width == extent->width && mip_extent.height == extent->height && mip_extent.depth == extent->depth;
 }
 
 static bool vk_rect_from_d3d12(const D3D12_RECT *rect, VkRect2D *vk_rect, const D3D12_RECT *clamp_rect)
@@ -3074,12 +3073,14 @@ static void d3d12_command_list_clear_attachment_inline(struct d3d12_command_list
         const VkClearValue *clear_value, UINT rect_count, const D3D12_RECT *rects)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    VkImageSubresourceLayers vk_subresource;
     VkClearAttachment vk_clear_attachment;
     VkClearRect vk_clear_rect;
     D3D12_RECT full_rect;
     unsigned int i;
 
-    full_rect = d3d12_get_image_rect(resource, view->info.texture.miplevel_idx);
+    vk_subresource = vk_subresource_layers_from_view(view);
+    full_rect = d3d12_get_image_rect(resource, &vk_subresource);
 
     if (!rect_count)
     {
@@ -3604,6 +3605,7 @@ static void d3d12_command_list_load_attachment(struct d3d12_command_list *list, 
     uint32_t plane_write_mask, i;
     VkDependencyInfo dep_info;
     bool separate_ds_layouts;
+    VkExtent3D view_extent;
     VkAccessFlags2 access;
     bool clear_op;
 
@@ -3619,12 +3621,14 @@ static void d3d12_command_list_load_attachment(struct d3d12_command_list *list, 
 
     stencil_attachment_info = attachment_info;
 
+    view_extent = d3d12_resource_get_view_subresource_extent(resource, view);
+
     memset(&rendering_info, 0, sizeof(rendering_info));
     rendering_info.sType = VK_STRUCTURE_TYPE_RENDERING_INFO;
     rendering_info.renderArea.offset.x = 0;
     rendering_info.renderArea.offset.y = 0;
-    rendering_info.renderArea.extent.width = d3d12_resource_desc_get_width(&resource->desc, view->info.texture.miplevel_idx);
-    rendering_info.renderArea.extent.height = d3d12_resource_desc_get_height(&resource->desc, view->info.texture.miplevel_idx);
+    rendering_info.renderArea.extent.width = view_extent.width;
+    rendering_info.renderArea.extent.height = view_extent.height;
     rendering_info.layerCount = view->info.texture.layer_count;
 
     if (view->format->vk_aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT)
@@ -11330,7 +11334,7 @@ static void d3d12_command_list_clear_attachment(struct d3d12_command_list *list,
 
     /* If one of the clear rectangles covers the entire image, we
      * may be able to use a fast path and re-initialize the image */
-    full_rect = d3d12_get_image_rect(resource, view->info.texture.miplevel_idx);
+    full_rect = d3d12_get_image_rect(resource, &vk_subresource_layers);
     full_clear = !rect_count;
 
     for (i = 0; i < rect_count && !full_clear; i++)
@@ -12264,6 +12268,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_DiscardResource(d3d12_command_l
     struct d3d12_resource *texture = impl_from_ID3D12Resource(resource);
     unsigned int i, first_subresource, subresource_count;
     bool has_bound_subresource, has_unbound_subresource;
+    VkImageSubresourceLayers vk_subresource_layers;
     VkImageSubresourceRange vk_subresource_range;
     unsigned int resource_subresource_count;
     VkImageSubresource vk_subresource;
@@ -12337,7 +12342,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_DiscardResource(d3d12_command_l
     if (!(full_discard = (!region || !region->NumRects)))
     {
         vk_subresource = d3d12_resource_get_vk_subresource(texture, first_subresource, false);
-        full_rect = d3d12_get_image_rect(texture, vk_subresource.mipLevel);
+        vk_subresource_layers = vk_subresource_layers_from_subresource(&vk_subresource);
+        full_rect = d3d12_get_image_rect(texture, &vk_subresource_layers);
 
         for (i = 0; i < region->NumRects && !full_discard; i++)
             full_discard = d3d12_rect_fully_covers_region(&region->pRects[i], &full_rect);

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -14245,7 +14245,7 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
             transcoded_height -= dst_y;
 
             /* Transcoded output doesn't have to cover everything. Cover minimum. */
-            vk_extent_3d_from_d3d12_miplevel(&extent, &src->desc, src_image_view_desc.miplevel_idx);
+            extent = d3d12_resource_desc_get_subresource_extent(&src->desc, src->format, src_image_view_desc.miplevel_idx);
             transcoded_width = min(transcoded_width, extent.width);
             transcoded_height = min(transcoded_height, extent.height);
 
@@ -14598,7 +14598,7 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
                 goto cleanup;
 
             /* Transcoded output doesn't have to cover everything. Cover minimum. */
-            vk_extent_3d_from_d3d12_miplevel(&extent, &dst->desc, dst_image_view_desc.miplevel_idx);
+            extent = d3d12_resource_desc_get_subresource_extent(&dst->desc, dst->format, dst_image_view_desc.miplevel_idx);
             transcoded_width = extent.width;
             transcoded_height = extent.height;
             if (dst_x >= transcoded_width || dst_y >= transcoded_height)

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -263,7 +263,8 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
 static unsigned int max_miplevel_count(const D3D12_RESOURCE_DESC1 *desc)
 {
     unsigned int size = max(desc->Width, desc->Height);
-    size = max(size, d3d12_resource_desc_get_depth(desc, 0));
+    if (desc->Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D)
+        size = max(size, desc->DepthOrArraySize);
     return vkd3d_log2i(size) + 1;
 }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3274,8 +3274,8 @@ static size_t vkd3d_compute_resource_layouts_from_desc(struct d3d12_device *devi
     struct vkd3d_format_footprint format_footprint;
     const struct vkd3d_format *format;
     unsigned int i, subresource_count;
-    uint32_t plane_idx, mip_idx;
     VkExtent3D block_count;
+    uint32_t plane_idx;
     size_t offset = 0;
 
     subresource_count = d3d12_resource_desc_get_sub_resource_count(device, desc);
@@ -3284,13 +3284,11 @@ static size_t vkd3d_compute_resource_layouts_from_desc(struct d3d12_device *devi
     for (i = 0; i < subresource_count; i++)
     {
         plane_idx = i / d3d12_resource_desc_get_sub_resource_count_per_plane(desc);
-        mip_idx = i % desc->MipLevels;
-
         format_footprint = vkd3d_format_footprint_for_plane(format, plane_idx);
 
-        block_count.width = align(d3d12_resource_desc_get_width(desc, mip_idx + format_footprint.subsample_x_log2), format_footprint.block_width) / format_footprint.block_width;
-        block_count.height = align(d3d12_resource_desc_get_height(desc, mip_idx + format_footprint.subsample_y_log2), format_footprint.block_height) / format_footprint.block_height;
-        block_count.depth = d3d12_resource_desc_get_depth(desc, mip_idx);
+        block_count = d3d12_resource_desc_get_subresource_extent(desc, format, i);
+        block_count.width = align(block_count.width, format_footprint.block_width) / format_footprint.block_width;
+        block_count.height = align(block_count.height, format_footprint.block_height) / format_footprint.block_height;
 
         if (layouts)
         {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -1103,6 +1103,7 @@ static uint32_t vkd3d_view_entry_hash(const void *key)
         case VKD3D_VIEW_TYPE_IMAGE:
             hash = hash_uint64((uint64_t)k->u.texture.image);
             hash = hash_combine(hash, k->u.texture.view_type);
+            hash = hash_combine(hash, k->u.texture.aspect_mask);
             hash = hash_combine(hash, (uintptr_t)k->u.texture.format);
             hash = hash_combine(hash, k->u.texture.miplevel_idx);
             hash = hash_combine(hash, k->u.texture.miplevel_count);
@@ -1167,6 +1168,7 @@ static bool vkd3d_view_entry_compare(const void *key, const struct hash_map_entr
         case VKD3D_VIEW_TYPE_IMAGE:
             return k->u.texture.image == e->key.u.texture.image &&
                     k->u.texture.view_type == e->key.u.texture.view_type &&
+                    k->u.texture.aspect_mask == e->key.u.texture.aspect_mask &&
                     k->u.texture.format == e->key.u.texture.format &&
                     k->u.texture.miplevel_idx == e->key.u.texture.miplevel_idx &&
                     k->u.texture.miplevel_count == e->key.u.texture.miplevel_count &&
@@ -4769,6 +4771,7 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
     object->vk_image_view = vk_view;
     object->format = format;
     object->info.texture.vk_view_type = desc->view_type;
+    object->info.texture.aspect_mask = desc->aspect_mask;
     object->info.texture.miplevel_idx = desc->miplevel_idx;
     object->info.texture.layer_idx = desc->layer_idx;
     object->info.texture.layer_count = desc->layer_count;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -6839,6 +6839,7 @@ void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_dev
 {
     struct vkd3d_view_key key;
     struct vkd3d_view *view;
+    VkExtent3D view_extent;
 
     if (!resource)
     {
@@ -6925,10 +6926,12 @@ void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_dev
 
     vkd3d_descriptor_debug_register_view_cookie(device->descriptor_qa_global_info, view->cookie, resource->res.cookie);
 
+    view_extent = d3d12_resource_get_view_subresource_extent(resource, view);
+
     rtv_desc->sample_count = vk_samples_from_dxgi_sample_desc(&resource->desc.SampleDesc);
     rtv_desc->format = key.u.texture.format;
-    rtv_desc->width = d3d12_resource_desc_get_width(&resource->desc, key.u.texture.miplevel_idx);
-    rtv_desc->height = d3d12_resource_desc_get_height(&resource->desc, key.u.texture.miplevel_idx);
+    rtv_desc->width = view_extent.width;
+    rtv_desc->height = view_extent.height;
     rtv_desc->layer_count = key.u.texture.layer_count;
     rtv_desc->view = view;
     rtv_desc->resource = resource;
@@ -6940,6 +6943,7 @@ void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_dev
 {
     struct vkd3d_view_key key;
     struct vkd3d_view *view;
+    VkExtent3D view_extent;
 
     if (!resource)
     {
@@ -7016,10 +7020,12 @@ void d3d12_rtv_desc_create_dsv(struct d3d12_rtv_desc *dsv_desc, struct d3d12_dev
 
     vkd3d_descriptor_debug_register_view_cookie(device->descriptor_qa_global_info, view->cookie, resource->res.cookie);
 
+    view_extent = d3d12_resource_get_view_subresource_extent(resource, view);
+
     dsv_desc->sample_count = vk_samples_from_dxgi_sample_desc(&resource->desc.SampleDesc);
     dsv_desc->format = key.u.texture.format;
-    dsv_desc->width = d3d12_resource_desc_get_width(&resource->desc, key.u.texture.miplevel_idx);
-    dsv_desc->height = d3d12_resource_desc_get_height(&resource->desc, key.u.texture.miplevel_idx);
+    dsv_desc->width = view_extent.width;
+    dsv_desc->height = view_extent.height;
     dsv_desc->layer_count = key.u.texture.layer_count;
     dsv_desc->view = view;
     dsv_desc->resource = resource;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5448,25 +5448,6 @@ static inline bool d3d12_box_is_empty(const D3D12_BOX *box)
     return box->right <= box->left || box->bottom <= box->top || box->back <= box->front;
 }
 
-static inline unsigned int d3d12_resource_desc_get_width(const D3D12_RESOURCE_DESC1 *desc,
-        unsigned int miplevel_idx)
-{
-    return max(1, desc->Width >> miplevel_idx);
-}
-
-static inline unsigned int d3d12_resource_desc_get_height(const D3D12_RESOURCE_DESC1 *desc,
-        unsigned int miplevel_idx)
-{
-    return max(1, desc->Height >> miplevel_idx);
-}
-
-static inline unsigned int d3d12_resource_desc_get_depth(const D3D12_RESOURCE_DESC1 *desc,
-        unsigned int miplevel_idx)
-{
-    unsigned int d = desc->Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D ? 1 : desc->DepthOrArraySize;
-    return max(1, d >> miplevel_idx);
-}
-
 static inline unsigned int d3d12_resource_desc_get_layer_count(const D3D12_RESOURCE_DESC1 *desc)
 {
     return desc->Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D ? desc->DepthOrArraySize : 1;
@@ -5525,14 +5506,6 @@ static inline bool d3d12_resource_desc_is_sampler_feedback(const D3D12_RESOURCE_
 static inline unsigned int d3d12_resource_desc_get_active_level_count(const D3D12_RESOURCE_DESC1 *desc)
 {
     return d3d12_resource_desc_is_sampler_feedback(desc) ? 1 : desc->MipLevels;
-}
-
-static inline void vk_extent_3d_from_d3d12_miplevel(VkExtent3D *extent,
-        const D3D12_RESOURCE_DESC1 *resource_desc, unsigned int miplevel_idx)
-{
-    extent->width = d3d12_resource_desc_get_width(resource_desc, miplevel_idx);
-    extent->height = d3d12_resource_desc_get_height(resource_desc, miplevel_idx);
-    extent->depth = d3d12_resource_desc_get_depth(resource_desc, miplevel_idx);
 }
 
 static inline VkExtent3D d3d12_resource_desc_get_active_feedback_extent(const D3D12_RESOURCE_DESC1 *desc,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1071,6 +1071,9 @@ VkImageSubresource vk_image_subresource_from_d3d12(
         const struct vkd3d_format *format, uint32_t subresource_idx,
         unsigned int miplevel_count, unsigned int layer_count,
         bool all_aspects);
+VkImageSubresourceLayers vk_image_subresource_layers_from_d3d12(
+        const struct vkd3d_format *format, unsigned int sub_resource_idx,
+        unsigned int miplevel_count, unsigned int layer_count);
 VkImageLayout vk_image_layout_from_d3d12_resource_state(
         struct d3d12_command_list *list, const struct d3d12_resource *resource, D3D12_RESOURCE_STATES state);
 UINT d3d12_plane_index_from_vk_aspect(VkImageAspectFlagBits aspect);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5538,8 +5538,15 @@ static inline void vk_extent_3d_from_d3d12_miplevel(VkExtent3D *extent,
 static inline VkExtent3D d3d12_resource_desc_get_active_feedback_extent(const D3D12_RESOURCE_DESC1 *desc,
         unsigned int mip_level)
 {
+    VkImageSubresourceLayers vk_subresource;
     VkExtent3D result;
-    vk_extent_3d_from_d3d12_miplevel(&result, desc, mip_level);
+
+    vk_subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    vk_subresource.mipLevel = mip_level;
+    vk_subresource.baseArrayLayer = 0;
+    vk_subresource.layerCount = 1;
+
+    result = d3d12_resource_desc_get_vk_subresource_extent(desc, NULL, &vk_subresource);
     result.width = DIV_ROUND_UP(result.width, desc->SamplerFeedbackMipRegion.Width);
     result.height = DIV_ROUND_UP(result.height, desc->SamplerFeedbackMipRegion.Height);
     return result;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1160,6 +1160,7 @@ struct vkd3d_view
         struct
         {
             VkImageViewType vk_view_type;
+            VkImageAspectFlags aspect_mask;
             unsigned int miplevel_idx;
             unsigned int layer_idx;
             unsigned int layer_count;
@@ -5429,7 +5430,7 @@ static inline VkImageSubresourceLayers vk_subresource_layers_from_subresource(co
 static inline VkImageSubresourceLayers vk_subresource_layers_from_view(const struct vkd3d_view *view)
 {
     VkImageSubresourceLayers layers;
-    layers.aspectMask = view->format->vk_aspect_mask;
+    layers.aspectMask = view->info.texture.aspect_mask;
     layers.mipLevel = view->info.texture.miplevel_idx;
     layers.baseArrayLayer = view->info.texture.layer_idx;
     layers.layerCount = view->info.texture.layer_count;


### PR DESCRIPTION
This is a fairly invasive refactor, so I'm doing this as a separate PR.

The goal here is to unify all the different ways in which we compute the size of a subresource to make it a) more consistent and b) correct w.r.t. subsampled planes. Currently it's all over the place and largely broken.

Another change is that we now store the aspect flag that is used to create a view in the view info. This is important in cases where we need to reconstruct the exact subresource of the image that the view covers, since it can be something like `PLANE_1_BIT` even if the format's aspect mask is `COLOR_BIT`.