### PR TITLE
vkd3d: Enable no_upload_hvv for ArmA Reforger.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -602,6 +602,8 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     /* Star Wars Outlaws (2842040). Attempt to workaround a possible NV driver bug. */
     { VKD3D_STRING_COMPARE_EXACT, "Outlaws.exe", VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT, 0 },
     { VKD3D_STRING_COMPARE_EXACT, "Outlaws_Plus.exe", VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT, 0 },
+    /* ArmA Reforger suffers from slow asset loading with HVV enabled */
+    { VKD3D_STRING_COMPARE_STARTS_WITH, "ArmaReforger", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV },
     /* Unreal Engine catch-all. ReBAR is a massive uplift on RX 7600 for example in Wukong.
      * AMD windows drivers also seem to have some kind of general app-opt for UE titles.
      * Use no-staggered-submit by default on UE. We've only observed issues in Wukong here, but


### PR DESCRIPTION
Fixes #2270 at the cost of some runtime performance.

Game seems to have a bunch of different executables, so let's be conservative here.