### PR TITLE
vkd3d: Add sync workaround for Wuthering Waves.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -849,6 +849,15 @@ static const struct vkd3d_shader_quirk_info death_stranding_quirks = {
     death_stranding_hashes, ARRAY_SIZE(death_stranding_hashes), 0,
 };
 
+static const struct vkd3d_shader_quirk_hash wuthering_waves_hashes[] = {
+    /* LightGridInjectionCS. Forgets to UAV barrier after ClearCS. */
+    { 0x6c82985f4152e2de, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
+};
+
+static const struct vkd3d_shader_quirk_info wuthering_waves_quirks = {
+    wuthering_waves_hashes, ARRAY_SIZE(wuthering_waves_hashes), 0,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
@@ -903,14 +912,16 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* Satisfactory (526870). */
     { VKD3D_STRING_COMPARE_EXACT, "FactoryGameSteam-Win64-Shipping.exe", &satisfactory_quirks },
     { VKD3D_STRING_COMPARE_EXACT, "FactoryGameEGS-Win64-Shipping.exe", &satisfactory_quirks },
-    /* Unreal Engine 4 */
-    { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
+    /* Wuthering Waves */
+    { VKD3D_STRING_COMPARE_EXACT, "Client-Win64-Shipping.exe", &wuthering_waves_quirks },
     /* Dead Space (2023) */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "Dead Space.exe", &deadspace_quirks },
     /* Death Stranding  */
     { VKD3D_STRING_COMPARE_EXACT, "ds.exe", &death_stranding_quirks },
     { VKD3D_STRING_COMPARE_EXACT, "DeathStranding.exe", &death_stranding_quirks },
     { VKD3D_STRING_COMPARE_EXACT, "3DMarkPortRoyal.exe", &heap_robustness_quirks },
+    /* Unreal Engine 4 */
+    { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     /* MSVC fails to compile empty array. */
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },
 };


### PR DESCRIPTION
Missing UAV barrier between custom clear shader and light injection.

Closes #2561.