### PR TITLE
Fix copy direction in deferred discard compaction loop

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5881,7 +5881,7 @@ static void d3d12_command_list_flush_clears_for_rendering(struct d3d12_command_l
         if (!d3d12_command_list_resource_overlaps_attachment(list, discard->resource, &discard->subresources))
         {
             if (dst < src)
-                list->deferred_discards[src] = list->deferred_discards[dst];
+                list->deferred_discards[dst] = list->deferred_discards[src];
 
             dst++;
         }


### PR DESCRIPTION
In d3d12_command_list_flush_clears_for_rendering, the in-place compaction loop for deferred discards copies in the wrong direction when removing entries that overlap bound attachments.

During compaction, the code currently writes deferred_discards[src] = deferred_discards[dst] instead of deferred_discards[dst] = deferred_discards[src]. As a result, kept entries can be overwritten by earlier elements, corrupting the compacted discard list. Subsequent flushes may then execute discards for incorrect resources/subresources, causing lost or misapplied discards (potentially visible as rendering artifacts).

The deferred-clears compaction loop directly above already uses the correct copy direction; this change aligns deferred-discards with the same pattern.
Current (wrong):


src	dst	overlap	action	array after
0	0	no	dst++	[A, B, C, D]
1	—	yes	skip	[A, B, C, D]
2	1	no	discards[2] = discards[1] (writes B)	[A, B, B, D]
3	2	no	discards[3] = discards[2] (writes B)	[A, B, B, B]

Result: count=3, array=[A, B, B, B] — C and D are lost, replaced by copies of B.

Fixed:


src	dst	overlap	action	array after
0	0	no	dst++	[A, B, C, D]
1	—	yes	skip	[A, B, C, D]
2	1	no	discards[1] = discards[2] (writes C)	[A, C, C, D]
3	2	no	discards[2] = discards[3] (writes D)	[A, C, D, D]

Result: count=3, array=[A, C, D, ...] — correct.

Pretty sure that's just your typo. I'm hitting the sack. Bye guys.