### PR TITLE
vkd3d: Bump RDNA1 compat path for VRS up to tier 2.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1704,7 +1704,7 @@ static D3D12_VARIABLE_SHADING_RATE_TIER d3d12_device_determine_variable_shading_
         if (vkd3d_application_feature_override == VKD3D_APPLICATION_FEATURE_RDNA1_COMPATIBILITY &&
             device->device_info.properties2.properties.vendorID == VKD3D_VENDOR_ID_AMD &&
             device->device_info.vulkan_1_3_properties.minSubgroupSize == 32)
-            return D3D12_VARIABLE_SHADING_RATE_TIER_1;
+            return D3D12_VARIABLE_SHADING_RATE_TIER_2;
         else
             return D3D12_VARIABLE_SHADING_RATE_TIER_NOT_SUPPORTED;
     }


### PR DESCRIPTION
Crimson Desert seems to hard require this in latest patch for whatever reason. We already handle the SetVRSImage calls in the fallback.