### PR TITLE
tests: Fix resource state of compute SRV in test_depth/stencil_load

### DIFF
--- a/tests/d3d12_depth_stencil.c
+++ b/tests/d3d12_depth_stencil.c
@@ -602,7 +602,7 @@ void test_depth_load(void)
         ID3D12GraphicsCommandList_ClearDepthStencilView(command_list, ds.dsv_handle,
                 D3D12_CLEAR_FLAG_DEPTH, tests[i], 0, 0, NULL);
         transition_sub_resource_state(command_list, ds.texture, 0,
-                D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+                D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
         ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -639,7 +639,7 @@ void test_depth_load(void)
         transition_sub_resource_state(command_list, texture, 0,
                 D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
         transition_sub_resource_state(command_list, ds.texture, 0,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
     }
     vkd3d_test_set_context(NULL);
 
@@ -837,7 +837,7 @@ void test_stencil_load(void)
         ID3D12GraphicsCommandList_ClearDepthStencilView(command_list, ds.dsv_handle,
                 D3D12_CLEAR_FLAG_STENCIL, 0.0f, tests[i], 0, NULL);
         transition_sub_resource_state(command_list, ds.texture, 0,
-                D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+                D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
         ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -874,7 +874,7 @@ void test_stencil_load(void)
         transition_sub_resource_state(command_list, texture, 0,
                 D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
         transition_sub_resource_state(command_list, ds.texture, 0,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
     }
     vkd3d_test_set_context(NULL);
 


### PR DESCRIPTION
Recently I found that `test_depth/stencil_load` failed with AMDVLK.
The results of compute shader sometimes are the clear values of last iteration which are incorrect. Just like the cs executed before the depth/stencil clear. (depth/stencil would be used as SRV here)

After investigation, I think the root cause is that these tests use incorrect dst resource state for depth/stencil.
Since only `D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE` is used, the sync is correct for ps but incorrect for cs.
Thus `D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE` is also required.