### PR TITLE
vkd3d: Workaround buggy API usage patterns with pipeline libraries.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2323,6 +2323,9 @@ struct d3d12_pipeline_library
 
     struct vkd3d_private_store private_store;
     struct d3d_destruction_notifier destruction_notifier;
+
+    const void *input_blob;
+    size_t input_blob_length;
 };
 
 enum vkd3d_pipeline_library_flags


### PR DESCRIPTION
FF XVI attempts to serialize back to same pointer that unserialized. This is not legal, but it would work if we guaranteed stable serialization, which we don't. Workaround it by detecting overlapping memory and serializing to temporary memory.