### PR TITLE
Fix memory allocation issues on ancient NVIDIA hardware

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -8497,15 +8497,24 @@ static D3D12_RESOURCE_HEAP_TIER d3d12_device_determine_heap_tier(struct d3d12_de
 {
     const VkPhysicalDeviceLimits *limits = &device->device_info.properties2.properties.limits;
     const struct vkd3d_memory_info *mem_info = &device->memory_info;
+    const struct vkd3d_memory_info_domain *fallback_domain;
     const struct vkd3d_memory_info_domain *non_cpu_domain;
 
     non_cpu_domain = &mem_info->non_cpu_accessible_domain;
+    fallback_domain = &mem_info->fallback_domain;
 
     /* Heap Tier 2 requires us to be able to create a heap that supports all resource
      * categories at the same time, except RT/DS textures on UPLOAD/READBACK heaps.
      * Ignore CPU visible heaps since we only place buffers there. Textures are promoted to committed always. */
-    if (limits->bufferImageGranularity > D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT ||
+    if ((limits->bufferImageGranularity > D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT) ||
             !(non_cpu_domain->buffer_type_mask & non_cpu_domain->sampled_type_mask & non_cpu_domain->rt_ds_type_mask))
+        return D3D12_RESOURCE_HEAP_TIER_1;
+
+    /* If we don't have VK_EXT_pageable_device_memory, we're at the risk of needing to fallback allocate
+     * memory from sysmem when we run out.
+     * For HEAP_TIER_2 to work, we need to ensure there is a heap index which can support this use case as well. */
+    if (!device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory &&
+            !(fallback_domain->buffer_type_mask & fallback_domain->sampled_type_mask & fallback_domain->rt_ds_type_mask))
         return D3D12_RESOURCE_HEAP_TIER_1;
 
     return D3D12_RESOURCE_HEAP_TIER_2;

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -641,7 +641,7 @@ static void vkd3d_memory_transfer_queue_wait_allocation(struct vkd3d_memory_tran
 static uint32_t vkd3d_select_memory_types(struct d3d12_device *device, const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags)
 {
     const VkPhysicalDeviceMemoryProperties *memory_info = &device->memory_properties;
-    uint32_t type_mask = (1 << memory_info->memoryTypeCount) - 1;
+    uint32_t type_mask = (1ull << memory_info->memoryTypeCount) - 1;
     const struct vkd3d_memory_info_domain *domain_info;
 
     domain_info = d3d12_device_get_memory_info_domain(device, heap_properties);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4106,6 +4106,9 @@ struct vkd3d_memory_info
      * Used when we want to allocate DEFAULT heaps or non-visible CUSTOM heaps.
      * For images, we only include memory types which are OPTIMAL tiled. */
     struct vkd3d_memory_info_domain non_cpu_accessible_domain;
+    /* Same as non_cpu_accessible_domain, but removes memory types which belong to the primary device-local heap.
+     * On iGPU, fallback_domain == non_cpu_accessible_domain. */
+    struct vkd3d_memory_info_domain fallback_domain;
 
     VkMemoryPropertyFlags upload_heap_memory_properties;
     VkMemoryPropertyFlags descriptor_heap_memory_properties;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5369,14 +5369,14 @@ static inline uint32_t vkd3d_bindless_state_find_set_info_index_fast(struct d3d1
 
 static inline const struct vkd3d_memory_info_domain *d3d12_device_get_memory_info_domain(
         struct d3d12_device *device,
-        const D3D12_HEAP_PROPERTIES *heap_properties)
+        const D3D12_HEAP_PROPERTIES *heap_properties, bool fallback)
 {
     /* Host visible and non-host visible memory types do not necessarily
      * overlap. Need to select memory types appropriately. */
     if (is_cpu_accessible_heap(heap_properties))
         return &device->memory_info.cpu_accessible_domain;
     else
-        return &device->memory_info.non_cpu_accessible_domain;
+        return fallback ? &device->memory_info.fallback_domain : &device->memory_info.non_cpu_accessible_domain;
 }
 
 static inline HRESULT d3d12_device_query_interface(struct d3d12_device *device, REFIID iid, void **object)


### PR DESCRIPTION
It's not possible to expose HEAP_TIER_2 on older NV GPUs. This matches native driver too, so it shouldn't cause issues.