### PR TITLE
vkd3d: Remove DXVK_FRAME_RATE env var.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,6 @@ commas or semicolons.
 ### Frame rate limit
 The `VKD3D_FRAME_RATE` environment variable can be used to limit the frame rate. A value of `0` uncaps the frame rate, while any positive value will limit rendering to the given number of frames per second.
 
-The `DXVK_FRAME_RATE` environment variable is also detected on VKD3D-Proton, so you may prefer to use that instead of having to remember two separate variables that do the same thing. `VKD3D_FRAME_RATE`, however, only applies to VKD3D (Direct3D 12) scenarios. If both variables are used, `VKD3D_FRAME_RATE` takes precedence.
-
 ## Shader cache
 
 By default, vkd3d-proton manages its own driver cache.

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -3048,8 +3048,7 @@ static HRESULT dxgi_vk_swap_chain_init_frame_rate_limiter(struct dxgi_vk_swap_ch
 
     pthread_mutex_init(&chain->frame_rate_limit.lock, NULL);
 
-    if (vkd3d_get_env_var("VKD3D_FRAME_RATE", env, sizeof(env)) ||
-            vkd3d_get_env_var("DXVK_FRAME_RATE", env, sizeof(env)))
+    if (vkd3d_get_env_var("VKD3D_FRAME_RATE", env, sizeof(env)))
     {
         target_frame_rate = strtod(env, NULL);
 


### PR DESCRIPTION
This is getting removed from DXVK, and we still have `VKD3D_FRAME_RATE`.