### PR TITLE
vkd3d: Make ignore_primitive_shading_rate rdna4+ specific.

### DIFF
--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -1919,7 +1919,7 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
     compile_args.min_subgroup_size = object->device->device_info.vulkan_1_3_properties.minSubgroupSize;
     compile_args.max_subgroup_size = object->device->device_info.vulkan_1_3_properties.maxSubgroupSize;
     /* Don't care about wave size promotion in RT. */
-    compile_args.quirks = &vkd3d_shader_quirk_info;
+    compile_args.quirks = &object->device->workarounds.quirks;
 
     if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_DRIVER_VERSION_SENSITIVE_SHADERS)
     {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -8087,7 +8087,7 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_buffer(struct d3d12_descr
 
     descriptor_count = descriptor_heap->desc.NumDescriptors;
     if (descriptor_heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
-            d3d12_descriptor_heap_require_padding_descriptors())
+            d3d12_descriptor_heap_require_padding_descriptors(device))
     {
         descriptor_count += VKD3D_DESCRIPTOR_DEBUG_NUM_PAD_DESCRIPTORS;
     }
@@ -9117,7 +9117,7 @@ void d3d12_descriptor_heap_cleanup(struct d3d12_descriptor_heap *descriptor_heap
     vkd3d_descriptor_debug_unregister_heap(descriptor_heap->cookie);
 }
 
-bool d3d12_descriptor_heap_require_padding_descriptors(void)
+bool d3d12_descriptor_heap_require_padding_descriptors(struct d3d12_device *device)
 {
     uint32_t quirks;
     unsigned int i;
@@ -9127,9 +9127,9 @@ bool d3d12_descriptor_heap_require_padding_descriptors(void)
 
     /* If we use descriptor heap robustness, reserve a dummy descriptor we can use
      * as fake NULL descriptor. */
-    quirks = vkd3d_shader_quirk_info.default_quirks | vkd3d_shader_quirk_info.global_quirks;
-    for (i = 0; i < vkd3d_shader_quirk_info.num_hashes; i++)
-        quirks |= vkd3d_shader_quirk_info.hashes[i].quirks;
+    quirks = device->workarounds.quirks.default_quirks | device->workarounds.quirks.global_quirks;
+    for (i = 0; i < device->workarounds.quirks.num_hashes; i++)
+        quirks |= device->workarounds.quirks.hashes[i].quirks;
     return !!(quirks & VKD3D_SHADER_QUIRK_DESCRIPTOR_HEAP_ROBUSTNESS);
 }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -246,7 +246,6 @@ struct vkd3d_instance
 };
 
 extern uint64_t vkd3d_config_flags;
-extern struct vkd3d_shader_quirk_info vkd3d_shader_quirk_info;
 
 struct vkd3d_queue_timeline_trace_cookie
 {
@@ -1610,7 +1609,7 @@ struct d3d12_descriptor_heap
 HRESULT d3d12_descriptor_heap_create(struct d3d12_device *device,
         const D3D12_DESCRIPTOR_HEAP_DESC *desc, struct d3d12_descriptor_heap **descriptor_heap);
 void d3d12_descriptor_heap_cleanup(struct d3d12_descriptor_heap *descriptor_heap);
-bool d3d12_descriptor_heap_require_padding_descriptors(void);
+bool d3d12_descriptor_heap_require_padding_descriptors(struct d3d12_device *device);
 
 static inline struct d3d12_descriptor_heap *impl_from_ID3D12DescriptorHeap(ID3D12DescriptorHeap *iface)
 {
@@ -5483,6 +5482,7 @@ struct d3d12_device
 
     struct
     {
+        struct vkd3d_shader_quirk_info quirks;
         bool amdgpu_broken_clearvram;
         bool amdgpu_broken_null_tile_mapping;
         bool tiler_renderpass_barriers;

--- a/libs/vkd3d/workgraphs.c
+++ b/libs/vkd3d/workgraphs.c
@@ -2180,7 +2180,7 @@ static HRESULT d3d12_wg_state_object_convert_entry_point(
     compile_args.min_subgroup_size = object->device->device_info.vulkan_1_3_properties.minSubgroupSize;
     compile_args.max_subgroup_size = object->device->device_info.vulkan_1_3_properties.maxSubgroupSize;
     /* Don't care about wave size promotion in RT. */
-    compile_args.quirks = &vkd3d_shader_quirk_info;
+    compile_args.quirks = &object->device->workarounds.quirks;
 
     if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_DRIVER_VERSION_SENSITIVE_SHADERS)
     {


### PR DESCRIPTION
Seen in multiple games now, so safest to just disable it until the issue has been root caused.