### PR TITLE
vkd3d: Fix crash on hardware that doesn't support sparse.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2808,7 +2808,10 @@ static HRESULT d3d12_device_create_vkd3d_queues(struct d3d12_device *device,
     device->unique_queue_mask = 0;
     device->queue_family_count = 0;
     memset(device->queue_families, 0, sizeof(device->queue_families));
-    memset(device->queue_family_indices, 0, sizeof(device->queue_family_indices));
+    for (i = 0; i < VKD3D_QUEUE_FAMILY_COUNT; i++)
+    {
+        device->queue_family_indices[i] = VK_QUEUE_FAMILY_IGNORED;
+    }
 
     for (i = 0, k = 0; i < VKD3D_QUEUE_FAMILY_COUNT; i++)
     {


### PR DESCRIPTION
Ever since commit 40e4b22fdc6d34a8b05334835c5d77c12c7feaf3, vkd3d would try and allocate a sparse queue unconditionally even if the hardware didn't support sparse. The cause of this comes from the logic inside of `d3d12_device_create_vkd3d_queues` which would skip any queues that were `VK_QUEUE_FAMILY_IGNORED` but was initializing `queue_family_indices` to zero. Zero is a valid queue index which would cause logic later to always try and allocate a queue unconditionally. The simple fix is to initialize these indices to be VK_QUEUE_FAMILY_IGNORED (which is ~0U) instead of zero.

Fixes a crash on Turnip (and any other driver that doesn't support sparse), when running any d3d12 game.