### PR TITLE
Extend `ID3D12DXVKInteropDevice` into `ID3D12DXVKInteropDevice1` to add `VkCommandBuffer` interop

### DIFF
--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -56,6 +56,21 @@ interface ID3D12DXVKInteropDevice : IUnknown
 }
 
 [
+    uuid(902d8115-59eb-4406-9518-fe00f991ee65),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12DXVKInteropDevice1 : ID3D12DXVKInteropDevice
+{
+    HRESULT GetVulkanResourceInfo1(ID3D12Resource *resource, UINT64 *vk_handle, UINT64 *buffer_offset, VkFormat *format);
+    HRESULT CreateInteropCommandQueue(const D3D12_COMMAND_QUEUE_DESC *pDesc, UINT32 vk_queue_family_index, ID3D12CommandQueue **ppQueue);
+    HRESULT CreateInteropCommandAllocator(D3D12_COMMAND_LIST_TYPE type, UINT32 vk_queue_family_index, ID3D12CommandAllocator **ppAllocator);
+    HRESULT BeginVkCommandBufferInterop(ID3D12CommandList *pCmdList, VkCommandBuffer *pCommandBuffer);
+    HRESULT EndVkCommandBufferInterop(ID3D12CommandList *pCmdList);
+}
+
+[
     uuid(f3112584-41f9-348d-a59b-00b7e1d285d6),
     object,
     local,

--- a/include/vkd3d_vk_includes.h
+++ b/include/vkd3d_vk_includes.h
@@ -35,6 +35,7 @@ typedef struct VkInstance_T *VkInstance;
 typedef struct VkDevice_T *VkDevice;
 typedef struct VkQueue_T *VkQueue;
 
+typedef enum VkFormat VkFormat;
 typedef enum VkResult VkResult;
 typedef enum VkImageLayout VkImageLayout;
 

--- a/libs/vkd3d/breadcrumbs.c
+++ b/libs/vkd3d/breadcrumbs.c
@@ -599,21 +599,24 @@ void vkd3d_breadcrumb_tracer_report_device_lost(struct vkd3d_breadcrumb_tracer *
     if (device->vk_info.NV_device_diagnostic_checkpoints)
     {
         /* vkGetQueueCheckpointDataNV does not require us to synchronize access to the queue. */
-        queue_family_info = d3d12_device_get_vkd3d_queue_family(device, D3D12_COMMAND_LIST_TYPE_DIRECT);
+        queue_family_info = d3d12_device_get_vkd3d_queue_family(device, D3D12_COMMAND_LIST_TYPE_DIRECT, VK_QUEUE_FAMILY_IGNORED);
+
         for (i = 0; i < queue_family_info->queue_count; i++)
         {
             vk_queue = queue_family_info->queues[i]->vk_queue;
             vkd3d_breadcrumb_tracer_report_queue_nv(tracer, device, vk_queue);
         }
 
-        queue_family_info = d3d12_device_get_vkd3d_queue_family(device, D3D12_COMMAND_LIST_TYPE_COMPUTE);
+        queue_family_info = d3d12_device_get_vkd3d_queue_family(device, D3D12_COMMAND_LIST_TYPE_COMPUTE, VK_QUEUE_FAMILY_IGNORED);
+
         for (i = 0; i < queue_family_info->queue_count; i++)
         {
             vk_queue = queue_family_info->queues[i]->vk_queue;
             vkd3d_breadcrumb_tracer_report_queue_nv(tracer, device, vk_queue);
         }
 
-        queue_family_info = d3d12_device_get_vkd3d_queue_family(device, D3D12_COMMAND_LIST_TYPE_COPY);
+        queue_family_info = d3d12_device_get_vkd3d_queue_family(device, D3D12_COMMAND_LIST_TYPE_COPY, VK_QUEUE_FAMILY_IGNORED);
+
         for (i = 0; i < queue_family_info->queue_count; i++)
         {
             vk_queue = queue_family_info->queues[i]->vk_queue;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2031,8 +2031,6 @@ static HRESULT d3d12_command_allocator_allocate_command_buffer(struct d3d12_comm
     return S_OK;
 }
 
-static void d3d12_command_list_invalidate_all_state(struct d3d12_command_list *list);
-
 static void d3d12_command_list_begin_new_sequence(struct d3d12_command_list *list)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
@@ -5652,7 +5650,7 @@ static void d3d12_command_list_reset_state(struct d3d12_command_list *list,
     d3d12_command_list_reset_internal_state(list);
 }
 
-static void d3d12_command_list_invalidate_all_state(struct d3d12_command_list *list)
+void d3d12_command_list_invalidate_all_state(struct d3d12_command_list *list)
 {
     d3d12_command_list_invalidate_current_pipeline(list, true);
     d3d12_command_list_invalidate_root_parameters(list, &list->graphics_bindings, true, NULL);
@@ -16776,7 +16774,7 @@ HRESULT d3d12_command_list_create(struct d3d12_device *device,
     return S_OK;
 }
 
-static struct d3d12_command_list *d3d12_command_list_from_iface(ID3D12CommandList *iface)
+struct d3d12_command_list *d3d12_command_list_from_iface(ID3D12CommandList *iface)
 {
     bool is_valid = false;
     if (!iface)

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2678,10 +2678,9 @@ void d3d12_device_unmap_vkd3d_queue(struct d3d12_device *device,
 }
 
 static HRESULT d3d12_command_allocator_init(struct d3d12_command_allocator *allocator,
-        struct d3d12_device *device, D3D12_COMMAND_LIST_TYPE type)
+        struct d3d12_device *device, D3D12_COMMAND_LIST_TYPE type, struct vkd3d_queue_family_info *queue_family)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    struct vkd3d_queue_family_info *queue_family;
     VkCommandPoolCreateInfo command_pool_info;
     VkResult vr;
     HRESULT hr;
@@ -2690,7 +2689,6 @@ static HRESULT d3d12_command_allocator_init(struct d3d12_command_allocator *allo
     if (FAILED(hr = vkd3d_private_store_init(&allocator->private_store)))
         return hr;
 
-    queue_family = d3d12_device_get_vkd3d_queue_family(device, type);
     allocator->ID3D12CommandAllocator_iface.lpVtbl = &d3d12_command_allocator_vtbl;
     allocator->refcount = 1;
     allocator->internal_refcount = 1;
@@ -2773,6 +2771,7 @@ static HRESULT d3d12_command_allocator_init(struct d3d12_command_allocator *allo
 HRESULT d3d12_command_allocator_create(struct d3d12_device *device,
         D3D12_COMMAND_LIST_TYPE type, struct d3d12_command_allocator **allocator)
 {
+    struct vkd3d_queue_family_info *family_info;
     struct d3d12_command_allocator *object;
     HRESULT hr;
 
@@ -2785,7 +2784,8 @@ HRESULT d3d12_command_allocator_create(struct d3d12_device *device,
     if (!(object = vkd3d_malloc(sizeof(*object))))
         return E_OUTOFMEMORY;
 
-    if (FAILED(hr = d3d12_command_allocator_init(object, device, type)))
+    family_info = d3d12_device_get_vkd3d_queue_family(device, type);
+    if (FAILED(hr = d3d12_command_allocator_init(object, device, type, family_info)))
     {
         vkd3d_free(object);
         return hr;
@@ -18698,7 +18698,7 @@ cleanup:
 }
 
 static HRESULT d3d12_command_queue_init(struct d3d12_command_queue *queue,
-        struct d3d12_device *device, const D3D12_COMMAND_QUEUE_DESC *desc)
+        struct d3d12_device *device, const D3D12_COMMAND_QUEUE_DESC *desc, struct vkd3d_queue_family_info *family_info)
 {
     HRESULT hr;
     int rc;
@@ -18711,8 +18711,7 @@ static HRESULT d3d12_command_queue_init(struct d3d12_command_queue *queue,
     if (!queue->desc.NodeMask)
         queue->desc.NodeMask = 0x1;
 
-    queue->vkd3d_queue = d3d12_device_allocate_vkd3d_queue(device,
-            d3d12_device_get_vkd3d_queue_family(device, desc->Type));
+    queue->vkd3d_queue = d3d12_device_allocate_vkd3d_queue(device, family_info);
     queue->submissions = NULL;
     queue->submissions_count = 0;
     queue->submissions_size = 0;
@@ -18775,13 +18774,16 @@ fail:
 HRESULT d3d12_command_queue_create(struct d3d12_device *device,
         const D3D12_COMMAND_QUEUE_DESC *desc, struct d3d12_command_queue **queue)
 {
+    struct vkd3d_queue_family_info *family_info;
     struct d3d12_command_queue *object;
     HRESULT hr;
 
     if (!(object = vkd3d_calloc(1, sizeof(*object))))
         return E_OUTOFMEMORY;
 
-    if (FAILED(hr = d3d12_command_queue_init(object, device, desc)))
+    family_info = d3d12_device_get_vkd3d_queue_family(device, desc->Type);
+
+    if (FAILED(hr = d3d12_command_queue_init(object, device, desc, family_info)))
     {
         vkd3d_free(object);
         return hr;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3411,7 +3411,7 @@ void d3d12_device_return_query_pool(struct d3d12_device *device, const struct vk
 
 /* ID3D12Device */
 extern ULONG STDMETHODCALLTYPE d3d12_device_vkd3d_ext_AddRef(d3d12_device_vkd3d_ext_iface *iface);
-extern ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_AddRef(ID3D12DXVKInteropDevice *iface);
+extern ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_AddRef(d3d12_dxvk_interop_device_iface *iface);
 extern ULONG STDMETHODCALLTYPE d3d12_low_latency_device_AddRef(ID3DLowLatencyDevice *iface);
 
 HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3649,7 +3649,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateCommandQueue(d3d12_device_if
     TRACE("iface %p, desc %p, riid %s, command_queue %p.\n",
             iface, desc, debugstr_guid(riid), command_queue);
 
-    if (FAILED(hr = d3d12_command_queue_create(device, desc, &object)))
+    if (FAILED(hr = d3d12_command_queue_create(device, desc, VK_QUEUE_FAMILY_IGNORED, &object)))
         return hr;
 
     return return_interface(&object->ID3D12CommandQueue_iface, &IID_ID3D12CommandQueue,
@@ -3676,7 +3676,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateCommandAllocator(d3d12_devic
     else
     {
         struct d3d12_command_allocator *object;
-        if (FAILED(hr = d3d12_command_allocator_create(device, type, &object)))
+        if (FAILED(hr = d3d12_command_allocator_create(device, type, VK_QUEUE_FAMILY_IGNORED, &object)))
             return hr;
         allocator_iface = &object->ID3D12CommandAllocator_iface;
     }

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3452,7 +3452,8 @@ HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
         return S_OK;
     }
 
-    if (IsEqualGUID(riid, &IID_ID3D12DXVKInteropDevice))
+    if (IsEqualGUID(riid, &IID_ID3D12DXVKInteropDevice)
+            || IsEqualGUID(riid, &IID_ID3D12DXVKInteropDevice1))
     {
         struct d3d12_device *device = impl_from_ID3D12Device(iface);
         d3d12_dxvk_interop_device_AddRef(&device->ID3D12DXVKInteropDevice_iface);
@@ -8711,7 +8712,7 @@ static void d3d12_device_replace_vtable(struct d3d12_device *device)
 }
 
 extern CONST_VTBL struct ID3D12DeviceExt1Vtbl d3d12_device_vkd3d_ext_vtbl;
-extern CONST_VTBL struct ID3D12DXVKInteropDeviceVtbl d3d12_dxvk_interop_device_vtbl;
+extern CONST_VTBL struct ID3D12DXVKInteropDevice1Vtbl d3d12_dxvk_interop_device_vtbl;
 extern CONST_VTBL struct ID3DLowLatencyDeviceVtbl d3d_low_latency_device_vtbl;
 
 static void vkd3d_scratch_pool_init(struct d3d12_device *device)

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -269,18 +269,18 @@ CONST_VTBL struct ID3D12DeviceExt1Vtbl d3d12_device_vkd3d_ext_vtbl =
 };
 
 
-static inline struct d3d12_device *d3d12_device_from_ID3D12DXVKInteropDevice(ID3D12DXVKInteropDevice *iface)
+static inline struct d3d12_device *d3d12_device_from_ID3D12DXVKInteropDevice(d3d12_dxvk_interop_device_iface *iface)
 {
     return CONTAINING_RECORD(iface, struct d3d12_device, ID3D12DXVKInteropDevice_iface);
 }
 
-ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_AddRef(ID3D12DXVKInteropDevice *iface)
+ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_AddRef(d3d12_dxvk_interop_device_iface *iface)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
     return d3d12_device_add_ref(device);
 }
 
-static ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_Release(ID3D12DXVKInteropDevice *iface)
+static ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_Release(d3d12_dxvk_interop_device_iface *iface)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
     return d3d12_device_release(device);
@@ -289,7 +289,7 @@ static ULONG STDMETHODCALLTYPE d3d12_dxvk_interop_device_Release(ID3D12DXVKInter
 extern HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
         REFIID riid, void **object);
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_QueryInterface(ID3D12DXVKInteropDevice *iface,
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_QueryInterface(d3d12_dxvk_interop_device_iface *iface,
         REFIID iid, void **out)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
@@ -297,7 +297,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_QueryInterface(ID3D12
     return d3d12_device_QueryInterface(&device->ID3D12Device_iface, iid, out);
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDXGIAdapter(ID3D12DXVKInteropDevice *iface,
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDXGIAdapter(d3d12_dxvk_interop_device_iface *iface,
         REFIID iid, void **object)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
@@ -305,7 +305,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDXGIAdapter(ID3D12
     return IUnknown_QueryInterface(device->parent, iid, object);
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanHandles(ID3D12DXVKInteropDevice *iface,
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanHandles(d3d12_dxvk_interop_device_iface *iface,
         VkInstance *vk_instance, VkPhysicalDevice *vk_physical_device, VkDevice *vk_device)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
@@ -319,7 +319,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanHandles(ID3D
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetInstanceExtensions(ID3D12DXVKInteropDevice *iface, UINT *extension_count, const char **extensions)
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetInstanceExtensions(d3d12_dxvk_interop_device_iface *iface, UINT *extension_count, const char **extensions)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
     struct vkd3d_instance *instance = device->vkd3d_instance;
@@ -339,7 +339,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetInstanceExtensions
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceExtensions(ID3D12DXVKInteropDevice *iface, UINT *extension_count, const char **extensions)
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceExtensions(d3d12_dxvk_interop_device_iface *iface, UINT *extension_count, const char **extensions)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
 
@@ -358,7 +358,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceExtensions(I
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceFeatures(ID3D12DXVKInteropDevice *iface, const VkPhysicalDeviceFeatures2 **features)
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceFeatures(d3d12_dxvk_interop_device_iface *iface, const VkPhysicalDeviceFeatures2 **features)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
 
@@ -368,7 +368,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetDeviceFeatures(ID3
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanQueueInfo(ID3D12DXVKInteropDevice *iface,
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanQueueInfo(d3d12_dxvk_interop_device_iface *iface,
         ID3D12CommandQueue *queue, VkQueue *vk_queue, UINT32 *vk_queue_family)
 {
     TRACE("iface %p, queue %p, vk_queue %p, vk_queue_family %p.\n", iface, queue, vk_queue, vk_queue_family);
@@ -381,7 +381,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanQueueInfo(ID
     return S_OK;
 }
 
-static void STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanImageLayout(ID3D12DXVKInteropDevice *iface,
+static void STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanImageLayout(d3d12_dxvk_interop_device_iface *iface,
         ID3D12Resource *resource, D3D12_RESOURCE_STATES state, VkImageLayout *vk_layout)
 {
     struct d3d12_resource *resource_impl = impl_from_ID3D12Resource(resource);
@@ -391,7 +391,7 @@ static void STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanImageLayout(ID3
     *vk_layout = vk_image_layout_from_d3d12_resource_state(NULL, resource_impl, state);
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanResourceInfo(ID3D12DXVKInteropDevice *iface,
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanResourceInfo(d3d12_dxvk_interop_device_iface *iface,
         ID3D12Resource *resource, UINT64 *vk_handle, UINT64 *buffer_offset)
 {
     struct d3d12_resource *resource_impl = impl_from_ID3D12Resource(resource);
@@ -412,7 +412,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanResourceInfo
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_LockCommandQueue(ID3D12DXVKInteropDevice *iface, ID3D12CommandQueue *queue)
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_LockCommandQueue(d3d12_dxvk_interop_device_iface *iface, ID3D12CommandQueue *queue)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DXVKInteropDevice(iface);
 
@@ -426,7 +426,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_LockCommandQueue(ID3D
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_UnlockCommandQueue(ID3D12DXVKInteropDevice *iface, ID3D12CommandQueue *queue)
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_UnlockCommandQueue(d3d12_dxvk_interop_device_iface *iface, ID3D12CommandQueue *queue)
 {
     TRACE("iface %p, queue %p.\n", iface, queue);
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2454,7 +2454,9 @@ struct d3d12_command_allocator
 };
 
 HRESULT d3d12_command_allocator_create(struct d3d12_device *device,
-        D3D12_COMMAND_LIST_TYPE type, struct d3d12_command_allocator **allocator);
+        D3D12_COMMAND_LIST_TYPE type,
+        uint32_t vk_family_index,
+        struct d3d12_command_allocator **allocator);
 bool d3d12_command_allocator_allocate_query_from_type_index(
         struct d3d12_command_allocator *allocator,
         uint32_t type_index, VkQueryPool *query_pool, uint32_t *query_index);
@@ -3216,7 +3218,7 @@ struct d3d12_command_queue
 };
 
 HRESULT d3d12_command_queue_create(struct d3d12_device *device,
-        const D3D12_COMMAND_QUEUE_DESC *desc, struct d3d12_command_queue **queue);
+        const D3D12_COMMAND_QUEUE_DESC *desc, uint32_t vk_family_index, struct d3d12_command_queue **queue);
 void d3d12_command_queue_submit_stop(struct d3d12_command_queue *queue);
 void d3d12_command_queue_signal_inline(struct d3d12_command_queue *queue, d3d12_fence_iface *fence, uint64_t value);
 void d3d12_command_queue_enqueue_callback(struct d3d12_command_queue *queue, void (*callback)(void *), void *userdata);
@@ -4852,7 +4854,8 @@ struct d3d12_device
 HRESULT d3d12_device_create(struct vkd3d_instance *instance,
         const struct vkd3d_device_create_info *create_info, struct d3d12_device **device);
 struct vkd3d_queue_family_info *d3d12_device_get_vkd3d_queue_family(struct d3d12_device *device,
-        D3D12_COMMAND_LIST_TYPE type);
+        D3D12_COMMAND_LIST_TYPE type,
+        uint32_t vk_family_index);
 struct vkd3d_queue *d3d12_device_allocate_vkd3d_queue(struct d3d12_device *device,
         struct vkd3d_queue_family_info *queue_family);
 void d3d12_device_unmap_vkd3d_queue(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2461,6 +2461,8 @@ bool d3d12_command_allocator_allocate_query_from_type_index(
         struct d3d12_command_allocator *allocator,
         uint32_t type_index, VkQueryPool *query_pool, uint32_t *query_index);
 
+struct d3d12_command_list *d3d12_command_list_from_iface(ID3D12CommandList *iface);
+
 enum vkd3d_pipeline_dirty_flag
 {
     VKD3D_PIPELINE_DIRTY_STATIC_SAMPLER_SET       = 0x00000001u,
@@ -2944,6 +2946,7 @@ HRESULT d3d12_command_list_create(struct d3d12_device *device,
 bool d3d12_command_list_reset_query(struct d3d12_command_list *list,
         VkQueryPool vk_pool, uint32_t index);
 void d3d12_command_list_end_current_render_pass(struct d3d12_command_list *list, bool suspend);
+void d3d12_command_list_invalidate_all_state(struct d3d12_command_list *list);
 
 static inline struct vkd3d_pipeline_bindings *d3d12_command_list_get_bindings(
         struct d3d12_command_list *list, enum vkd3d_pipeline_type pipeline_type)
@@ -4550,7 +4553,7 @@ struct vkd3d_descriptor_qa_heap_buffer_data;
 typedef ID3D12DeviceExt1 d3d12_device_vkd3d_ext_iface;
 
 /* ID3D12DXVKInteropDevice */
-typedef ID3D12DXVKInteropDevice d3d12_dxvk_interop_device_iface;
+typedef ID3D12DXVKInteropDevice1 d3d12_dxvk_interop_device_iface;
 
 /* ID3DLowLatencyDevice */
 typedef ID3DLowLatencyDevice d3d_low_latency_device_iface;

--- a/tests/d3d12_dxvk_interop_device.c
+++ b/tests/d3d12_dxvk_interop_device.c
@@ -1,0 +1,165 @@
+
+/*
+ * Copyright 2024 NVIDIA Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+#include "d3d12_crosstest.h"
+
+void test_vkd3d_dxvk_cmdbuf_interop(void)
+{
+    PFN_vkCmdUpdateBuffer pfn_vkCmdUpdateBuffer;
+    ID3D12DXVKInteropDevice1 *interop_device;
+    ID3D12GraphicsCommandList *command_list;
+    ID3D12CommandAllocator *allocator;
+    VkPhysicalDevice vkPhysicalDevice;
+    struct resource_readback rb;
+    struct test_context context;
+    ID3D12CommandQueue *queue;
+    VkCommandBuffer vkCmdBuf;
+    ID3D12Resource *buffer;
+    ID3D12Device *device;
+    VkInstance vkInstance;
+    unsigned int value;
+    VkDevice vkDevice;
+    VkFormat format;
+    UINT64 vkBuffer;
+    UINT64 offset;
+    HRESULT hr;
+
+    static const unsigned int data_values[] = {0xdeadbeef, 0xf00baa, 0xdeadbeef, 0xf00baa};
+    static const uint32_t update_data[3] = { 0x1020304, 0xc0d0e0f, 0x5060708};
+
+    // Initialize pointer to GDPA function
+    if (!init_vulkan_loader())
+        return;
+
+    if (!init_test_context(&context, NULL))
+        return;
+
+    device = context.device;
+
+    if (FAILED(hr = ID3D12Device_QueryInterface(device,
+            &IID_ID3D12DXVKInteropDevice1, (void **)&interop_device)))
+    {
+        skip("ID3D12DXVKInteropDevice1 not implemented.\n");
+        destroy_test_context(&context);
+        return;
+    }
+
+    if (FAILED(hr = ID3D12DXVKInteropDevice1_GetVulkanHandles(interop_device,
+        &vkInstance,
+        &vkPhysicalDevice,
+        &vkDevice)))
+    {
+        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_GetVulkanHandles failed %#x.\n", hr);
+        destroy_test_context(&context);
+        return;
+    }
+
+    pfn_vkCmdUpdateBuffer = (PFN_vkCmdUpdateBuffer)pfn_vkGetDeviceProcAddr(vkDevice, "vkCmdUpdateBuffer");
+    if (!pfn_vkCmdUpdateBuffer)
+    {
+        ok(pfn_vkCmdUpdateBuffer, "vkCmdUpdateBuffer not found.\n");
+        destroy_test_context(&context);
+        return;
+    }
+
+    if (FAILED(hr = ID3D12DXVKInteropDevice1_CreateInteropCommandAllocator(interop_device,
+        D3D12_COMMAND_LIST_TYPE_DIRECT,
+        VK_QUEUE_FAMILY_IGNORED,
+        &allocator)))
+    {
+        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_CreateInteropCommandAllocator failed %#x.\n", hr);
+        destroy_test_context(&context);
+        return;
+    }
+
+    if (FAILED(hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
+            allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list)))
+    {
+        ok(hr == S_OK, "ID3D12Device_CreateCommandList failed %#x.\n", hr);
+        destroy_test_context(&context);
+        return;
+    }
+
+    if (FAILED(hr = ID3D12DXVKInteropDevice1_BeginVkCommandBufferInterop(interop_device,
+        (ID3D12CommandList*)command_list,
+        &vkCmdBuf)))
+    {
+        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_BeginVulkanCmdHandles failed %#x.\n", hr);
+        destroy_test_context(&context);
+        return;
+    }
+
+    queue = context.queue;
+
+    // Create a D3D12 Buffer
+    buffer = create_default_buffer(device,
+                sizeof(data_values),
+                D3D12_RESOURCE_FLAG_NONE,
+                D3D12_RESOURCE_STATE_COPY_DEST);
+    upload_buffer_data(buffer, 0, sizeof(data_values), data_values, queue, command_list);
+    reset_command_list(command_list, allocator);
+
+
+    // Export it to VK and use VK functions to manipulate it
+    ID3D12DXVKInteropDevice1_GetVulkanResourceInfo1(interop_device,
+        buffer,
+        &vkBuffer,
+        &offset,
+        &format);
+
+    // Update in the pattern 0 1 - 2
+    pfn_vkCmdUpdateBuffer(vkCmdBuf, (VkBuffer)vkBuffer, 0, sizeof(data_values[0]) * 2, &update_data[0]);
+    pfn_vkCmdUpdateBuffer(vkCmdBuf, (VkBuffer)vkBuffer, sizeof(data_values[0]) * 3, sizeof(data_values[0]), &update_data[2]);
+
+    if (FAILED(hr = ID3D12DXVKInteropDevice1_EndVkCommandBufferInterop(interop_device,
+        (ID3D12CommandList*)command_list)))
+    {
+        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_EndVulkanCmdHandles failed %#x.\n", hr);
+        destroy_test_context(&context);
+        return;
+    }
+
+    // Back to D3D12 logic, close the command list + execute it
+    hr = ID3D12GraphicsCommandList_Close(command_list);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    exec_command_list(queue, command_list);
+    wait_queue_idle(device, queue);
+    reset_command_list(command_list, allocator);
+
+
+    // Validate data
+    get_buffer_readback_with_command_list(buffer, DXGI_FORMAT_R32_UINT, &rb, queue, command_list);
+    value = get_readback_uint(&rb, 0, 0, 0);
+    ok(value == update_data[0], "Got unexpected value %#x, expected %#x.\n", value, update_data[0]);
+    value = get_readback_uint(&rb, 1, 0, 0);
+    ok(value == update_data[1], "Got unexpected value %#x, expected %#x.\n", value, update_data[1]);
+    value = get_readback_uint(&rb, 2, 0, 0);
+    ok(value == data_values[2], "Got unexpected value %#x, expected %#x.\n", value, data_values[2]);
+    value = get_readback_uint(&rb, 3, 0, 0);
+    ok(value == update_data[2], "Got unexpected value %#x, expected %#x.\n", value, update_data[2]);
+    release_resource_readback(&rb);
+    reset_command_list(command_list, allocator);
+
+    ID3D12Resource_Release(buffer);
+    ID3D12GraphicsCommandList_Release(command_list);
+    ID3D12CommandAllocator_Release(allocator);
+    ID3D12DXVKInteropDevice1_Release(interop_device);
+    destroy_test_context(&context);
+}

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -424,3 +424,4 @@ decl_test(test_sm68_draw_parameters);
 decl_test(test_sm68_wave_size_range);
 decl_test(test_sm68_sample_cmp_bias_grad);
 decl_test(test_planar_video_formats);
+decl_test(test_vkd3d_dxvk_cmdbuf_interop);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,7 @@ d3d12_test_utils_lib = static_library('d3d12-test-utils', 'd3d12_test_utils.c',
   include_directories : vkd3d_private_includes)
 
 d3d12_test_src = [
+  'd3d12_dxvk_interop_device.c',
   'd3d12_clip_cull_distance.c',
   'd3d12_enhanced_barriers.c',
   'd3d12_sampler_feedback.c',


### PR DESCRIPTION
Add functionality for grabbing the `VkCommandBuffer` which is internal to a `ID3D12CommandList` object. This allows for applications to do interop using DX12 synchronization primitives but enqueue work onto queues which are otherwise not exposed through traditional DX12 APIs.

This will be used as a basis for `dxvk-nvapi` to create a DX12 offering of the `VK_NV_optical_flow` functionality. Tagging @jp7677 and @Saancreed from that project as any feedback received here will be relevant to a follow-up pull request I will be making there.

## Two open points of discussion:
### Interface Naming
Should this be called `ID3D12DXVKInteropDevice1` ? It has a high overlap in functionality with `ID3D12DXVKInteropDevice` so it seemed appropriate for it to inherit the methods. Saancreed suggested via Discord that it may make sense to rename `ID3D12DXVKInteropDevice` to `ID3D12VKInteropDevice` (keeping the same GUID, thus preserving ABI).

### Scope of VkCommandBuffer retrieval
I chose to keep a simpler implementation where we can only retrieve the internal `VkCommandBuffer` from command lists which are reset with an interop-enabled `ID3D12CommandAllocator`. We could also in theory define some more fine-grained synchronization contracts so that the internal command buffer could be retrieved from non-interop command lists.

I don't see a pressing use-case for that to be needed right now, but I can think of plenty reasons why it may be attractive though. One may be to move the VK calls for `CubinComputeShader*` functionality back into dxvk-nvapi, where it can just record dispatches into the command-buffer directly rather than relying on vkd3d-proton to be updated in order to support new functions in that space. I'm unclear on what the maintenance burden would be for supporting this kind of thing (I know that vkd3d-proton does commandlist-internal work tracking and this would definitely complicate that if it had to account for a mix of internally+externally recorded work).