### PR TITLE
Test and fix some large heap behaviour

### DIFF
--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -343,10 +343,13 @@ static HRESULT vkd3d_memory_transfer_queue_flush_locked(struct vkd3d_memory_tran
         switch (transfer->op)
         {
             case VKD3D_MEMORY_TRANSFER_OP_CLEAR_ALLOCATION:
-                VK_CALL(vkCmdFillBuffer(vk_cmd_buffer,
-                        transfer->allocation->resource.vk_buffer,
-                        transfer->allocation->offset,
-                        transfer->allocation->resource.size, 0));
+                for (buffer_offset = 0u; buffer_offset < transfer->allocation->resource.size; buffer_offset += VKD3D_MAX_FILL_BUFFER_SIZE)
+                {
+                    VK_CALL(vkCmdFillBuffer(vk_cmd_buffer,
+                            transfer->allocation->resource.vk_buffer,
+                            transfer->allocation->offset + buffer_offset,
+                            min(transfer->allocation->resource.size - buffer_offset, VKD3D_MAX_FILL_BUFFER_SIZE), 0));
+                }
                 break;
 
             case VKD3D_MEMORY_TRANSFER_OP_WRITE_SUBRESOURCE:

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4689,7 +4689,7 @@ bool vkd3d_create_acceleration_structure_view(struct d3d12_device *device, const
 
 static void vkd3d_get_metadata_buffer_view_for_resource(struct d3d12_device *device,
         struct d3d12_resource *resource, DXGI_FORMAT view_format,
-        unsigned int offset, unsigned int size, unsigned int structure_stride,
+        VkDeviceSize offset, VkDeviceSize size, VkDeviceSize structure_stride,
         struct vkd3d_descriptor_metadata_buffer_view *view)
 {
     VkDeviceSize element_size;
@@ -4710,7 +4710,7 @@ static void vkd3d_get_metadata_buffer_view_for_resource(struct d3d12_device *dev
 
 static bool vkd3d_create_buffer_view_for_resource(struct d3d12_device *device,
         struct d3d12_resource *resource, DXGI_FORMAT view_format,
-        unsigned int offset, unsigned int size, unsigned int structure_stride,
+        VkDeviceSize offset, VkDeviceSize size, VkDeviceSize structure_stride,
         unsigned int flags, struct vkd3d_view **view)
 {
     const struct vkd3d_format *format;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -263,6 +263,12 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
     if (desc->Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL))
         FIXME("Unsupported resource flags %#x.\n", desc->Flags);
 
+    if (desc->Width > device->device_info.vulkan_1_3_properties.maxBufferSize)
+    {
+        FIXME("Buffer size %"PRIu64" exceeds maxBufferSize of %"PRIu64".\n",
+                desc->Width, device->device_info.vulkan_1_3_properties.maxBufferSize);
+    }
+
     /* In case we get address binding callbacks, ensure driver knows it's not a sparse bind that happens async. */
     vkd3d_address_binding_tracker_mark_user_thread();
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -68,6 +68,9 @@
 
 #define VKD3D_TILE_SIZE (65536ull)
 
+/* Minimum required maxBufferSize in Vulkan */
+#define VKD3D_MAX_FILL_BUFFER_SIZE (1ull << 30)
+
 typedef ID3D12Fence1 d3d12_fence_iface;
 
 struct d3d12_command_list;

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -441,3 +441,4 @@ decl_test(test_gs_topology_mismatch_dxbc);
 decl_test(test_gs_topology_mismatch_dxil);
 decl_test(test_sm67_helper_lane_only_wave_ops);
 decl_test(test_srgb_unorm_mismatch_usage_aliasing);
+decl_test(test_large_heap);


### PR DESCRIPTION
Not exhaustive. TLDR this tests a 6GB heap with:
- UAV + copies involving small placed buffers at large offsets
- UAV + copies involving one large placed buffer covering the entire allocation
- binding tiles to a small sparse buffer

This currently doesn't test other buffer uses, or creating placed images.

Heap creation is allowed to fail (and does so on WARP), however Assetto Corsa EVO crashes if we do that, so not supporting large heaps isn't exactly an option.

Creating a placed buffer to cover the entire heap seems to be required in D3D12 and does work, however AMD native crashes when trying to create view descriptors at ≥4GB *buffer* offsets. Smaller placed buffers on a large heap work as expected.

On the vkd3d-proton side, we exceed `maxBufferSize` on mesa drivers as well as amdvlk since the limit is <4GB, which is technically out of spec, but with the exception of one trivial RADV issue where buffer view offsets are treated as 32-bits, this happens to work anyway, so I'm not sure if it's really worth reworking the entire global buffer thing, especially since there's nothing stopping an app from using huge buffers anyway.