### PR TITLE
Implement ID3DDestructionNotifier

### DIFF
--- a/include/vkd3d_d3dcommon.idl
+++ b/include/vkd3d_d3dcommon.idl
@@ -96,6 +96,21 @@ interface ID3D10Blob : IUnknown
 typedef ID3D10Blob ID3DBlob;
 cpp_quote("#define IID_ID3DBlob IID_ID3D10Blob")
 
+typedef void (__stdcall *PFN_DESTRUCTION_CALLBACK)(void*);
+
+[
+    uuid(a06eb39a-50da-425b-8c31-4eecd6c270f3),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3DDestructionNotifier : IUnknown
+{
+    HRESULT RegisterDestructionCallback(PFN_DESTRUCTION_CALLBACK callback,
+        void *data, UINT *callback_id);
+    HRESULT UnregisterDestructionCallback(UINT callback_id);
+}
+
 cpp_quote("DEFINE_GUID(WKPDID_D3DDebugObjectName,0x429b8c22,0x9188,0x4b0c,0x87,0x42,0xac,0xb0,0xbf,0x85,0xc2,0x00);")
 cpp_quote("DEFINE_GUID(WKPDID_D3DDebugObjectNameW,0x4cca5fd8,0x921f,0x42c8,0x85,0x66,0x70,0xca,0xf2,0xa9,0xb7,0x41);")
 cpp_quote("DEFINE_GUID(WKPDID_CommentStringW,0xd0149dc0,0x90e8,0x4ec8,0x81,0x44,0xe9,0x00,0xad,0x26,0x6b,0xb2);")

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2480,6 +2480,7 @@ struct d3d12_command_allocator
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 
 #ifdef VKD3D_ENABLE_BREADCRUMBS
     unsigned int *breadcrumb_context_indices;
@@ -3032,6 +3033,7 @@ struct d3d12_bundle_allocator
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 HRESULT d3d12_bundle_allocator_create(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1054,6 +1054,7 @@ struct d3d12_resource
     VkImageView vrs_view;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 static inline bool d3d12_resource_is_buffer(const struct d3d12_resource *resource)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3278,6 +3278,7 @@ struct d3d12_command_queue
 
     struct vkd3d_fence_worker fence_worker;
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
     struct dxgi_vk_swap_chain_factory vk_swap_chain_factory;
     unsigned int submission_thread_tid;
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1663,6 +1663,7 @@ struct d3d12_query_heap
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_HEAP_DESC *desc,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2322,6 +2322,7 @@ struct d3d12_pipeline_library
     uint32_t stream_archive_cancellation_point;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 enum vkd3d_pipeline_library_flags

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2144,6 +2144,7 @@ struct d3d12_pipeline_state
     bool pso_is_fully_dynamic;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 static inline bool d3d12_pipeline_state_is_compute(const struct d3d12_pipeline_state *state)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -599,6 +599,7 @@ struct d3d12_fence
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 static inline struct d3d12_fence *impl_from_ID3D12Fence1(ID3D12Fence1 *iface)
@@ -648,6 +649,7 @@ struct d3d12_shared_fence
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 static inline struct d3d12_shared_fence *shared_impl_from_ID3D12Fence1(ID3D12Fence1 *iface)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -343,19 +343,6 @@ VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3
 void vkd3d_va_map_init(struct vkd3d_va_map *va_map);
 void vkd3d_va_map_cleanup(struct vkd3d_va_map *va_map);
 
-struct vkd3d_gpu_va_allocation
-{
-    D3D12_GPU_VIRTUAL_ADDRESS base;
-    size_t size;
-    void *ptr;
-};
-
-struct vkd3d_gpu_va_slab
-{
-    size_t size;
-    void *ptr;
-};
-
 struct vkd3d_private_store
 {
     pthread_mutex_t mutex;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5427,6 +5427,7 @@ struct d3d12_meta_command
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 struct d3d12_meta_command *impl_from_ID3D12MetaCommand(ID3D12MetaCommand *iface);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -515,6 +515,32 @@ static inline HRESULT vkd3d_set_private_data_interface(struct vkd3d_private_stor
 
 HRESULT STDMETHODCALLTYPE d3d12_object_SetName(ID3D12Object *iface, const WCHAR *name);
 
+struct d3d_destruction_callback_entry
+{
+    PFN_DESTRUCTION_CALLBACK callback;
+    void *userdata;
+    UINT callback_id;
+};
+
+struct d3d_destruction_notifier
+{
+    ID3DDestructionNotifier ID3DDestructionNotifier_iface;
+
+    IUnknown *parent;
+
+    pthread_mutex_t mutex;
+
+    struct d3d_destruction_callback_entry *callbacks;
+    size_t callback_size;
+    size_t callback_count;
+
+    UINT next_callback_id;
+};
+
+void d3d_destruction_notifier_init(struct d3d_destruction_notifier *notifier, IUnknown *parent);
+void d3d_destruction_notifier_free(struct d3d_destruction_notifier *notifier);
+void d3d_destruction_notifier_notify(struct d3d_destruction_notifier *notifier);
+
 /* ID3D12Fence */
 struct d3d12_fence_value
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4903,6 +4903,7 @@ struct d3d12_device
     LUID adapter_luid;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
     struct d3d12_caps d3d12_caps;
 
     struct vkd3d_memory_transfer_queue memory_transfers;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -916,6 +916,7 @@ struct d3d12_heap
 
     struct d3d12_device *device;
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 HRESULT d3d12_heap_create(struct d3d12_device *device, const D3D12_HEAP_DESC *desc,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5361,6 +5361,7 @@ struct d3d12_state_object
 #endif
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 HRESULT d3d12_state_object_create(struct d3d12_device *device, const D3D12_STATE_OBJECT_DESC *desc,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1819,6 +1819,7 @@ struct d3d12_root_signature
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 HRESULT d3d12_root_signature_create(struct d3d12_device *device, const void *bytecode,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2983,6 +2983,7 @@ struct d3d12_command_list
     struct vkd3d_queue_timeline_trace_cookie timeline_cookie;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 
 #ifdef VKD3D_ENABLE_BREADCRUMBS
     unsigned int breadcrumb_context_index;
@@ -3060,6 +3061,7 @@ struct d3d12_bundle
     struct d3d12_bundle_command *tail;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 HRESULT d3d12_bundle_create(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3364,6 +3364,7 @@ struct d3d12_command_signature
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 };
 
 HRESULT d3d12_command_signature_create(struct d3d12_device *device, struct d3d12_root_signature *root_signature,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1486,6 +1486,7 @@ struct d3d12_descriptor_heap
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
+    struct d3d_destruction_notifier destruction_notifier;
 
     /* Here we pack metadata data structures for CBV_SRV_UAV and SAMPLER.
      * For RTV/DSV heaps, we just encode rtv_desc structs inline. */

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -428,3 +428,5 @@ decl_test(test_sm68_sample_cmp_bias_grad);
 decl_test(test_planar_video_formats);
 decl_test(test_vkd3d_dxvk_cmdbuf_interop);
 decl_test(test_large_texel_buffer_view);
+decl_test(test_destruction_notifier_callback);
+decl_test(test_destruction_notifier_interfaces);


### PR DESCRIPTION
I lost multiple brain cells writing this code, but the TL;DR is that *every* D3D12 COM object supports this interface, and according to the docs it's supposed to fire any registered callback *before* references to other objects are released, hence the jank around objects that we keep alive internally.

Apparently this is needed by The Forever Winter, although I haven't seen it use the interface myself while testing.