### PR TITLE
vkd3d: Fix stale OMM pNext after RTAS batch realloc.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -19713,6 +19713,7 @@ static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
+    VkAccelerationStructureGeometryKHR *geometry;
     unsigned int i, geometry_index, usage_index;
 
     if (!rtas_batch->build_info_count && !rtas_batch->omm_build_info_count)
@@ -19756,6 +19757,20 @@ static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
         rtas_batch->omm_build_infos[i].pUsageCounts = &rtas_batch->omm_usage_infos[usage_index];
 
         usage_index += usage_count;
+    }
+
+    /* pNext pointers on Geometry AS. Currently limited to Opacity micromaps */
+    for (i = 0; i < rtas_batch->geometry_info_count; i++)
+    {
+        geometry = &rtas_batch->geometry_infos[i];
+
+        if (geometry->geometry.triangles.pNext)
+        {
+            assert(geometry->geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR);
+            assert(((const VkBaseInStructure *)&rtas_batch->omm_infos[i])->sType ==
+                   VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT);
+            geometry->geometry.triangles.pNext = &rtas_batch->omm_infos[i];
+        }
     }
 
     d3d12_command_list_end_current_render_pass(list, true);


### PR DESCRIPTION
This addresses a use-after-free bug that occurs in the following situation:

1. `geometry.triangles.pNext` is set to `rtas_batch->omm_infos[i]` when converting `OMM_TRIANGLES`.
2. Enough triangles get converted afterwards that `rtas_batch->omm_infos` is realloced and its base pointer changes.

In this case `vkCmdBuildAccelerationStructuresKHR` will dereference a stale pointer.

This bug is limited to when DXR 1.2 is enabled, and OMM is used by an application.