### PR TITLE
Add NO_UPLOAD_HVV workaround for Red Dead Redemption

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -595,6 +595,8 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     { VKD3D_STRING_COMPARE_EXACT, "witcher3.exe", VKD3D_CONFIG_FLAG_DISABLE_SIMULTANEOUS_UAV_COMPRESSION, 0 },
     /* Age of Wonders 4 (1669000). Extremely stuttery performance with ReBAR. */
     { VKD3D_STRING_COMPARE_EXACT, "AOW4.exe", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0 },
+    /* Red Dead Redemption (2668510). Inconsistent performance with ReBAR at cutscenes of the game. */
+    { VKD3D_STRING_COMPARE_EXACT, "RDR.exe", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0 },
     /* Horizon Forbidden West (2420110). Work around RADV 23.3.1 that ships on stableOS at time of making WAR. */
     { VKD3D_STRING_COMPARE_EXACT, "HorizonForbiddenWest.exe", VKD3D_CONFIG_FLAG_DRIVER_VERSION_SENSITIVE_SHADERS, 0 },
     /* Starfield (1716740) */


### PR DESCRIPTION
Game suffers from performance dips (on my end from 165 fps to 82 [lowest] and then back up to 165) with Rebar on while cutscenes are playing. no_upload_hvv fixes the issue. Tested with 7900 XTX-RADV-Mesa 24.2.5.

Fixes https://github.com/HansKristian-Work/vkd3d-proton/issues/2178