### PR TITLE
Remove zero check for grid dimensions in LaunchCubinShaderEx

### DIFF
--- a/libs/vkd3d/command_list_vkd3d_ext.c
+++ b/libs/vkd3d/command_list_vkd3d_ext.c
@@ -85,7 +85,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_vkd3d_ext_LaunchCubinShaderE
     TRACE("iface %p, handle %p, block_x %u, block_y %u, block_z %u, smem_size %u, params %p, param_size %u, raw_params %p, raw_params_count %u\n",
            iface, handle, block_x, block_y, block_z, smem_size, params, param_size, raw_params, raw_params_count);
 
-    if (!handle || !block_x || !block_y || !block_z || !params || !param_size)
+    if (!handle || !params || !param_size)
         return E_INVALIDARG;
 
     launchInfo.function = handle->vkCuFunction;


### PR DESCRIPTION
Dispatching a kernel with zero size is a valid operation which acts as a no-op. Though generally this doesn't make sense, it's possible to hit this scenario when calculating grid sizes directly from a buffer size, for example.

This change removes the validation which enforced that `block_x/y/z` must be nonzero in `LaunchCubinShaderEx`, bringing the behaviour in line with the NVIDIA D3D12 driver implementation.