### PR TITLE
Update validation of VKD3D_PRIMITIVE_ID to allow all the stages where the primitive id can be generated.

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -4674,7 +4674,20 @@ static bool vkd3d_shader_semantic_is_generated_for_stage(enum vkd3d_sysval_seman
             return curr_stage == VK_SHADER_STAGE_VERTEX_BIT;
 
         case VKD3D_SV_PRIMITIVE_ID:
-            return prev_stage == VK_SHADER_STAGE_VERTEX_BIT;
+            /* Per HLSL semantics, SV_PrimitiveID is a system value that may be provided as an
+            * input without being explicitly exported by the previous stage. In particular,
+            * it can be read by HS/DS/GS/PS.
+            *
+            * Therefore, when validating signature linkage, allow SV_PrimitiveID to be missing
+            * from the previous stage output signature for those stages.
+            *
+            * If the previous stage *does* export it, we still validate register/component matching
+            * in vkd3d_validate_shader_io_signatures().
+            */
+            return curr_stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
+                curr_stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT ||
+                curr_stage == VK_SHADER_STAGE_GEOMETRY_BIT ||
+                curr_stage == VK_SHADER_STAGE_FRAGMENT_BIT;
 
         case VKD3D_SV_IS_FRONT_FACE:
         case VKD3D_SV_SAMPLE_INDEX:


### PR DESCRIPTION
Per the MSDN documentation here: https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics

`SV_PrimitiveID: Per-primitive identifier automatically generated by the runtime (see Using System-Generated Values (Direct3D 10)). Can be written to by the geometry or pixel shaders, and read by the geometry, pixel, hull or domain shaders.`

Current code only allows implicit SV_PrimitiveID if the previous state is vertex. Documentation (and DX12 in practice) appears to allow GS, PS, and TS. 

Strawman attached.

[dx12pipeline.zip](https://github.com/user-attachments/files/24537745/dx12pipeline.zip)

Found while testing with C4D/Redshift in their real-time raytracing mode. Pipeline generation fails (as seen with strawman example) and C4D closes. Running the strawman natively shows the pipeline is successfully created and used.