### PR TITLE
vkd3d: Clean up reporting and checking maximum descriptor counts.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -7864,6 +7864,25 @@ static D3D12_SAMPLER_FEEDBACK_TIER d3d12_device_determine_sampler_feedback_tier(
     return D3D12_SAMPLER_FEEDBACK_TIER_0_9;
 }
 
+uint32_t d3d12_device_get_max_descriptor_heap_size(struct d3d12_device *device, D3D12_DESCRIPTOR_HEAP_TYPE heap_type)
+{
+    /* For now, hard-code descriptor counts to the minimum numbers required by D3D12.
+     * We could support more based on device capabilities, but that would change
+     * pipeline layouts. */
+    switch (heap_type)
+    {
+        case D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV:
+            return VKD3D_MIN_VIEW_DESCRIPTOR_COUNT;
+
+        case D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER:
+            return VKD3D_MIN_SAMPLER_DESCRIPTOR_COUNT;
+
+        default:
+            WARN("Unhandled descriptor heap type %u.\n", heap_type);
+            return 0u;
+    }
+}
+
 static void d3d12_device_caps_init_feature_options(struct d3d12_device *device)
 {
     const VkPhysicalDeviceFeatures *features = &device->device_info.features2.features;
@@ -8164,9 +8183,9 @@ static void d3d12_device_caps_init_feature_options19(struct d3d12_device *device
     /* Report legacy D3D12 limits for now. Increasing descriptor count limits
      * would require changing changing descriptor set layouts, and more samplers
      * need additional considerations w.r.t. Vulkan device limits. */
-    options19->MaxSamplerDescriptorHeapSize = 2048;
-    options19->MaxSamplerDescriptorHeapSizeWithStaticSamplers = 2048;
-    options19->MaxViewDescriptorHeapSize = 1000000;
+    options19->MaxSamplerDescriptorHeapSize = d3d12_device_get_max_descriptor_heap_size(device, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+    options19->MaxSamplerDescriptorHeapSizeWithStaticSamplers = options19->MaxSamplerDescriptorHeapSize;
+    options19->MaxViewDescriptorHeapSize = d3d12_device_get_max_descriptor_heap_size(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 }
 
 static void d3d12_device_caps_init_feature_options20(struct d3d12_device *device)

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -9098,7 +9098,7 @@ HRESULT vkd3d_global_descriptor_buffer_init(struct vkd3d_global_descriptor_buffe
          * We will not add even more code paths to deal with that.
          * Non-mutable + descriptor buffer is only relevant on AMD Windows driver for the time being,
          * and eventually we will make mutable a hard requirement, so don't bother checking that case. */
-        VkDeviceSize required_resource_descriptors = 1000000 + 1; /* One magic SSBO for internal VA buffer. */
+        VkDeviceSize required_resource_descriptors = VKD3D_MIN_VIEW_DESCRIPTOR_COUNT + 1; /* One magic SSBO for internal VA buffer. */
         uint32_t flags = VKD3D_BINDLESS_MUTABLE_TYPE;
         VkDeviceSize mutable_desc_size;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -63,6 +63,9 @@
 #define VKD3D_MAX_MUTABLE_DESCRIPTOR_TYPES 6u
 #define VKD3D_MAX_DESCRIPTOR_SIZE 256u /* Maximum allowed value in VK_EXT_descriptor_buffer. */
 
+#define VKD3D_MIN_VIEW_DESCRIPTOR_COUNT (1000000u)
+#define VKD3D_MIN_SAMPLER_DESCRIPTOR_COUNT (2048u)
+
 #define VKD3D_TILE_SIZE 65536
 
 typedef ID3D12Fence1 d3d12_fence_iface;
@@ -4996,6 +4999,8 @@ VkPipeline d3d12_device_get_or_create_vertex_input_pipeline(struct d3d12_device 
         const struct vkd3d_vertex_input_pipeline_desc *desc);
 VkPipeline d3d12_device_get_or_create_fragment_output_pipeline(struct d3d12_device *device,
         const struct vkd3d_fragment_output_pipeline_desc *desc);
+
+uint32_t d3d12_device_get_max_descriptor_heap_size(struct d3d12_device *device, D3D12_DESCRIPTOR_HEAP_TYPE heap_type);
 
 static inline struct d3d12_device *unsafe_impl_from_ID3D12Device(d3d12_device_iface *iface)
 {


### PR DESCRIPTION
Fallout from the Stalker 2 thing. Unclear if we want to add validation since ANV worked around the problem for now, but I think having the numbers in one place is good practice.

D3D12 behaviour is a mess, all drviers allow creating view descriptor heaps with >1M descriptors, but creating a heap *too* large can either return `E_OUTOFMEMORY` or remove the device entirely.