### PR TITLE
tests: Tweak sampler feedback aniso test to reduce precision errors.

### DIFF
--- a/tests/d3d12_sampler_feedback.c
+++ b/tests/d3d12_sampler_feedback.c
@@ -3183,6 +3183,7 @@ void test_sampler_feedback_implicit_lod_aniso(void)
 #define FEEDBACK_WIDTH (TEX_WIDTH / MIP_REGION_WIDTH)
 #define FEEDBACK_HEIGHT (TEX_HEIGHT / MIP_REGION_HEIGHT)
 #define TEX_MIP_LEVELS 3
+#define E (1.0f / 128.0f)
 
     const struct test
     {
@@ -3196,27 +3197,27 @@ void test_sampler_feedback_implicit_lod_aniso(void)
     } tests[] = {
         /* Sample a little left of the texel center of bottom-right texel in the mip region to avoid 0 weight scenario which is not well defined
          * (can trigger use or not, vkd3d-proton is conservative here but hardware tends to not be). */
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { 1, 0 }, { 0, 1 }, 0, { 1, 0, 0 }, true, true },
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { 1, 0 }, { 0, 1 }, 1.0f / 512.0f, { 1, 0, 0 }, true, true },
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { 1, 0 }, { 0, 1 }, 0, { 1, 0, 0 }, true, true },
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { 1, 0 }, { 0, 1 }, 1.0f / 512.0f, { 1, 0, 0 }, true, true },
         /* Tri-linear aniso is out of spec on most implementations. They try really hard to snap to integer LOD.
          * Use a larger LOD bias than we should need to trigger it.
          * Also shift the texel a bit to account for our conservative aniso extent in vkd3d-proton. */
-        { { MIP_REGION_WIDTH - 1.51f, MIP_REGION_HEIGHT - 1.51f }, { 1, 0 }, { 0, 1 }, 80.0f / 256.0f, { 1, 1, 0 }, true, true },
+        { { MIP_REGION_WIDTH - 1.5f - E, MIP_REGION_HEIGHT - 1.5f - E }, { 1, 0 }, { 0, 1 }, 80.0f / 256.0f, { 1, 1, 0 }, true, true },
         /* Test different square rotations of gradient. */
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { 2, 0 }, { 0, 1 }, 0, { 2, 0, 0 }, true, true },
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { 1, 0 }, { 0, 2 }, 0, { 2, 0, 0 }, true, true },
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { 0, 2 }, { 1, 0 }, 0, { 2, 0, 0 }, true, true },
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { 0, 1 }, { 2, 0 }, 0, { 2, 0, 0 }, true, true },
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { 2, 0 }, { 0, 1 }, 0, { 2, 0, 0 }, true, true },
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { 1, 0 }, { 0, 2 }, 0, { 2, 0, 0 }, true, true },
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { 0, 2 }, { 1, 0 }, 0, { 2, 0, 0 }, true, true },
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { 0, 1 }, { 2, 0 }, 0, { 2, 0, 0 }, true, true },
 
         /* Test diagonal gradients. Study how LOD is computed. Vulkan is very fuzzy when it comes to how LOD is computed, only giving a lower and upper LOD bound.
          * D3D11 functional spec seems to mandate max(length(ddx), length(ddy)). Verify this. AMD seems to be accurate to spec, but not NV. */
 #define SQRT_1_2 0.70710678118f
 
 #define DECL_ROTATED(D, B, lod1) \
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { (D), (D) }, { -(D), (D) }, B, { 1, lod1 ? 1 : 0, 0 }, true, true }, \
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { -(D), (D) }, { -(D), -(D) }, B, { 1, lod1 ? 1 : 0, 0 }, true, true }, \
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { (D), -(D) }, { -(D), -(D) }, B, { 1, lod1 ? 1 : 0, 0 }, true, true }, \
-        { { MIP_REGION_WIDTH - 0.51f, MIP_REGION_HEIGHT - 0.51f }, { (D), (D) }, { (D), -(D) }, B, { 1, lod1 ? 1 : 0, 0 }, true, true }
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { (D), (D) }, { -(D), (D) }, B, { 1, lod1 ? 1 : 0, 0 }, true, true }, \
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { -(D), (D) }, { -(D), -(D) }, B, { 1, lod1 ? 1 : 0, 0 }, true, true }, \
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { (D), -(D) }, { -(D), -(D) }, B, { 1, lod1 ? 1 : 0, 0 }, true, true }, \
+        { { MIP_REGION_WIDTH - 0.5f - E, MIP_REGION_HEIGHT - 0.5f - E }, { (D), (D) }, { (D), -(D) }, B, { 1, lod1 ? 1 : 0, 0 }, true, true }
 
         DECL_ROTATED(SQRT_1_2, 0.0f, false),
         DECL_ROTATED(SQRT_1_2, 0.4f, true), /* Should compute LOD > 0 and trigger tri-linear. */
@@ -3229,8 +3230,8 @@ void test_sampler_feedback_implicit_lod_aniso(void)
 #define CONSERVATIVE_ANISO_EXTENT(rate, bias) (0.5f * exp2f(ceilf(log2f(rate)))) * exp2f(bias)
 #define RATE_IS_POT(rate) (exp2f(ceilf(log2f(rate))) == (rate))
 #define DECL_ANISO(rate) \
