### PR TITLE
tests: skip larger-than-supported texel buffer count tests on Adreno

### DIFF
--- a/tests/d3d12_resource.c
+++ b/tests/d3d12_resource.c
@@ -4857,7 +4857,8 @@ void test_large_texel_buffer_view(void)
 
         if (tests[i].element_count > (1 << D3D12_REQ_BUFFER_RESOURCE_TEXEL_COUNT_2_TO_EXP))
         {
-            if (is_adreno_device(context.device)) {
+            if (is_adreno_device(context.device))
+            {
                 skip("Adreno doesn't support more than D3D12-specified minimum of 2^27 texel buffer elements\n");
                 continue;
             }


### PR DESCRIPTION
In test_large_texel_buffer_view, specific test cases will use texel counts that go beyond the value supported on Adreno (2^27, which is the minimum D3D12 requirement).

D3D12 doesn't provide a way to query for the actual driver's limit, so Vulkan's maxTexelBufferElements value can't be relayed to that. Instead just skip the tests on Adreno if the texel count is too large.