### PR TITLE
vkd3d: Remove shader quirk for Rebirth.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -767,15 +767,6 @@ static const struct vkd3d_shader_quirk_info gzw_quirks = {
     NULL, 0, VKD3D_SHADER_QUIRK_FORCE_ROBUST_PHYSICAL_CBV_LOAD_FORWARDING,
 };
 
-static const struct vkd3d_shader_quirk_hash rebirth_hashes[] = {
-    /* ComputeBatchedMeshletOffsetsCS(). Missing barrier after a CS based clear. */
-    { 0xe96ea58529226db2, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
-};
-
-static const struct vkd3d_shader_quirk_info rebirth_quirks = {
-    rebirth_hashes, ARRAY_SIZE(rebirth_hashes), 0,
-};
-
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
@@ -810,8 +801,6 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "M1-Win64-Shipping.exe", &tfd_quirks },
     /* Gray Zone Warfare (2479810) */
     { VKD3D_STRING_COMPARE_EXACT, "GZWClientSteam-Win64-Shipping.exe", &gzw_quirks },
-    /* FFVII Rebirth (2909400). */
-    { VKD3D_STRING_COMPARE_EXACT, "ff7rebirth_.exe", &rebirth_quirks },
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* MSVC fails to compile empty array. */


### PR DESCRIPTION
The game updated today.

The shader hash in question changed to f6ce99fa20cc4da2 for reference, and it seems like the game now adds a proper UAV barrier.