### PR TITLE
Implement GPU upload heap.

### DIFF
--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -110,6 +110,7 @@ extern "C" {
 #define VKD3D_CONFIG_FLAG_FORCE_DYNAMIC_MSAA (1ull << 52)
 #define VKD3D_CONFIG_FLAG_INSTRUCTION_QA_CHECKS (1ull << 53)
 #define VKD3D_CONFIG_FLAG_TRANSFER_QUEUE (1ull << 54)
+#define VKD3D_CONFIG_FLAG_NO_GPU_UPLOAD_HEAP (1ull << 55)
 
 struct vkd3d_instance;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -8820,6 +8820,7 @@ HRESULT vkd3d_memory_info_init(struct vkd3d_memory_info *info,
     info->descriptor_heap_memory_properties =
             vkd3d_memory_info_descriptor_heap_memory_properties(&topology, device);
     vkd3d_memory_info_init_budgets(info, &topology, device);
+    info->has_used_gpu_upload_heap = 0;
 
     if (pthread_mutex_init(&info->budget_lock, NULL) != 0)
         return E_OUTOFMEMORY;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -491,7 +491,7 @@ static bool vkd3d_resource_can_be_vrs(struct d3d12_device *device,
             desc->SampleDesc.Quality == 0 &&
             desc->Layout == D3D12_TEXTURE_LAYOUT_UNKNOWN &&
             heap_properties &&
-            !is_cpu_accessible_heap(heap_properties) &&
+            !is_cpu_accessible_system_memory_heap(heap_properties) &&
             !(desc->Flags & (D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL |
                 D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER |
                 D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS |
@@ -637,7 +637,7 @@ static HRESULT vkd3d_get_image_create_info(struct d3d12_device *device,
     if (heap_properties && is_cpu_accessible_heap(heap_properties) &&
             (format->vk_aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)))
     {
-        FIXME("Creating host-visible depth-stencil images not supported.\n");
+        FIXME("Creating depth-stencil images in system memory is not supported.\n");
         return E_NOTIMPL;
     }
 
@@ -3405,6 +3405,14 @@ static HRESULT d3d12_resource_create(struct d3d12_device *device, uint32_t flags
         vkd3d_view_map_destroy(&object->view_map, device);
         vkd3d_free(object);
         return hr;
+    }
+
+    if (heap_properties
+        && is_cpu_accessible_heap(heap_properties)
+        && (heap_flags & (D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER | D3D12_HEAP_FLAG_ALLOW_DISPLAY)))
+    {
+        WARN("D3D12_HEAP_FLAG_SHARED, D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER, D3D12_HEAP_FLAG_ALLOW_DISPLAY are not supported for CPU accessible heaps.\n");
+        return E_INVALIDARG;
     }
 
     object->refcount = 1;
@@ -8645,34 +8653,18 @@ static VkMemoryPropertyFlags vkd3d_memory_info_descriptor_heap_memory_properties
     }
 }
 
-static VkMemoryPropertyFlags vkd3d_memory_info_upload_hvv_memory_properties(
+static bool vkd3d_memory_info_decide_hvv_usage(
         const struct vkd3d_memory_topology *topology,
         const struct d3d12_device *device)
 {
-    if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_FORCE_HOST_CACHED)
-    {
-        INFO("Topology: Forcing HOST_CACHED | HOST_COHERENT for UPLOAD heap.\n");
-        return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
-                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    }
-
-    if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV)
-    {
-        INFO("Topology: Forcing HOST_COHERENT for UPLOAD heap.\n");
-        return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    }
-
     if (vkd3d_memory_topology_is_uma_like(topology))
     {
         /* Verify that there exists a DEVICE_LOCAL type that is not HOST_VISIBLE on this device
          * which maps to the largest device local heap. That way, it is safe to mask out all memory types which are
          * DEVICE_LOCAL | HOST_VISIBLE.
          * Similarly, there must exist a host-only type. */
-        INFO("Topology: UMA-like topology. Using DEVICE_LOCAL | HOST_COHERENT for UPLOAD.\n");
-        return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        INFO("Topology: UMA-like topology.\n");
+        return true;
     }
     else if (topology->device_local_heap_count <= 1)
     {
@@ -8691,25 +8683,68 @@ static VkMemoryPropertyFlags vkd3d_memory_info_upload_hvv_memory_properties(
 
         if (largest_size < minimum_rebar_size)
         {
-            INFO("Topology largest device local heap is too small (%"PRIu64" bytes) for effective ReBAR, using HOST_COHERENT for UPLOAD.\n", largest_size);
-            return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            INFO("Topology largest device local heap is too small (%"PRIu64" bytes) for effective ReBAR.\n", largest_size);
+            return false;
         }
         else
         {
             /* If we only have one device local heap. */
-            INFO("Topology: No more than 1 device local heap, assuming ReBAR-style access. Using DEVICE_LOCAL | HOST_COHERENT for UPLOAD.\n");
+            INFO("Topology: No more than 1 device local heap, assuming ReBAR-style access.\n");
             /* If DEVICE_LOCAL_BIT does not actually exist, that is fine,
              * we'll fallback to VISIBLE | COHERENT when allocating. */
-            return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                    VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            return true;
         }
     }
     else
     {
-        INFO("Topology: Device heaps are split. Assuming small BAR situation. Using HOST_COHERENT only.\n");
+        INFO("Topology: Device heaps are split. Assuming small BAR situation.\n");
+        return false;
+    }
+}
+
+static VkMemoryPropertyFlags vkd3d_memory_info_upload_hvv_memory_properties(bool is_hvv_use_allowed)
+{
+    if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_FORCE_HOST_CACHED)
+    {
+        INFO("Topology: Forcing HOST_CACHED | HOST_COHERENT for UPLOAD heap.\n");
+        return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    }
+
+    if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV)
+    {
+        INFO("Topology: Forcing HOST_COHERENT for UPLOAD heap.\n");
         return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     }
+
+    if (is_hvv_use_allowed)
+    {
+        INFO("Topology: HVV usage is allowed, using DEVICE_LOCAL | HOST_COHERENT for UPLOAD.\n");
+        return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    }
+    else
+    {
+        INFO("Topology: HVV usage is not allowed, using HOST_COHERENT for UPLOAD.\n");
+        return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    }
+}
+
+
+static bool vkd3d_memory_info_decide_gpu_upload_heap(bool is_hvv_use_allowed)
+{
+    if (!is_hvv_use_allowed)
+        return false;
+
+    if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_FORCE_HOST_CACHED)
+        return false;
+
+    if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_NO_GPU_UPLOAD_HEAP)
+        return false;
+
+    return true;
 }
 
 static void vkd3d_memory_info_init_budgets(struct vkd3d_memory_info *info,
@@ -8774,11 +8809,14 @@ HRESULT vkd3d_memory_info_init(struct vkd3d_memory_info *info,
     uint32_t host_visible_mask;
     uint32_t buffer_type_mask;
     uint32_t rt_ds_type_mask;
+    bool is_hvv_use_allowed;
     uint32_t i;
 
     vkd3d_memory_info_get_topology(&topology, device);
+    is_hvv_use_allowed = vkd3d_memory_info_decide_hvv_usage(&topology, device);
     info->upload_heap_memory_properties =
-            vkd3d_memory_info_upload_hvv_memory_properties(&topology, device);
+            vkd3d_memory_info_upload_hvv_memory_properties(is_hvv_use_allowed);
+    info->has_gpu_upload_heap = vkd3d_memory_info_decide_gpu_upload_heap(is_hvv_use_allowed);
     info->descriptor_heap_memory_properties =
             vkd3d_memory_info_descriptor_heap_memory_properties(&topology, device);
     vkd3d_memory_info_init_budgets(info, &topology, device);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3928,6 +3928,7 @@ struct vkd3d_memory_info
     VkDeviceSize type_current[VK_MAX_MEMORY_TYPES];
 
     pthread_mutex_t budget_lock;
+    uint32_t has_used_gpu_upload_heap;
 };
 
 HRESULT vkd3d_memory_info_init(struct vkd3d_memory_info *info,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3922,6 +3922,8 @@ struct vkd3d_memory_info
     VkDeviceSize rebar_budget;
     VkDeviceSize rebar_current;
 
+    bool has_gpu_upload_heap;
+
     /* Only used for debug logging. */
     VkDeviceSize type_current[VK_MAX_MEMORY_TYPES];
 
@@ -4980,6 +4982,21 @@ static inline bool is_cpu_accessible_heap(const D3D12_HEAP_PROPERTIES *propertie
     {
         return properties->CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE
                 || properties->CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_BACK;
+    }
+    return true;
+}
+
+static inline bool is_cpu_accessible_system_memory_heap(const D3D12_HEAP_PROPERTIES *properties)
+{
+    if (properties->Type == D3D12_HEAP_TYPE_DEFAULT)
+        return false;
+    if (properties->Type == D3D12_HEAP_TYPE_GPU_UPLOAD)
+        return false;
+    if (properties->Type == D3D12_HEAP_TYPE_CUSTOM)
+    {
+        return (properties->CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE
+                || properties->CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_BACK)
+                && properties->MemoryPoolPreference == D3D12_MEMORY_POOL_L0;
     }
     return true;
 }

--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -781,4 +781,15 @@ static inline void enable_d3d12_debug_layer(int argc, char **argv)
     }
 }
 
