### PR TITLE
vkd3d-shader: Fix cull/clip distance used as shader input.

### DIFF
--- a/tests/d3d12_clip_cull_distance.c
+++ b/tests/d3d12_clip_cull_distance.c
@@ -742,12 +742,8 @@ static void test_clip_distance(bool use_dxil)
 
     /* geometry shader */
     pso_desc.GS = gs;
-    if (!use_dxil)
-        vkd3d_mute_validation_message("08743", "See vkd3d-proton issue 2379");
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso);
-    if (!use_dxil)
-        vkd3d_unmute_validation_message("08743");
     ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
 
     check_clip_distance(&context, pso, vbv, vb[1], vs_cb, gs_cb);


### PR DESCRIPTION
Fixes #2379.

Highly cursed in that we simply didn't support clip/cull as shader input at all, and multi-dimensional arrays were also not really supported - except in PS because PS inputs use different instructions compared to everything else, but we weren't declaring it correctly there either.

Can't really reuse any of the existing code for clip/cull either because outputs are handled very differently from inputs.

Domain shaders are entirely excluded here because we simply pass vec4 arrays around without checking for semantics. The only thing that's semi-interesting there is tess factors.

Should probably be tested with real games as well; test suite passes though and I'm not seeing any spirv-val errors.