### PR TITLE
vkd3d: Fix wrong format being used for depth bias representation.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6740,7 +6740,8 @@ static void d3d12_command_list_update_dynamic_state(struct d3d12_command_list *l
 
         if (list->device->device_info.depth_bias_control_features.depthBiasControl)
         {
-            vkd3d_get_depth_bias_representation(&depth_bias_representation, list->device, list->dsv.format);
+            vkd3d_get_depth_bias_representation(&depth_bias_representation, list->device,
+                    list->dsv.format ? list->dsv.format->dxgi_format : DXGI_FORMAT_UNKNOWN);
 
             memset(&depth_bias_info, 0, sizeof(depth_bias_info));
             depth_bias_info.sType = VK_STRUCTURE_TYPE_DEPTH_BIAS_INFO_EXT;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -5017,7 +5017,7 @@ static HRESULT d3d12_pipeline_state_init_graphics_create_info(struct d3d12_pipel
         }
         else
         {
-            vkd3d_get_depth_bias_representation(&graphics->rs_depth_bias_info, device, format);
+            vkd3d_get_depth_bias_representation(&graphics->rs_depth_bias_info, device, desc->dsv_format);
             vk_prepend_struct(&graphics->rs_desc, &graphics->rs_depth_bias_info);
         }
     }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5612,7 +5612,7 @@ static inline unsigned int d3d12_resource_get_sub_resource_count(const struct d3
 }
 
 static inline void vkd3d_get_depth_bias_representation(VkDepthBiasRepresentationInfoEXT *info,
-        const struct d3d12_device *device, const struct vkd3d_format *dsv_format)
+        const struct d3d12_device *device, DXGI_FORMAT dsv_format)
 {
     memset(info, 0, sizeof(*info));
     info->sType = VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT;
@@ -5622,7 +5622,7 @@ static inline void vkd3d_get_depth_bias_representation(VkDepthBiasRepresentation
     /* Checking only strongly typed formats should work here since we take the
      * format from the DSV or PSO desc, where typeless formats are not allowed */
     if (device->device_info.depth_bias_control_features.leastRepresentableValueForceUnormRepresentation &&
-            dsv_format && (dsv_format->dxgi_format == DXGI_FORMAT_D16_UNORM || dsv_format->dxgi_format == DXGI_FORMAT_D24_UNORM_S8_UINT))
+            (dsv_format == DXGI_FORMAT_D16_UNORM || dsv_format == DXGI_FORMAT_D24_UNORM_S8_UINT))
         info->depthBiasRepresentation = VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT;
 }
 


### PR DESCRIPTION
The christmas tree certainly contributed to this one going unnoticed, `format` isn't our dsv format....

Explicitly pass the DXGI format instead to avoid confusion.