### PR TITLE
vkd3d: Ignore lazily_allocated when scanning memory types.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4630,6 +4630,10 @@ bool d3d12_device_is_uma(struct d3d12_device *device, bool *coherent)
 
     for (i = 0; i < device->memory_properties.memoryTypeCount; ++i)
     {
+		/* Ignore these types. We never use them and they won't be HOST_VISIBLE. */
+		if (device->memory_properties.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
+			continue;
+
         if (!(device->memory_properties.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT))
             return false;
         if (coherent && !(device->memory_properties.memoryTypes[i].propertyFlags

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -9445,6 +9445,10 @@ static void vkd3d_memory_info_get_topology(struct vkd3d_memory_topology *topolog
         flags = device->memory_properties.memoryTypes[i].propertyFlags;
         heap_index = device->memory_properties.memoryTypes[i].heapIndex;
 
+        /* Ignore these types. We never use them and they won't be HOST_VISIBLE. */
+        if (flags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
+            continue;
+
         if (heap_index == topology->largest_device_local_heap_index &&
                 (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0 &&
                 (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)


### PR DESCRIPTION
Fix #2806.