### PR TITLE
vkd3d: Update shader quirk hash for Wuthering Waves 3.1

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -859,7 +859,7 @@ static const struct vkd3d_shader_quirk_info death_stranding_quirks = {
 
 static const struct vkd3d_shader_quirk_hash wuthering_waves_hashes[] = {
     /* LightGridInjectionCS. Forgets to UAV barrier after ClearCS. */
-    { 0xc9d920e5cce36266, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
+    { 0x3961a9adabf4e1e4, VKD3D_SHADER_QUIRK_FORCE_PRE_COMPUTE_BARRIER },
 };
 
 static const struct vkd3d_shader_quirk_info wuthering_waves_quirks = {


### PR DESCRIPTION
New game version, so the shader hash changed again.

Renderdoc capture: https://drive.google.com/file/d/1oqoZt3AiMnyZLy9T6OqAD3ieiO-pbM9F/view

Tested with Wine 11.1 on Lutris with SteamOS=1 environment variable set.
