### PR TITLE
Clean up manual `S_FALSE` handling when output COMPtr is NULL

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -7289,16 +7289,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreatePipelineLibrary(d3d12_device
             flags, &pipeline_library)))
         return hr;
 
-    if (lib)
-    {
-        return return_interface(&pipeline_library->ID3D12PipelineLibrary_iface,
-                &IID_ID3D12PipelineLibrary, iid, lib);
-    }
-    else
-    {
-        ID3D12PipelineLibrary1_Release(&pipeline_library->ID3D12PipelineLibrary_iface);
-        return S_FALSE;
-    }
+    return return_interface(&pipeline_library->ID3D12PipelineLibrary_iface,
+            &IID_ID3D12PipelineLibrary, iid, lib);
 }
 
 static HRESULT STDMETHODCALLTYPE d3d12_device_SetEventOnMultipleFenceCompletion(d3d12_device_iface *iface,

--- a/libs/vkd3d/vkd3d_main.c
+++ b/libs/vkd3d/vkd3d_main.c
@@ -65,12 +65,6 @@ HRESULT vkd3d_create_device(const struct vkd3d_device_create_info *create_info,
     if (FAILED(hr))
         return hr;
 
-    if (!device)
-    {
-        ID3D12Device12_Release(&object->ID3D12Device_iface);
-        return S_FALSE;
-    }
-
     return return_interface(&object->ID3D12Device_iface, &IID_ID3D12Device, iid, device);
 }
 


### PR DESCRIPTION
For https://github.com/HansKristian-Work/vkd3d-proton/pull/2817#discussion_r2803750439

Both branches were introduced well before `return_interface()` was generalized to return `S_FALSE` if the output COMPtr is NULL.  Since these paths already use `return_interface()`, delete custom handling of the output COMPtr being NULL in favour of the generic implementation.