### PR TITLE
vkd3d: Use CPU query resets when feasible.

### DIFF
--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -421,8 +421,6 @@ static void vkd3d_acceleration_structure_write_postbuild_info(
         return;
     }
 
-    d3d12_command_list_reset_query(list, vk_query_pool, vk_query_index);
-
     VK_CALL(vkCmdWriteAccelerationStructuresPropertiesKHR(list->cmd.vk_command_buffer,
             1, &vk_acceleration_structure, vk_query_type, vk_query_pool, vk_query_index));
     VK_CALL(vkCmdCopyQueryPoolResults(list->cmd.vk_command_buffer,
@@ -441,8 +439,6 @@ static void vkd3d_acceleration_structure_write_postbuild_info(
                 ERR("Failed to allocate query.\n");
                 return;
             }
-
-            d3d12_command_list_reset_query(list, vk_query_pool, vk_query_index);
 
             VK_CALL(vkCmdWriteAccelerationStructuresPropertiesKHR(list->cmd.vk_command_buffer,
                     1, &vk_acceleration_structure, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR,

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4035,6 +4035,8 @@ static HRESULT d3d12_device_create_query_pool(struct d3d12_device *device, uint3
     pool->type_index = type_index;
     pool->query_count = pool_info.queryCount;
     pool->next_index = 0;
+
+    VK_CALL(vkResetQueryPool(device->vk_device, pool->vk_query_pool, 0, pool->query_count));
     return S_OK;
 }
 
@@ -4049,6 +4051,7 @@ static void d3d12_device_destroy_query_pool(struct d3d12_device *device, const s
 
 HRESULT d3d12_device_get_query_pool(struct d3d12_device *device, uint32_t type_index, struct vkd3d_query_pool *pool)
 {
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     size_t i;
 
     pthread_mutex_lock(&device->mutex);
@@ -4062,6 +4065,8 @@ HRESULT d3d12_device_get_query_pool(struct d3d12_device *device, uint32_t type_i
             if (--device->query_pool_count != i)
                 device->query_pools[i] = device->query_pools[device->query_pool_count];
             pthread_mutex_unlock(&device->mutex);
+
+            VK_CALL(vkResetQueryPool(device->vk_device, pool->vk_query_pool, 0, pool->query_count));
             return S_OK;
         }
     }

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -192,8 +192,6 @@ void vkd3d_opacity_micromap_write_postbuild_info(
         return;
     }
 
-    d3d12_command_list_reset_query(list, vk_query_pool, vk_query_index);
-
     VK_CALL(vkCmdWriteMicromapsPropertiesEXT(list->cmd.vk_command_buffer,
             1, &vk_opacity_micromap, vk_query_type, vk_query_pool, vk_query_index));
     VK_CALL(vkCmdCopyQueryPoolResults(list->cmd.vk_command_buffer,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2767,7 +2767,7 @@ struct vkd3d_active_query
 
 enum vkd3d_query_range_flag
 {
-    VKD3D_QUERY_RANGE_RESET = 0x1,
+    VKD3D_QUERY_RANGE_GPU_RESET = 0x1,
 };
 
 struct vkd3d_query_range


### PR DESCRIPTION
Using GPU query resets for virtual queries is not necessary.