### PR TITLE
Silence some log spam

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -7273,7 +7273,7 @@ static void STDMETHODCALLTYPE d3d12_device_GetCopyableFootprints1(d3d12_device_i
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     static const struct vkd3d_format vkd3d_format_unknown
-            = {DXGI_FORMAT_UNKNOWN, VK_FORMAT_UNDEFINED, 1, 1, 1, 1, 0, 1};
+            = {DXGI_FORMAT_UNKNOWN, VK_FORMAT_UNDEFINED, 1, 1, 1, 1, VK_IMAGE_ASPECT_COLOR_BIT, 1};
 
     unsigned int i, sub_resource_idx, row_count, row_size, row_pitch;
     unsigned int num_subresources_per_plane, plane_idx;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -4651,14 +4651,12 @@ static HRESULT d3d12_pipeline_state_init_graphics_create_info(struct d3d12_pipel
     {
         if (!(format->vk_aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT))
         {
-            WARN("Ignoring depthTestEnable due to lack of depth aspect.\n");
             graphics->ds_desc.depthTestEnable = VK_FALSE;
             graphics->ds_desc.depthBoundsTestEnable = VK_FALSE;
         }
 
         if (!(format->vk_aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT))
         {
-            WARN("Ignoring stencilTestEnable due to lack of stencil aspect.\n");
             graphics->ds_desc.stencilTestEnable = VK_FALSE;
         }
     }


### PR DESCRIPTION
Two things that have been bothering me for a while:
- There's absolutely nothing about the `stencilTestEnable` thing that's worth logging, it is however something we hit in countless games in thousands of pipelines, so we might as well get rid of it. Also removed the `depthTestEnable` one since this can only really happen if the DSV format is not a depth-stencil format, which gets validated and logged in a different place anyway.
- The `Invalid plane index 0 for format 0.` thing is fallout from the NV12 work quite a while back. Now the fix of just making the aspect non-zero is rather lazy, but the entire function seems a bit lazy to begin with given that we're shoehorning buffers onto the image path by defining a custom `UNDEFINED` format anyway and it silences the message.
  The alternative here would be to clean the whole thing up and have a separate code path for buffers.