### PR TITLE
vkd3d: Add heap robustness workaround to MHW.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-set-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Until we understand what is going on, this seems to be needed.