### PR TITLE
vkd3d: Disable UAV compression in Shadow of the Tomb Raider.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -562,8 +562,9 @@ static const struct vkd3d_instance_application_meta application_override[] = {
      * Invariant workarounds actually cause more issues than they resolve on NV.
      * RADV already has workarounds by default.
      * FIXME: The proper workaround will be a workaround which force-emits mul + add + precise. The vertex shaders
-     * are broken enough that normal invariance is not enough. */
-    { VKD3D_STRING_COMPARE_EXACT, "SOTTR.exe", VKD3D_CONFIG_FLAG_FORCE_NO_INVARIANT_POSITION, 0 },
+     * are broken enough that normal invariance is not enough.
+     * DCC stores causes glitches when SMAA4x is enabled with RADV. */
+    { VKD3D_STRING_COMPARE_EXACT, "SOTTR.exe", VKD3D_CONFIG_FLAG_FORCE_NO_INVARIANT_POSITION | VKD3D_CONFIG_FLAG_DISABLE_UAV_COMPRESSION, 0 },
     /* Elden Ring (1245620).
      * Game is really churny on committed memory allocations, and does not use NOT_ZEROED. Clearing works causes bubbles.
      * It seems to work just fine however to skip the clears. */


### PR DESCRIPTION
SMAA4x causes DCC glitches when screen effects are enabled and bloom is disabled on RDNA3 (RX 7600). No glitches on Raphael or with AMDVLK. `radv_disable_dcc_stores=true` fixes it on RADV. SMAA4x is not an option on the native version.