### PR TITLE
vkd3d: Add vulkan queue locking methods.

### DIFF
--- a/include/vkd3d.h
+++ b/include/vkd3d.h
@@ -178,6 +178,8 @@ uint32_t vkd3d_get_vk_queue_index(ID3D12CommandQueue *queue);
 uint32_t vkd3d_get_vk_queue_flags(ID3D12CommandQueue *queue);
 VkQueue vkd3d_acquire_vk_queue(ID3D12CommandQueue *queue);
 void vkd3d_release_vk_queue(ID3D12CommandQueue *queue);
+VkQueue vkd3d_lock_vk_queue(ID3D12CommandQueue *queue);
+void vkd3d_unlock_vk_queue(ID3D12CommandQueue *queue);
 void vkd3d_enqueue_initial_transition(ID3D12CommandQueue *queue, ID3D12Resource *resource);
 
 HRESULT vkd3d_create_image_resource(ID3D12Device *device,

--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -71,6 +71,20 @@ interface ID3D12DXVKInteropDevice1 : ID3D12DXVKInteropDevice
 }
 
 [
+    uuid(90ecf26e-b212-43f5-b62a-825ad7b1385e),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12DXVKInteropDevice2 : ID3D12DXVKInteropDevice1
+{
+    /* Unlike LockCommandQueue this doesn't drain or lock d3d12 queue but only locks the access to the underlying
+     * Vulkan queue so it can be used outside of d3d12. */
+    HRESULT LockVulkanQueue(ID3D12CommandQueue *queue);
+    HRESULT UnlockVulkanQueue(ID3D12CommandQueue *queue);
+}
+
+[
     uuid(f3112584-41f9-348d-a59b-00b7e1d285d6),
     object,
     local,

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20814,6 +20814,25 @@ VkQueue vkd3d_acquire_vk_queue(ID3D12CommandQueue *queue)
     return vk_queue;
 }
 
+VkQueue vkd3d_lock_vk_queue(ID3D12CommandQueue *queue)
+{
+    struct d3d12_command_queue *d3d12_queue = impl_from_ID3D12CommandQueue(queue);
+    VkQueue vk_queue;
+
+    VKD3D_REGION_DECL(lock_vk_queue);
+    VKD3D_REGION_BEGIN(lock_vk_queue);
+    vk_queue = vkd3d_queue_acquire(d3d12_queue->vkd3d_queue);
+    VKD3D_REGION_END(lock_vk_queue);
+    return vk_queue;
+}
+
+void vkd3d_unlock_vk_queue(ID3D12CommandQueue *queue)
+{
+    struct d3d12_command_queue *d3d12_queue = impl_from_ID3D12CommandQueue(queue);
+
+    vkd3d_queue_release(d3d12_queue->vkd3d_queue);
+}
+
 void vkd3d_release_vk_queue(ID3D12CommandQueue *queue)
 {
     struct d3d12_command_queue *d3d12_queue = impl_from_ID3D12CommandQueue(queue);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4076,7 +4076,8 @@ HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
     }
 
     if (IsEqualGUID(riid, &IID_ID3D12DXVKInteropDevice)
-            || IsEqualGUID(riid, &IID_ID3D12DXVKInteropDevice1))
+            || IsEqualGUID(riid, &IID_ID3D12DXVKInteropDevice1)
+            || IsEqualGUID(riid, &IID_ID3D12DXVKInteropDevice2))
     {
         d3d12_dxvk_interop_device_AddRef(&device->ID3D12DXVKInteropDevice_iface);
         *object = &device->ID3D12DXVKInteropDevice_iface;
@@ -9703,7 +9704,7 @@ static void d3d12_device_replace_vtable(struct d3d12_device *device)
 }
 
 extern CONST_VTBL struct ID3D12DeviceExt1Vtbl d3d12_device_vkd3d_ext_vtbl;
-extern CONST_VTBL struct ID3D12DXVKInteropDevice1Vtbl d3d12_dxvk_interop_device_vtbl;
+extern CONST_VTBL struct ID3D12DXVKInteropDevice2Vtbl d3d12_dxvk_interop_device_vtbl;
 extern CONST_VTBL struct ID3DLowLatencyDeviceVtbl d3d_low_latency_device_vtbl;
 extern CONST_VTBL struct IAmdExtAntiLagApiVtbl d3d_amd_ext_anti_lag_vtbl;
 

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -530,7 +530,23 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_EndVkCommandBufferInt
     return S_OK;
 }
 