+static inline bool device_supports_gpu_upload_heap(ID3D12Device *device)
+{
+    D3D12_FEATURE_DATA_D3D12_OPTIONS16 options16;
+    HRESULT hr;
+    hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_D3D12_OPTIONS16, &options16, sizeof(options16));
+    if (hr != S_OK)
+        return false;
+
+    return options16.GPUUploadHeapSupported;
+}
+
 #endif  /* __VKD3D_D3D12_CROSSTEST_H */


### PR DESCRIPTION
God of War Ragnarok appears to use it.

Not 100% sure about the interaction with the existing system that promotes the regular UPLOAD_HEAP to rebar based on a budget.
I decided to go for the following:
- We only report support for the GPU_UPLOAD_HEAP if the existing logic has decided that we have a Rebar budget. Otherwise the same problem of potentially taking VRAM from other resources which need it more applies even if the application itself decides to put it in Rebar.
- When actually allocating memory the budget is ignored if it was the application that decided to put it into Rebar instead of our automatic promotion logic.
- After feedback: Once we allocate memory for either GPU_UPLOAD_HEAP or an equivalent custom heap, the automatically promotion logic gets disabled.
-  Resource creation checks whether GPU_UPLOAD_HEAP is supported when it (or an equivalent custom heap) gets specified.

