### PR TITLE
vkd3d-shader: Use shader metadata for control flow hints.

### DIFF
--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -605,10 +605,13 @@ static bool vkd3d_dxil_converter_set_quirks(dxil_spv_converter converter,
         }
     }
 
-    if (quirks & VKD3D_SHADER_QUIRK_FORCE_LOOP)
     {
         struct dxil_spv_option_branch_control helper = { { DXIL_SPV_OPTION_BRANCH_CONTROL } };
-        helper.force_loop = DXIL_SPV_TRUE;
+        if (quirks & VKD3D_SHADER_QUIRK_FORCE_LOOP)
+            helper.force_loop = DXIL_SPV_TRUE;
+        else
+            helper.use_shader_metadata = DXIL_SPV_TRUE;
+
         if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
         {
             WARN("dxil-spirv does not support BRANCH_CONTROL.\n");


### PR DESCRIPTION
Not entirely sure why this hasn't been done yet.
Possibly concerns of shader cache invalidations.

Potentially a very large sweeping change that could affect every game, so need to be a bit careful ...