### PR TITLE
vkd3d: Export D3D12GetInterface from d3d12.dll as well.

### DIFF
--- a/libs/d3d12/d3d12.def
+++ b/libs/d3d12/d3d12.def
@@ -9,3 +9,4 @@ EXPORTS
     D3D12EnableExperimentalFeatures
     D3D12SerializeRootSignature
     D3D12SerializeVersionedRootSignature
+    D3D12GetInterface


### PR DESCRIPTION
Closes #2140.