### PR TITLE
tests: Add test for ClearUAV without heap bound.

### DIFF
--- a/tests/d3d12_test_utils.h
+++ b/tests/d3d12_test_utils.h
@@ -402,6 +402,8 @@ static inline unsigned int format_size(DXGI_FORMAT format)
             return 16;
         case DXGI_FORMAT_R16G16B16A16_TYPELESS:
         case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        case DXGI_FORMAT_R16G16B16A16_UINT:
+        case DXGI_FORMAT_R16G16B16A16_SINT:
         case DXGI_FORMAT_R32G32_UINT:
         case DXGI_FORMAT_R32G32_SINT:
         case DXGI_FORMAT_R32G32_FLOAT:

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -505,3 +505,4 @@ decl_test(test_root_constant_indexing_dxil);
 decl_test(test_root_constant_indexing_dxbc);
 decl_test(test_nvx_cubin);
 decl_test(test_use_before_alloc_stress);
+decl_test(test_clear_uav_mismatch_heap);


### PR DESCRIPTION
Verifies that native drivers never look at the GPU heap for ClearUAV, so we can never make use of it since there is very high chance of game breakage. D3D12 validation complains violently, but runtime doesn't trip device lost.