### PR TITLE
Fix the incorrect access mask of barrier for render pass resolve

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -9045,7 +9045,7 @@ static void d3d12_get_resolve_barrier_for_dst_resource(struct d3d12_resource *re
     else
     {
         barrier->srcStageMask = outside_stages;
-        barrier->srcAccessMask = VK_ACCESS_2_NONE;
+        barrier->srcAccessMask = outside_access;
         barrier->dstStageMask = resolve_stages;
         barrier->dstAccessMask = resolve_access;
         barrier->oldLayout = writes_full_subresource ? VK_IMAGE_LAYOUT_UNDEFINED : outside_layout;
@@ -9110,7 +9110,7 @@ static void d3d12_get_resolve_barrier_for_src_resource(struct d3d12_resource *re
     else
     {
         barrier->srcStageMask = outside_stages;
-        barrier->srcAccessMask = VK_ACCESS_2_NONE;
+        barrier->srcAccessMask = outside_access;
         barrier->dstStageMask = resolve_stages;
         barrier->dstAccessMask = resolve_access;
         barrier->oldLayout = outside_layout;


### PR DESCRIPTION
Recently I found that `test_renderpass_rendering` failed with RADV.
The failures are in the `render pass resolve` and the results may be the clear values of resolved render target. Just like the draw calls for `rt_ms` do not take effect.
(It seems there are 2 bug_if here....)

After investigation, I think the root cause is that this test uses incorrect `srcAccessMask` of pipeline barrier between multi-sample target and resolved target. (the pre_resolve barrier)
Since `srcAccessMask = VK_ACCESS_2_NONE`, thus CB cache would not be flushed.
https://github.com/HansKristian-Work/vkd3d-proton/blob/a187ec876edf5dcd1736d027c0b9e2fba6a01f8e/libs/vkd3d/command.c#L9101-L9118
While `outside_access` here is `VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT`, so we could just use it.
https://github.com/HansKristian-Work/vkd3d-proton/blob/a187ec876edf5dcd1736d027c0b9e2fba6a01f8e/libs/vkd3d/command.c#L15500-L15510

Same modification is also made for `d3d12_get_resolve_barrier_for_dst_resource`.
`d3d12_get_resolve_barrier_for_src_resource` and `d3d12_get_resolve_barrier_for_dst_resource` are also called in `d3d12_command_list_resolve_subresource` and its logic won't be affect by this change.

These failures sometimes could also be observed with AMDVLK.

### Software information
vkd3d test: `test_renderpass_rendering`

### System information
- GPU: Radeon 7900XTX
- Driver: RADV