### PR TITLE
vkd3d: Add raw CBV VA for Eve Online.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -627,6 +627,8 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     /* Wreckfest 2 (1203190). Aliases block-compressed textures with color images on the
      * same heap and expects image data to be interpreted consistently. */
     { VKD3D_STRING_COMPARE_EXACT, "Wreckfest2.exe", VKD3D_CONFIG_FLAG_PLACED_TEXTURE_ALIASING, 0 },
+    /* Eve online. Uses DGC with CBV updates. Kinda questionable exename ... */
+    { VKD3D_STRING_COMPARE_EXACT, "exefile.exe", VKD3D_CONFIG_FLAG_FORCE_RAW_VA_CBV, 0 },
     /* Unreal Engine catch-all. ReBAR is a massive uplift on RX 7600 for example in Wukong.
      * AMD windows drivers also seem to have some kind of general app-opt for UE titles.
      * Use no-staggered-submit by default on UE. We've only observed issues in Wukong here, but


### PR DESCRIPTION
It uses DGC now for ... some reason.