### PR TITLE
vkd3d: Use push descriptors for root CBV on Qualcomm

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -6962,12 +6962,13 @@ static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *dev
     /* We must use root SRV and UAV due to alignment requirements for 16-bit storage,
      * but root CBV is more lax. */
     flags |= VKD3D_RAW_VA_ROOT_DESCRIPTOR_SRV_UAV;
-    /* CBV's really require push descriptors on NVIDIA to get maximum performance.
+    /* CBV's really require push descriptors on NVIDIA and Qualcomm to get maximum performance.
      * The difference in performance is profound (~15% in some cases).
      * On ACO, BDA with NonWritable can be promoted directly to scalar loads,
      * which is great. */
     if ((vkd3d_config_flags & VKD3D_CONFIG_FLAG_FORCE_RAW_VA_CBV) ||
-            device_info->properties2.properties.vendorID != VKD3D_VENDOR_ID_NVIDIA)
+            (device_info->properties2.properties.vendorID != VKD3D_VENDOR_ID_NVIDIA &&
+	     device_info->properties2.properties.vendorID != VKD3D_VENDOR_ID_QUALCOMM))
         flags |= VKD3D_RAW_VA_ROOT_DESCRIPTOR_CBV;
 
     if (device_info->properties2.properties.vendorID == VKD3D_VENDOR_ID_NVIDIA &&

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -6208,6 +6208,7 @@ HANDLE vkd3d_open_kmt_handle(HANDLE kmt_handle);
 #define VKD3D_VENDOR_ID_NVIDIA 0x10DE
 #define VKD3D_VENDOR_ID_AMD 0x1002
 #define VKD3D_VENDOR_ID_INTEL 0x8086
+#define VKD3D_VENDOR_ID_QUALCOMM 0x5143
 
 #define VKD3D_DRIVER_VERSION_MAJOR_NV(v) ((v) >> 22)
 #define VKD3D_DRIVER_VERSION_MINOR_NV(v) (((v) >> 14) & 0xff)


### PR DESCRIPTION
Raw BDA access, even with NonWriteable, is terrible. This can sometimes be mitigated if the CBV offset is uniform over the whole draw via prefetching, but when that isn't the case then performance really suffers.