### PR TITLE
Make sure that our internal sparse queue does not alias with other user queues

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -19048,7 +19048,7 @@ static void d3d12_command_queue_bind_sparse(struct d3d12_command_queue *command_
     queue = command_queue->vkd3d_queue;
 
     if (!(queue->vk_queue_flags & VK_QUEUE_SPARSE_BINDING_BIT))
-        queue_sparse = command_queue->device->queue_families[VKD3D_QUEUE_FAMILY_SPARSE_BINDING]->queues[0];
+        queue_sparse = command_queue->device->internal_sparse_queue;
     else
         queue_sparse = queue;
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3665,6 +3665,9 @@ static void d3d12_device_destroy(struct d3d12_device *device)
 
     d3d_destruction_notifier_free(&device->destruction_notifier);
 
+    if (device->internal_sparse_queue)
+        d3d12_device_unmap_vkd3d_queue(device->internal_sparse_queue, NULL);
+
     for (i = 0; i < VKD3D_SCRATCH_POOL_KIND_COUNT; i++)
         for (j = 0; j < device->scratch_pools[i].scratch_buffer_count; j++)
             d3d12_device_destroy_scratch_buffer(device, &device->scratch_pools[i].scratch_buffers[j]);
@@ -8890,6 +8893,16 @@ static void vkd3d_scratch_pool_init(struct d3d12_device *device)
             VKD3D_SCRATCH_BUFFER_COUNT_INDIRECT_PREPROCESS;
 }
 
+static void d3d12_device_reserve_internal_sparse_queue(struct d3d12_device *device)
+{
+    /* This cannot fail. We're not allocating memory here. */
+    if (device->queue_family_indices[VKD3D_QUEUE_FAMILY_SPARSE_BINDING] != VK_QUEUE_FAMILY_IGNORED)
+    {
+        device->internal_sparse_queue = d3d12_device_allocate_vkd3d_queue(
+                device->queue_families[VKD3D_QUEUE_FAMILY_SPARSE_BINDING], NULL);
+    }
+}
+
 static HRESULT d3d12_device_init(struct d3d12_device *device,
         struct vkd3d_instance *instance, const struct vkd3d_device_create_info *create_info)
 {
@@ -9042,6 +9055,7 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
         vkd3d_renderdoc_begin_capture(device->vkd3d_instance->vk_instance);
 #endif
 
+    d3d12_device_reserve_internal_sparse_queue(device);
     d3d_destruction_notifier_init(&device->destruction_notifier, (IUnknown*)&device->ID3D12Device_iface);
     return S_OK;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3101,7 +3101,7 @@ static HRESULT d3d12_resource_bind_sparse_metadata(struct d3d12_resource *resour
     bind_info.signalSemaphoreCount = 0;
     bind_info.pSignalSemaphores = NULL;
 
-    vkd3d_queue = device->queue_families[VKD3D_QUEUE_FAMILY_SPARSE_BINDING]->queues[0];
+    vkd3d_queue = device->internal_sparse_queue;
 
     if (!(vk_queue = vkd3d_queue_acquire(vkd3d_queue)))
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4907,6 +4907,8 @@ struct d3d12_device
     struct vkd3d_memory_transfer_queue memory_transfers;
     struct vkd3d_memory_allocator memory_allocator;
 
+    struct vkd3d_queue *internal_sparse_queue;
+
     struct d3d12_device_scratch_pool scratch_pools[VKD3D_SCRATCH_POOL_KIND_COUNT];
 
     struct vkd3d_query_pool query_pools[VKD3D_VIRTUAL_QUERY_POOL_COUNT];


### PR DESCRIPTION
Reserve a queue similar to internal compute queue.
Also, make sure that the internal sparse queue attempts to use something other than the graphics queue if possible.