### PR TITLE
vkd3d: Use 8x8x8 WGs for 3D ClearUAV.

### DIFF
--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -532,7 +532,7 @@ VkExtent3D vkd3d_meta_get_clear_image_uav_workgroup_size(VkImageViewType view_ty
         }
         case VK_IMAGE_VIEW_TYPE_3D:
         {
-            VkExtent3D result = { 4, 4, 4 };
+            VkExtent3D result = { 8, 8, 8 };
             return result;
         }
         default:

--- a/libs/vkd3d/shaders/cs_clear_uav_image_3d_float.comp
+++ b/libs/vkd3d/shaders/cs_clear_uav_image_3d_float.comp
@@ -1,6 +1,6 @@
 #version 450
 
-layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 
 layout(binding = 0)
 writeonly uniform image3D dst;

--- a/libs/vkd3d/shaders/cs_clear_uav_image_3d_uint.comp
+++ b/libs/vkd3d/shaders/cs_clear_uav_image_3d_uint.comp
@@ -1,6 +1,6 @@
 #version 450
 
-layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 
 layout(binding = 0)
 writeonly uniform uimage3D dst;


### PR DESCRIPTION
XTHICK tiling on AMD is 8x8x8 at least, so this seems to have favorable behavior.

https://gitlab.freedesktop.org/mesa/mesa/-/issues/12779#note_3165515 did some simple microbenching. Seems faster on NV too.