### PR TITLE
vkd3d: Demote very spammy semaphore warnings to TRACE.

### DIFF
--- a/include/private/vkd3d_native_sync_handle.h
+++ b/include/private/vkd3d_native_sync_handle.h
@@ -72,7 +72,7 @@ static inline int vkd3d_native_sync_handle_release(vkd3d_native_sync_handle hand
             /* Failing to release semaphore is expected if the counter exceeds the maximum limit.
              * If the application does not wait for the semaphore once per present, this
              * will eventually happen. */
-            WARN("Failed to release semaphore (#%x).\n", GetLastError());
+            TRACE("Failed to release semaphore (#%x).\n", GetLastError());
             prev = -1;
         }
         return prev;

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -2859,13 +2859,13 @@ static void *dxgi_vk_swap_chain_wait_worker(void *chain_)
                  * That's a good sign the application is actually not behaving correctly. */
                 if (previous_semaphore >= (int)chain->frame_latency + 4)
                 {
-                    WARN("Incrementing frame latency semaphore beyond max latency. "
+                    TRACE("Incrementing frame latency semaphore beyond max latency. "
                             "Did application forget to acquire? (new count = %d, max latency = %u)\n",
                             previous_semaphore + 1, chain->frame_latency);
                 }
             }
             else
-                WARN("Failed to increment swapchain semaphore. Did application forget to acquire?\n");
+                TRACE("Failed to increment swapchain semaphore. Did application forget to acquire?\n");
         }
 
         if (vkd3d_native_sync_handle_is_valid(chain->frame_latency_event_internal))


### PR DESCRIPTION
These are often misinterpreted.