### PR TITLE
script: Update installscript

### DIFF
--- a/setup_vkd3d_proton.sh
+++ b/setup_vkd3d_proton.sh
@@ -43,42 +43,65 @@ if [ -n "$WINEPREFIX" ] && ! [ -f "$WINEPREFIX/system.reg" ]; then
 fi
 
 # find wine executable
-export WINEDEBUG=-all
+export WINEDEBUG="${WINEDEBUG:--all}"
 # disable mscoree and mshtml to avoid downloading
 # wine gecko and mono
-export WINEDLLOVERRIDES="mscoree,mshtml="
+export WINEDLLOVERRIDES="${WINEDLLOVERRIDES:-}${WINEDLLOVERRIDES:+,}mscoree,mshtml="
 
-wine="wine"
-wine64="wine64"
-wineboot="wineboot"
+wine_path="$(which wine 2>/dev/null)"
+wine64_path="$(which wine64 2>/dev/null)"
 
-# $PATH is the way for user to control where wine is located (including custom Wine versions).
-# Pure 64-bit Wine (non Wow64) requries skipping 32-bit steps.
-# In such case, wine64 and winebooot will be present, but wine binary will be missing,
-# however it can be present in other PATHs, so it shouldn't be used, to avoid versions mixing.
-wine_path=$(dirname "$(which $wineboot)")
-wow64=true
-if ! [ -f "$wine_path/$wine" ]; then
-   wine=$wine64
-   wow64=false
+if [ -n "$wine_path" ] && [ -n "$wine64_path" ] && [ "$(dirname "$wine_path")" != "$(dirname "$wine64_path")" ]; then
+    echo "Multiple Wine installations detected:"
+    echo "1) $wine_path"
+    echo "2) $wine64_path"
+
+    while true; do
+        read -p "Select the Wine binary to use (1 or 2): " choice
+        case "$choice" in
+          1) wine="wine"; break ;;
+          2) wine="wine64"; break ;;
+          *) echo "Invalid choice. Please enter 1 or 2." ;;
+        esac
+    done
+else
+    if [ -n "$wine_path" ]; then
+      wine="wine"
+    fi
+    if [ -n "$wine64_path" ]; then
+      wine="wine64"
+    fi
 fi
 
-# resolve 32-bit and 64-bit system32 path
 winever=$($wine --version | grep wine)
 if [ -z "$winever" ]; then
-    echo "$wine: Not a wine executable. Check your $wine." >&2
+    echo "$wine:"' Not a wine executable. Check your $wine.' >&2
     exit 1
 fi
+echo "Using: $winever"
+
+wineboot="$wine wineboot"
+win64=true
+win32=true
 
 # ensure wine placeholder dlls are recreated
 # if they are missing
 $wineboot -u
 
-win64_sys_path=$($wine64 winepath -u 'C:\windows\system32' 2> /dev/null)
+win64_sys_path="$($wine cmd /c '%SystemRoot%\system32\winepath.exe -u C:\windows\system32' 2>/dev/null)"
 win64_sys_path="${win64_sys_path/$'\r'/}"
-if $wow64; then
-  win32_sys_path=$($wine winepath -u 'C:\windows\system32' 2> /dev/null)
+
+[ -z "$win64_sys_path" ] && win64=false
+
+if grep --quiet -e '#arch=win32' "${WINEPREFIX:-$HOME/.wine}/system.reg"; then
+  win32_sys_path=$win64_sys_path
+  win64=false
+  win32=true
+else
+  win32_sys_path="$($wine cmd /c '%SystemRoot%\syswow64\winepath.exe -u C:\windows\system32' 2>/dev/null)"
   win32_sys_path="${win32_sys_path/$'\r'/}"
+
+  [ -z "$win32_sys_path" ] && win32=false
 fi
 
 if [ -z "$win32_sys_path" ] && [ -z "$win64_sys_path" ]; then
@@ -157,31 +180,37 @@ uninstallFile() {
 }
 
 install() {
-  installFile "$win64_sys_path" "$vkd3d_lib64" "$1"
-  inst64_ret="$?"
+  inst64_ret=-1
+  if [ $win64 = "true" ]; then
+    installFile "$win64_sys_path" "$vkd3d_lib64" "$1"
+    inst64_ret="$?"
+  fi
 
   inst32_ret=-1
-  if $wow64; then
+  if [ $win32 = "true" ]; then
     installFile "$win32_sys_path" "$vkd3d_lib32" "$1"
     inst32_ret="$?"
   fi
 
-  if (( (inst32_ret == 0) || (inst64_ret == 0) )); then
+  if (( ($inst32_ret == 0) || ($inst64_ret == 0) )); then
     overrideDll "$1"
   fi
 }
 
 uninstall() {
-  uninstallFile "$win64_sys_path" "$vkd3d_lib64" "$1"
-  uninst64_ret="$?"
+  uninst64_ret=-1
+  if [ $win64 = "true" ]; then
+    uninstallFile "$win64_sys_path" "$vkd3d_lib64" "$1"
+    uninst64_ret="$?"
+  fi
 
   uninst32_ret=-1
-  if $wow64; then
+  if [ $win32 = "true" ]; then
     uninstallFile "$win32_sys_path" "$vkd3d_lib32" "$1"
     uninst32_ret="$?"
   fi
 
-  if (( (uninst32_ret == 0) || (uninst64_ret == 0) )); then
+  if (( ($uninst32_ret == 0) || ($uninst64_ret == 0) )); then
     restoreDll "$1"
   fi
 }


### PR DESCRIPTION
This will make it work with wine >=10.2 and older

Some "major" changes to wine-10.2 dropped the usage of `wine64` binary, so a lot of scripts broke as they depended on checking system32/syswow64 usage when using wine64/wine respectively.
This should do some checks to verify folder structures so it is useful again.