### PR TITLE
vkd3d: enable EXT_device_generated_commands

### DIFF
--- a/libs/vkd3d/heap.c
+++ b/libs/vkd3d/heap.c
@@ -280,6 +280,7 @@ static HRESULT d3d12_heap_init(struct d3d12_heap *heap, struct d3d12_device *dev
     alloc_info.heap_desc = heap->desc;
     alloc_info.host_ptr = host_address;
     alloc_info.extra_allocation_flags = 0;
+    alloc_info.explicit_global_buffer_usage = 0;
 
     if ((alloc_info.heap_desc.Flags & D3D12_HEAP_FLAG_DENY_BUFFERS) &&
             device->d3d12_caps.options.ResourceHeapTier >= D3D12_RESOURCE_HEAP_TIER_2)

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -1640,6 +1640,7 @@ static HRESULT vkd3d_memory_allocator_try_add_chunk(struct vkd3d_memory_allocato
     alloc_info.flags = VKD3D_ALLOCATION_FLAG_NO_FALLBACK;
     alloc_info.optional_memory_properties = optional_properties;
     alloc_info.vk_memory_priority = vkd3d_convert_to_vk_prio(D3D12_RESIDENCY_PRIORITY_NORMAL);
+    alloc_info.explicit_global_buffer_usage = 0;
 
     if (minimum_size < VKD3D_VA_BLOCK_SIZE)
         alloc_info.memory_requirements.size = VKD3D_MEMORY_CHUNK_SIZE;
@@ -1941,6 +1942,7 @@ HRESULT vkd3d_allocate_heap_memory(struct d3d12_device *device, struct vkd3d_mem
     alloc_info.heap_flags = info->heap_desc.Flags;
     alloc_info.host_ptr = info->host_ptr;
     alloc_info.vk_memory_priority = info->vk_memory_priority;
+    alloc_info.explicit_global_buffer_usage = info->explicit_global_buffer_usage;
 
     alloc_info.flags |= info->extra_allocation_flags;
 

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -1637,7 +1637,8 @@ static HRESULT vkd3d_predicate_ops_init(struct vkd3d_predicate_ops *meta_predica
         meta_predicate_ops->data_sizes[i] = spec_data[i].arg_count * sizeof(uint32_t);
     }
 
-    if (device->device_info.device_generated_commands_features_nv.deviceGeneratedCommands)
+    if (device->device_info.device_generated_commands_features_nv.deviceGeneratedCommands ||
+        device->device_info.device_generated_commands_features_ext.deviceGeneratedCommandsEXT)
     {
         uint32_t num_active_words;
         spec_info.mapEntryCount = 1;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3552,6 +3552,7 @@ HRESULT d3d12_resource_create_committed(struct d3d12_device *device, const D3D12
         memset(&allocate_info, 0, sizeof(allocate_info));
         allocate_info.memory_requirements = memory_requirements.memoryRequirements;
         allocate_info.heap_flags = heap_flags;
+        allocate_info.explicit_global_buffer_usage = 0;
 
         if (object->flags & VKD3D_RESOURCE_LINEAR_STAGING_COPY)
         {

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -6710,18 +6710,23 @@ static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *dev
     }
 
     if ((vkd3d_config_flags & VKD3D_CONFIG_FLAG_REQUIRES_COMPUTE_INDIRECT_TEMPLATES) &&
-            !device->device_info.device_generated_commands_compute_features_nv.deviceGeneratedCompute)
+            !device->device_info.device_generated_commands_compute_features_nv.deviceGeneratedCompute &&
+            !(device->device_info.device_generated_commands_properties_ext.supportedIndirectCommandsShaderStages & VK_SHADER_STAGE_COMPUTE_BIT))
     {
         INFO("Forcing push UBO path for compute root parameters.\n");
         flags |= VKD3D_FORCE_COMPUTE_ROOT_PARAMETERS_PUSH_UBO;
     }
 
-    if (device->device_info.device_generated_commands_compute_features_nv.deviceGeneratedCompute &&
-            device->device_info.device_generated_commands_features_nv.deviceGeneratedCommands)
+    if ((device->device_info.device_generated_commands_compute_features_nv.deviceGeneratedCompute &&
+            device->device_info.device_generated_commands_features_nv.deviceGeneratedCommands) ||
+        device->device_info.device_generated_commands_properties_ext.supportedIndirectCommandsShaderStages &
+           (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_COMPUTE_BIT))
     {
         INFO("Enabling fast paths for advanced ExecuteIndirect() graphics and compute.\n");
     }
-    else if (device->device_info.device_generated_commands_features_nv.deviceGeneratedCommands)
+    else if (device->device_info.device_generated_commands_features_nv.deviceGeneratedCommands ||
+             device->device_info.device_generated_commands_properties_ext.supportedIndirectCommandsShaderStages &
+                (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT))
     {
         INFO("Enabling fast paths for advanced ExecuteIndirect() graphics.\n");
     }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -136,6 +136,7 @@ struct vkd3d_vulkan_info
     bool EXT_conservative_rasterization;
     bool EXT_custom_border_color;
     bool EXT_depth_clip_enable;
+    bool EXT_device_generated_commands;
     bool EXT_image_view_min_lod;
     bool EXT_robustness2;
     bool EXT_shader_stencil_export;
@@ -710,6 +711,7 @@ struct vkd3d_allocate_heap_memory_info
     void *host_ptr;
     uint32_t extra_allocation_flags;
     float vk_memory_priority;
+    VkBufferUsageFlags explicit_global_buffer_usage;
 };
 
 struct vkd3d_allocate_resource_memory_info
@@ -3309,8 +3311,10 @@ struct d3d12_command_signature
             VkBuffer buffer;
             VkDeviceAddress buffer_va;
             struct vkd3d_device_memory_allocation memory;
-            VkIndirectCommandsLayoutNV layout_implicit;
-            VkIndirectCommandsLayoutNV layout_preprocess;
+            VkIndirectCommandsLayoutNV layout_implicit_nv;
+            VkIndirectCommandsLayoutNV layout_preprocess_nv;
+            VkIndirectCommandsLayoutEXT layout_implicit_ext;
+            VkIndirectCommandsLayoutEXT layout_preprocess_ext;
             uint32_t stride;
             struct vkd3d_execute_indirect_info pipeline;
         } dgc;
@@ -4444,6 +4448,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_properties;
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_properties;
     VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV device_generated_commands_properties_nv;
+    VkPhysicalDeviceDeviceGeneratedCommandsPropertiesEXT device_generated_commands_properties_ext;
     VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties;
     VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT shader_module_identifier_properties;
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties;
@@ -4481,6 +4486,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceCoherentMemoryFeaturesAMD device_coherent_memory_features_amd;
     VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR ray_tracing_maintenance1_features;
     VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV device_generated_commands_features_nv;
+    VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT device_generated_commands_features_ext;
     VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features;
     VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_identifier_features;
     VkPhysicalDevicePresentIdFeaturesKHR present_id_features;

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -338,6 +338,13 @@ VK_DEVICE_EXT_PFN(vkGetGeneratedCommandsMemoryRequirementsNV)
 VK_DEVICE_EXT_PFN(vkCmdExecuteGeneratedCommandsNV)
 VK_DEVICE_EXT_PFN(vkCmdPreprocessGeneratedCommandsNV)
 
+/* VK_EXT_device_generated_commands */
+VK_DEVICE_EXT_PFN(vkCreateIndirectCommandsLayoutEXT)
+VK_DEVICE_EXT_PFN(vkDestroyIndirectCommandsLayoutEXT)
+VK_DEVICE_EXT_PFN(vkGetGeneratedCommandsMemoryRequirementsEXT)
+VK_DEVICE_EXT_PFN(vkCmdExecuteGeneratedCommandsEXT)
+VK_DEVICE_EXT_PFN(vkCmdPreprocessGeneratedCommandsEXT)
+
 /* VK_EXT_shader_module_identifier */
 VK_DEVICE_EXT_PFN(vkGetShaderModuleIdentifierEXT)
 


### PR DESCRIPTION
this adds new paths to use the EXT version of the functionality when available instead of NV, enabling broader support across drivers/hardware while providing the same functionality