### PR TITLE
vkd3d: Make code to check for workgraph support common code.

### DIFF
--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -2107,9 +2107,7 @@ static HRESULT vkd3d_workgraph_ops_init(struct vkd3d_workgraph_indirect_ops *wor
     unsigned int i;
     VkResult vr;
 
-    if (!device->device_info.vulkan_1_2_features.vulkanMemoryModel ||
-            !device->device_info.vulkan_1_3_features.subgroupSizeControl ||
-            !(device->device_info.vulkan_1_3_properties.requiredSubgroupSizeStages & VK_SHADER_STAGE_COMPUTE_BIT))
+    if (!d3d12_device_supports_workgraphs(device))
         return S_OK;
 
     push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5517,6 +5517,7 @@ bool d3d12_device_supports_ray_tracing_tier_1_2(const struct d3d12_device *devic
 UINT d3d12_determine_shading_rate_image_tile_size(struct d3d12_device *device);
 bool d3d12_device_supports_required_subgroup_size_for_stage(
         struct d3d12_device *device, VkShaderStageFlagBits stage);
+bool d3d12_device_supports_workgraphs(const struct d3d12_device *device);
 
 static inline void d3d12_device_register_swapchain(struct d3d12_device *device, struct dxgi_vk_swap_chain *chain)
 {


### PR DESCRIPTION
Fixes a segfault on GCN when running test suite.