### PR TITLE
vkd3d: Don't expose PointSamplingAddressesNeverRoundUp on Turnip

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -8416,9 +8416,11 @@ static void d3d12_device_caps_init_feature_options19(struct d3d12_device *device
     /* Requires SampleCount > 1 for pipelinesm, not just ForcedSamplecount */
     options19->SupportedSampleCountsWithNoOutputs = 0x1;
     /* D3D12 expectations w.r.t. rounding match Vulkan spec.
-     * However, both AMD and Intel native drivers round to even. RADV has no-trunc-coord workarounds. */
+     * However, both AMD and Intel native drivers round to even. RADV has no-trunc-coord workarounds.
+     * Turnip enables round-to-even behavior for vkd3d. */
     options19->PointSamplingAddressesNeverRoundUp =
-            device->device_info.vulkan_1_2_properties.driverID != VK_DRIVER_ID_MESA_RADV;
+            device->device_info.vulkan_1_2_properties.driverID != VK_DRIVER_ID_MESA_RADV &&
+            device->device_info.vulkan_1_2_properties.driverID != VK_DRIVER_ID_MESA_TURNIP;
     options19->RasterizerDesc2Supported = TRUE;
     /* We default to a line width of 1.0 anyway */
     options19->NarrowQuadrilateralLinesSupported = TRUE;


### PR DESCRIPTION
For vkd3d, Turnip enables D3D round-to-even behavior for texcoords, making exposing PointSamplingAddressesNeverRoundUp incorrect.