-CONST_VTBL struct ID3D12DXVKInteropDevice1Vtbl d3d12_dxvk_interop_device_vtbl =
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_LockVulkanQueue(d3d12_dxvk_interop_device_iface *iface, ID3D12CommandQueue *queue)
+{
+    TRACE("iface %p, queue %p.\n", iface, queue);
+
+    vkd3d_lock_vk_queue(queue);
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_UnlockVulkanQueue(d3d12_dxvk_interop_device_iface *iface, ID3D12CommandQueue *queue)
+{
+    TRACE("iface %p, queue %p.\n", iface, queue);
+
+    vkd3d_unlock_vk_queue(queue);
+    return S_OK;
+}
+
+CONST_VTBL struct ID3D12DXVKInteropDevice2Vtbl d3d12_dxvk_interop_device_vtbl =
 {
     /* IUnknown methods */
     d3d12_dxvk_interop_device_QueryInterface,
@@ -555,6 +571,10 @@ CONST_VTBL struct ID3D12DXVKInteropDevice1Vtbl d3d12_dxvk_interop_device_vtbl =
     d3d12_dxvk_interop_device_CreateInteropCommandAllocator,
     d3d12_dxvk_interop_device_BeginVkCommandBufferInterop,
     d3d12_dxvk_interop_device_EndVkCommandBufferInterop,
+
+    /* ID3D12DXVKInteropDevice2 methods */
+    d3d12_dxvk_interop_device_LockVulkanQueue,
+    d3d12_dxvk_interop_device_UnlockVulkanQueue,
 };
 
 static inline struct d3d12_device *d3d12_device_from_ID3DLowLatencyDevice(d3d_low_latency_device_iface *iface)

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -248,9 +248,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetVulkanQueueInfoEx(d3d
     TRACE("iface %p, queue %p, vk_queue %p, vk_queue_index %p, vk_queue_flags %p vk_queue_family %p.\n",
             iface, queue, vk_queue, vk_queue_index, vk_queue_flags, vk_queue_family);
 
-    /* This only gets called during D3D11 device creation */
-    *vk_queue = vkd3d_acquire_vk_queue(queue);
-    vkd3d_release_vk_queue(queue);
+    *vk_queue = vkd3d_lock_vk_queue(queue);
+    vkd3d_unlock_vk_queue(queue);
 
     *vk_queue_index = vkd3d_get_vk_queue_index(queue);
     *vk_queue_flags = vkd3d_get_vk_queue_flags(queue);
@@ -384,9 +383,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanQueueInfo(d3
 {
     TRACE("iface %p, queue %p, vk_queue %p, vk_queue_family %p.\n", iface, queue, vk_queue, vk_queue_family);
 
-    /* This only gets called during D3D11 device creation */
-    *vk_queue = vkd3d_acquire_vk_queue(queue);
-    vkd3d_release_vk_queue(queue);
+    *vk_queue = vkd3d_lock_vk_queue(queue);
+    vkd3d_unlock_vk_queue(queue);
 
     *vk_queue_family = vkd3d_get_vk_queue_family_index(queue);
     return S_OK;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4984,7 +4984,7 @@ struct vkd3d_timestamp_profiler;
 typedef ID3D12DeviceExt1 d3d12_device_vkd3d_ext_iface;
 
 /* ID3D12DXVKInteropDevice */
-typedef ID3D12DXVKInteropDevice1 d3d12_dxvk_interop_device_iface;
+typedef ID3D12DXVKInteropDevice2 d3d12_dxvk_interop_device_iface;
 
 /* ID3DLowLatencyDevice */
 typedef ID3DLowLatencyDevice d3d_low_latency_device_iface;


### PR DESCRIPTION
LockCommandQueue() is currently used in Proton's vrclient / wineopenxr to wrap the calls where VR runtime may be accessing Vk queue backing d3d12 queue.  LockCommandQueue, besides locking access to Vulkan queue, does much more of heavy syncing: drains and locks d3d12 queue. In the majority of cases in vrclient and wineopenxr the latter is excessive: apart from select call where we do need to make sure d3d12 queue contents has reached Vulkan queue we just need to synchronize access to Vulkan queue while we don't care about the d3d12-side queued contents.

The second patch also avoids queue draining in GetVulkanQueueInfo[Ex], those are used in vrclient twice each frame (as there is no generally configured d3d12 queue, the queue is passed as a part of texture data in each call to VRCompositor::Submit for each eye).