### PR TITLE
tests: add an Adreno-specific bug_if in test_deferred_clears

### DIFF
--- a/tests/d3d12_clear.c
+++ b/tests/d3d12_clear.c
@@ -1811,6 +1811,8 @@ void test_deferred_clears(void)
 
     transition_resource_state(context.list, rt[0], D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE);
 
+    /* On Adreno the image compression is incompatible between the two render target image formats */
+    bug_if(is_adreno_device(context.device))
     check_sub_resource_uint(rt[0], 0, context.queue, context.list, 1u, 0u);
     reset_command_list(context.list, context.allocator);
 


### PR DESCRIPTION
The subtest of two aliased render targets, where one is cleared and the other is tested for the correct content, fails on Adreno because the hardware uses incompatible image compression encodings for the underlyng Vulkan image formats. The test otherwise passes if image compression is force-disabled in Turnip through debug options.