### PR TITLE
vkd3d: Fix wait condition in d3d12_command_queue_acquire_serialized()…

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20487,7 +20487,7 @@ static void d3d12_command_queue_acquire_serialized(struct d3d12_command_queue *q
     current_drain = ++queue->drain_count;
     d3d12_command_queue_add_submission_locked(queue, &sub);
 
-    while (current_drain < queue->queue_drain_count)
+    while (current_drain > queue->queue_drain_count)
         pthread_cond_wait(&queue->queue_cond, &queue->queue_lock);
 }
 


### PR DESCRIPTION
…, again.

Unfortunately my commit 29118094b1069d36ac7f948d215a727cf802ae1b, while fixed lock up, made the wait a no-op, condition should be the opposite.