### PR TITLE
Format query memoization

### DIFF
--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -3207,7 +3207,6 @@ ULONG dxgi_vk_swap_chain_decref(struct dxgi_vk_swap_chain *chain)
 
     if (!refcount)
     {
-
         dxgi_vk_swap_chain_cleanup(chain);
         vkd3d_free(chain);
     }


### PR DESCRIPTION
Fixes a memory leak as explained in https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30014.
Even if drivers fix all the leaks, we should still memoize, since it's still a dumb memory allocation that should not be necessary, and our existing code to do format query was quite awkward in hindsight.
Some games tend to spam CheckColorSpaceSupport every frame, which we should optimize for.