### PR TITLE
tests: Update VVL mutes to reflect recent VVL update.

### DIFF
--- a/tests/d3d12_mesh_shader.c
+++ b/tests/d3d12_mesh_shader.c
@@ -479,9 +479,9 @@ void test_mesh_shader_rendering(void)
     /* Test SV_CullPrimitive */
     pipeline_desc.ms = ms_cull_primitive_subobject;
     pipeline_desc.ps = ps_culling_subobject;
-    vkd3d_mute_validation_message("08737", "See VVL issue 9615, waiting for VVL to pull in latest spirv-val");
+    vkd3d_mute_validation_message("07036", "See VVL issue 9615, blocked on bugged spirv-tools");
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    vkd3d_unmute_validation_message("08737");
+    vkd3d_unmute_validation_message("07036");
     ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
 
     reset_command_list(context.list, context.allocator);

--- a/tests/d3d12_tessellation.c
+++ b/tests/d3d12_tessellation.c
@@ -2711,10 +2711,10 @@ void test_tessellation_read_tesslevel(void)
     pso_desc.StreamOutput.pBufferStrides = &stride;
     pso_desc.StreamOutput.NumStrides = 1;
     pso_desc.StreamOutput.RasterizedStream = D3D12_SO_NO_RASTERIZED_STREAM;
-    vkd3d_mute_validation_message("08737", "See vkd3d-proton issue 2378");
+    vkd3d_mute_validation_message("09658", "See vkd3d-proton issue 2378");
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    vkd3d_unmute_validation_message("08737");
+    vkd3d_unmute_validation_message("09658");
     ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
 
     so_buffer = create_default_buffer(context.device, 4096,


### PR DESCRIPTION
VVL tries to report the spirv-val VUID now instead of generic SPIR-V vuid.