### PR TITLE
tests: adjust timeout in test_fence_pending_signal_cpu_rewind on slow…

### DIFF
--- a/tests/d3d12_sync.c
+++ b/tests/d3d12_sync.c
@@ -1819,7 +1819,7 @@ static void test_fence_pending_signal_cpu_rewind(bool use_shared)
 
             /* The heavy-GPU-load dispatch will take more time on weaker GPUs */
             if (is_adreno_device(context.device))
-               wait_timeout = 8000;
+                wait_timeout = 8000;
 
             /* GPU is busy now. Reset the fence to 0 while there's a pending signal to 10.
              * Technically this is a bit racy. */


### PR DESCRIPTION
…er GPUs

Adreno GPUs will take a bit more time on the heavy-load dispatch used in the test_fence_pending_signal_cpu_rewind test case, so an increased event timeout value should be used there.