### PR TITLE
vkd3d: Update shader quirk hash for Wuthering Waves 3.0

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -857,7 +857,7 @@ static const struct vkd3d_shader_quirk_info death_stranding_quirks = {
 
 static const struct vkd3d_shader_quirk_hash wuthering_waves_hashes[] = {
     /* LightGridInjectionCS. Forgets to UAV barrier after ClearCS. */
-    { 0x513ffbb9ffc55d06, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
+    { 0xc9d920e5cce36266, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
 };
 
 static const struct vkd3d_shader_quirk_info wuthering_waves_quirks = {


### PR DESCRIPTION
Once again, the shader hash changed after the latest game update.

Renderdoc capture: https://drive.google.com/file/d/1MjpUgXZ7Fxqfj9U7lMAg3cDJXq9zIuma/view

Tested with Wine 10.20 on Lutris with SteamOS=1 environment variable set.