### PR TITLE
vkd3d: Change shader quirk hash for Wuthering Waves

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -852,7 +852,7 @@ static const struct vkd3d_shader_quirk_info death_stranding_quirks = {
 
 static const struct vkd3d_shader_quirk_hash wuthering_waves_hashes[] = {
     /* LightGridInjectionCS. Forgets to UAV barrier after ClearCS. */
-    { 0x6c82985f4152e2de, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
+    { 0x63bad782eb2380fb, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
 };
 
 static const struct vkd3d_shader_quirk_info wuthering_waves_quirks = {


### PR DESCRIPTION
Since the game's latest update (2.7), the texture flickering issue (#2561) came back.
Looking at the Renderdoc capture, the LightGridInjectionCS hash changed and applying this new hash in place of #2617 fixed the issue, so I'm opening this MR to change it.

Renderdoc capture of the issue: https://drive.google.com/file/d/1Urxu-LLXqB39kMnv9LWy3Ns2LQWbifvK/view?usp=drive_link

Tested with Wine 10.16 on Lutris with SteamOS=1 environment variable set.

git-master:

https://github.com/user-attachments/assets/f0298124-3905-4e2d-9d1e-1835bb9f8fd9

This MR:

https://github.com/user-attachments/assets/7913c19b-6e72-4982-a545-8773b18974dd