### PR TITLE
vkd3d: Remove shared heap CPU visible check.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3407,14 +3407,6 @@ static HRESULT d3d12_resource_create(struct d3d12_device *device, uint32_t flags
         return hr;
     }
 
-    if (heap_properties
-        && is_cpu_accessible_heap(heap_properties)
-        && (heap_flags & (D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER | D3D12_HEAP_FLAG_ALLOW_DISPLAY)))
-    {
-        WARN("D3D12_HEAP_FLAG_SHARED, D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER, D3D12_HEAP_FLAG_ALLOW_DISPLAY are not supported for CPU accessible heaps.\n");
-        return E_INVALIDARG;
-    }
-
     object->refcount = 1;
     object->internal_refcount = 1;
     object->desc = *desc;


### PR DESCRIPTION
While this matches what the docs say, it breaks Halo Infinite.

The heap Halo creates is on `D3D12_HEAP_TYPE_CUSTOM`, `D3D12_MEMORY_POOL_L0` and `D3D12_CPU_PAGE_PROPERTY_WRITE_BACK`.
The flags are: `D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER | D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES`.

Both the [spec for the GPU upload heap](https://microsoft.github.io/DirectX-Specs/d3d/D3D12GPUUploadHeaps.html#restrictions) as well as the [documentation for shared heaps](https://learn.microsoft.com/en-us/windows/win32/direct3d12/shared-heaps) say this is illegal.
Cross Adapter heaps are even more specific:
> Either D3D12_HEAP_TYPE_DEFAULT must be set or D3D12_HEAP_TYPE_CUSTOM with D3D12_MEMORY_POOL_L0 and D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE must be set.

However it does break Halo and doesn't solve anything, so just get rid of it for now. We can still revisit this in the future.
