### PR TITLE
Force precise vertex shaders in Hunt: Showdown

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -449,7 +449,11 @@ enum vkd3d_shader_quirk
     VKD3D_SHADER_QUIRK_FORCE_GRAPHICS_BARRIER = (1 << 18),
 
     /* VK_PIPELINE_CREATE_DISABLE_OPTIMIZATIONS. For driver workarounds where optimizations break stuff. */
-    VKD3D_SHADER_QUIRK_DISABLE_OPTIMIZATIONS = (1 << 19)
+    VKD3D_SHADER_QUIRK_DISABLE_OPTIMIZATIONS = (1 << 19),
+
+    /* Forces NoContract on every expression that can take it (only applies to VS).
+     * Useful as a global quirk when games are shipping broken code. */
+    VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH_VS = (1 << 20)
 };
 
 struct vkd3d_shader_quirk_hash

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -796,10 +796,16 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
     }
 
     {
+        bool force_nocontract =
+                (quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH) ||
+                ((quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH_VS) &&
+                shader_interface_info->stage == VK_SHADER_STAGE_VERTEX_BIT);
+
         const struct dxil_spv_option_precise_control helper =
                 { { DXIL_SPV_OPTION_PRECISE_CONTROL },
-                        (quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH) ? DXIL_SPV_TRUE : DXIL_SPV_FALSE,
+                        force_nocontract ? DXIL_SPV_TRUE : DXIL_SPV_FALSE,
                         DXIL_SPV_FALSE };
+
         if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
         {
             WARN("dxil-spirv does not support PRECISE_CONTROL.\n");

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -2424,6 +2424,12 @@ struct vkd3d_dxbc_compiler *vkd3d_dxbc_compiler_create(const struct vkd3d_shader
 
     compiler->shader_version = *shader_version;
     compiler->quirks = vkd3d_shader_compile_arguments_select_quirks(compile_args, shader_hash);
+
+    /* Easier to normalize the quirk here than refactor all the checks. */
+    if ((compiler->quirks & VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH_VS) &&
+            shader_interface->stage == VK_SHADER_STAGE_VERTEX_BIT)
+        compiler->quirks |= VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH;
+
 #ifdef VKD3D_ENABLE_DESCRIPTOR_QA
     compiler->descriptor_qa_shader_hash = shader_hash;
 #endif

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -740,6 +740,11 @@ static const struct vkd3d_shader_quirk_info ffxvi_quirks = {
     ffxvi_hashes, ARRAY_SIZE(ffxvi_hashes),
 };
 
+/* Some shaders use precise, some don't, leading to invariance issues. */
+static const struct vkd3d_shader_quirk_info hunt_quirks = {
+    NULL, 0, VKD3D_SHADER_QUIRK_FORCE_NOCONTRACT_MATH_VS,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
@@ -766,6 +771,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "ACMirage_plus.exe", &ac_mirage_quirks },
     /* FF XVI. */
     { VKD3D_STRING_COMPARE_STARTS_WITH, "ffxvi", &ffxvi_quirks },
+    /* Hunt: Showdown 1896 (594650) */
+    { VKD3D_STRING_COMPARE_EXACT, "HuntGame.exe", &hunt_quirks },
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* MSVC fails to compile empty array. */


### PR DESCRIPTION
Should fix glitched graphics due to game bug.