### PR TITLE
vkd3d: Fix drain wait in d3d12_command_queue_acquire_serialized().

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20483,7 +20483,7 @@ static void d3d12_command_queue_acquire_serialized(struct d3d12_command_queue *q
     current_drain = ++queue->drain_count;
     d3d12_command_queue_add_submission_locked(queue, &sub);
 
-    while (current_drain != queue->queue_drain_count)
+    while (current_drain < queue->queue_drain_count)
         pthread_cond_wait(&queue->queue_cond, &queue->queue_lock);
 }
 


### PR DESCRIPTION
If there are concurrent callers to d3d12_command_queue_acquire_serialized() (happens with d3d12 / OpenVR game with Proton), queue_drain_count may jump over current_drain before the wait here is satisifed.