### PR TITLE
Fix the missing access flags of image resource barrier conversion

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4883,10 +4883,10 @@ static void vk_access_and_stage_flags_from_d3d12_resource_state(const struct d3d
 
             case D3D12_RESOURCE_STATE_RENDER_TARGET:
                 *stages |= VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-                /* If the corresponding image layout is COLOR_ATTACHMENT_OPTIMAL, we won't get automatic barriers,
+                /* If the corresponding image layout is COLOR_ATTACHMENT_OPTIMAL or GENERAL, we won't get automatic barriers,
                  * so add access masks as appropriate. */
-                if (d3d12_resource_pick_layout(resource, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) ==
-                        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+                if ((d3d12_resource_pick_layout(resource, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) ==
+                        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) || (resource->flags & VKD3D_RESOURCE_GENERAL_LAYOUT))
                 {
                     *access |= VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
                 }

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4883,13 +4883,7 @@ static void vk_access_and_stage_flags_from_d3d12_resource_state(const struct d3d
 
             case D3D12_RESOURCE_STATE_RENDER_TARGET:
                 *stages |= VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-                /* If the corresponding image layout is COLOR_ATTACHMENT_OPTIMAL or GENERAL, we won't get automatic barriers,
-                 * so add access masks as appropriate. */
-                if ((d3d12_resource_pick_layout(resource, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) ==
-                        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) || (resource->flags & VKD3D_RESOURCE_GENERAL_LAYOUT))
-                {
-                    *access |= VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
-                }
+                *access |= VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
                 break;
 
             case D3D12_RESOURCE_STATE_UNORDERED_ACCESS:


### PR DESCRIPTION
### Motivation:
When I was playing The Witcher 3, I found that moving the mouse quickly would cause blocky corruption. After investigation, I found that it was because vkd3d did not correctly convert the d3d12 call, resulting in a missing barrier in the use of a certain image.

System info:
OS: Ubuntu 22.04
GPU: AMD RX 7800XT
DRIVER: AMDVLK or amdvlk-pro
Proton: Experimental, 9.0-3, 8.0-5

Steps to reproduce:
1. Launch The Witcher 3: Wild Hunt in Steam, select New Game
2. Move or rotate the mouse quickly and watch the blocky corruption

### FIX
If the image has general layout and render target state, then add color attachment access masks for its resource barrier.

### Analyses
Witcher 3 - Corruption
![image](https://github.com/user-attachments/assets/484a483e-8ac4-4368-ab98-bebd7850e6ad)

Witcher 3 - D3D Capture
![image](https://github.com/user-attachments/assets/22c2d929-c80f-4af8-b0df-7300cd8daf10)

Witcher 3 - Proton debug (d3d-proton)  
Below is my detailed debugging process for the above problem: You can see that the resource barriers passed by D3D include an image barrier, and its state has changed before and after, but the access flags in the memory barrier of the final vulkan api call do not reflect this.
```
Wine-gdb> c
Continuing.

Thread 33 "0264" hit Breakpoint 3, d3d12_command_list_clear_attachment_pass (list=0x14c1b5040, resource=0x14b2ebef0, view=0x14b2f0f10, clear_aspects=1, clear_value=0x15884fd50, rect_count=0, rects=0x0, is_bound=false) at ../src-vkd3d-proton/libs/vkd3d/command.c:3688
3688        VK_CALL(vkCmdBeginRendering(list->cmd.vk_command_buffer, &rendering_info));
1: rendering_info = {
  sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
  pNext = 0x0,
  flags = 0,
  renderArea = {
    offset = {
      x = 0,
      y = 0
    },
    extent = {
      width = 512,
      height = 384
    }
  },
  layerCount = 1,
  viewMask = 0,
  colorAttachmentCount = 1,
  pColorAttachments = 0x15884fbd0,
  pDepthAttachment = 0x0,
  pStencilAttachment = 0x0
}

Wine-gdb> p dep_info.pImageMemoryBarriers[0]
$1 = {
  sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
  pNext = 0x0,
  srcStageMask = 1024,
  srcAccessMask = 256,
  dstStageMask = 1024,
  dstAccessMask = 256,
  oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
  newLayout = VK_IMAGE_LAYOUT_GENERAL,
  srcQueueFamilyIndex = 4294967295,
  dstQueueFamilyIndex = 4294967295,
  image = 0x7ba72c5fc600,
  subresourceRange = {
    aspectMask = 1,
    baseMipLevel = 0,
    levelCount = 1,
    baseArrayLayer = 0,
    layerCount = 1
  }
}

Wine-gdb> bt
#0  d3d12_command_list_clear_attachment_pass (list=0x14c1b5040, resource=0x14b2ebef0, view=0x14b2f0f10, clear_aspects=1, clear_value=0x15884fd50, rect_count=0, rects=0x0, is_bound=false) at ../src-vkd3d-proton/libs/vkd3d/command.c:3688
#1  0x00000001cafcca4e in d3d12_command_list_clear_attachment (list=0x14c1b5040, resource=0x14b2ebef0, view=0x14b2f0f10, clear_aspects=1, clear_value=0x15884fd50, rect_count=0, rects=0x0) at ../src-vkd3d-proton/libs/vkd3d/command.c:10898
#2  0x00000001cafbe798 in d3d12_command_list_ClearRenderTargetView (iface=0x14c1b5040, rtv=..., color=0x60fa101c8, rect_count=0, rects=0x0) at ../src-vkd3d-proton/libs/vkd3d/command.c:10982
#3  0x000000014208a34a in witcher3!?WriteBytes@WriteBytesCount@AK@@UEAA_NPEBXHAEAH@Z () from /steam/SteamLibrary/steamapps/common/The Witcher 3/bin/x64_dx12/witcher3.exe
#4  0x000000014c1b5040 in ?? ()
#5  0x000000014b2e94c0 in ?? ()
#6  0x000000060fa101c8 in ?? ()
#7  0x0000000300000000 in ?? ()
#8  0x0000000000000000 in ?? ()

<skip some steps here>

Wine-gdb> c
Continuing.

Thread 33 "0264" hit Breakpoint 6, d3d12_command_list_ResourceBarrier (iface=0x14b1d6240, barrier_count=3, barriers=0x5cb746c40) at ../src-vkd3d-proton/libs/vkd3d/command.c:9796
9796                    if (old_layout != new_layout)

Wine-gdb> p i
$1 = 1

Wine-gdb> p * preserve_resource
$2 = {ID3D12Resource_iface = {lpVtbl = 0x1cb0b3940 <d3d12_resource_vtbl>}, refcount = 1, internal_refcount = 1, desc = {Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D, Alignment = 0, Width = 512, Height = 384, DepthOrArraySize = 1, MipLevels = 1, Format = DXGI_FORMAT_R11G11B10_FLOAT, SampleDesc = {Count = 1, Quality = 0}, Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
    Flags = (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS), SamplerFeedbackMipRegion = {Width = 0, Height = 0, Depth = 0}}, heap_properties = {Type = D3D12_HEAP_TYPE_DEFAULT, CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN, MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN, CreationNodeMask = 1, VisibleNodeMask = 1},
  heap_flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES, mem = {resource = {{vk_buffer = 0x0, vk_image = 0x0}, cookie = 13057, va = 0, size = 0, view_map = 0x0}, device_allocation = {vk_memory = 0x7ba72c421a30, vk_memory_type = 0, size = 786432}, offset = 0, cpu_address = 0x0, heap_type = D3D12_HEAP_TYPE_DEFAULT, heap_flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES, flags = 0,
    explicit_global_buffer_usage = 0, clear_semaphore_value = 0, chunk = 0x0}, private_mem = {resource = {{vk_buffer = 0x0, vk_image = 0x0}, cookie = 0, va = 0, size = 0, view_map = 0x0}, device_allocation = {vk_memory = 0x0, vk_memory_type = 0, size = 0}, offset = 0, cpu_address = 0x0, heap_type = 0, heap_flags = D3D12_HEAP_FLAG_NONE, flags = 0, explicit_global_buffer_usage = 0, clear_semaphore_value = 0,
    chunk = 0x0}, res = {{vk_buffer = 0x7ba72c421dc0, vk_image = 0x7ba72c421dc0}, cookie = 13058, va = 0, size = 0, view_map = 0x0}, heap = 0x14af52850, flags = 130, common_layout = VK_IMAGE_LAYOUT_GENERAL, initial_state = D3D12_RESOURCE_STATE_COMMON, initial_layout_transition = 0, initial_layout_transition_validate_only = true, sparse = {tile_count = 0, tiling_count = 0, tiles = 0x0, tile_shape = {
      WidthInTexels = 0, HeightInTexels = 0, DepthInTexels = 0}, packed_mips = {NumStandardMips = 0 '\000', NumPackedMips = 0 '\000', NumTilesForPackedMips = 0, StartTileIndexInOverallResource = 0}, tilings = 0x0, vk_metadata_memory = {vk_memory = 0x0, vk_memory_type = 0, size = 0}}, view_map = {spinlock = 0, map = {hash_func = 0x1cb0a3280 <vkd3d_view_entry_hash>,
      compare_func = 0x1cb0a2eb0 <vkd3d_view_entry_compare>, entries = 0x14b16bf10, entry_size = 104, entry_count = 37, used_count = 3}}, subresource_layouts = 0x0, format_compatibility_list = {format_count = 0, vk_formats = {VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED,
      VK_FORMAT_UNDEFINED}, uint_format = DXGI_FORMAT_UNKNOWN}, priority = {allows_dynamic_residency = false, spinlock = 0, d3d12priority = D3D12_RESIDENCY_PRIORITY_NORMAL, residency_count = 1}, device = 0x5aff0080, format = 0x62defe0, vrs_view = 0x0, private_store = {mutex = {lock = {Ptr = 0x0}}, content = {next = 0x14aff3030, prev = 0x14aff3030}}}

Wine-gdb> p transition_src_stage_mask
$3 = 1024
Wine-gdb> p transition_src_access
$4 = 0
Wine-gdb> p transition_dst_stage_mask
$5 = 128
Wine-gdb> p transition_dst_access
$6 = 32

Wine-gdb> p old_layout
$7 = VK_IMAGE_LAYOUT_GENERAL
Wine-gdb> p new_layout
$8 = VK_IMAGE_LAYOUT_GENERAL

Wine-gdb> c
Continuing.

Thread 33 "0264" hit Breakpoint 4, d3d12_command_list_ResourceBarrier (iface=0x14b1d6240, barrier_count=3, barriers=0x5cb746c40) at ../src-vkd3d-proton/libs/vkd3d/command.c:9922
9922        d3d12_command_list_barrier_batch_end(list, &batch);

Wine-gdb> p barriers[1]
$9 = {Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION, Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE, {Transition = {pResource = 0x14aff2dc0, Subresource = 4294967295, StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET, StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE}, Aliasing = {pResourceBefore = 0x14aff2dc0, pResourceAfter = 0x4ffffffff}, UAV = {pResource = 0x14aff2dc0}}}

Wine-gdb> p batch.image_barrier_count
$10 = 0
Wine-gdb> p batch.vk_memory_barrier
$11 = {sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2, pNext = 0x0, srcStageMask = 1152, srcAccessMask = 32, dstStageMask = 1152, dstAccessMask = 32}

```