### PR TITLE
meson: Fix pkg-config build.

### DIFF
--- a/libs/d3d12/meson.build
+++ b/libs/d3d12/meson.build
@@ -19,8 +19,8 @@ endif
 
 d3d12_needs_defs = (not vkd3d_is_msvc) and (vkd3d_platform == 'windows')
 
-d3d12_lib = shared_library('d3d12', d3d12_src,
-  name_prefix         : d3d12_name_prefix,
+d3d12_lib = shared_library(d3d12_name_prefix + 'd3d12', d3d12_src,
+  name_prefix         : '',
   dependencies        : d3d12_dependencies,
   include_directories : vkd3d_private_includes,
   install             : true,

--- a/libs/d3d12core/meson.build
+++ b/libs/d3d12core/meson.build
@@ -13,8 +13,8 @@ endif
 
 d3d12core_needs_defs = (not vkd3d_is_msvc) and (vkd3d_platform == 'windows')
 
-d3d12core_lib = shared_library('d3d12core', d3d12core_src,
-  name_prefix         : d3d12core_name_prefix,
+d3d12core_lib = shared_library(d3d12core_name_prefix + 'd3d12core', d3d12core_src,
+  name_prefix         : '',
   dependencies        : d3d12core_dependencies,
   include_directories : vkd3d_private_includes,
   install             : true,

--- a/meson.build
+++ b/meson.build
@@ -183,8 +183,8 @@ endif
 
 if vkd3d_platform == 'linux'
   pkg = import('pkgconfig')
-  pkg.generate(vkd3d_lib, filebase : 'libvkd3d-proton', subdirs : 'vkd3d-proton', description : 'The vkd3d-proton D3D12 implementation')
-  install_headers('include/vkd3d_sonames.h', 'include/vkd3d.h', 'include/vkd3d_types.h', 'include/vkd3d_win32.h', 'include/vkd3d_windows.h', subdir : 'vkd3d-proton')
+  pkg.generate(d3d12_lib, filebase : 'libvkd3d-proton-d3d12', subdirs : 'vkd3d-proton', description : 'The vkd3d-proton D3D12 implementation')
+  install_headers('include/vkd3d_vk_includes.h', 'include/vkd3d_types.h', 'include/vkd3d_win32.h', 'include/vkd3d_windows.h', subdir : 'vkd3d-proton')
   # IDL generated headers (like vkd3d_d3d12.h) are installed via include/meson.build
 endif
 


### PR DESCRIPTION
Makes it possible to link against vkd3d-proton via pkg-config properly. The old code only worked with the now defunct private API that doesn't go via D3D12CreateDevice and friends.