### PR TITLE
vkd3d: Use GPU upload heap for internal scratch allocations.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -19558,7 +19558,8 @@ static HRESULT d3d12_command_signature_init_patch_commands_buffer(struct d3d12_c
     void *ptr;
 
     memset(&heap_info, 0, sizeof(heap_info));
-    heap_info.Type = D3D12_HEAP_TYPE_UPLOAD;
+    heap_info.Type = device->memory_info.has_gpu_upload_heap ?
+            D3D12_HEAP_TYPE_GPU_UPLOAD : D3D12_HEAP_TYPE_UPLOAD;
     memset(&buffer_desc, 0, sizeof(buffer_desc));
     buffer_desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
     buffer_desc.Width = command_count * sizeof(struct vkd3d_patch_command);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3255,7 +3255,8 @@ static HRESULT d3d12_device_create_scratch_buffer(struct d3d12_device *device, e
         assert(memory_types == ~0u);
 
         memset(&alloc_info, 0, sizeof(alloc_info));
-        alloc_info.heap_desc.Properties.Type = D3D12_HEAP_TYPE_UPLOAD;
+        alloc_info.heap_desc.Properties.Type = device->memory_info.has_gpu_upload_heap ?
+                D3D12_HEAP_TYPE_GPU_UPLOAD : D3D12_HEAP_TYPE_UPLOAD;
         alloc_info.heap_desc.SizeInBytes = size;
         alloc_info.heap_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
         alloc_info.heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS | D3D12_HEAP_FLAG_CREATE_NOT_ZEROED;


### PR DESCRIPTION
Avoids pessimizing performance when no_upload_hvv is used.