### PR TITLE
vkd3d-shader: Dump raw and proper root signatures.

### DIFF
--- a/libs/vkd3d-shader/dxbc.c
+++ b/libs/vkd3d-shader/dxbc.c
@@ -2917,7 +2917,7 @@ int vkd3d_shader_parse_root_signature_raw(const char *data, unsigned int data_si
     {
         struct vkd3d_shader_code code = { data, data_size };
         *compatibility_hash = vkd3d_shader_hash(&code);
-        vkd3d_shader_dump_shader(*compatibility_hash, &code, "rs");
+        vkd3d_shader_dump_shader(*compatibility_hash, &code, "rsraw");
     }
 
     return VKD3D_OK;
@@ -2966,6 +2966,9 @@ int vkd3d_shader_parse_root_signature(const struct vkd3d_shader_code *dxbc,
         vkd3d_shader_free_root_signature(root_signature);
         return ret;
     }
+
+    if (compatibility_hash)
+        vkd3d_shader_dump_shader(*compatibility_hash, dxbc, "rs");
 
     return VKD3D_OK;
 }


### PR DESCRIPTION
The full root signatures can be reused in offline tools later.