### PR TITLE
vkd3d: aligned fields for 64-bit platform move/copy struct optimization

### DIFF
--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -113,9 +113,9 @@ struct vkd3d_instance_create_info
     PFN_vkGetInstanceProcAddr pfn_vkGetInstanceProcAddr;
 
     const char * const *instance_extensions;
-    uint32_t instance_extension_count;
-
     const char * const *optional_instance_extensions;
+
+    uint32_t instance_extension_count;
     uint32_t optional_instance_extension_count;
 };
 

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -340,8 +340,8 @@ struct vkd3d_shader_transform_feedback_element
 struct vkd3d_shader_transform_feedback_info
 {
     const struct vkd3d_shader_transform_feedback_element *elements;
-    unsigned int element_count;
     const unsigned int *buffer_strides;
+    unsigned int element_count;
     unsigned int buffer_stride_count;
 };
 
@@ -462,13 +462,13 @@ struct vkd3d_shader_quirk_info
 
 struct vkd3d_shader_compile_arguments
 {
-    enum vkd3d_shader_target target;
+    const enum vkd3d_shader_target_extension *target_extensions;
+    const struct vkd3d_shader_parameter *parameters;
 
     unsigned int target_extension_count;
-    const enum vkd3d_shader_target_extension *target_extensions;
-
     unsigned int parameter_count;
-    const struct vkd3d_shader_parameter *parameters;
+
+    enum vkd3d_shader_target target;
 
     bool dual_source_blending;
     const unsigned int *output_swizzles;
@@ -673,13 +673,13 @@ enum vkd3d_root_parameter_type
 struct vkd3d_root_parameter
 {
     enum vkd3d_root_parameter_type parameter_type;
+    enum vkd3d_shader_visibility shader_visibility;
     union
     {
         struct vkd3d_root_descriptor_table descriptor_table;
         struct vkd3d_root_constants constants;
         struct vkd3d_root_descriptor descriptor;
     };
-    enum vkd3d_shader_visibility shader_visibility;
 };
 
 enum vkd3d_root_signature_flags
@@ -750,30 +750,30 @@ struct vkd3d_root_descriptor1
 struct vkd3d_root_parameter1
 {
     enum vkd3d_root_parameter_type parameter_type;
+    enum vkd3d_shader_visibility shader_visibility;
     union
     {
         struct vkd3d_root_descriptor_table1 descriptor_table;
         struct vkd3d_root_constants constants;
         struct vkd3d_root_descriptor1 descriptor;
     };
-    enum vkd3d_shader_visibility shader_visibility;
 };
 
 struct vkd3d_root_signature_desc1
 {
-    unsigned int parameter_count;
     const struct vkd3d_root_parameter1 *parameters;
-    unsigned int static_sampler_count;
     const struct vkd3d_static_sampler_desc *static_samplers;
+    unsigned int parameter_count;
+    unsigned int static_sampler_count;
     enum vkd3d_root_signature_flags flags;
 };
 
 struct vkd3d_root_signature_desc2
 {
-    unsigned int parameter_count;
     const struct vkd3d_root_parameter1 *parameters;
-    unsigned int static_sampler_count;
     const struct vkd3d_static_sampler_desc1 *static_samplers;
+    unsigned int parameter_count;
+    unsigned int static_sampler_count;
     enum vkd3d_root_signature_flags flags;
 };
 
@@ -990,8 +990,6 @@ enum vkd3d_shader_subobject_kind
 
 struct vkd3d_shader_library_subobject
 {
-    enum vkd3d_shader_subobject_kind kind;
-
     /* All const pointers here point directly to the DXBC blob,
      * so they do not need to be freed.
      * Fortunately for us, the C strings are zero-terminated in the blob itself. */
@@ -999,6 +997,8 @@ struct vkd3d_shader_library_subobject
     /* In the blob, ASCII is used as identifier, where API uses wide strings, sigh ...
      * We need to dup this name for deferred COLLECTIONS, so use wchar instead. */
     WCHAR *name;
+
+    enum vkd3d_shader_subobject_kind kind;
 
     /* If true, any pointers below are just borrowed. */
     bool borrowed_payloads;

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -541,8 +541,8 @@ struct vkd3d_shader_register
     enum vkd3d_shader_register_type type;
     enum vkd3d_shader_register_modifier modifier;
     enum vkd3d_data_type data_type;
-    struct vkd3d_shader_register_index idx[3];
     enum vkd3d_immconst_type immconst_type;
+    struct vkd3d_shader_register_index idx[3];
     union
     {
         uint32_t immconst_uint[VKD3D_VEC4_SIZE];

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -516,15 +516,15 @@ struct vkd3d_shader_quirk_info vkd3d_shader_quirk_info;
 
 struct vkd3d_instance_application_meta
 {
-    enum vkd3d_string_compare_mode mode;
     const char *name;
     uint64_t global_flags_add;
     uint64_t global_flags_remove;
+    enum vkd3d_string_compare_mode mode;
     enum vkd3d_application_feature_override override;
 };
 static const struct vkd3d_instance_application_meta application_override[] = {
     /* MSVC fails to compile empty array. */
-    { VKD3D_STRING_COMPARE_EXACT, "GravityMark.exe", VKD3D_CONFIG_FLAG_FORCE_MINIMUM_SUBGROUP_SIZE, 0 },
+    { "GravityMark.exe", VKD3D_CONFIG_FLAG_FORCE_MINIMUM_SUBGROUP_SIZE, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Halo Infinite (1240440).
      * Game relies on NON_ZEROED committed UAVs to be cleared to zero on allocation.
      * This works okay with zerovram on first game boot, but not later, since this memory is guaranteed to be recycled.
@@ -533,73 +533,73 @@ static const struct vkd3d_instance_application_meta application_override[] = {
      * Need another config flag to workaround that as well.
      * Poor loading times and performance with ReBar on some devices.
      */
-    { VKD3D_STRING_COMPARE_EXACT, "HaloInfinite.exe",
+    { "HaloInfinite.exe",
             VKD3D_CONFIG_FLAG_ZERO_MEMORY_WORKAROUNDS_COMMITTED_BUFFER_UAV | VKD3D_CONFIG_FLAG_FORCE_RAW_VA_CBV |
             VKD3D_CONFIG_FLAG_USE_HOST_IMPORT_FALLBACK | VKD3D_CONFIG_FLAG_PREALLOCATE_SRV_MIP_CLAMPS |
             VKD3D_CONFIG_FLAG_REQUIRES_COMPUTE_INDIRECT_TEMPLATES | VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV |
-            VKD3D_CONFIG_FLAG_DISABLE_NV_DGCC, 0 },
+            VKD3D_CONFIG_FLAG_DISABLE_NV_DGCC, 0, VKD3D_STRING_COMPARE_EXACT },
     /* (1182900) Workaround amdgpu kernel bug with host memory import and concurrent submissions. */
-    { VKD3D_STRING_COMPARE_EXACT, "APlagueTaleRequiem_x64.exe",
-            VKD3D_CONFIG_FLAG_USE_HOST_IMPORT_FALLBACK | VKD3D_CONFIG_FLAG_DISABLE_UAV_COMPRESSION, 0 },
+    { "APlagueTaleRequiem_x64.exe",
+            VKD3D_CONFIG_FLAG_USE_HOST_IMPORT_FALLBACK | VKD3D_CONFIG_FLAG_DISABLE_UAV_COMPRESSION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Shadow of the Tomb Raider (750920).
      * Invariant workarounds actually cause more issues than they resolve on NV.
      * RADV already has workarounds by default.
      * FIXME: The proper workaround will be a workaround which force-emits mul + add + precise. The vertex shaders
      * are broken enough that normal invariance is not enough. */
-    { VKD3D_STRING_COMPARE_EXACT, "SOTTR.exe", VKD3D_CONFIG_FLAG_FORCE_NO_INVARIANT_POSITION, 0 },
+    { "SOTTR.exe", VKD3D_CONFIG_FLAG_FORCE_NO_INVARIANT_POSITION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Elden Ring (1245620).
      * Game is really churny on committed memory allocations, and does not use NOT_ZEROED. Clearing works causes bubbles.
      * It seems to work just fine however to skip the clears. */
-    { VKD3D_STRING_COMPARE_EXACT, "eldenring.exe",
+    { "eldenring.exe",
             VKD3D_CONFIG_FLAG_MEMORY_ALLOCATOR_SKIP_CLEAR | VKD3D_CONFIG_FLAG_PIPELINE_LIBRARY_IGNORE_MISMATCH_DRIVER |
-            VKD3D_CONFIG_FLAG_RECYCLE_COMMAND_POOLS, 0 },
+            VKD3D_CONFIG_FLAG_RECYCLE_COMMAND_POOLS, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Serious Sam 4 (257420).
      * Invariant workarounds cause graphical glitches when rendering foliage on NV. */
-    { VKD3D_STRING_COMPARE_EXACT, "Sam4.exe", VKD3D_CONFIG_FLAG_FORCE_NO_INVARIANT_POSITION, 0 },
+    { "Sam4.exe", VKD3D_CONFIG_FLAG_FORCE_NO_INVARIANT_POSITION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Cyberpunk 2077 (1091500). */
-    { VKD3D_STRING_COMPARE_EXACT, "Cyberpunk2077.exe", VKD3D_CONFIG_FLAG_ALLOW_SBT_COLLECTION, 0 },
+    { "Cyberpunk2077.exe", VKD3D_CONFIG_FLAG_ALLOW_SBT_COLLECTION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Resident Evil: Village (1196590).
      * Game relies on mesh + sampler feedback to be exposed to use DXR.
      * Likely used as a proxy for Turing+ to avoid potential software fallbacks on Pascal. */
-    { VKD3D_STRING_COMPARE_EXACT, "re8.exe",
-            VKD3D_CONFIG_FLAG_FORCE_NATIVE_FP16, 0, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
+    { "re8.exe",
+            VKD3D_CONFIG_FLAG_FORCE_NATIVE_FP16, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
     /* Resident Evil 2 remake (883710). Same as RE: Village. */
-    { VKD3D_STRING_COMPARE_EXACT, "re2.exe",
-            VKD3D_CONFIG_FLAG_FORCE_NATIVE_FP16, 0, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
-    { VKD3D_STRING_COMPARE_EXACT, "re3.exe",
-            VKD3D_CONFIG_FLAG_FORCE_NATIVE_FP16, 0, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
-    { VKD3D_STRING_COMPARE_EXACT, "re4.exe",
-            0, 0, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
-    { VKD3D_STRING_COMPARE_EXACT, "re4demo.exe",
-            0, 0, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
-    { VKD3D_STRING_COMPARE_EXACT, "re7.exe",
-            VKD3D_CONFIG_FLAG_FORCE_NATIVE_FP16, 0, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
+    { "re2.exe",
+            VKD3D_CONFIG_FLAG_FORCE_NATIVE_FP16, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
+    { "re3.exe",
+            VKD3D_CONFIG_FLAG_FORCE_NATIVE_FP16, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
+    { "re4.exe",
+            0, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
+    { "re4demo.exe",
+            0, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
+    { "re7.exe",
+            VKD3D_CONFIG_FLAG_FORCE_NATIVE_FP16, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_OVERRIDE_PROMOTE_DXR_TO_ULTIMATE },
     /* Control (870780). Control fails to detect DXR if 1.1 is exposed. */
-    { VKD3D_STRING_COMPARE_EXACT, "Control_DX12.exe", 0, 0, VKD3D_APPLICATION_FEATURE_LIMIT_DXR_1_0 },
+    { "Control_DX12.exe", 0, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_LIMIT_DXR_1_0 },
     /* Hellblade: Senua's Sacrifice (414340). Enables RT by default if supported which is ... jarring and particularly jarring on Deck. */
-    { VKD3D_STRING_COMPARE_EXACT, "HellbladeGame-Win64-Shipping.exe", 0, 0, VKD3D_APPLICATION_FEATURE_NO_DEFAULT_DXR_ON_DECK },
+    { "HellbladeGame-Win64-Shipping.exe", 0, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_NO_DEFAULT_DXR_ON_DECK },
     /* Lost Judgment (2058190) */
-    { VKD3D_STRING_COMPARE_EXACT, "LostJudgment.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
+    { "LostJudgment.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Marvel's Spider-Man Remastered (1817070) */
-    { VKD3D_STRING_COMPARE_EXACT, "Spider-Man.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
+    { "Spider-Man.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Marvel’s Spider-Man: Miles Morales (1817190) */
-    { VKD3D_STRING_COMPARE_EXACT, "MilesMorales.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
-    /* Deus Ex: Mankind United (337000) */
-    { VKD3D_STRING_COMPARE_EXACT, "DXMD.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0 },
+    { "MilesMorales.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0, VKD3D_STRING_COMPARE_EXACT },
+    /* Deus Ex: Mankind Divided (337000) */
+    { "DXMD.exe", VKD3D_CONFIG_FLAG_FORCE_INITIAL_TRANSITION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Dead Space (2023) (1693980) */
-    { VKD3D_STRING_COMPARE_EXACT, "Dead Space.exe", VKD3D_CONFIG_FLAG_FORCE_DEDICATED_IMAGE_ALLOCATION, 0 },
+    { "Dead Space.exe", VKD3D_CONFIG_FLAG_FORCE_DEDICATED_IMAGE_ALLOCATION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Witcher 3 (2023) (292030) */
-    { VKD3D_STRING_COMPARE_EXACT, "witcher3.exe", VKD3D_CONFIG_FLAG_DISABLE_SIMULTANEOUS_UAV_COMPRESSION, 0 },
+    { "witcher3.exe", VKD3D_CONFIG_FLAG_DISABLE_SIMULTANEOUS_UAV_COMPRESSION, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Age of Wonders 4 (1669000). Extremely stuttery performance with ReBAR. */
-    { VKD3D_STRING_COMPARE_EXACT, "AOW4.exe", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0 },
+    { "AOW4.exe", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Horizon Forbidden West (2420110). Work around RADV 23.3.1 that ships on stableOS at time of making WAR. */
-    { VKD3D_STRING_COMPARE_EXACT, "HorizonForbiddenWest.exe", VKD3D_CONFIG_FLAG_DRIVER_VERSION_SENSITIVE_SHADERS, 0 },
+    { "HorizonForbiddenWest.exe", VKD3D_CONFIG_FLAG_DRIVER_VERSION_SENSITIVE_SHADERS, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Starfield (1716740) */
-    { VKD3D_STRING_COMPARE_EXACT, "Starfield.exe",
-            VKD3D_CONFIG_FLAG_REQUIRES_COMPUTE_INDIRECT_TEMPLATES | VKD3D_CONFIG_FLAG_REJECT_PADDED_SMALL_RESOURCE_ALIGNMENT, 0 },
+    { "Starfield.exe",
+            VKD3D_CONFIG_FLAG_REQUIRES_COMPUTE_INDIRECT_TEMPLATES | VKD3D_CONFIG_FLAG_REJECT_PADDED_SMALL_RESOURCE_ALIGNMENT, 0, VKD3D_STRING_COMPARE_EXACT },
     /* Persona 3 Reload (2161700). Enables RT by default on Deck and does not run acceptably for a verified title. */
-    { VKD3D_STRING_COMPARE_EXACT, "P3R.exe", 0, 0, VKD3D_APPLICATION_FEATURE_NO_DEFAULT_DXR_ON_DECK },
-    { VKD3D_STRING_COMPARE_NEVER, NULL, 0, 0 }
+    { "P3R.exe", 0, 0, VKD3D_STRING_COMPARE_EXACT, VKD3D_APPLICATION_FEATURE_NO_DEFAULT_DXR_ON_DECK },
+    { NULL, 0, 0, VKD3D_STRING_COMPARE_NEVER }
 };
 
 struct vkd3d_shader_quirk_meta

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -1895,46 +1895,46 @@ static HRESULT vkd3d_sampler_feedback_ops_init(struct vkd3d_sampler_feedback_res
 
     static const struct pipeline
     {
-        enum vkd3d_sampler_feedback_resolve_type type;
         const uint32_t *code;
         size_t code_size;
+        enum vkd3d_sampler_feedback_resolve_type type;
         bool is_encode;
         bool is_compute;
     } pipelines[] = {
         {
-            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER,
             cs_sampler_feedback_decode_buffer_min_mip,
             sizeof(cs_sampler_feedback_decode_buffer_min_mip),
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER,
             false, true,
         },
         {
-            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE,
             fs_sampler_feedback_decode_image_min_mip,
             sizeof(fs_sampler_feedback_decode_image_min_mip),
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE,
             false, false,
         },
         {
-            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE,
             fs_sampler_feedback_decode_image_mip_used,
             sizeof(fs_sampler_feedback_decode_image_mip_used),
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE,
             false, false,
         },
         {
-            VKD3D_SAMPLER_FEEDBACK_RESOLVE_BUFFER_TO_MIN_MIP,
             cs_sampler_feedback_encode_buffer_min_mip,
             sizeof(cs_sampler_feedback_encode_buffer_min_mip),
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_BUFFER_TO_MIN_MIP,
             true, true,
         },
         {
-            VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIN_MIP,
             cs_sampler_feedback_encode_image_min_mip,
             sizeof(cs_sampler_feedback_encode_image_min_mip),
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIN_MIP,
             true, true,
         },
         {
-            VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIP_USED,
             cs_sampler_feedback_encode_image_mip_used,
             sizeof(cs_sampler_feedback_encode_image_mip_used),
+            VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIP_USED,
             true, true,
         },
     };

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -64,8 +64,8 @@ struct dxgi_vk_swap_chain_present_request
     DXGI_FORMAT dxgi_format;
     DXGI_COLOR_SPACE_TYPE dxgi_color_space_type;
     DXGI_VK_HDR_METADATA dxgi_hdr_metadata;
-    uint32_t swap_interval;
     uint64_t low_latency_frame_id;
+    uint32_t swap_interval;
     struct low_latency_state requested_low_latency_state;
     bool low_latency_update_requested;
     bool modifies_hdr_metadata;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -540,12 +540,12 @@ enum vkd3d_waiting_event_type
 
 struct vkd3d_waiting_event
 {
-    enum vkd3d_waiting_event_type wait_type;
     uint64_t value;
     vkd3d_native_sync_handle handle;
     bool *latch;
     uint32_t *payload;
     struct vkd3d_queue_timeline_trace_cookie timeline_cookie;
+    enum vkd3d_waiting_event_type wait_type;
 };
 
 struct d3d12_fence
@@ -793,13 +793,14 @@ enum vkd3d_memory_transfer_op
 
 struct vkd3d_memory_transfer_info
 {
-    enum vkd3d_memory_transfer_op op;
     struct vkd3d_memory_allocation *allocation;
 
     struct d3d12_resource *resource;
     uint32_t subresource_idx;
     VkOffset3D offset;
     VkExtent3D extent;
+
+    enum vkd3d_memory_transfer_op op;
 };
 
 struct vkd3d_memory_transfer_tracked_resource
@@ -5205,8 +5206,8 @@ struct d3d12_state_object_variant
         VkPipelineLayout pipeline_layout;
         VkDescriptorSet desc_set;
         VkDescriptorPool desc_pool;
-        uint32_t set_index;
         uint64_t compatibility_hash;
+        uint32_t set_index;
         bool owned_handles;
     } local_static_sampler;
 };


### PR DESCRIPTION
@HansKristian-Work, I tried to keep  context structure fields and readability. PR changes is really useful, building configuration in Release, fps increase will be very inaccurate ~5%

- vkd3d_instance_create_info (40 bytes -> 32 bytes)
- vkd3d_instance_application_meta (40 bytes -> 32 bytes)
- vkd3d_shader_transform_feedback_info (32 bytes -> 24 bytes)
- vkd3d_shader_compile_arguments (80 bytes -> 72 bytes)
- vkd3d_shader_library_subobject (64 bytes -> 56 bytes)
- vkd3d_shader_register (88 bytes -> 80 bytes)
- vkd3d_root_parameter1 (32 bytes -> 24 bytes)
- vkd3d_root_parameter (32 bytes -> 24 bytes)
- vkd3d_root_signature_desc1 (40 bytes -> 32 bytes)
- vkd3d_root_signature_desc2 (40 bytes -> 32 bytes)
- vkd3d_memory_transfer_info (56 bytes -> 48 bytes)
- vkd3d_waiting_event (48 bytes -> 40 bytes)
- pipeline (32 bytes -> 24 bytes)
- local_static_sampler (56 bytes -> 48 bytes)
- dxgi_vk_swap_chain_present_request (88 bytes -> 80 bytes)
- D3D12_RESOURCE_DESC (56 bytes -> 48 bytes)
- D3D12_ROOT_PARAMETER (32 bytes -> 24 bytes)
- D3D12_ROOT_PARAMETER1 (32 bytes -> 24 bytes)
- D3D12_ROOT_SIGNATURE_DESC1 (40 bytes -> 32 bytes)
- D3D12_FEATURE_DATA_FEATURE_LEVELS (24 bytes -> 16 bytes)
- D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS (48 bytes -> 40 bytes)
- D3D12_VIEW_INSTANCING_DESC (24 bytes -> 16 bytes)
- D3D12_COMPUTE_PIPELINE_STATE_DESC (56 bytes -> 48 bytes)
- D3D12_GENERIC_PROGRAM_DESC (40 bytes -> 32 bytes)
- D3D12_HEAP_DESC (48 bytes -> 40 bytes)