### PR TITLE
tests: remove Adreno-specific bug_ifs in streamout tests

### DIFF
--- a/tests/d3d12_streamout.c
+++ b/tests/d3d12_streamout.c
@@ -155,8 +155,6 @@ void test_primitive_restart_list_topology_stream_output(void)
     get_buffer_readback_with_command_list(counter_buffer, DXGI_FORMAT_R32_UINT, &rb, queue, command_list);
     counter = get_readback_uint(&rb, 0, 0, 0);
 
-    /* adreno hardware omits degenerate triangles */
-    bug_if(is_adreno_device(context.device))
     ok(counter == sizeof(expected_output), "Got unexpected counter %u, expected %u.\n",
             counter, (unsigned int)sizeof(expected_output));
 
@@ -168,8 +166,6 @@ void test_primitive_restart_list_topology_stream_output(void)
         const struct vec4 *expected = &expected_output[i];
         data = get_readback_vec4(&rb, i, 0);
 
-        /* adreno hardware omits degenerate triangles */
-        bug_if(is_adreno_device(context.device))
         ok(compare_vec4(data, expected, 1),
                 "Got {%.8e, %.8e, %.8e, %.8e}, expected {%.8e, %.8e, %.8e, %.8e}.\n",
                 data->x, data->y, data->z, data->w, expected->x, expected->y, expected->z, expected->w);
@@ -422,10 +418,6 @@ void test_index_buffer_edge_case_stream_output(void)
 
     get_buffer_readback_with_command_list(counter_buffer, DXGI_FORMAT_R32_UINT, &rb, queue, command_list);
     counter = get_readback_uint(&rb, 0, 0, 0);
-    /*
-     * adreno hardware omits degenerate triangles
-     */
-    bug_if(is_adreno_device(context.device))
     ok(counter == 15 * sizeof(struct vec4), "Got unexpected counter %u.\n", counter);
     release_resource_readback(&rb);
     reset_command_list(command_list, context.allocator);
@@ -434,10 +426,6 @@ void test_index_buffer_edge_case_stream_output(void)
     {
         const struct vec4 *expected = &expected_output[i];
         data = get_readback_vec4(&rb, i, 0);
-        /*
-        * adreno hardware omits degenerate triangles
-        */
-        bug_if(is_adreno_device(context.device))
         ok(compare_vec4(data, expected, 1),
                 "Got {%.8e, %.8e, %.8e, %.8e}, expected {%.8e, %.8e, %.8e, %.8e}.\n",
                 data->x, data->y, data->z, data->w, expected->x, expected->y, expected->z, expected->w);


### PR DESCRIPTION
Missing register state setup in Turnip was causing degenerate triangles to not be included in stream output. Fixed by https://gitlab.freedesktop.org/mesa/mesa/-/commit/ba054f1c338d37d1b8637ecfe325f73b74f24a76. The proprietary driver never had this problem.