### PR TITLE
vkd3d: Enable low SSBO alignment path on NVK too.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1632,9 +1632,14 @@ static void vkd3d_physical_device_info_apply_workarounds(struct vkd3d_physical_d
      * The 16 byte offset is a lie, as that is only actually required when we
      * use vectorized load-stores. When we emit vectorized load-store ops,
      * the storage buffer must be aligned properly, so this is fine in practice
-     * and is a nice speed boost. */
-    if (info->vulkan_1_2_properties.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY)
+     * and is a nice speed boost.
+     * On NVK, robustness2 SSBO access is pessimized enough that this cannot cause issues.
+     * See https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33613 for details. */
+    if (info->vulkan_1_2_properties.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY ||
+            info->vulkan_1_2_properties.driverID == VK_DRIVER_ID_MESA_NVK)
+    {
         info->properties2.properties.limits.minStorageBufferOffsetAlignment = 4;
+    }
 
     /* UE5 is broken and assumes that if mesh shaders are supported, barycentrics are also supported.
      * This happens to be the case on RDNA2+ and Turing+ on Windows, but Mesa landed barycentrics long


### PR DESCRIPTION
Enables descriptor buffers too.