### PR TITLE
vkd3d: Ignore primitive shading rate in RE8.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -738,6 +738,11 @@ static const struct vkd3d_shader_quirk_info re2_quirks = {
     re_hashes, ARRAY_SIZE(re_hashes), VKD3D_SHADER_QUIRK_IGNORE_PRIMITIVE_SHADING_RATE,
 };
 
+/* Works around the same weird GPU hang as above (RE2) but for RE8. */
+static const struct vkd3d_shader_quirk_info re8_quirks = {
+    re_hashes, ARRAY_SIZE(re_hashes), VKD3D_SHADER_QUIRK_IGNORE_PRIMITIVE_SHADING_RATE,
+};
+
 /* There are lots of shaders which cause random flicker due to bad 16-bit behavior.
  * These shaders really need 32-bit it seems to render properly, so just do that. */
 static const struct vkd3d_shader_quirk_info re4_quirks = {
@@ -922,6 +927,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "Ronin.exe", &team_ninja_quirks },
     /* Resident Evil 2 (883710) */
     { VKD3D_STRING_COMPARE_EXACT, "re2.exe", &re2_quirks },
+    /* Resident Evil Village (1196590) */
+    { VKD3D_STRING_COMPARE_EXACT, "re8.exe", &re8_quirks },
     /* Resident Evil 7 (418370) */
     { VKD3D_STRING_COMPARE_EXACT, "re7.exe", &re_quirks },
     /* Resident Evil 4 (2050650) */


### PR DESCRIPTION
I noticed that you merged your RE2 workaround into main so I wanted to give a heads up with this PR that RE8 also runs into the same ring 0 timeout on 9070XT (and most likely other RDNA 4 cards).

Before I found your workaround, the way I fixed the system crashes on RE2 was to revert to the non-RT DX11 build that seemed to fix the issue and some other graphical artefacts, probably because it switched to DXVK instead of VKD3D.

Sadly that is not possible for RE8 as it's DX12 only so even with RT off in settings I would run into the same crashes as RE2.

Having found your fix in the [mesa gitlab](https://gitlab.freedesktop.org/mesa/mesa/-/issues/14812), I applied the RE8 patch locally and it seemed to fix the crashes I had since the beginning so it seems that Village is also doing some weird things with shaders like RE2.

An interesting thing to note is that both RE7 and RE3 Remake are not crashing at all (at least for me). Both were on DX12 RT enabled builds and weirdly enough, even though RE3R is newer than RE2R, it just never crashed for me so RE2R's weird shader stuff is likely not present in 3.

All games were played for more than 30 hours each. RE2R would crash in the sewers almost always like the bug report states and Village would crash near the beginning when you first step into the village randomly but often.