### PR TITLE
Rework semaphore waiting

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3094,7 +3094,6 @@ struct vkd3d_queue
 
     VkCommandPool barrier_pool;
     VkCommandBuffer barrier_command_buffer;
-    VkSemaphore serializing_binary_semaphore;
     VkSemaphore submission_timeline;
     uint64_t submission_timeline_count;
 
@@ -3307,6 +3306,8 @@ struct d3d12_command_queue
     VkSemaphoreSubmitInfo *wait_semaphores;
     size_t wait_semaphores_size;
     size_t wait_semaphore_count;
+
+    VkSemaphore serializing_semaphore;
 };
 
 HRESULT d3d12_command_queue_create(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3250,6 +3250,7 @@ HRESULT dxgi_vk_swap_chain_factory_init(struct d3d12_command_queue *queue, struc
 enum vkd3d_wait_semaphore_flags
 {
     VKD3D_WAIT_SEMAPHORES_EXTERNAL        = (1u << 0),
+    VKD3D_WAIT_SEMAPHORES_SERIALIZING     = (1u << 1),
 };
 
 struct vkd3d_fence_virtual_wait
@@ -3308,6 +3309,7 @@ struct d3d12_command_queue
     size_t wait_semaphore_count;
 
     VkSemaphore serializing_semaphore;
+    bool serializing_semaphore_signaled;
 };
 
 HRESULT d3d12_command_queue_create(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3248,6 +3248,11 @@ ULONG dxgi_vk_swap_chain_decref(struct dxgi_vk_swap_chain *chain);
 
 HRESULT dxgi_vk_swap_chain_factory_init(struct d3d12_command_queue *queue, struct dxgi_vk_swap_chain_factory *chain);
 
+enum vkd3d_wait_semaphore_flags
+{
+    VKD3D_WAIT_SEMAPHORES_EXTERNAL        = (1u << 0),
+};
+
 struct vkd3d_fence_virtual_wait
 {
     struct d3d12_fence *fence;


### PR DESCRIPTION
Workaround for #2215.

This moves fence wait tracking from `vkd3d_queue` to the virtual queues and optimizes away most of the empty submissions that only do a semaphore wait and a semaphore signal, which is what caused the massive performance degradation in Cyberpunk since AMDGPU does not handle this very well.

Additionally, sparse binding serialization now uses the queue's timeline instead of the binary semaphore. At worst, there will now be one extra `vkQueueSubmit` on the first sparse binding call in order to flush waiters, rather than doing a round-trip over the graphics queue each time.

One potential concern is that this may delay fence signals in scenarios where we set `NO_STAGGERED_SUBMIT` in case the app does something like `queue->Wait(...); nothing for quite some time; queue->Signal(...)` with no commands being submitted. The only solution I can think of would involve stalling the signaling queue worker until all pending waits have completed in that case, which is something that we're kind of trying to avoid, but I'm not sure if this is even an issue in practice - Black Myth Wukong doesn't seem to run into this problem with FSR framegen enabled at all, so at least UE5 should be fine.

Most of this code was written on four hours of sleep, so this will need extensive testing.