### PR TITLE
tests: fix small-texture allocation size tests for Adreno

### DIFF
--- a/tests/d3d12_test_utils.h
+++ b/tests/d3d12_test_utils.h
@@ -395,11 +395,13 @@ static inline unsigned int format_size(DXGI_FORMAT format)
 {
     switch (format)
     {
+        case DXGI_FORMAT_R32G32B32A32_TYPELESS:
         case DXGI_FORMAT_R32G32B32A32_FLOAT:
         case DXGI_FORMAT_R32G32B32A32_UINT:
         case DXGI_FORMAT_R32G32B32A32_SINT:
             return 16;
         case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+        case DXGI_FORMAT_R16G16B16A16_FLOAT:
         case DXGI_FORMAT_R32G32_UINT:
         case DXGI_FORMAT_R32G32_SINT:
         case DXGI_FORMAT_R32G32_FLOAT:
@@ -410,6 +412,7 @@ static inline unsigned int format_size(DXGI_FORMAT format)
         case DXGI_FORMAT_R32_FLOAT:
         case DXGI_FORMAT_R32_UINT:
         case DXGI_FORMAT_R32_SINT:
+        case DXGI_FORMAT_R16G16_TYPELESS:
         case DXGI_FORMAT_R16G16_FLOAT:
         case DXGI_FORMAT_R16G16_UNORM:
         case DXGI_FORMAT_R16G16_UINT:


### PR DESCRIPTION
This fix tries to address failures on Adreno (via Turnip) in the `test_suballocate_small_textures_size` test case. Failures were initially observed on very narrow textures, but there's enough other conditions at play (15% of tests were failing) that it might not make sense to provide specific exceptions for expected failures.

Adreno-specific computation of the expected size is provided. It follows Freedreno's layout computation, but doesn't necessarily address different cases we don't hit in this test. The computation is used for both Adreno blob and Turnip, though it was only tested on the latter (vkd3d doesn't run cleanly on blob last I heard).