### PR TITLE
Revert "vkd3d: Disable staggered submit on implementations with broke…

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -22521,11 +22521,6 @@ static bool d3d12_command_queue_needs_cpu_waits_locked(struct d3d12_command_queu
     if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_NO_STAGGERED_SUBMIT)
         return false;
 
-    /* If we risk massive stalls due to broken timeline semaphores,
-     * it's better to just go ahead. */
-    if (d3d12_device_has_slow_cpu_timeline_semaphores(command_queue->device))
-        return false;
-
     current_time_ns = vkd3d_get_current_time_ns();
 
     for (i = 0; i < command_queue->vkd3d_queue->command_queue_count; i++)
@@ -23421,10 +23416,6 @@ static bool d3d12_command_queue_needs_staggered_submissions_locked(struct d3d12_
         return false;
 
     if (vkd3d_config_flags & VKD3D_CONFIG_FLAG_NO_STAGGERED_SUBMIT)
-        return false;
-
-    /* Anything that requires spamming CPU waits of timeline semaphores should be banned. */
-    if (d3d12_device_has_slow_cpu_timeline_semaphores(command_queue->device))
         return false;
 
     /* Cannot meaningfully stagger submits if we're doing suspend resume style render passes. */


### PR DESCRIPTION
…n timeline."

This reverts commit 540c3d93516439a8fcf8b0c53b40076d43adc614.

Seems like we still need this path even though it's "slower", sigh ... HZD spams queues so hard that even NV hits stagger paths for compute.