### PR TITLE
Reduce NVIDIA latency marker warnings in acceptable cases

### DIFF
--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -682,26 +682,18 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_l
 
     switch (vk_marker)
     {
-        case VK_LATENCY_MARKER_SIMULATION_START_NV:
-            if (internal_frame_id <= device->frame_markers.simulation)
-            {
-                WARN("SIMULATION_START_NV is non-monotonic %"PRIu64" <= %"PRIu64".\n",
-                        internal_frame_id, device->frame_markers.simulation);
-            }
-            device->frame_markers.simulation = internal_frame_id;
-            break;
         case VK_LATENCY_MARKER_RENDERSUBMIT_START_NV:
-            if (internal_frame_id <= device->frame_markers.render)
+            if (internal_frame_id < device->frame_markers.render)
             {
-                WARN("RENDERSUBMIT_START_NV is non-monotonic %"PRIu64" <= %"PRIu64".\n",
+                WARN("RENDERSUBMIT_START_NV is non-monotonic %"PRIu64" < %"PRIu64".\n",
                         internal_frame_id, device->frame_markers.render);
             }
             device->frame_markers.render = internal_frame_id;
             break;
         case VK_LATENCY_MARKER_PRESENT_START_NV:
-            if (internal_frame_id <= device->frame_markers.present)
+            if (internal_frame_id < device->frame_markers.present)
             {
-                WARN("PRESENT_START_NV is non-monotonic %"PRIu64" <= %"PRIu64".\n",
+                WARN("PRESENT_START_NV is non-monotonic %"PRIu64" < %"PRIu64".\n",
                         internal_frame_id, device->frame_markers.present);
             }
             vkd3d_atomic_uint64_store_explicit(

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4897,7 +4897,6 @@ struct vkd3d_device_swapchain_info
 #define VKD3D_LOW_LATENCY_FRAME_ID_STRIDE 10000
 struct vkd3d_device_frame_markers
 {
-    UINT64 simulation;
     UINT64 render;
     UINT64 present;
     UINT64 consumed_present_id;


### PR DESCRIPTION
These warning messages are stricter than necessary. This change removes warnings when we receive repeated PRESENT or RENDER markers with the same frame id, and removes warnings for SIMULATION markers entirely.

For more context see the discussion on this dxvk-nvapi pull request to remove their filtering of doubled markers: https://github.com/jp7677/dxvk-nvapi/pull/307.

Many apps send doubled present markers in the pattern below. This behavior is widespread even in Vulkan native apps, and not worth logging a warning for. The NVIDIA driver handles this case reasonably.
VK_LATENCY_MARKER_PRESENT_START_NV
VK_LATENCY_MARKER_PRESENT_START_NV
present
VK_LATENCY_MARKER_PRESENT_END_NV
VK_LATENCY_MARKER_PRESENT_END_NV

On top of that I see that Hitman World of Assassination issues two SIMULATION start and end pairs per frame, with a gap in between where other frames in the pipeline are doing other SIMULATIONs. As a result this value will sometimes decrease. vkd3d does nothing with the SIMULATION marker tracking other than printing warnings. IMO these warnings add unnecessary confusion, it is the NVIDIA driver's responsibility to handle odd app behavior like this.