### PR TITLE
tests: also use todo_if in test_custom_border_color_limits for Turnip

### DIFF
--- a/tests/d3d12_descriptors.c
+++ b/tests/d3d12_descriptors.c
@@ -6165,7 +6165,7 @@ void test_custom_border_color_limits(void)
         /* NV will fail around 4k unique samplers. */
         if (is_nvidia_device(context.device))
             is_todo = flat_index >= 4000;
-        else if (is_amd_vulkan_device(context.device))
+        else if (is_amd_vulkan_device(context.device) || is_adreno_device(context.device))
             is_todo = flat_index >= 4096;
         else
             is_todo = false;


### PR DESCRIPTION
In test_custom_border_color_limits Turnip also hits the custom border color sampler limit of 4K samplers, so let's make use of the existing conditional todo.