### PR TITLE
vkd3d: Reintroduce shader quirk barrier for Rebirth.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -7420,6 +7420,7 @@ static void d3d12_command_list_check_pre_compute_barrier(struct d3d12_command_li
         VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
         VKD3D_BREADCRUMB_TAG("ForcePreBarrier");
         VKD3D_BREADCRUMB_COMMAND(BARRIER);
+        d3d12_command_list_debug_mark_label(list, "ForcePreBarrier", 1.0f, 1.0f, 0.0f, 1.0f);
 
         list->current_compute_meta_flags &= ~(VKD3D_SHADER_META_FLAG_FORCE_GRAPHICS_BEFORE_DISPATCH |
                 VKD3D_SHADER_META_FLAG_FORCE_PRE_RASTERIZATION_BEFORE_DISPATCH |
@@ -7461,6 +7462,7 @@ static void d3d12_command_list_check_compute_barrier(struct d3d12_command_list *
         VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
         VKD3D_BREADCRUMB_TAG("ForceBarrier");
         VKD3D_BREADCRUMB_COMMAND(BARRIER);
+        d3d12_command_list_debug_mark_label(list, "ForcePostBarrier", 1.0f, 1.0f, 0.0f, 1.0f);
     }
 }
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -776,6 +776,16 @@ static const struct vkd3d_shader_quirk_info starfield_quirks = {
     NULL, 0, VKD3D_SHADER_QUIRK_AGGRESSIVE_NONUNIFORM,
 };
 
+static const struct vkd3d_shader_quirk_hash rebirth_hashes[] = {
+    /* GenerateMassiveEnvironmentBatchedNodesCS(). Missing barrier after a CS based clear.
+     * Exactly same bug as before, but then it was ComputeBatchedMeshletOffsetsCS(). */
+    { 0xe6cb9c843fa1bd18, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
+};
+
+static const struct vkd3d_shader_quirk_info rebirth_quirks = {
+    rebirth_hashes, ARRAY_SIZE(rebirth_hashes), 0,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
@@ -812,6 +822,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "GZWClientSteam-Win64-Shipping.exe", &gzw_quirks },
     /* Starfield (1716740) */
     { VKD3D_STRING_COMPARE_EXACT, "Starfield.exe", &starfield_quirks },
+    /* FFVII Rebirth (2909400). */
+    { VKD3D_STRING_COMPARE_EXACT, "ff7rebirth_.exe", &rebirth_quirks },
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* MSVC fails to compile empty array. */


### PR DESCRIPTION
Exactly same bug, but now it's in a different shader. Triggers on the central ocean in chapter 12. Likely caused by only terrain being present, so it doesn't have a chance to barrier on normal meshlets.