### PR TITLE
vkd3d: Respect unified_layout in swapchain blit.

### DIFF
--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -2163,7 +2163,7 @@ static void dxgi_vk_swap_chain_record_render_pass(struct dxgi_vk_swap_chain *cha
         write_info.dstArrayElement = 0;
         write_info.descriptorCount = 1;
         image_info.imageView = chain->user.vk_image_views[chain->request.user_index];
-        image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        image_info.imageLayout = d3d12_resource_pick_layout(chain->user.backbuffers[chain->request.user_index], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         image_info.sampler = VK_NULL_HANDLE;
 
         VK_CALL(vkCmdPushDescriptorSetKHR(vk_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,


### PR DESCRIPTION
The swapchain user backbuffers are allocated using `d3d12_resource_create_committed`. This means they'll also use `VK_IMAGE_LAYOUT_GENERAL` everywhere if `VK_KHR_unified_image_layouts` is supported.

So we also need to respect that in the swapchain blit.

Fixes a bunch of validation errors according to Runar.
I can't really test it myself because Nvidia doesnt support `VK_KHR_unified_image_layouts` yet.
EDIT: Actually, I can just hardcode support for unified_image_layouts because Nvidia HW works like that anyway.