### PR TITLE
vkd3d: Demote d3d12_command_list_QueryInterface warning to trace

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5293,7 +5293,7 @@ HRESULT STDMETHODCALLTYPE d3d12_command_list_QueryInterface(d3d12_command_list_i
         return S_OK;
     }
 
-    WARN("%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid(iid));
+    TRACE("%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid(iid));
 
     *object = NULL;
     return E_NOINTERFACE;


### PR DESCRIPTION
Some games like Assassin's Creed Shadows will spam this quite excessively to put it mildly