-        { { MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 0) - 0.01f, MIP_REGION_HEIGHT - 0.51f }, { rate, 0 }, { 0, 1 }, 0, { 1, 0, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }, \
-        { { MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 0) + 0.01f, MIP_REGION_HEIGHT - 0.51f }, { rate, 0 }, { 0, 1 }, 0, { 2, 0, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }
+        { { MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 0) - E, MIP_REGION_HEIGHT - 0.5f - E }, { rate, 0 }, { 0, 1 }, 0, { 1, 0, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }, \
+        { { MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 0) + E, MIP_REGION_HEIGHT - 0.5f - E }, { rate, 0 }, { 0, 1 }, 0, { 2, 0, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }
 
         DECL_ANISO(1), DECL_ANISO(2), DECL_ANISO(3), DECL_ANISO(4), DECL_ANISO(5), DECL_ANISO(6), DECL_ANISO(7), DECL_ANISO(8),
         DECL_ANISO(9), DECL_ANISO(10), DECL_ANISO(11), DECL_ANISO(12), DECL_ANISO(13), DECL_ANISO(14), DECL_ANISO(15), DECL_ANISO(16),
@@ -3238,22 +3239,22 @@ void test_sampler_feedback_implicit_lod_aniso(void)
         DECL_ANISO(9.5f), DECL_ANISO(10.5f), DECL_ANISO(11.5f), DECL_ANISO(12.5f), DECL_ANISO(13.5f), DECL_ANISO(14.5f), DECL_ANISO(15.5f),
 
 #define DECL_ANISO_LOD1(rate) \
-        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 0) - 0.01f, MIP_REGION_HEIGHT - 0.51f }, { rate, 0 }, { 0, 2 }, 0, { 0, 1, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }, \
-        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 0) + 0.01f, 2 * (MIP_REGION_HEIGHT - 0.51f) }, { rate, 0 }, { 0, 2 }, 0, { 0, 2, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }
+        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 0) - E, MIP_REGION_HEIGHT - 0.5f - E }, { rate, 0 }, { 0, 2 }, 0, { 0, 1, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }, \
+        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 0) + E, 2 * (MIP_REGION_HEIGHT - 0.5f - E) }, { rate, 0 }, { 0, 2 }, 0, { 0, 2, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }
         DECL_ANISO_LOD1(2), DECL_ANISO_LOD1(3), DECL_ANISO_LOD1(4), DECL_ANISO_LOD1(5), DECL_ANISO_LOD1(6), DECL_ANISO_LOD1(7), DECL_ANISO_LOD1(8),
 
         /* Esoteric as all hell. It seems like LOD bias will stretch out the extent! */
 #undef DECL_ANISO_LOD1
 #define DECL_ANISO_LOD1(rate) \
-        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 1) - 0.01f, MIP_REGION_HEIGHT - 0.51f }, { rate, 0 }, { 0, 1 }, 1, { 0, 1, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }, \
-        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 1) + 0.01f, 2 * (MIP_REGION_HEIGHT - 0.51f) }, { rate, 0 }, { 0, 1 }, 1, { 0, 2, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }
+        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 1) - E, MIP_REGION_HEIGHT - 0.5f - E }, { rate, 0 }, { 0, 1 }, 1, { 0, 1, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }, \
+        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, 1) + E, 2 * (MIP_REGION_HEIGHT - 0.5f - E) }, { rate, 0 }, { 0, 1 }, 1, { 0, 2, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }
         DECL_ANISO_LOD1(2), DECL_ANISO_LOD1(3), DECL_ANISO_LOD1(4), DECL_ANISO_LOD1(5), DECL_ANISO_LOD1(6), DECL_ANISO_LOD1(7), DECL_ANISO_LOD1(8),
 
         /* And negative LOD bias will shrink the footprint ... */
 #undef DECL_ANISO_LOD1
 #define DECL_ANISO_LOD1(rate) \
-        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, -1) - 0.01f, MIP_REGION_HEIGHT - 0.51f }, { rate, 0 }, { 0, 2 }, -1, { 1, 0, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }, \
-        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, -1) + 0.01f, 2 * (MIP_REGION_HEIGHT - 0.51f) }, { rate, 0 }, { 0, 2 }, -1, { 2, 0, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }
+        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, -1) - E, MIP_REGION_HEIGHT - 0.5f - E }, { rate, 0 }, { 0, 2 }, -1, { 1, 0, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }, \
+        { { 2 * MIP_REGION_WIDTH - CONSERVATIVE_ANISO_EXTENT(rate, -1) + E, 2 * (MIP_REGION_HEIGHT - 0.5f - E) }, { rate, 0 }, { 0, 2 }, -1, { 2, 0, 0 }, RATE_IS_POT(rate), RATE_IS_POT(rate) }
         DECL_ANISO_LOD1(2), DECL_ANISO_LOD1(3), DECL_ANISO_LOD1(4), DECL_ANISO_LOD1(5), DECL_ANISO_LOD1(6), DECL_ANISO_LOD1(7), DECL_ANISO_LOD1(8),
     };
 
@@ -3455,6 +3456,7 @@ void test_sampler_feedback_implicit_lod_aniso(void)
 #undef FEEDBACK_WIDTH
 #undef FEEDBACK_HEIGHT
 #undef TEX_MIP_LEVELS
+#undef E
 }
 
 void test_sampler_feedback_implicit_lod(void)


### PR DESCRIPTION
Using 0.01 for epsilons causes some gradients to be integer +/- epsilon, which made QueryLOD behave very slightly differently on NVK, leading to a test failure. Just use a more FP friendly epsilon to fix.