### PR TITLE
Disable Reflex when a second swapchain is first used, rather than created

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5102,7 +5102,7 @@ struct vkd3d_cached_command_allocator
 struct vkd3d_device_swapchain_info
 {
     struct dxgi_vk_swap_chain *low_latency_swapchain;
-    uint32_t swapchain_count;
+    uint32_t vk_swapchain_count;
     bool mode;
     bool boost;
     union
@@ -5751,21 +5751,13 @@ static inline void d3d12_device_register_swapchain(struct d3d12_device *device, 
 {
     spinlock_acquire(&device->low_latency_swapchain_spinlock);
 
-    if (!device->swapchain_info.low_latency_swapchain && device->swapchain_info.swapchain_count == 0)
+    if (!device->swapchain_info.low_latency_swapchain)
     {
         dxgi_vk_swap_chain_incref(chain);
         device->swapchain_info.low_latency_swapchain = chain;
         dxgi_vk_swap_chain_set_latency_sleep_mode(chain, device->swapchain_info.mode,
                 device->swapchain_info.boost, device->swapchain_info.minimum_us);
     }
-    else
-    {
-        if (device->swapchain_info.low_latency_swapchain)
-            dxgi_vk_swap_chain_decref(device->swapchain_info.low_latency_swapchain);
-        device->swapchain_info.low_latency_swapchain = NULL;
-    }
-
-    device->swapchain_info.swapchain_count++;
 
     spinlock_release(&device->low_latency_swapchain_spinlock);
 }
@@ -5779,8 +5771,6 @@ static inline void d3d12_device_remove_swapchain(struct d3d12_device *device, st
         dxgi_vk_swap_chain_decref(chain);
         device->swapchain_info.low_latency_swapchain = NULL;
     }
-
-    device->swapchain_info.swapchain_count--;
 
     spinlock_release(&device->low_latency_swapchain_spinlock);
 }


### PR DESCRIPTION
I've observed Arc Raiders and The Finals creating a second DXGI swapchain after a few minutes of gameplay, which is immediately destroyed and never presented to. Today this leads to clearing out low_latency_swapchain so vkd3d-proton no longer passes along Reflex API calls. This is done because the Reflex NvAPIs don't allow for multi swapchain support.

This change adjusts the Reflex multi swapchain disablement to happen when multiple Vulkan swapchains are created, rather than dxgi swapchains. The Vulkan swapchain is created on first present. This way we'll ignore the temporary swapchains created by these games and continue passing along Reflex API calls.

This fixes part of issue https://github.com/HansKristian-Work/vkd3d-proton/issues/2794.

**Testing**
I've tested this on Arc Raiders and confirmed that the Reflex API calls no longer stop being delivered after a few minutes of gameplay. They continue to be delivered after resizing the game window a few times.