### PR TITLE
Signal fences on CPU to reduce delays on muxed queues

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -36,6 +36,7 @@ static void d3d12_shared_fence_dec_ref(struct d3d12_shared_fence *fence);
 static void d3d12_fence_iface_inc_ref(d3d12_fence_iface *iface);
 static void d3d12_fence_iface_dec_ref(d3d12_fence_iface *iface);
 static ULONG d3d12_command_allocator_dec_ref(struct d3d12_command_allocator *allocator);
+static HRESULT d3d12_fence_signal_cpu_timeline_semaphore(struct d3d12_fence *fence, uint64_t value);
 
 #define MAX_BATCHED_IMAGE_BARRIERS 16
 struct d3d12_command_list_barrier_batch
@@ -618,12 +619,24 @@ static void vkd3d_wait_for_gpu_timeline_semaphore(struct vkd3d_fence_worker *wor
     vkd3d_shader_debug_ring_kick(&device->debug_ring, device, false);
     vkd3d_descriptor_debug_kick_qa_check(device->descriptor_qa_global_info);
 
-    if (fence->fence_info.fence && !is_shared_ID3D12Fence1(fence->fence_info.fence) && fence->fence_info.signal_mode)
+    if (fence->fence_info.fence && !is_shared_ID3D12Fence1(fence->fence_info.fence))
     {
         local_fence = impl_from_ID3D12Fence1(fence->fence_info.fence);
-        TRACE("Signaling fence %p value %#"PRIx64".\n", local_fence, fence->fence_info.vk_semaphore_value);
-        if (FAILED(hr = d3d12_fence_signal(local_fence, worker, fence->fence_info.vk_semaphore_value)))
-            ERR("Failed to signal D3D12 fence, hr %#x.\n", hr);
+
+        if (fence->fence_info.signal_mode == VKD3D_FENCE_SIGNAL_GPU_PHYSICAL)
+        {
+            TRACE("Signaling fence %p physical value %#"PRIx64".\n", local_fence, fence->fence_info.vk_semaphore_value);
+
+            if (FAILED(hr = d3d12_fence_signal(local_fence, worker, fence->fence_info.vk_semaphore_value)))
+                ERR("Failed to signal D3D12 fence, hr %#x.\n", hr);
+        }
+        else if (fence->fence_info.signal_mode == VKD3D_FENCE_SIGNAL_CPU_VIRTUAL)
+        {
+            TRACE("Signaling fence %p virtual value %#"PRIx64".\n", local_fence, fence->fence_info.virtual_value);
+
+            if (FAILED(hr = d3d12_fence_signal_cpu_timeline_semaphore(local_fence, fence->fence_info.virtual_value)))
+                ERR("Failed to signal D3D12 fence, hr %#x.\n", hr);
+        }
     }
 
     if (fence->fence_info.fence)
@@ -17774,6 +17787,7 @@ static void d3d12_command_queue_wait(struct d3d12_command_queue *command_queue,
 static void d3d12_command_queue_signal(struct d3d12_command_queue *command_queue,
         struct d3d12_fence *fence, UINT64 value)
 {
+    uint64_t physical_value, signal_value, completed_value;
     struct vkd3d_queue_timeline_trace_cookie cookie;
     const struct vkd3d_vk_device_procs *vk_procs;
     VkSemaphoreSubmitInfo signal_semaphore_info;
@@ -17781,8 +17795,6 @@ static void d3d12_command_queue_signal(struct d3d12_command_queue *command_queue
     struct vkd3d_queue *vkd3d_queue;
     struct d3d12_device *device;
     VkSubmitInfo2 submit_info;
-    uint64_t physical_value;
-    uint64_t signal_value;
     VkQueue vk_queue;
     VkResult vr;
     HRESULT hr;
@@ -17791,65 +17803,92 @@ static void d3d12_command_queue_signal(struct d3d12_command_queue *command_queue
     vk_procs = &device->vk_procs;
     vkd3d_queue = command_queue->vkd3d_queue;
 
-    d3d12_fence_lock(fence);
-
     TRACE("queue %p, fence %p, value %#"PRIx64".\n", command_queue, fence, value);
-
-    physical_value = d3d12_fence_add_pending_signal_locked(fence, value, vkd3d_queue);
-
-    signal_value = physical_value;
-
-    /* Need to hold the fence lock while we're submitting, since another thread could come in and signal the semaphore
-     * to a higher value before we call vkQueueSubmit, which creates a non-monotonically increasing value. */
-    memset(&signal_semaphore_info, 0, sizeof(signal_semaphore_info));
-    signal_semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
-    signal_semaphore_info.semaphore = fence->timeline_semaphore;
-    signal_semaphore_info.value = signal_value;
-    signal_semaphore_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-
-    memset(&submit_info, 0, sizeof(submit_info));
-    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
-    submit_info.signalSemaphoreInfoCount = 1;
-    submit_info.pSignalSemaphoreInfos = &signal_semaphore_info;
 
     if (!(vk_queue = vkd3d_queue_acquire(vkd3d_queue)))
     {
         ERR("Failed to acquire queue %p.\n", vkd3d_queue);
+        return;
+    }
+
+    completed_value = 0;
+
+    if ((vr = VK_CALL(vkGetSemaphoreCounterValue(command_queue->device->vk_device,
+            vkd3d_queue->submission_timeline, &completed_value))))
+        ERR("Failed to query timeline semaphore, vr %d.\n", vr);
+
+    if (vkd3d_queue->submission_timeline_count > command_queue->last_submission_timeline_value ||
+                completed_value >= command_queue->last_submission_timeline_value)
+    {
+        /* If the last submission to the vkd3d_queue was made from a different virtual
+         * queue or if the virtual queue is idle, process the signal on the CPU in order
+         * to avoid additional delays. */
+        vkd3d_queue_release(vkd3d_queue);
+
+        cookie = vkd3d_queue_timeline_trace_register_signal(&command_queue->device->queue_timeline_trace,
+                &fence->ID3D12Fence_iface, value);
+
+        memset(&fence_info, 0, sizeof(fence_info));
+        fence_info.fence = &fence->ID3D12Fence_iface;
+        fence_info.vk_semaphore = vkd3d_queue->submission_timeline;
+        fence_info.vk_semaphore_value = command_queue->last_submission_timeline_value;
+        fence_info.virtual_value = value;
+        fence_info.signal_mode = VKD3D_FENCE_SIGNAL_CPU_VIRTUAL;
+
+        if (FAILED(hr = vkd3d_enqueue_timeline_semaphore(&command_queue->fence_worker, &fence_info, &cookie)))
+            ERR("Failed to enqueue timeline semaphore, hr #%x.\n", hr);
+    }
+    else
+    {
+        d3d12_fence_lock(fence);
+
+        physical_value = d3d12_fence_add_pending_signal_locked(fence, value, vkd3d_queue);
+
+        signal_value = physical_value;
+
+        /* Need to hold the fence lock while we're submitting, since another thread could come in and signal the semaphore
+         * to a higher value before we call vkQueueSubmit, which creates a non-monotonically increasing value. */
+        memset(&signal_semaphore_info, 0, sizeof(signal_semaphore_info));
+        signal_semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+        signal_semaphore_info.semaphore = fence->timeline_semaphore;
+        signal_semaphore_info.value = signal_value;
+        signal_semaphore_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+
+        memset(&submit_info, 0, sizeof(submit_info));
+        submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+        submit_info.signalSemaphoreInfoCount = 1;
+        submit_info.pSignalSemaphoreInfos = &signal_semaphore_info;
+
+        vr = VK_CALL(vkQueueSubmit2(vk_queue, 1, &submit_info, VK_NULL_HANDLE));
+
+        if (vr == VK_SUCCESS)
+            d3d12_fence_update_pending_value_locked(fence);
         d3d12_fence_unlock(fence);
-        return;
+
+        vkd3d_queue_release(vkd3d_queue);
+
+        if (vr < 0)
+        {
+            ERR("Failed to submit signal operation, vr %d.\n", vr);
+            return;
+        }
+
+        VKD3D_DEVICE_REPORT_FAULT_AND_BREADCRUMB_IF(command_queue->device, vr == VK_ERROR_DEVICE_LOST);
+
+        cookie = vkd3d_queue_timeline_trace_register_signal(&command_queue->device->queue_timeline_trace,
+                &fence->ID3D12Fence_iface, value);
+
+        memset(&fence_info, 0, sizeof(fence_info));
+        fence_info.fence = &fence->ID3D12Fence_iface;
+        fence_info.vk_semaphore = fence->timeline_semaphore;
+        fence_info.vk_semaphore_value = physical_value;
+        fence_info.signal_mode = VKD3D_FENCE_SIGNAL_GPU_PHYSICAL;
+
+        if (FAILED(hr = vkd3d_enqueue_timeline_semaphore(&command_queue->fence_worker, &fence_info, &cookie)))
+            ERR("Failed to enqueue timeline semaphore, hr #%x.\n", hr);
+
+        /* We should probably trigger DEVICE_REMOVED if we hit any errors in the submission thread. */
     }
-
-    vr = VK_CALL(vkQueueSubmit2(vk_queue, 1, &submit_info, VK_NULL_HANDLE));
-
-    if (vr == VK_SUCCESS)
-        d3d12_fence_update_pending_value_locked(fence);
-    d3d12_fence_unlock(fence);
-
-    vkd3d_queue_release(vkd3d_queue);
-
-    if (vr < 0)
-    {
-        ERR("Failed to submit signal operation, vr %d.\n", vr);
-        return;
-    }
-
-    VKD3D_DEVICE_REPORT_FAULT_AND_BREADCRUMB_IF(command_queue->device, vr == VK_ERROR_DEVICE_LOST);
-
-    cookie = vkd3d_queue_timeline_trace_register_signal(&command_queue->device->queue_timeline_trace,
-            &fence->ID3D12Fence_iface, value);
-
-    memset(&fence_info, 0, sizeof(fence_info));
-    fence_info.fence = &fence->ID3D12Fence_iface;
-    fence_info.vk_semaphore = fence->timeline_semaphore;
-    fence_info.vk_semaphore_value = physical_value;
-    fence_info.signal_mode = VKD3D_FENCE_SIGNAL_GPU_PHYSICAL;
-
-    if (FAILED(hr = vkd3d_enqueue_timeline_semaphore(&command_queue->fence_worker, &fence_info, &cookie)))
-    {
-        ERR("Failed to enqueue timeline semaphore, hr #%x.\n", hr);
-    }
-
-    /* We should probably trigger DEVICE_REMOVED if we hit any errors in the submission thread. */
 }
 
 static void d3d12_command_queue_wait_shared(struct d3d12_command_queue *command_queue,

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -1928,6 +1928,7 @@ static void dxgi_vk_swap_chain_present_signal_blit_semaphore(struct dxgi_vk_swap
     const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
     struct vkd3d_queue_timeline_trace_cookie cookie;
     VkSemaphoreSubmitInfo signal_semaphore_info;
+    struct vkd3d_fence_wait_info fence_info;
     VkSubmitInfo2 submit_info;
     VkQueue vk_queue;
     VkResult vr;
@@ -1957,8 +1958,11 @@ static void dxgi_vk_swap_chain_present_signal_blit_semaphore(struct dxgi_vk_swap
 
     if (vkd3d_queue_timeline_trace_cookie_is_valid(cookie))
     {
-        vkd3d_enqueue_timeline_semaphore(&chain->queue->fence_worker, NULL, chain->present.vk_complete_semaphore,
-                present_count, false, NULL, 0, &cookie);
+        memset(&fence_info, 0, sizeof(fence_info));
+        fence_info.vk_semaphore = chain->present.vk_complete_semaphore;
+        fence_info.vk_semaphore_value = chain->present.present_count;
+
+        vkd3d_enqueue_timeline_semaphore(&chain->queue->fence_worker, &fence_info, &cookie);
     }
 
     if (vr)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -230,6 +230,7 @@ enum vkd3d_fence_signal_mode
 {
     VKD3D_FENCE_SIGNAL_NONE,
     VKD3D_FENCE_SIGNAL_GPU_PHYSICAL,
+    VKD3D_FENCE_SIGNAL_CPU_VIRTUAL,
 };
 
 struct vkd3d_fence_wait_info
@@ -237,6 +238,7 @@ struct vkd3d_fence_wait_info
     d3d12_fence_iface *fence;
     VkSemaphore vk_semaphore;
     uint64_t vk_semaphore_value;
+    uint64_t virtual_value;
     struct d3d12_command_allocator **command_allocators;
     size_t num_command_allocators;
     enum vkd3d_fence_signal_mode signal_mode;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -226,15 +226,26 @@ struct vkd3d_queue_timeline_trace_cookie
     unsigned int index;
 };
 
-struct vkd3d_waiting_fence
+enum vkd3d_fence_signal_mode
+{
+    VKD3D_FENCE_SIGNAL_NONE,
+    VKD3D_FENCE_SIGNAL_GPU_PHYSICAL,
+};
+
+struct vkd3d_fence_wait_info
 {
     d3d12_fence_iface *fence;
-    VkSemaphore submission_timeline;
-    uint64_t value;
+    VkSemaphore vk_semaphore;
+    uint64_t vk_semaphore_value;
     struct d3d12_command_allocator **command_allocators;
     size_t num_command_allocators;
+    enum vkd3d_fence_signal_mode signal_mode;
+};
+
+struct vkd3d_waiting_fence
+{
+    struct vkd3d_fence_wait_info fence_info;
     struct vkd3d_queue_timeline_trace_cookie timeline_cookie;
-    bool signal;
 };
 
 struct vkd3d_fence_worker
@@ -286,8 +297,7 @@ struct vkd3d_fence_worker
 #define VKD3D_VA_NEXT_MASK (VKD3D_VA_NEXT_COUNT - 1)
 
 HRESULT vkd3d_enqueue_timeline_semaphore(struct vkd3d_fence_worker *worker,
-        d3d12_fence_iface *fence, VkSemaphore timeline, uint64_t value, bool signal,
-        struct d3d12_command_allocator **command_allocators, size_t num_command_allocators,
+        const struct vkd3d_fence_wait_info *fence_info,
         const struct vkd3d_queue_timeline_trace_cookie *timeline_cookie);
 
 struct vkd3d_unique_resource;


### PR DESCRIPTION
Suppose we have two virtual queues `A` and `B` both sharing the same `vkd3d_queue`, and the application does something like this:
```
A->ExecuteCommands(...);
B->ExecuteCommands(...);
A->Signal(fence, ...);
```
then actually signaling the fence may be delayed until work submitted to `B` completes, which can delay both app threads waiting on the fence as well as command submissions to any queues that wait on said fence. To solve this, we instead queue up a CPU-side wait on the last submission performed by the signaling command queue and signal the fence manually.

This also takes the early signal idea from #2075 and queues up a CPU signal in case the virtual queue has no pending submissions.

This expands upon the per-queue submission tracker introduced in 5ac07816f05770401ccc9d27b96e715549f83c79, which now needs to be updated for **all** submissions made from d3d12 scope (waits, sparse binding, 11on12 interop stuff, etc) for correctness.