### PR TITLE
tests: add --list-tests to list all the tests

### DIFF
--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -772,6 +772,12 @@ static inline void parse_args(int argc, char **argv)
             use_warp_device = true;
         else if (!strcmp(argv[i], "--adapter") && i + 1 < argc)
             use_adapter_idx = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--list-tests")) {
+#define decl_test(x) printf("%s\n", #x)
+#include "d3d12_tests.h"
+#undef decl_test
+          exit(0);
+        }
     }
 }
 

--- a/tests/test-runner.sh
+++ b/tests/test-runner.sh
@@ -53,7 +53,7 @@ if [[ -z $d3d12_bin || ! -f "$d3d12_bin" ]] ; then
 	exit 1
 fi
 
-mapfile -t tests < <(grep -w decl_test tests/d3d12_tests.h|cut -d'(' -f2|cut -d')' -f1)
+mapfile -t tests < <("$d3d12_bin" --list-tests)
 if [[ -z $run_stress ]] ; then
 	for index in "${!tests[@]}" ; do
 		[[ "${tests[$index]}" != *stress* ]] || unset -v 'tests[$index]'


### PR DESCRIPTION
This makes `test-runner.sh` self-contained, avoiding having to ship the
sources to run it, and allows other runners to work using only the
`d3d12` test binary.

(for context, I'm working on adding support for running these tests in [deqp-runner](https://gitlab.freedesktop.org/mesa/deqp-runner))