### PR TITLE
Misc smaller sparse improvements

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -18782,8 +18782,9 @@ static void d3d12_command_queue_bind_sparse(struct d3d12_command_queue *command_
         goto cleanup;
     }
 
-    /* NV driver is buggy and test_update_tile_mappings fails (bug 3274618). */
-    can_compact = command_queue->device->device_info.properties2.properties.vendorID != VKD3D_VENDOR_ID_NVIDIA;
+    /* NV driver before r535 is buggy and test_update_tile_mappings fails (bug 3274618). */
+    can_compact = command_queue->device->device_info.vulkan_1_2_properties.driverID != VK_DRIVER_ID_NVIDIA_PROPRIETARY ||
+            VKD3D_DRIVER_VERSION_MAJOR_NV(command_queue->device->device_info.properties2.properties.driverVersion) >= 535;
     count = vkd3d_compact_sparse_bind_ranges(src_resource, bind_ranges, bind_infos, count, mode, can_compact);
 
     first_packed_tile = dst_resource->sparse.tile_count;

--- a/libs/vkd3d/queue_timeline.c
+++ b/libs/vkd3d/queue_timeline.c
@@ -253,6 +253,26 @@ void vkd3d_queue_timeline_trace_complete_low_latency_sleep(struct vkd3d_queue_ti
 }
 
 struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_sparse(struct vkd3d_queue_timeline_trace *trace, uint32_t num_tiles)
+{
+    struct vkd3d_queue_timeline_trace_cookie cookie = {0};
+    struct vkd3d_queue_timeline_trace_state *state;
+    uint64_t submission_count;
+    if (!trace->active)
+        return cookie;
+
+    cookie.index = vkd3d_queue_timeline_trace_allocate_index(trace, &submission_count);
+    if (!cookie.index)
+        return cookie;
+
+    state = &trace->state[cookie.index];
+    state->type = VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_SUBMISSION;
+    state->start_ts = vkd3d_get_current_time_ns();
+    snprintf(state->desc, sizeof(state->desc), "SPARSE #%"PRIu64" (%u tiles)", submission_count, num_tiles);
+    return cookie;
+}
+
+struct vkd3d_queue_timeline_trace_cookie
 vkd3d_queue_timeline_trace_register_execute(struct vkd3d_queue_timeline_trace *trace,
         ID3D12CommandList * const *command_lists, unsigned int count)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4731,6 +4731,8 @@ struct vkd3d_queue_timeline_trace_cookie
 vkd3d_queue_timeline_trace_register_low_latency_sleep(struct vkd3d_queue_timeline_trace *trace,
         uint64_t present_id);
 struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_sparse(struct vkd3d_queue_timeline_trace *trace, uint32_t num_tiles);
+struct vkd3d_queue_timeline_trace_cookie
 vkd3d_queue_timeline_trace_register_execute(struct vkd3d_queue_timeline_trace *trace,
         ID3D12CommandList * const *command_lists, unsigned int count);
 struct vkd3d_queue_timeline_trace_cookie


### PR DESCRIPTION
- Add queue profiling support for sparse.
- Remove old compaction workaround for NV drivers. Reported to be fixed on r535.