### PR TITLE
tests: add VKD3D_TEST_MATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,13 @@ commas or semicolons.
    not use even if available.
  - `VKD3D_TEST_DEBUG` - enables additional debug messages in tests. Set to 0, 1
    or 2.
+ - `VKD3D_TEST_MATCH` - a match string. Only the tests whose names exactly match the
+   string will be run, e.g. `VKD3D_TEST_FILTER=clear_render_target` will only match
+   tests named 'clear_render_target'.
+   Useful for debugging or developing new tests.
  - `VKD3D_TEST_FILTER` - a filter string. Only the tests whose names matches the
-   filter string will be run, e.g. `VKD3D_TEST_FILTER=clear_render_target`.
+   filter string will be run, e.g. `VKD3D_TEST_FILTER=clear_render` will match
+   tests named 'clear_render_target' or 'target_clear_render'.
    Useful for debugging or developing new tests.
  - `VKD3D_TEST_EXCLUDE` - excludes tests of which the name is included in the string,
    e.g. `VKD3D_TEST_EXCLUDE=test_root_signature_priority,test_conservative_rasterization_dxil`.

--- a/include/private/vkd3d_test.h
+++ b/include/private/vkd3d_test.h
@@ -123,6 +123,7 @@ struct vkd3d_test_state_context
     bool bug_enabled;
 
     const char *test_name_filter;
+    const char *test_name_match;
     const char *test_exclude_list;
     char context[1024];
 };
@@ -275,14 +276,22 @@ int main(int argc, char **argv)
 {
     const char *exclude_list = getenv("VKD3D_TEST_EXCLUDE");
     const char *test_filter = getenv("VKD3D_TEST_FILTER");
+    const char *test_match = getenv("VKD3D_TEST_MATCH");
     const char *debug_level = getenv("VKD3D_TEST_DEBUG");
     const char *test_platform = getenv("VKD3D_TEST_PLATFORM");
     const char *bug = getenv("VKD3D_TEST_BUG");
+
+    if (test_filter && test_match)
+    {
+        fprintf(stderr, "Cannot specify both VKD3D_TEST_FILTER and VKD3D_TEST_MATCH!\n");
+        exit(1);
+    }
 
     memset(&vkd3d_test_state, 0, sizeof(vkd3d_test_state));
     vkd3d_test_state.debug_level = debug_level ? atoi(debug_level) : 1;
     vkd3d_test_state.bug_enabled = bug ? atoi(bug) : true;
     vkd3d_test_state.test_name_filter = test_filter;
+    vkd3d_test_state.test_name_match = test_match;
     vkd3d_test_state.test_exclude_list = exclude_list;
 
     if (test_platform)
@@ -373,6 +382,9 @@ typedef void (*vkd3d_test_pfn)(void);
 static inline void vkd3d_run_test(const char *name, vkd3d_test_pfn test_pfn)
 {
     const char *old_test_name;
+
+    if (vkd3d_test_state.test_name_match && strcmp(name, vkd3d_test_state.test_name_match))
+        return;
 
     if (vkd3d_test_state.test_name_filter && !strstr(name, vkd3d_test_state.test_name_filter))
         return;

--- a/tests/test-runner.sh
+++ b/tests/test-runner.sh
@@ -76,9 +76,9 @@ run_tests() {
 	while (($counter < $nr_cpus)) ; do
 		# output to /dev/null by default
 		if [[ -z "$output_dir" ]] ; then
-			VKD3D_TEST_FILTER=${tests[$test_idx]} "$d3d12_bin" &>/dev/null &
+			VKD3D_TEST_MATCH=${tests[$test_idx]} "$d3d12_bin" &>/dev/null &
 		else
-			VKD3D_TEST_FILTER=${tests[$test_idx]} "$d3d12_bin" &> "$output_dir/${tests[$test_idx]}.log" &
+			VKD3D_TEST_MATCH=${tests[$test_idx]} "$d3d12_bin" &> "$output_dir/${tests[$test_idx]}.log" &
 		fi
 		# capture pid of subprocess
 		pids[$test_idx]=${!}
@@ -132,7 +132,7 @@ echo "***********************"
 echo "Finished in ${SECONDS}s!"
 
 if [[ "${#fails[@]}" != 0 ]] ; then
-	echo "${#fails[@]} FAILURES: (run with 'VKD3D_TEST_FILTER=<name> $d3d12_bin')"
+	echo "${#fails[@]} FAILURES: (run with 'VKD3D_TEST_MATCH=<name> $d3d12_bin')"
 	for fail in "${fails[@]}" ; do
 		echo "$fail"
 	done


### PR DESCRIPTION
TEST_FILTER is not ideal for anyone wanting to run exactly one test where that test name may a substring of another test

this is particularly noticeable with the test runner script, which is intended to only run one test per thread but will actually run many tests due to inaccurate substring matching