### PR TITLE
Limit tessellation factors for Rise of the Ronin

### DIFF
--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -651,7 +651,7 @@ static int vkd3d_dxil_converter_set_options(dxil_spv_converter converter,
 {
     dxil_spv_option_compute_shader_derivatives compute_shader_derivatives = {{ DXIL_SPV_OPTION_COMPUTE_SHADER_DERIVATIVES }};
     dxil_spv_option_denorm_preserve_support denorm_preserve = {{ DXIL_SPV_OPTION_DENORM_PRESERVE_SUPPORT }};
-    unsigned int i, j;
+    unsigned int i, j, max_tess_factor;
 
     if (!vkd3d_dxil_converter_set_quirks(converter, shader_interface_info, quirks))
     {
@@ -1060,6 +1060,17 @@ static int vkd3d_dxil_converter_set_options(dxil_spv_converter converter,
     {
         ERR("dxil-spirv does not support DENORM_PRESERVE_SUPPORT.\n");
         return VKD3D_ERROR_NOT_IMPLEMENTED;
+    }
+
+    if ((max_tess_factor = vkd3d_shader_quirk_to_tess_factor_limit(quirks)))
+    {
+        const dxil_spv_option_max_tess_factor helper =
+                { { DXIL_SPV_OPTION_MAX_TESS_FACTOR }, max_tess_factor };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+        {
+            ERR("dxil-spirv does not support MAX_TESS_FACTOR.\n");
+            return VKD3D_ERROR_NOT_IMPLEMENTED;
+        }
     }
 
     return VKD3D_OK;

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -32,22 +32,6 @@
 #include "vkd3d_descriptor_qa_data.h"
 #endif
 
-static unsigned int vkd3d_shader_quirk_to_tess_factor_limit(uint32_t quirks)
-{
-    if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_4)
-        return 4;
-    else if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_8)
-        return 8;
-    else if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_12)
-        return 12;
-    else if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_16)
-        return 16;
-    else if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_32)
-        return 32;
-
-    return 0;
-}
-
 static bool vkd3d_sysval_semantic_is_tessellation_factor(enum vkd3d_sysval_semantic sysval)
 {
     switch (sysval)

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -912,6 +912,22 @@ static inline unsigned int vkd3d_compact_swizzle(unsigned int swizzle, unsigned 
     return compacted_swizzle;
 }
 
+static inline unsigned int vkd3d_shader_quirk_to_tess_factor_limit(uint32_t quirks)
+{
+    if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_4)
+        return 4;
+    else if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_8)
+        return 8;
+    else if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_12)
+        return 12;
+    else if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_16)
+        return 16;
+    else if (quirks & VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_32)
+        return 32;
+
+    return 0;
+}
+
 #define VKD3D_DXBC_MAX_SOURCE_COUNT 6
 #define VKD3D_DXBC_HEADER_SIZE (8 * sizeof(uint32_t))
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -671,7 +671,7 @@ static const struct vkd3d_shader_quirk_info borderlands3_quirks = {
 };
 
 /* Terrain is rendered with extreme tessellation factors. Limit it to something more reasonable. */
-static const struct vkd3d_shader_quirk_info wolong_quirks = {
+static const struct vkd3d_shader_quirk_info team_ninja_quirks = {
     NULL, 0, VKD3D_SHADER_QUIRK_LIMIT_TESS_FACTORS_8,
 };
 
@@ -801,7 +801,9 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* Borderlands 3 (397540) */
     { VKD3D_STRING_COMPARE_EXACT, "Borderlands3.exe", &borderlands3_quirks },
     /* Wo Long: Fallen Dynasty (2285240) */
-    { VKD3D_STRING_COMPARE_EXACT, "WoLong.exe", &wolong_quirks },
+    { VKD3D_STRING_COMPARE_EXACT, "WoLong.exe", &team_ninja_quirks },
+    /* Rise of the Ronin (1340990) */
+    { VKD3D_STRING_COMPARE_EXACT, "Ronin.exe", &team_ninja_quirks },
     /* Resident Evil 2 (883710) */
     { VKD3D_STRING_COMPARE_EXACT, "re2.exe", &re_quirks },
     /* Resident Evil 7 (418370) */


### PR DESCRIPTION
Same story as with Wu Long, the game renders extremely over-tessellated terrain for no reason at all.

In the main menu, the singular draw that renders terrain goes from ~3ms to ~0.6ms on my 6900XT.