### PR TITLE
vkd3d: Skip non-aligned latency reports instead of discarding all

### DIFF
--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -3299,14 +3299,16 @@ void dxgi_vk_swap_chain_get_latency_info(struct dxgi_vk_swap_chain *chain, D3D12
                 D3D12_FRAME_REPORT *report;
 
                 /* If the frame ID isn't a natural aligned value,
-                 * we assume it's a fake frame that the application never submitted a marker for.
-                 * Ignore it. */
+                 * we assume it's a frame that the application never submitted a marker for.
+                 * Non-aligned IDs appear when the monotonicity guard in the present path
+                 * bumps a stale or duplicate low_latency_frame_id (e.g. after a Wayland
+                 * compositor workspace switch stalls presents, or when DLSS Frame Generation
+                 * presents interpolated frames without setting new latency markers).
+                 * Skip these entries rather than discarding all reports, since Streamline's
+                 * sl.dlss_g module checks latency reports to verify Reflex is active and
+                 * will disable Frame Generation if all reports are zeroed. */
                 if (frame_reports[i].presentID % VKD3D_LOW_LATENCY_FRAME_ID_STRIDE != 0 || frame_reports[i].presentID == 0)
-                {
-                    /* We either have to report all frames, or nothing. */
-                    memset(latency_results->frame_reports, 0, sizeof(latency_results->frame_reports));
-                    goto unlock_out;
-                }
+                    continue;
 
                 report = &latency_results->frame_reports[i];
 
@@ -3336,7 +3338,6 @@ void dxgi_vk_swap_chain_get_latency_info(struct dxgi_vk_swap_chain *chain, D3D12
         }
     }
 
-unlock_out:
     pthread_mutex_unlock(&chain->present.low_latency_swapchain_lock);
 }
 


### PR DESCRIPTION
## Summary

When presents use a stale or duplicate `low_latency_frame_id`, the monotonicity guard in the present path bumps the present ID to a non-stride-aligned value (e.g. `N*10000+1` instead of `N*10000`). This happens when:

- A **Wayland compositor** stalls presents (e.g. switching workspaces on Hyprland)
- **DLSS Frame Generation** presents interpolated frames without setting new latency markers

Previously, `dxgi_vk_swap_chain_get_latency_info()` would zero **all 64** latency reports if **any** report had a non-aligned `presentID`. This caused Streamline's `sl.dlss_g` module to conclude Reflex was inactive (`eDLSSGStatusFailReflexNotDetectedAtRuntime`), disabling Frame Generation and freezing the game.

## The fix

Skip non-aligned entries (`continue`) instead of discarding all reports (`memset` + `goto`). The output array is already pre-zeroed, so skipped slots remain zero. Valid application frames are reported normally.

## Game log showing the bug (Crimson Desert, before fix)

```
[streamline][error] Unable to find 'common' constants for frame 7098 - id 0
[streamline][error] eDLSSGStatusFailReflexNotDetectedAtRuntime - sl.reflex must be enabled and active 7098 != 15476
[streamline][error] eDLSSGStatusFailReflexNotDetectedAtRuntime - sl.reflex must be enabled and active 25880 != 30786
```

## Testing

- Built via GE-Proton SDK container, replaced DLLs in Proton Hotfix
- Crimson Desert with DLSS Frame Generation enabled
- Verified fix: game no longer freezes after workspace switch on Hyprland
- Verified bug: reverted to original DLLs → freeze reproduced