### PR TITLE
vkd3d: Add workarounds for Guardians of the Galaxy.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -659,6 +659,8 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     { VKD3D_STRING_COMPARE_EXACT, "DeathStranding.exe", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0 },
     /* AC: Valhalla (2208920). Very ugly use-after-free in some cases. The main culprit seems a sparse resource. */
     { VKD3D_STRING_COMPARE_EXACT, "ACValhalla.exe", VKD3D_CONFIG_FLAG_DEFER_RESOURCE_DESTRUCTION, 0 },
+    /* Guardians of the Galaxy: Tries to use root descriptors with indirect rendering if it detects an Nvidia GPU. */
+    { VKD3D_STRING_COMPARE_EXACT, "gotg.exe", VKD3D_CONFIG_FLAG_FORCE_RAW_VA_CBV, 0 },
     { VKD3D_STRING_COMPARE_NEVER, NULL, 0, 0 }
 };
 


### PR DESCRIPTION
Fixes #2768

On top of that the game crashes right now when you start it on Steam on a Nvidia GPU.
The problem is that the game is using root descriptors with indirect rendering when it detects a Nvidia GPU.

There's two ways to work around that:
* hide the Nvidia (in which case I'd make a PR for DXVK to add a default config for Guardians there).
* Enable `VKD3D_CONFIG_FLAG_FORCE_RAW_VA_CBV`. 

The latter option allows using DLSS so I prefer that one.