I hope I'm properly covering all spots that interact with the heap types or custom heap properties.

Memory property flags are based on: https://microsoft.github.io/DirectX-Specs/d3d/D3D12GPUUploadHeaps.html

For tests I mostly copied everything that tested something for HEAP_TYPE_UPLOAD and adapted it to also test HEAP_TYPE_GPU_UPLOAD. I noticed that it was legal to create textures on HEAP_TYPE_GPU_UPLOAD, so I tested that with both render targets and depth stencil textures. I also tried to test the more flexible initial state.

While implementing this, I noticed there were a lot of spots where `is_cpu_accessible_heap()` gets called. As you can see from the diff, I replaced some of those with checks for system memory.

I wasn't sure about all spots where this function got used. So here are the ones that I did **not** change. Please also review those!

- https://github.com/HansKristian-Work/vkd3d-proton/blob/7856e20cccdc090319d485288caf7a6f113c85ec/libs/vkd3d/resource.c#L637-L642
- https://github.com/HansKristian-Work/vkd3d-proton/blob/7856e20cccdc090319d485288caf7a6f113c85ec/libs/vkd3d/memory.c#L1960-L1968
- https://github.com/HansKristian-Work/vkd3d-proton/blob/7856e20cccdc090319d485288caf7a6f113c85ec/libs/vkd3d/resource.c#L208-L212
- https://github.com/HansKristian-Work/vkd3d-proton/blob/7856e20cccdc090319d485288caf7a6f113c85ec/libs/vkd3d/resource.c#L851-L852
- https://github.com/HansKristian-Work/vkd3d-proton/blob/7856e20cccdc090319d485288caf7a6f113c85ec/libs/vkd3d/resource.c#L921-L929
- https://github.com/HansKristian-Work/vkd3d-proton/blob/7856e20cccdc090319d485288caf7a6f113c85ec/libs/vkd3d/resource.c#L3434-L3437

