### PR TITLE
Fence worker callback + work around MHW sparse bug

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -586,7 +586,7 @@ static void vkd3d_wait_for_gpu_timeline_semaphore(struct vkd3d_fence_worker *wor
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkSemaphoreWaitInfo wait_info;
     uint64_t timeout = UINT64_MAX;
-    int vr;
+    VkResult vr;
 
     TRACE("worker %p, vk_semaphore %p, vk_semaphore_value %#"PRIx64".\n", worker,
             fence->fence_info.vk_semaphore, fence->fence_info.vk_semaphore_value);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -238,12 +238,8 @@ typedef void (*vkd3d_waiting_fence_callback)(struct vkd3d_fence_worker *, void *
 
 struct vkd3d_fence_wait_info
 {
-    d3d12_fence_iface *fence;
     VkSemaphore vk_semaphore;
     uint64_t vk_semaphore_value;
-    uint64_t virtual_value;
-    uint64_t update_count;
-    bool signal;
     vkd3d_waiting_fence_callback release_callback;
     unsigned char userdata[32];
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3379,7 +3379,7 @@ struct d3d12_command_queue
 
         struct
         {
-            const struct d3d12_resource *resource;
+            struct d3d12_resource *resource;
             uint32_t *tile_mask;
         } *tracked;
         size_t tracked_size;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -243,8 +243,6 @@ struct vkd3d_fence_wait_info
     uint64_t vk_semaphore_value;
     uint64_t virtual_value;
     uint64_t update_count;
-    struct d3d12_command_allocator **command_allocators;
-    size_t num_command_allocators;
     bool signal;
     vkd3d_waiting_fence_callback release_callback;
     unsigned char userdata[32];

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -232,6 +232,10 @@ struct vkd3d_queue_timeline_trace_cookie
     unsigned int index;
 };
 
+struct vkd3d_fence_worker;
+
+typedef void (*vkd3d_waiting_fence_callback)(struct vkd3d_fence_worker *, void *, bool);
+
 struct vkd3d_fence_wait_info
 {
     d3d12_fence_iface *fence;
@@ -242,6 +246,8 @@ struct vkd3d_fence_wait_info
     struct d3d12_command_allocator **command_allocators;
     size_t num_command_allocators;
     bool signal;
+    vkd3d_waiting_fence_callback release_callback;
+    unsigned char userdata[32];
 };
 
 struct vkd3d_waiting_fence


### PR DESCRIPTION
The callback refactor moves all the hardcoded stuff that we do in the fence worker to callbacks, and stores callback data within the `vkd3d_fence_wait_info` structure. 

For fence waits it doesn't look like there was any reason at all to keep the fence objects alive, so I removed that part.

Lastly, this adds some tracking to keep sparse resources alive through page table updates; otherwise, Monster Hunter Wilds screws up synchronization somewhere and will either crash or hang on Nvidia when starting the benchmark with DLSS FG enabled.