### PR TITLE
Attempt to workaround Outlaws hang on NV

### DIFF
--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -111,6 +111,7 @@ extern "C" {
 #define VKD3D_CONFIG_FLAG_INSTRUCTION_QA_CHECKS (1ull << 53)
 #define VKD3D_CONFIG_FLAG_TRANSFER_QUEUE (1ull << 54)
 #define VKD3D_CONFIG_FLAG_NO_GPU_UPLOAD_HEAP (1ull << 55)
+#define VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT (1ull << 56)
 
 struct vkd3d_instance;
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1906,7 +1906,8 @@ static HRESULT d3d12_command_list_begin_command_buffer(struct d3d12_command_list
 
     begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     begin_info.pNext = NULL;
-    begin_info.flags = 0;
+    begin_info.flags = (vkd3d_config_flags & VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT) ?
+            VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT : 0;
     begin_info.pInheritanceInfo = NULL;
 
     if ((vr = VK_CALL(vkBeginCommandBuffer(list->cmd.vk_command_buffer, &begin_info))) < 0)
@@ -2018,7 +2019,8 @@ static void d3d12_command_list_begin_new_sequence(struct d3d12_command_list *lis
 
     begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     begin_info.pNext = NULL;
-    begin_info.flags = 0;
+    begin_info.flags = (vkd3d_config_flags & VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT) ?
+            VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT : 0;
     begin_info.pInheritanceInfo = NULL;
     if ((vr = VK_CALL(vkBeginCommandBuffer(iteration->vk_command_buffer, &begin_info))) < 0)
     {
@@ -2112,7 +2114,8 @@ static HRESULT d3d12_command_allocator_allocate_init_command_buffer(struct d3d12
 
     begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     begin_info.pNext = NULL;
-    begin_info.flags = 0;
+    begin_info.flags = (vkd3d_config_flags & VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT) ?
+            VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT : 0;
     begin_info.pInheritanceInfo = NULL;
 
     if ((vr = VK_CALL(vkBeginCommandBuffer(list->cmd.iterations[0].vk_init_commands, &begin_info))) < 0)
@@ -2162,7 +2165,8 @@ static HRESULT d3d12_command_allocator_allocate_init_post_indirect_command_buffe
 
     begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     begin_info.pNext = NULL;
-    begin_info.flags = 0;
+    begin_info.flags = (vkd3d_config_flags & VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT) ?
+            VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT : 0;
     begin_info.pInheritanceInfo = NULL;
 
     if ((vr = VK_CALL(vkBeginCommandBuffer(iteration->vk_init_commands, &begin_info))) < 0)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -982,6 +982,7 @@ static const struct vkd3d_debug_option vkd3d_config_options[] =
     {"instruction_qa_checks", VKD3D_CONFIG_FLAG_INSTRUCTION_QA_CHECKS},
     {"transfer_queue", VKD3D_CONFIG_FLAG_TRANSFER_QUEUE},
     {"no_gpu_upload_heap", VKD3D_CONFIG_FLAG_NO_GPU_UPLOAD_HEAP},
+    {"one_time_submit", VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT},
 };
 
 static void vkd3d_config_flags_init_once(void)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -599,6 +599,9 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     { VKD3D_STRING_COMPARE_STARTS_WITH, "tlou-i", VKD3D_CONFIG_FLAG_NO_STAGGERED_SUBMIT, 0 },
     /* Skull and Bones (2853730). Seems to require unsupported dcomp when reflex is enabled for some reason *shrug */
     { VKD3D_STRING_COMPARE_EXACT, "skullandbones.exe", 0, 0, VKD3D_APPLICATION_FEATURE_DISABLE_NV_REFLEX },
+    /* Star Wars Outlaws (2842040). Attempt to workaround a possible NV driver bug. */
+    { VKD3D_STRING_COMPARE_EXACT, "Outlaws.exe", VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT, 0 },
+    { VKD3D_STRING_COMPARE_EXACT, "Outlaws_Plus.exe", VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT, 0 },
     /* Unreal Engine catch-all. ReBAR is a massive uplift on RX 7600 for example in Wukong.
      * AMD windows drivers also seem to have some kind of general app-opt for UE titles.
      * Use no-staggered-submit by default on UE. We've only observed issues in Wukong here, but


### PR DESCRIPTION
Fix #2092.

This doesn't make much sense, but it seems to fix the hang for me.
Breadcrumbs are pointing to "nothing", suggesting that the hang happens in internal driver code which does who knows what. Hopefully this is a viable workaround and we can report something actionable to NV.