### PR TITLE
vkd3d: Implicitly bind RTPSO root signature for DispatchRays when none is set

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -7139,16 +7139,49 @@ static bool d3d12_command_list_update_raygen_pipeline(struct d3d12_command_list 
                 list->rt_state->pipelines[i].global_root_signature,
                 list->compute_bindings.root_signature))
         {
-            /* We might have degenerate variants. */
+            /* We might have degenerate variants with no compiled pipeline.
+             * Skip them and continue searching for a valid one. */
             if (list->rt_state->pipelines[i].pipeline)
+            {
                 list->rt_state_variant = &list->rt_state->pipelines[i];
-            break;
+                break;
+            }
         }
     }
 
     if (!list->rt_state_variant)
     {
-        WARN("Global root signature compatible with the RTPSO.\n");
+        /* Some applications (e.g. RT64) call DispatchRays without explicitly calling
+         * SetComputeRootSignature, relying on the RTPSO's embedded global root signature.
+         * Native D3D12 drivers handle this implicitly. When the bound root signature is
+         * NULL or empty, fall back to the first variant with a valid pipeline and
+         * implicitly bind its global root signature for correct descriptor layout. */
+        if (!list->compute_bindings.root_signature ||
+                list->compute_bindings.root_signature->layout_compatibility_hash == 0)
+        {
+            for (i = 0; i < list->rt_state->pipelines_count; i++)
+            {
+                if (list->rt_state->pipelines[i].pipeline)
+                {
+                    WARN("No compute root signature bound for DispatchRays, "
+                            "falling back to RTPSO variant %u.\n", i);
+                    list->rt_state_variant = &list->rt_state->pipelines[i];
+
+                    list->compute_bindings.root_signature = list->rt_state_variant->global_root_signature;
+                    if (list->rt_state_variant->global_root_signature)
+                        list->compute_bindings.static_sampler_set =
+                                list->rt_state_variant->global_root_signature->vk_sampler_set;
+                    d3d12_command_list_invalidate_root_parameters(list,
+                            &list->compute_bindings, true, NULL);
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!list->rt_state_variant)
+    {
+        WARN("Global root signature not compatible with the RTPSO.\n");
         return false;
     }
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -7116,6 +7116,9 @@ static bool d3d12_command_list_update_compute_pipeline(struct d3d12_command_list
     return true;
 }
 
+static void d3d12_command_list_set_root_signature(struct d3d12_command_list *list,
+        struct vkd3d_pipeline_bindings *bindings, const struct d3d12_root_signature *root_signature);
+
 static bool d3d12_command_list_update_raygen_pipeline(struct d3d12_command_list *list)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
@@ -7155,7 +7158,13 @@ static bool d3d12_command_list_update_raygen_pipeline(struct d3d12_command_list 
          * SetComputeRootSignature, relying on the RTPSO's embedded global root signature.
          * Native D3D12 drivers handle this implicitly. When the bound root signature is
          * NULL or empty, fall back to the first variant with a valid pipeline and
-         * implicitly bind its global root signature for correct descriptor layout. */
+         * implicitly bind its global root signature for correct descriptor layout.
+         *
+         * An RTPSO can have multiple incompatible global root signatures in it,
+         * so we can't really just pick a default in all cases,
+         * but if we're in this path the application is already broken,
+         * so just do what workarounds the buggy app.
+         */
         if (!list->compute_bindings.root_signature ||
                 list->compute_bindings.root_signature->layout_compatibility_hash == 0)
         {
@@ -7166,13 +7175,8 @@ static bool d3d12_command_list_update_raygen_pipeline(struct d3d12_command_list 
                     WARN("No compute root signature bound for DispatchRays, "
                             "falling back to RTPSO variant %u.\n", i);
                     list->rt_state_variant = &list->rt_state->pipelines[i];
-
-                    list->compute_bindings.root_signature = list->rt_state_variant->global_root_signature;
-                    if (list->rt_state_variant->global_root_signature)
-                        list->compute_bindings.static_sampler_set =
-                                list->rt_state_variant->global_root_signature->vk_sampler_set;
-                    d3d12_command_list_invalidate_root_parameters(list,
-                            &list->compute_bindings, true, NULL);
+                    d3d12_command_list_set_root_signature(list,
+                            &list->compute_bindings, list->rt_state_variant->global_root_signature);
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

Some DXR applications call `DispatchRays` without explicitly calling `SetComputeRootSignature`, relying on the RTPSO's embedded global root signature. Native D3D12 drivers (tested: NVIDIA) handle this implicitly.

**Without this fix**, vkd3d-proton silently drops every `DispatchRays` call with:
```
warn: d3d12_command_list_DispatchRays: Failed to update raygen state, ignoring dispatch.
```

**Root cause** (two issues in `d3d12_command_list_update_raygen_pipeline`):

1. The degenerate variant (`pipelines[0]`, NULL root signature fallback) matches the NULL bound root signature but has `pipeline == VK_NULL_HANDLE`. The loop `break`s after this match, never reaching the real variant.

2. Even when the correct variant is found via fallback, `compute_bindings.root_signature` remains NULL, so `d3d12_command_list_update_descriptors` cannot bind any descriptors — resulting in black frames.

**This fix:**
- Skips degenerate variants with NULL pipeline handles instead of breaking the loop
- When bound RS is NULL/empty, falls back to the first variant with a valid pipeline and implicitly binds its global root signature for correct descriptor layout

## Test case

**sm64rt** (Super Mario 64 with RT64 path tracer) — legacy DXR 1.0 application that calls `DispatchRays` without `SetComputeRootSignature`.

| | Before | After |
|---|---|---|
| DispatchRays | Every call dropped silently | All calls succeed |
| Rendering | Black screen (only 2D HUD visible) | Full path-traced scene |
| Stability | N/A | Stable, no crashes, no validation errors |

**Hardware**: NVIDIA GeForce RTX 3090 Ti, driver 595.58.03, Vulkan 1.4.329

**Environment**: Wine 11.6, DXVK 2.7.1 (dxgi), Arch Linux (CachyOS kernel 6.19.12)

## Debug data that confirmed the root cause

```
bound_rs = 0x0000000000000000 (hash = 0x0000000000000000)  ← app never calls SetComputeRootSignature

variant[0]: rs hash = 0x0000000000000000, pipeline = NULL   ← degenerate, matches but unusable
variant[1]: rs hash = 0xd94d12186c0f2fb7, pipeline = VALID  ← real variant, doesn't match NULL
```

After the fallback binds variant[1]'s root signature, subsequent frames match variant[1] directly through the normal path (self-correcting).

## Risk assessment

- **Low risk**: The fallback only triggers when `compute_bindings.root_signature` is NULL/empty — games that correctly call `SetComputeRootSignature` are unaffected
- **Matches native D3D12 behavior**: NVIDIA's driver implicitly uses the RTPSO's root signature when none is explicitly bound
- The degenerate variant skip (`break` moved inside `if (pipeline)`) is a strict improvement — breaking on a NULL pipeline was always a bug