### PR TITLE
vkd3d: Change shader quirk hash for Wuthering Waves v2.8

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -857,7 +857,7 @@ static const struct vkd3d_shader_quirk_info death_stranding_quirks = {
 
 static const struct vkd3d_shader_quirk_hash wuthering_waves_hashes[] = {
     /* LightGridInjectionCS. Forgets to UAV barrier after ClearCS. */
-    { 0x63bad782eb2380fb, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
+    { 0x513ffbb9ffc55d06, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
 };
 
 static const struct vkd3d_shader_quirk_info wuthering_waves_quirks = {


### PR DESCRIPTION
Similar to #2653, the game had an update (2.8) a few days ago and the shader hash changed again.

Renderdoc capture: https://drive.google.com/file/d/1fa01rAKSICQikZwP8ZL2GZ6K9zcIbEPZ/view