### PR TITLE
vkd3d: Perform minimal validation on page table updates.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -954,6 +954,8 @@ enum vkd3d_resource_flag
     VKD3D_RESOURCE_GENERAL_LAYOUT         = (1u << 7),
 };
 
+#define VKD3D_INVALID_TILE_INDEX (~0u)
+
 struct d3d12_sparse_image_region
 {
     VkImageSubresource subresource;


### PR DESCRIPTION
When misusing `UpdateTileMappings`, I experimented a bit on Windows drivers and got wildly inconsistent results. Two main scenarios are scary:

Binding valid memory to out-of-bounds tile indices:
- WARP removes the device
- AMD wraps around (???) and starts binding early tiles, at least for buffers
  (unless the base tile is out of bounds, in which case it silently ignores  the call)
- Nvidia only ignores out-of-bound tiles, but otherwise succeeds

Binding out-of-bounds heap memory to a valid tile:
- WARP and Nvidia remove the device
- AMD silently ignores the call

With other invalid / questionable uses, such as passing invalid subresource indices, out-of-bounds image coordinates, setting `UseBox` when mapping a buffer etc I've seen all sorts of combinations of driver segfaults, calls getting ignored and `DEVICE_REMOVED` that sometimes even depend on how big the resource is, so... yeah.

Since this is clearly light years deep into UB territory and doesn't really seem possible to any sort of tests for, and I'm not aware of any games misusing this function to begin with, I only really added minimal checks here to ensure that:
- we don't access and potentially corrupt out-of-bounds areas of our own data structures, and
- we don't bind out-of-bounds heap regions to a sparse resource.

The latter has the potential to be a real problem if the heap we end up binding is suballocated, since it would be legal Vulkan and go completely unnoticed.