### PR TITLE
vkd3d: Avoid assertion if attempting to render with compute shader.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6763,7 +6763,7 @@ static void d3d12_command_list_promote_dsv_layout(struct d3d12_command_list *lis
      * read-state shenanigans. If we cannot promote yet, the pipeline will override dsv_layout as required
      * by write enable bits. */
     if (list->dsv_layout == VK_IMAGE_LAYOUT_UNDEFINED &&
-            list->state &&
+            d3d12_pipeline_state_is_graphics(list->state) &&
             d3d12_command_list_has_depth_stencil_view(list) &&
             list->dsv.resource)
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2120,8 +2120,7 @@ static inline bool d3d12_pipeline_state_is_compute(const struct d3d12_pipeline_s
 
 static inline bool d3d12_pipeline_state_is_graphics(const struct d3d12_pipeline_state *state)
 {
-    return state && (state->pipeline_type == VKD3D_PIPELINE_TYPE_GRAPHICS ||
-            state->pipeline_type == VKD3D_PIPELINE_TYPE_MESH_GRAPHICS);
+    return state && state->pipeline_type != VKD3D_PIPELINE_TYPE_COMPUTE;
 }
 
 /* This returns true for invalid D3D12 API usage. Game intends to use depth-stencil tests,


### PR DESCRIPTION
We should nop out the draw call, but it happens after this check.