### PR TITLE
vkd3d: Expose 16-bit min precision support.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -8139,8 +8139,8 @@ static void d3d12_device_caps_init_feature_options(struct d3d12_device *device)
             device->device_info.vulkan_1_2_properties.denormBehaviorIndependence != VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE;
 
     options->OutputMergerLogicOp = features->logicOp;
-    /* Currently not supported */
-    options->MinPrecisionSupport = D3D12_SHADER_MIN_PRECISION_SUPPORT_NONE;
+    /* Ignored in DXBC, but properly supported in DXIL if device supports 16-bit ops */
+    options->MinPrecisionSupport = D3D12_SHADER_MIN_PRECISION_SUPPORT_16_BIT;
     options->TiledResourcesTier = d3d12_device_determine_tiled_resources_tier(device);
     options->ResourceBindingTier = D3D12_RESOURCE_BINDING_TIER_3;
     options->PSSpecifiedStencilRefSupported = vk_info->EXT_shader_stencil_export;


### PR DESCRIPTION
War Thunder doesn't render anything otherwise.

Should be safe to do this since min16 stuff doesn't *really* have any guarantees, and we implement this properly in DXIL if the device supports 16-bit things anyway.