### PR TITLE
Return `S_FALSE` on NULL output COMPtr in `D3D12GetInterface()`

### DIFF
--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -1001,7 +1001,8 @@ static HRESULT d3d12core_D3D12GetInterface(REFCLSID rcslid, REFIID iid, void **d
     {
         if (IsEqualGUID(iid, &IID_IVKD3DCoreInterface))
         {
-            if (debug) {
+            if (debug)
+            {
                 *debug = (void*)&d3d12core_interface_instance;
                 return S_OK;
             }
@@ -1013,7 +1014,8 @@ static HRESULT d3d12core_D3D12GetInterface(REFCLSID rcslid, REFIID iid, void **d
     {
         if (IsEqualGUID(iid, &IID_IVKD3DDebugControlInterface))
         {
-            if (debug) {
+            if (debug)
+            {
                 *debug = (void*)&vkd3d_debug_control_instance;
                 return S_OK;
             }


### PR DESCRIPTION
The output pointer in `D3D12GetInterface()` is allowed to be `NULL` according to `_COM_Outptr_opt_`, which is useful in cases where the caller wants to check if a certain CLSID/IID is supported by the implementation (which returns a positive success code `S_FALSE` or `E_NOINTERFACE` when it is not available), without actually returning an owned interface object.


https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-d3d12getinterface
