### PR TITLE
Queue profile improvements rebase

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -589,14 +589,15 @@ static void *vkd3d_fence_worker_main(void *arg)
 
     snprintf(worker->timeline.tid, sizeof(worker->timeline.tid),
 #ifdef _WIN32
-            "family %u, %s, tid 0x%04x, prio %d",
+            "family %u, %s, tid 0x%04x, prio %d, %p",
 #else
-            "family %u, %s, tid %u, prio %d",
+            "family %u, %s, tid %u, prio %d, %p",
 #endif
             worker->queue->vkd3d_queue->vk_family_index,
             type_str,
             vkd3d_get_current_thread_id(),
-            worker->queue->desc.Priority);
+            worker->queue->desc.Priority,
+            (void *)worker->queue->vkd3d_queue->vk_queue);
 
     cur_fence_count = 0;
     cur_fences_size = 0;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -18936,6 +18936,7 @@ static void d3d12_command_queue_execute(struct d3d12_command_queue *command_queu
 
         if (is_first)
         {
+            vkd3d_queue_timeline_trace_begin_execute_overhead(&command_queue->device->queue_timeline_trace, timeline_cookie);
             d3d12_command_queue_gather_wait_semaphores_locked(command_queue, &submit_desc[0],
                   VKD3D_WAIT_SEMAPHORES_EXTERNAL | VKD3D_WAIT_SEMAPHORES_SERIALIZING);
         }
@@ -18988,6 +18989,8 @@ static void d3d12_command_queue_execute(struct d3d12_command_queue *command_queu
         /* Update timeline value *after* waiting for staggered submissions */
         command_queue->last_submission_timeline_value = signal_semaphore_infos[0].value;
     }
+
+    vkd3d_queue_timeline_trace_end_execute_overhead(&command_queue->device->queue_timeline_trace, timeline_cookie);
 
 #ifdef VKD3D_ENABLE_RENDERDOC
     if (debug_capture)

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -18230,6 +18230,7 @@ static void d3d12_command_queue_wait(struct d3d12_command_queue *command_queue,
         struct d3d12_fence *fence, UINT64 value)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &command_queue->device->vk_procs;
+    struct vkd3d_queue_timeline_trace_cookie cookie;
     struct d3d12_fence_value fence_value;
     VkSemaphoreWaitInfo wait_info;
     struct vkd3d_queue *queue;
@@ -18247,7 +18248,9 @@ static void d3d12_command_queue_wait(struct d3d12_command_queue *command_queue,
      * but we don't have virtualized queues in Vulkan, so we need to handle the case
      * where multiple queues alias over the same physical queue, so effectively, we need to manage out-of-order submits
      * ourselves. */
+    cookie = vkd3d_queue_timeline_trace_register_generic_region(&fence->device->queue_timeline_trace, "WAIT BEFORE SIGNAL");
     d3d12_fence_block_until_pending_value_reaches_locked(fence, value);
+    vkd3d_queue_timeline_trace_complete_execute(&fence->device->queue_timeline_trace, &command_queue->fence_worker, cookie);
 
     /* If a host signal unblocked us, or we know that the fence has reached a specific value, there is no need
      * to queue up a wait. */
@@ -18279,8 +18282,10 @@ static void d3d12_command_queue_wait(struct d3d12_command_queue *command_queue,
         wait_info.pSemaphores = &fence_value.vk_semaphore;
         wait_info.pValues = &fence_value.vk_semaphore_value;
 
+        cookie = vkd3d_queue_timeline_trace_register_generic_region(&fence->device->queue_timeline_trace, "CPU WAIT");
         if ((vr = VK_CALL(vkWaitSemaphores(command_queue->device->vk_device, &wait_info, UINT64_MAX))))
             ERR("Failed to wait for timeline semaphore, vr %d.\n", vr);
+        vkd3d_queue_timeline_trace_complete_execute(&fence->device->queue_timeline_trace, &command_queue->fence_worker, cookie);
     }
     else
     {
@@ -19404,6 +19409,7 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
 {
     struct d3d12_command_queue_submission submission;
     struct d3d12_command_queue_transition_pool pool;
+    struct vkd3d_queue_timeline_trace_cookie cookie;
     struct d3d12_command_queue *queue = userdata;
     VkSemaphoreSubmitInfo transition_semaphore;
     VkCommandBufferSubmitInfo transition_cmd;
@@ -19434,17 +19440,20 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
         switch (submission.type)
         {
         case VKD3D_SUBMISSION_STOP:
+            cookie = vkd3d_queue_timeline_trace_register_generic_region(&queue->device->queue_timeline_trace, "STOP");
             goto cleanup;
 
         case VKD3D_SUBMISSION_WAIT:
             VKD3D_REGION_BEGIN(queue_wait);
             if (is_shared_ID3D12Fence1(submission.wait.fence))
             {
+                cookie = vkd3d_queue_timeline_trace_register_generic_region(&queue->device->queue_timeline_trace, "WAIT (shared)");
                 d3d12_command_queue_flush_waiters(queue, 0u);
                 d3d12_command_queue_wait_shared(queue, shared_impl_from_ID3D12Fence1(submission.wait.fence), submission.wait.value);
             }
             else
             {
+                cookie = vkd3d_queue_timeline_trace_register_generic_region(&queue->device->queue_timeline_trace, "WAIT (normal)");
                 d3d12_command_queue_wait(queue, impl_from_ID3D12Fence1(submission.wait.fence), submission.wait.value);
             }
 
@@ -19453,6 +19462,7 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
             break;
 
         case VKD3D_SUBMISSION_SIGNAL:
+            cookie = vkd3d_queue_timeline_trace_register_generic_region(&queue->device->queue_timeline_trace, "SIGNAL");
             d3d12_command_queue_flush_waiters(queue, 0u);
 
             VKD3D_REGION_BEGIN(queue_signal);
@@ -19463,6 +19473,7 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
 
         case VKD3D_SUBMISSION_EXECUTE:
             VKD3D_REGION_BEGIN(queue_execute);
+            cookie = vkd3d_queue_timeline_trace_register_generic_region(&queue->device->queue_timeline_trace, "EXECUTE");
 
             memset(&transition_cmd, 0, sizeof(transition_cmd));
             transition_cmd.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO;
@@ -19512,6 +19523,7 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
             break;
 
         case VKD3D_SUBMISSION_BIND_SPARSE:
+            cookie = vkd3d_queue_timeline_trace_register_generic_region(&queue->device->queue_timeline_trace, "SPARSE");
             d3d12_command_queue_flush_waiters(queue, VKD3D_WAIT_SEMAPHORES_EXTERNAL);
 
             d3d12_command_queue_bind_sparse(queue, submission.bind_sparse.mode,
@@ -19521,6 +19533,7 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
             break;
 
         case VKD3D_SUBMISSION_DRAIN:
+            cookie = vkd3d_queue_timeline_trace_register_generic_region(&queue->device->queue_timeline_trace, "DRAIN");
             /* Full flush needed to synchronize interop */
             d3d12_command_queue_flush_waiters(queue, VKD3D_WAIT_SEMAPHORES_EXTERNAL | VKD3D_WAIT_SEMAPHORES_SERIALIZING);
 
@@ -19531,6 +19544,7 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
             break;
 
         case VKD3D_SUBMISSION_CALLBACK:
+            cookie = vkd3d_queue_timeline_trace_register_generic_region(&queue->device->queue_timeline_trace, "CALLBACK");
             d3d12_command_queue_flush_waiters(queue, VKD3D_WAIT_SEMAPHORES_EXTERNAL | VKD3D_WAIT_SEMAPHORES_SERIALIZING);
 
             submission.callback.callback(submission.callback.userdata);
@@ -19540,6 +19554,8 @@ static void *d3d12_command_queue_submission_worker_main(void *userdata)
             ERR("Unrecognized submission type %u.\n", submission.type);
             break;
         }
+
+        vkd3d_queue_timeline_trace_complete_execute(&queue->device->queue_timeline_trace, &queue->fence_worker, cookie);
     }
 
 cleanup:

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4732,7 +4732,9 @@ struct vkd3d_queue_timeline_trace_state
     uint64_t start_submit_ts;
     uint64_t record_end_ts;
     uint64_t record_cookie;
-    char desc[128 - 5 * sizeof(uint64_t)];
+    uint32_t overhead_start_offset;
+    uint32_t overhead_end_offset;
+    char desc[128 - 6 * sizeof(uint64_t)];
 };
 
 struct vkd3d_queue_timeline_trace
@@ -4810,6 +4812,10 @@ void vkd3d_queue_timeline_trace_complete_low_latency_sleep(struct vkd3d_queue_ti
 void vkd3d_queue_timeline_trace_close_command_list(struct vkd3d_queue_timeline_trace *trace,
         struct vkd3d_queue_timeline_trace_cookie cookie);
 void vkd3d_queue_timeline_trace_begin_execute(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_queue_timeline_trace_cookie cookie);
+void vkd3d_queue_timeline_trace_begin_execute_overhead(struct vkd3d_queue_timeline_trace *trace,
+        struct vkd3d_queue_timeline_trace_cookie cookie);
+void vkd3d_queue_timeline_trace_end_execute_overhead(struct vkd3d_queue_timeline_trace *trace,
         struct vkd3d_queue_timeline_trace_cookie cookie);
 
 struct vkd3d_address_binding_report_buffer_info

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4705,6 +4705,9 @@ enum vkd3d_queue_timeline_trace_state_type
     /* Waiting for present wait to complete. */
     VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_PRESENT_WAIT,
 
+    /* Generic region markers. */
+    VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_GENERIC_REGION,
+
     /* Time spent blocking in ::Present() in user thread. */
     VKD3D_QUEUE_TIMELINE_TRACE_STATE_TYPE_PRESENT_BLOCK,
 
@@ -4796,6 +4799,9 @@ vkd3d_queue_timeline_trace_register_command_list(struct vkd3d_queue_timeline_tra
 
 void vkd3d_queue_timeline_trace_register_instantaneous(struct vkd3d_queue_timeline_trace *trace,
         enum vkd3d_queue_timeline_trace_state_type type, uint64_t value);
+
+struct vkd3d_queue_timeline_trace_cookie
+vkd3d_queue_timeline_trace_register_generic_region(struct vkd3d_queue_timeline_trace *trace, const char *tag);
 
 void vkd3d_queue_timeline_trace_complete_event_signal(struct vkd3d_queue_timeline_trace *trace,
         struct vkd3d_fence_worker *worker,


### PR DESCRIPTION
Adds more actionable information to queue profiles.

- Shows overhead done in the submission threads for QueueSubmit
- Marks regions for all submission thread operations such as waiting, signalling, etc.
- Adds the VkQueue pointer to the capture, making it easier to figure out which queues alias.