### PR TITLE
vkd3d: Disable load_store_op compatibility for Turnip.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3830,7 +3830,6 @@ static void d3d12_device_init_workarounds(struct d3d12_device *device)
      * Be spec correct by default, and go a bit out of spec if we know the drivers are sensible. */
     switch (device->device_info.vulkan_1_2_properties.driverID)
     {
-        case VK_DRIVER_ID_MESA_TURNIP:
         case VK_DRIVER_ID_MESA_RADV:
         case VK_DRIVER_ID_MESA_NVK:
         case VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA:


### PR DESCRIPTION
It doesn't work like we want right now and we need a vendor extension to sort this out to do it properly.
Keep the hackery for IMR for now to keep things testable until we have a more robust solution.