### PR TITLE
Only allocate device memory if explicitly requested

### DIFF
--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -998,7 +998,7 @@ HRESULT vkd3d_allocate_device_memory(struct d3d12_device *device,
              * E.g. there exists no memory type that is not DEVICE_LOCAL and covers both RT and DS.
              * For this case, we have no choice but to not allocate,
              * and defer actual memory allocation to CreatePlacedResource() time.
-			 * NVIDIA bug reference for fixing this case: 2175829. */
+             * NVIDIA bug reference for fixing this case: 2175829. */
             WARN("Memory allocation failed, but it is not possible to fallback to system memory here. Deferring allocation.\n");
             return hr;
         }


### PR DESCRIPTION
Matches DXVK behaviour and should fix #2258, but needs testing.

The idea here is that if we want to allocate system memory (as a fallback or otherwise, e.g. `UPLOAD` heaps in an app that also uses GPU upload heaps), we should never try to allocate from device-local memory unless all supported memory types for a given allocation are device-local.

Also fixes the possible case where a fallback allocation with no property flags would attempt to allocate from `DEVICE_LOCAL` again. This only hasn't been an issue so far because most drivers allow oversubscribing VRAM, but this is not guarateed.