### PR TITLE
Options struct size fix

### DIFF
--- a/include/vkd3d_d3d12.idl
+++ b/include/vkd3d_d3d12.idl
@@ -920,6 +920,7 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS19
     UINT MaxSamplerDescriptorHeapSize;
     UINT MaxSamplerDescriptorHeapSizeWithStaticSamplers;
     UINT MaxViewDescriptorHeapSize;
+    BOOL ComputeOnlyCustomHeapSupported;
 } D3D12_FEATURE_DATA_D3D12_OPTIONS19;
 
 typedef enum D3D12_RECREATE_AT_TIER

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -5273,6 +5273,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CheckFeatureSupport(d3d12_device_i
             TRACE("MaxSamplerDescriptorHeapSize %u\n", data->MaxSamplerDescriptorHeapSize);
             TRACE("MaxSamplerDescriptorHeapSizeWithStaticSamplers %u\n", data->MaxSamplerDescriptorHeapSizeWithStaticSamplers);
             TRACE("MaxViewDescriptorHeapSize %u\n", data->MaxViewDescriptorHeapSize);
+            TRACE("ComputeOnlyCustomHeapSupported %u\n", data->ComputeOnlyCustomHeapSupported);
 
             return S_OK;
         }
@@ -8673,6 +8674,7 @@ static void d3d12_device_caps_init_feature_options19(struct d3d12_device *device
     options19->MaxSamplerDescriptorHeapSize = d3d12_device_get_max_descriptor_heap_size(device, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
     options19->MaxSamplerDescriptorHeapSizeWithStaticSamplers = options19->MaxSamplerDescriptorHeapSize;
     options19->MaxViewDescriptorHeapSize = d3d12_device_get_max_descriptor_heap_size(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    options19->ComputeOnlyCustomHeapSupported = FALSE;
 }
 
 static void d3d12_device_caps_init_feature_options20(struct d3d12_device *device)

--- a/tests/d3d12_pso.c
+++ b/tests/d3d12_pso.c
@@ -2750,7 +2750,13 @@ void test_line_rasterization(void)
     create_root_signature(context.device, &rs_desc, &context.root_signature);
 
     memset(&options19, 0, sizeof(options19));
-    ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS19, &options19, sizeof(options19));
+    hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS19, &options19, sizeof(options19));
+    if (FAILED(hr))
+    {
+        skip("OPTIONS19 not supported.\n");
+        destroy_test_context(&context);
+        return;
+    }
 
     rt = create_default_texture2d(context.device, 4, 4, 1, 1, DXGI_FORMAT_R8_UNORM, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE);
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -401,6 +401,7 @@ decl_test(test_sampler_non_normalized_coordinates);
 decl_test(test_dynamic_depth_bias);
 decl_test(test_dynamic_index_strip_cut);
 decl_test(test_depth_bias_behaviour);
+decl_test(test_line_rasterization);
 decl_test(test_depth_bias_formats);
 decl_test(test_sampler_feedback_resource_creation);
 decl_test(test_sampler_feedback_format_features);


### PR DESCRIPTION
Checked the agility SDKs and this was added in 610, and the field was always there, so don't think there's any risk of there having been a break.

Closes #2511.