### PR TITLE
Revert "vkd3d: Enable no_upload_hvv for ArmA Reforger."

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -608,8 +608,6 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     /* Star Wars Outlaws (2842040). Attempt to workaround a possible NV driver bug. */
     { VKD3D_STRING_COMPARE_EXACT, "Outlaws.exe", VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT, 0 },
     { VKD3D_STRING_COMPARE_EXACT, "Outlaws_Plus.exe", VKD3D_CONFIG_FLAG_ONE_TIME_SUBMIT, 0 },
-    /* ArmA Reforger suffers from slow asset loading with HVV enabled */
-    { VKD3D_STRING_COMPARE_STARTS_WITH, "ArmaReforger", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV },
     /* FFVII Rebirth (2909400).
      * Game can destroy PSOs while they are in-flight.
      * Also, add no-staggered since this is a UE title without the common workaround,


### PR DESCRIPTION
There was an [update](https://store.steampowered.com/news/app/1874880/view/529845510803031624) for the game with the next changelog

> ### Stability and Performance
> Changed: Optimization of memory usage in rendering

I decided to check if it did anything, loaded game with GE-Proton9-10 which should contain old vkd3d version without this fix and I couldn't reproduce it anymore. I guess there's no issue with asset loading so we can drop this workaround in order to increase performance.