### PR TITLE
Fix RGBA <-> BCn image copies

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5649,6 +5649,44 @@ static inline VkExtent3D d3d12_resource_desc_get_vk_subresource_extent(const D3D
     return extent;
 }
 
+static inline VkExtent3D vkd3d_compute_block_count(VkExtent3D extent, const struct vkd3d_format *format)
+{
+    if (max(format->block_width, format->block_height) == 1u)
+        return extent;
+
+    extent.width += format->block_width - 1u;
+    extent.width /= format->block_width;
+
+    extent.height += format->block_height - 1u;
+    extent.height /= format->block_height;
+
+    return extent;
+}
+
+static inline VkOffset3D vkd3d_compute_block_offset(VkOffset3D offset, const struct vkd3d_format *format)
+{
+    if (max(format->block_width, format->block_height) == 1u)
+        return offset;
+
+    offset.x /= format->block_width;
+    offset.y /= format->block_height;
+    return offset;
+}
+
+static inline VkExtent3D vkd3d_compute_texel_count_from_blocks(VkExtent3D extent, const struct vkd3d_format *format)
+{
+    extent.width *= format->block_width;
+    extent.height *= format->block_height;
+    return extent;
+}
+
+static inline VkOffset3D vkd3d_compute_texel_offset_from_blocks(VkOffset3D offset, const struct vkd3d_format *format)
+{
+    offset.x *= format->block_width;
+    offset.y *= format->block_height;
+    return offset;
+}
+
 static inline VkExtent3D d3d12_resource_desc_get_subresource_extent(const struct D3D12_RESOURCE_DESC1 *desc,
         const struct vkd3d_format *format, unsigned int subresource_idx)
 {

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -160,6 +160,7 @@ decl_test(test_vertex_id_dxil);
 decl_test(test_copy_texture);
 decl_test(test_copy_texture_ds_edge_cases);
 decl_test(test_copy_texture_buffer);
+decl_test(test_copy_texture_bc_rgba);
 decl_test(test_copy_buffer_texture);
 decl_test(test_copy_block_compressed_texture);
 decl_test(test_copy_buffer_overlap);


### PR DESCRIPTION
Basically changes `vk_image_copy_from_d3d12` to do all the relevant math on compressed blocks rather than texels in order to fix various issues with copies between different formats.