### PR TITLE
Band-aid fix for Dead Space derivatives

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -484,7 +484,13 @@ enum vkd3d_shader_quirk
 
     /* Do more aggressive analysis of when nonuniform may be missing from shaders.
      * Not done by default since it's overly conservative. */
-    VKD3D_SHADER_QUIRK_AGGRESSIVE_NONUNIFORM = (1 << 24)
+    VKD3D_SHADER_QUIRK_AGGRESSIVE_NONUNIFORM = (1 << 24),
+
+    /* Move derivative instructions to the beginning of the function
+     * when they are used inside the main function,
+     * aren't dynamically indexed and use a PS input or
+     * CBV value. */
+    VKD3D_SHADER_QUIRK_HOIST_DERIVATIVES = (1 << 25)
 };
 
 struct vkd3d_shader_quirk_hash

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -818,6 +818,16 @@ static const struct vkd3d_shader_quirk_info satisfactory_quirks = {
     satisfactory_hashes, ARRAY_SIZE(satisfactory_hashes), 0,
 };
 
+static const struct vkd3d_shader_quirk_hash deadspace_hashes[] = {
+    /* Shader calculates derivatives in non-uniform control flow,
+     * leading to NaN pixels on Nvidia GPUs. */
+    { 0x8b981fdafe14b649, VKD3D_SHADER_QUIRK_HOIST_DERIVATIVES },
+};
+
+static const struct vkd3d_shader_quirk_info deadspace_quirks = {
+    deadspace_hashes, ARRAY_SIZE(deadspace_hashes), 0,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
@@ -874,6 +884,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "FactoryGameEGS-Win64-Shipping.exe", &satisfactory_quirks },
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
+    /* Dead Space (2023) */
+    { VKD3D_STRING_COMPARE_ENDS_WITH, "Dead Space.exe", &deadspace_quirks },
     /* MSVC fails to compile empty array. */
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };


### PR DESCRIPTION
Fixes #2530

Basically the idea is that if we encounter a derivative instruction which uses one of the input registers as the src without dynamic indexing and we're in the main function, put the derivative instruction at the beginning of the function.

It's not pretty but it seems to work for Dead Space and the shader that caused the bug validates fine. I've not really tested it beyond that. It would serve as a temporary solution until there's a proper compiler.
There's probably a bunch of edge cases I'm not thinking of right now, so consider this PR more of an RFC.