### PR TITLE
Add initial support for NV shader intrinsics and NV flavor of SER

### DIFF
--- a/include/private/nvShaderExtnEnums.h
+++ b/include/private/nvShaderExtnEnums.h
@@ -1,0 +1,179 @@
+/*********************************************************************************************************\
+|*                                                                                                        *|
+|* SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  *|
+|* SPDX-License-Identifier: MIT                                                                           *|
+|*                                                                                                        *|
+|* Permission is hereby granted, free of charge, to any person obtaining a                                *|
+|* copy of this software and associated documentation files (the "Software"),                             *|
+|* to deal in the Software without restriction, including without limitation                              *|
+|* the rights to use, copy, modify, merge, publish, distribute, sublicense,                               *|
+|* and/or sell copies of the Software, and to permit persons to whom the                                  *|
+|* Software is furnished to do so, subject to the following conditions:                                   *|
+|*                                                                                                        *|
+|* The above copyright notice and this permission notice shall be included in                             *|
+|* all copies or substantial portions of the Software.                                                    *|
+|*                                                                                                        *|
+|* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                             *|
+|* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                               *|
+|* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL                               *|
+|* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                             *|
+|* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING                                *|
+|* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER                                    *|
+|* DEALINGS IN THE SOFTWARE.                                                                              *|
+|*                                                                                                        *|
+|*                                                                                                        *|
+\*********************************************************************************************************/
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////// NVIDIA SHADER EXTENSIONS ////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+// This file can be included both from HLSL shader code as well as C++ code.
+// The app should call NvAPI_D3D11_IsNvShaderExtnOpCodeSupported() / NvAPI_D3D12_IsNvShaderExtnOpCodeSupported()
+// to check for support for every nv shader extension opcode it plans to use
+
+
+
+//----------------------------------------------------------------------------//
+//---------------------------- NV Shader Extn Version  -----------------------//
+//----------------------------------------------------------------------------//
+#define NV_SHADER_EXTN_VERSION                              1
+
+//----------------------------------------------------------------------------//
+//---------------------------- Misc constants --------------------------------//
+//----------------------------------------------------------------------------//
+#define NV_WARP_SIZE                                       32
+#define NV_WARP_SIZE_LOG2                                   5
+
+//----------------------------------------------------------------------------//
+//---------------------------- opCode constants ------------------------------//
+//----------------------------------------------------------------------------//
+
+
+#define NV_EXTN_OP_SHFL                                     1
+#define NV_EXTN_OP_SHFL_UP                                  2
+#define NV_EXTN_OP_SHFL_DOWN                                3
+#define NV_EXTN_OP_SHFL_XOR                                 4
+
+#define NV_EXTN_OP_VOTE_ALL                                 5
+#define NV_EXTN_OP_VOTE_ANY                                 6
+#define NV_EXTN_OP_VOTE_BALLOT                              7
+
+#define NV_EXTN_OP_GET_LANE_ID                              8
+#define NV_EXTN_OP_FP16_ATOMIC                             12
+#define NV_EXTN_OP_FP32_ATOMIC                             13
+
+#define NV_EXTN_OP_GET_SPECIAL                             19
+
+#define NV_EXTN_OP_UINT64_ATOMIC                           20
+
+#define NV_EXTN_OP_MATCH_ANY                               21 
+
+// FOOTPRINT - For Sample and SampleBias
+#define NV_EXTN_OP_FOOTPRINT                               28
+#define NV_EXTN_OP_FOOTPRINT_BIAS                          29
+
+#define NV_EXTN_OP_GET_SHADING_RATE                        30
+
+// FOOTPRINT - For SampleLevel and SampleGrad
+#define NV_EXTN_OP_FOOTPRINT_LEVEL                         31
+#define NV_EXTN_OP_FOOTPRINT_GRAD                          32
+
+// SHFL Generic
+#define NV_EXTN_OP_SHFL_GENERIC                            33
+
+#define NV_EXTN_OP_VPRS_EVAL_ATTRIB_AT_SAMPLE              51
+#define NV_EXTN_OP_VPRS_EVAL_ATTRIB_SNAPPED                52
+
+// HitObject API
+#define NV_EXTN_OP_HIT_OBJECT_TRACE_RAY                    67
+#define NV_EXTN_OP_HIT_OBJECT_MAKE_HIT                     68
+#define NV_EXTN_OP_HIT_OBJECT_MAKE_HIT_WITH_RECORD_INDEX   69
+#define NV_EXTN_OP_HIT_OBJECT_MAKE_MISS                    70
+#define NV_EXTN_OP_HIT_OBJECT_REORDER_THREAD               71
+#define NV_EXTN_OP_HIT_OBJECT_INVOKE                       72
+#define NV_EXTN_OP_HIT_OBJECT_IS_MISS                      73
+#define NV_EXTN_OP_HIT_OBJECT_GET_INSTANCE_ID              74
+#define NV_EXTN_OP_HIT_OBJECT_GET_INSTANCE_INDEX           75
+#define NV_EXTN_OP_HIT_OBJECT_GET_PRIMITIVE_INDEX          76
+#define NV_EXTN_OP_HIT_OBJECT_GET_GEOMETRY_INDEX           77
+#define NV_EXTN_OP_HIT_OBJECT_GET_HIT_KIND                 78
+#define NV_EXTN_OP_HIT_OBJECT_GET_RAY_DESC                 79
+#define NV_EXTN_OP_HIT_OBJECT_GET_ATTRIBUTES               80
+#define NV_EXTN_OP_HIT_OBJECT_GET_SHADER_TABLE_INDEX       81
+#define NV_EXTN_OP_HIT_OBJECT_LOAD_LOCAL_ROOT_TABLE_CONSTANT  82
+#define NV_EXTN_OP_HIT_OBJECT_IS_HIT                       83
+#define NV_EXTN_OP_HIT_OBJECT_IS_NOP                       84
+#define NV_EXTN_OP_HIT_OBJECT_MAKE_NOP                     85
+
+// Micro-map API
+#define NV_EXTN_OP_RT_TRIANGLE_OBJECT_POSITIONS            86
+#define NV_EXTN_OP_RT_MICRO_TRIANGLE_OBJECT_POSITIONS      87
+#define NV_EXTN_OP_RT_MICRO_TRIANGLE_BARYCENTRICS          88
+#define NV_EXTN_OP_RT_IS_MICRO_TRIANGLE_HIT                89
+#define NV_EXTN_OP_RT_IS_BACK_FACING                       90
+#define NV_EXTN_OP_RT_MICRO_VERTEX_OBJECT_POSITION         91
+#define NV_EXTN_OP_RT_MICRO_VERTEX_BARYCENTRICS            92
+
+// Megageometry API
+#define NV_EXTN_OP_RT_GET_CLUSTER_ID                        93
+#define NV_EXTN_OP_RT_GET_CANDIDATE_CLUSTER_ID              94
+#define NV_EXTN_OP_RT_GET_COMMITTED_CLUSTER_ID              95
+#define NV_EXTN_OP_HIT_OBJECT_GET_CLUSTER_ID                96
+#define NV_EXTN_OP_RT_CANDIDATE_TRIANGLE_OBJECT_POSITIONS   97
+#define NV_EXTN_OP_RT_COMMITTED_TRIANGLE_OBJECT_POSITIONS   98
+#define NV_EXTN_OP_HIT_OBJECT_GET_TRIANGLE_OBJECT_POSITIONS 99
+
+// Linear Swept Sphere API
+#define NV_EXTN_OP_RT_SPHERE_OBJECT_POSITION_AND_RADIUS             100
+#define NV_EXTN_OP_RT_CANDIDATE_SPHERE_OBJECT_POSITION_AND_RADIUS   101
+#define NV_EXTN_OP_RT_COMMITTED_SPHERE_OBJECT_POSITION_AND_RADIUS   102
+#define NV_EXTN_OP_HIT_OBJECT_GET_SPHERE_OBJECT_POSITION_AND_RADIUS 103
+#define NV_EXTN_OP_RT_LSS_OBJECT_POSITIONS_AND_RADII                104
+#define NV_EXTN_OP_RT_CANDIDATE_LSS_OBJECT_POSITIONS_AND_RADII      105
+#define NV_EXTN_OP_RT_COMMITTED_LSS_OBJECT_POSITIONS_AND_RADII      106
+#define NV_EXTN_OP_HIT_OBJECT_GET_LSS_OBJECT_POSITIONS_AND_RADII    107
+#define NV_EXTN_OP_RT_IS_SPHERE_HIT                                 108
+#define NV_EXTN_OP_RT_CANDIDATE_IS_NONOPAQUE_SPHERE                 109
+#define NV_EXTN_OP_RT_COMMITTED_IS_SPHERE                           110
+#define NV_EXTN_OP_HIT_OBJECT_IS_SPHERE_HIT                         111
+#define NV_EXTN_OP_RT_IS_LSS_HIT                                    112
+#define NV_EXTN_OP_RT_CANDIDATE_IS_NONOPAQUE_LSS                    113
+#define NV_EXTN_OP_RT_COMMITTED_IS_LSS                              114
+#define NV_EXTN_OP_HIT_OBJECT_IS_LSS_HIT                            115
+#define NV_EXTN_OP_RT_CANDIDATE_LSS_HIT_PARAMETER                   116
+#define NV_EXTN_OP_RT_COMMITTED_LSS_HIT_PARAMETER                   117
+#define NV_EXTN_OP_RT_CANDIDATE_BUILTIN_PRIMITIVE_RAY_T             118
+#define NV_EXTN_OP_RT_COMMIT_NONOPAQUE_BUILTIN_PRIMITIVE_HIT        119
+//----------------------------------------------------------------------------//
+//-------------------- GET_SPECIAL subOpCode constants -----------------------//
+//----------------------------------------------------------------------------//
+#define NV_SPECIALOP_THREADLTMASK                           4
+#define NV_SPECIALOP_FOOTPRINT_SINGLELOD_PRED               5
+#define NV_SPECIALOP_GLOBAL_TIMER_LO                        9
+#define NV_SPECIALOP_GLOBAL_TIMER_HI                       10
+
+//----------------------------------------------------------------------------//
+//----------------------------- Texture Types  -------------------------------//
+//----------------------------------------------------------------------------//
+#define NV_EXTN_TEXTURE_1D                                  2
+#define NV_EXTN_TEXTURE_1D_ARRAY                            3
+#define NV_EXTN_TEXTURE_2D                                  4
+#define NV_EXTN_TEXTURE_2D_ARRAY                            5
+#define NV_EXTN_TEXTURE_3D                                  6
+#define NV_EXTN_TEXTURE_CUBE                                7
+#define NV_EXTN_TEXTURE_CUBE_ARRAY                          8
+
+
+//---------------------------------------------------------------------------//
+//----------------FOOTPRINT Enums for NvFootprint* extns---------------------//
+//---------------------------------------------------------------------------//
+#define NV_EXTN_FOOTPRINT_MODE_FINE                         0
+#define NV_EXTN_FOOTPRINT_MODE_COARSE                       1
+
+//----------------------------------------------------------------------------//
+//--------------------------- Cluster Constants  -----------------------------//
+//----------------------------------------------------------------------------//
+
+#define NV_EXTN_CLUSTER_ID_INVALID                 0xffffffff
+

--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -151,6 +151,18 @@ interface ID3D12DeviceExt3 : ID3D12DeviceExt2
     HRESULT SetAGSUAVSlot(UINT uavSlot);
 }
 
+[
+    uuid(a91b5617-a06a-4d6f-b437-03ebbef91415),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12DeviceExt4 : ID3D12DeviceExt3
+{
+    BOOL IsNvShaderExtnOpCodeSupported(UINT32 op_code);
+    HRESULT SetNvShaderExtnSlotSpace(UINT32 uav_slot, UINT32 uav_space, BOOL local_thread);
+}
+
 /* 1:1 implementation of ffx_antilag2_dx12.h */
 struct AmdAntiLagAPIData_v1
 {

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -591,6 +591,9 @@ struct vkd3d_shader_compile_arguments
     VkDriverId driver_id;
     uint32_t driver_version;
 
+    uint32_t nv_shader_extn_uav_slot;
+    uint32_t nv_shader_extn_uav_space;
+
     struct
     {
         bool enable;

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -1147,6 +1147,19 @@ static int vkd3d_dxil_converter_set_options(dxil_spv_converter converter,
                 return VKD3D_ERROR_NOT_IMPLEMENTED;
             }
         }
+
+        if (compiler_args->nv_shader_extn_uav_slot != UINT32_MAX)
+        {
+            const dxil_spv_option_nvapi helper =
+                    { { DXIL_SPV_OPTION_NVAPI },
+                    DXIL_SPV_TRUE, compiler_args->nv_shader_extn_uav_slot, compiler_args->nv_shader_extn_uav_space };
+            if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+            {
+                ERR("dxil-spirv does not support NVAPI.\n");
+                return VKD3D_ERROR_NOT_IMPLEMENTED;
+            }
+        }
+
         if (compiler_args->dual_source_blending)
         {
             static const dxil_spv_option_dual_source_blending helper =

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4722,6 +4722,8 @@ static void d3d12_device_destroy(struct d3d12_device *device)
 
     vkd3d_free((void *)device->vk_info.extension_names);
     VK_CALL(vkDestroyDevice(device->vk_device, NULL));
+    hash_map_free(&device->nv_shader_extns);
+    rwlock_destroy(&device->nv_shader_lock);
     rwlock_destroy(&device->fragment_output_lock);
     rwlock_destroy(&device->vertex_input_lock);
     pthread_mutex_destroy(&device->mutex);
@@ -10521,6 +10523,7 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
 
     device->adapter_luid = create_info->adapter_luid;
     device->removed_reason = S_OK;
+    device->has_nv_shader_extns = false;
 
     device->vk_device = VK_NULL_HANDLE;
 
@@ -10551,8 +10554,14 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
         goto out_free_vertex_input_lock;
     }
 
-    if (FAILED(hr = vkd3d_create_vk_device(device, create_info)))
+    if ((rc = rwlock_init(&device->nv_shader_lock)))
+    {
+        hr = hresult_from_errno(rc);
         goto out_free_fragment_output_lock;
+    }
+
+    if (FAILED(hr = vkd3d_create_vk_device(device, create_info)))
+        goto out_free_nv_shader_lock;
 
     if (FAILED(hr = vkd3d_private_store_init(&device->private_store)))
         goto out_free_vk_resources;
@@ -10631,6 +10640,11 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
             vkd3d_fragment_output_pipeline_desc_compare,
             sizeof(struct vkd3d_fragment_output_pipeline));
 
+    hash_map_init(&device->nv_shader_extns,
+            vkd3d_nv_shader_extn_entry_hash,
+            vkd3d_nv_shader_extn_entry_compare,
+            sizeof(struct vkd3d_nv_shader_extn_entry));
+
     if ((device->parent = create_info->parent))
         IUnknown_AddRef(device->parent);
 
@@ -10697,6 +10711,8 @@ out_free_vk_resources:
     VK_CALL(vkDestroyDevice(device->vk_device, NULL));
 out_free_instance:
     vkd3d_instance_decref(device->vkd3d_instance);
+out_free_nv_shader_lock:
+    rwlock_destroy(&device->nv_shader_lock);
 out_free_fragment_output_lock:
     rwlock_destroy(&device->fragment_output_lock);
 out_free_vertex_input_lock:

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4506,7 +4506,8 @@ HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
     if (IsEqualGUID(riid, &IID_ID3D12DeviceExt)
             || IsEqualGUID(riid, &IID_ID3D12DeviceExt1)
             || IsEqualGUID(riid, &IID_ID3D12DeviceExt2)
-            || IsEqualGUID(riid, &IID_ID3D12DeviceExt3))
+            || IsEqualGUID(riid, &IID_ID3D12DeviceExt3)
+            || IsEqualGUID(riid, &IID_ID3D12DeviceExt4))
     {
         d3d12_device_vkd3d_ext_AddRef(&device->ID3D12DeviceExt_iface);
         *object = &device->ID3D12DeviceExt_iface;
@@ -10442,7 +10443,7 @@ static void d3d12_device_replace_vtable(struct d3d12_device *device)
     }
 }
 
-extern CONST_VTBL struct ID3D12DeviceExt3Vtbl d3d12_device_vkd3d_ext_vtbl;
+extern CONST_VTBL struct ID3D12DeviceExt4Vtbl d3d12_device_vkd3d_ext_vtbl;
 extern CONST_VTBL struct ID3D12DXVKInteropDevice3Vtbl d3d12_dxvk_interop_device_vtbl;
 extern CONST_VTBL struct ID3DLowLatencyDeviceVtbl d3d_low_latency_device_vtbl;
 extern CONST_VTBL struct IAmdExtAntiLagApiVtbl d3d_amd_ext_anti_lag_vtbl;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -152,6 +152,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION_VERSION(NV_LOW_LATENCY_2, NV_low_latency2, 2),
     VK_EXTENSION(NV_RAW_ACCESS_CHAINS, NV_raw_access_chains),
     VK_EXTENSION(NV_COOPERATIVE_MATRIX_2, NV_cooperative_matrix2),
+    VK_EXTENSION_DISABLE_COND(NV_RAY_TRACING_INVOCATION_REORDER, NV_ray_tracing_invocation_reorder, VKD3D_CONFIG_FLAG_NO_DXR),
     /* VALVE extensions */
     VK_EXTENSION(VALVE_MUTABLE_DESCRIPTOR_TYPE, VALVE_mutable_descriptor_type),
     VK_EXTENSION(VALVE_SHADER_MIXED_FLOAT_DOT_PRODUCT, VALVE_shader_mixed_float_dot_product),
@@ -2521,6 +2522,12 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     {
         info->present_timing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_TIMING_FEATURES_EXT;
         vk_prepend_struct(&info->features2, &info->present_timing_features);
+    }
+
+    if (vulkan_info->NV_ray_tracing_invocation_reorder)
+    {
+        info->ray_tracing_invocation_reorder_features_nv.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV;
+        vk_prepend_struct(&info->features2, &info->ray_tracing_invocation_reorder_features_nv);
     }
 
     VK_CALL(vkGetPhysicalDeviceFeatures2(device->vk_physical_device, &info->features2));

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3759,6 +3759,10 @@ static HRESULT vkd3d_select_queues(const struct d3d12_device *device,
 
 static void d3d12_device_init_vendor_hacks(struct d3d12_device *device)
 {
+    int rc = vkd3d_nv_shader_init(device);
+    if (rc)
+        ERR("Failed to init NvShader, rc %d.\n", rc);
+
     /* We don't do anything with this library directly, but various AMD provided dlls
      * like FSR and AntiLag check if amdxc64.dll is loaded, then attempt
      * calling into it. On Proton, this DLL is purely a shim intended to forward calls
@@ -3767,8 +3771,6 @@ static void d3d12_device_init_vendor_hacks(struct d3d12_device *device)
      * but the logical thing to do is to load the DLL when the d3d12 device is created,
      * since this is literally the name of the d3d12 driver on Windows.
      * Don't bother with 32-bit since 32-bit d3d12 is not really a thing. */
-    (void)device;
-
 #ifdef _WIN64
     /* Don't try to load the native amdxc64.dll, that will only crash since AMD's driver will
      * assume certain things about their own ID3D12Device implementation. */
@@ -3783,6 +3785,8 @@ static void d3d12_device_init_vendor_hacks(struct d3d12_device *device)
 
 static void d3d12_device_cleanup_vendor_hacks(struct d3d12_device *device)
 {
+    vkd3d_nv_shader_cleanup(device);
+
 #ifdef _WIN64
     if (device->vendor_hacks.amdxc64)
         FreeLibrary(device->vendor_hacks.amdxc64);
@@ -4730,8 +4734,6 @@ static void d3d12_device_destroy(struct d3d12_device *device)
 
     vkd3d_free((void *)device->vk_info.extension_names);
     VK_CALL(vkDestroyDevice(device->vk_device, NULL));
-    hash_map_free(&device->nv_shader_extns);
-    rwlock_destroy(&device->nv_shader_lock);
     rwlock_destroy(&device->fragment_output_lock);
     rwlock_destroy(&device->vertex_input_lock);
     pthread_mutex_destroy(&device->mutex);
@@ -10531,7 +10533,6 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
 
     device->adapter_luid = create_info->adapter_luid;
     device->removed_reason = S_OK;
-    device->has_nv_shader_extns = false;
 
     device->vk_device = VK_NULL_HANDLE;
 
@@ -10562,14 +10563,8 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
         goto out_free_vertex_input_lock;
     }
 
-    if ((rc = rwlock_init(&device->nv_shader_lock)))
-    {
-        hr = hresult_from_errno(rc);
-        goto out_free_fragment_output_lock;
-    }
-
     if (FAILED(hr = vkd3d_create_vk_device(device, create_info)))
-        goto out_free_nv_shader_lock;
+        goto out_free_fragment_output_lock;
 
     if (FAILED(hr = vkd3d_private_store_init(&device->private_store)))
         goto out_free_vk_resources;
@@ -10648,11 +10643,6 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
             vkd3d_fragment_output_pipeline_desc_compare,
             sizeof(struct vkd3d_fragment_output_pipeline));
 
-    hash_map_init(&device->nv_shader_extns,
-            vkd3d_nv_shader_extn_entry_hash,
-            vkd3d_nv_shader_extn_entry_compare,
-            sizeof(struct vkd3d_nv_shader_extn_entry));
-
     if ((device->parent = create_info->parent))
         IUnknown_AddRef(device->parent);
 
@@ -10719,8 +10709,6 @@ out_free_vk_resources:
     VK_CALL(vkDestroyDevice(device->vk_device, NULL));
 out_free_instance:
     vkd3d_instance_decref(device->vkd3d_instance);
-out_free_nv_shader_lock:
-    rwlock_destroy(&device->nv_shader_lock);
 out_free_fragment_output_lock:
     rwlock_destroy(&device->fragment_output_lock);
 out_free_vertex_input_lock:

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -19,6 +19,7 @@
 #define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
 
 #include "vkd3d_private.h"
+#include "nvShaderExtnEnums.h"
 
 uint32_t vkd3d_nv_shader_extn_entry_hash(const void *key)
 {
@@ -486,10 +487,31 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetAGSUAVSlot(d3d12_devi
 static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_IsNvShaderExtnOpCodeSupported(d3d12_device_vkd3d_ext_iface *iface,
         UINT32 op_code)
 {
+    struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     TRACE("iface %p, op_code %"PRIu32".\n", iface, op_code);
 
     switch (op_code)
     {
+        case NV_EXTN_OP_HIT_OBJECT_TRACE_RAY:
+        case NV_EXTN_OP_HIT_OBJECT_MAKE_HIT:
+        case NV_EXTN_OP_HIT_OBJECT_MAKE_HIT_WITH_RECORD_INDEX:
+        case NV_EXTN_OP_HIT_OBJECT_MAKE_MISS:
+        case NV_EXTN_OP_HIT_OBJECT_REORDER_THREAD:
+        case NV_EXTN_OP_HIT_OBJECT_INVOKE:
+        case NV_EXTN_OP_HIT_OBJECT_IS_MISS:
+        case NV_EXTN_OP_HIT_OBJECT_GET_INSTANCE_ID:
+        case NV_EXTN_OP_HIT_OBJECT_GET_INSTANCE_INDEX:
+        case NV_EXTN_OP_HIT_OBJECT_GET_PRIMITIVE_INDEX:
+        case NV_EXTN_OP_HIT_OBJECT_GET_GEOMETRY_INDEX:
+        case NV_EXTN_OP_HIT_OBJECT_GET_HIT_KIND:
+        case NV_EXTN_OP_HIT_OBJECT_GET_RAY_DESC:
+        case NV_EXTN_OP_HIT_OBJECT_GET_ATTRIBUTES:
+        case NV_EXTN_OP_HIT_OBJECT_GET_SHADER_TABLE_INDEX:
+        case NV_EXTN_OP_HIT_OBJECT_LOAD_LOCAL_ROOT_TABLE_CONSTANT:
+        case NV_EXTN_OP_HIT_OBJECT_IS_HIT:
+        case NV_EXTN_OP_HIT_OBJECT_IS_NOP:
+        case NV_EXTN_OP_HIT_OBJECT_MAKE_NOP:
+            return device->device_info.ray_tracing_invocation_reorder_features_nv.rayTracingInvocationReorder ? TRUE : FALSE;
         default:
             return FALSE;
     }

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -20,6 +20,53 @@
 
 #include "vkd3d_private.h"
 
+uint32_t vkd3d_nv_shader_extn_entry_hash(const void *key)
+{
+    return *(const unsigned int *)key;
+}
+
+bool vkd3d_nv_shader_extn_entry_compare(const void *key, const struct hash_map_entry *entry)
+{
+    const struct vkd3d_nv_shader_extn_entry *extn = (const void*)entry;
+    const unsigned int *thread_id = key;
+    return *thread_id == extn->thread_id;
+}
+
+struct vkd3d_nv_shader_extn d3d12_device_get_nv_shader_extn(struct d3d12_device *device)
+{
+    struct vkd3d_nv_shader_extn result = { UINT32_MAX, 0 };
+    struct vkd3d_nv_shader_extn_entry *entry;
+    unsigned int key;
+    int rc;
+
+    if (!device->has_nv_shader_extns)
+        return result;
+
+    key = vkd3d_get_current_thread_id();
+
+    if ((rc = rwlock_lock_read(&device->nv_shader_lock)))
+    {
+        ERR("Failed to lock mutex, rc %d.\n", rc);
+        return result;
+    }
+
+    entry = (void*)hash_map_find(&device->nv_shader_extns, &key);
+
+    if (!entry || entry->extn.uav_slot == UINT32_MAX)
+    {
+        key = 0;
+        entry = (void*)hash_map_find(&device->nv_shader_extns, &key);
+    }
+
+    if (entry)
+        result = entry->extn;
+
+    if ((rc = rwlock_unlock_read(&device->nv_shader_lock)))
+        ERR("Failed to unlock mutex, rc %d.\n", rc);
+
+    return result;
+}
+
 static inline struct d3d12_device *d3d12_device_from_ID3D12DeviceExt(d3d12_device_vkd3d_ext_iface *iface)
 {
     return CONTAINING_RECORD(iface, struct d3d12_device, ID3D12DeviceExt_iface);
@@ -446,6 +493,66 @@ static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_IsNvShaderExtnOpCodeSupport
         default:
             return FALSE;
     }
+}
+
+static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace(d3d12_device_vkd3d_ext_iface *iface,
+        UINT32 uav_slot, UINT32 uav_space, BOOL local_thread)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
+    unsigned int key = local_thread ? vkd3d_get_current_thread_id() : 0;
+    struct vkd3d_nv_shader_extn_entry extn, *entry;
+    int rc;
+
+    TRACE("iface %p, uav_slot %"PRIu32", uav_space %"PRIu32", local_thread %i.\n", iface, uav_slot, uav_space, local_thread);
+
+    device->has_nv_shader_extns = true;
+
+    if ((rc = rwlock_lock_read(&device->nv_shader_lock)))
+    {
+        ERR("Failed to lock mutex, rc %d.\n", rc);
+        return E_FAIL;
+    }
+
+    entry = (void*)hash_map_find(&device->nv_shader_extns, &key);
+
+    if (entry)
+    {
+        entry->extn.uav_slot = uav_slot;
+        entry->extn.uav_space = uav_space;
+
+        if ((rc = rwlock_unlock_read(&device->nv_shader_lock)))
+        {
+            ERR("Failed to unlock mutex, rc %d.\n", rc);
+            return E_FAIL;
+        }
+
+        return S_OK;
+    }
+
+    if ((rc = rwlock_unlock_read(&device->nv_shader_lock)))
+    {
+        ERR("Failed to unlock mutex, rc %d.\n", rc);
+        return E_FAIL;
+    }
+
+    if ((rc = rwlock_lock_write(&device->nv_shader_lock)))
+    {
+        ERR("Failed to lock mutex, rc %d.\n", rc);
+        return E_FAIL;
+    }
+
+    extn.thread_id = key;
+    entry = (void*)hash_map_insert(&device->nv_shader_extns, &key, &extn.entry);
+    entry->extn.uav_slot = uav_slot;
+    entry->extn.uav_space = uav_space;
+
+    if ((rc = rwlock_unlock_write(&device->nv_shader_lock)))
+    {
+        ERR("Failed to unlock mutex, rc %d.\n", rc);
+        return E_FAIL;
+    }
+
+    return S_OK;
 }
 
 CONST_VTBL struct ID3D12DeviceExt3Vtbl d3d12_device_vkd3d_ext_vtbl =

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -436,6 +436,18 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetAGSUAVSlot(d3d12_devi
     return E_NOTIMPL;
 }
 
+static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_IsNvShaderExtnOpCodeSupported(d3d12_device_vkd3d_ext_iface *iface,
+        UINT32 op_code)
+{
+    TRACE("iface %p, op_code %"PRIu32".\n", iface, op_code);
+
+    switch (op_code)
+    {
+        default:
+            return FALSE;
+    }
+}
+
 CONST_VTBL struct ID3D12DeviceExt3Vtbl d3d12_device_vkd3d_ext_vtbl =
 {
     /* IUnknown methods */

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -35,7 +35,7 @@ bool vkd3d_nv_shader_extn_entry_compare(const void *key, const struct hash_map_e
 
 int vkd3d_nv_shader_init(struct d3d12_device *device)
 {
-    int rc = rwlock_init(&device->vendor_hacks.nv_shader.lock);
+    int rc = pthread_mutex_init(&device->vendor_hacks.nv_shader.mutex, NULL);
 
     device->vendor_hacks.nv_shader.initialized = false;
     device->vendor_hacks.nv_shader.enabled = false;
@@ -60,7 +60,7 @@ void vkd3d_nv_shader_cleanup(struct d3d12_device *device)
 
     device->vendor_hacks.nv_shader.initialized = false;
     hash_map_free(&device->vendor_hacks.nv_shader.map);
-    rwlock_destroy(&device->vendor_hacks.nv_shader.lock);
+    pthread_mutex_destroy(&device->vendor_hacks.nv_shader.mutex);
 }
 
 struct vkd3d_nv_shader_extn d3d12_device_get_nv_shader_extn(struct d3d12_device *device)
@@ -75,7 +75,7 @@ struct vkd3d_nv_shader_extn d3d12_device_get_nv_shader_extn(struct d3d12_device 
 
     key = vkd3d_get_current_thread_id();
 
-    if ((rc = rwlock_lock_read(&device->vendor_hacks.nv_shader.lock)))
+    if ((rc = pthread_mutex_lock(&device->vendor_hacks.nv_shader.mutex)))
     {
         ERR("Failed to lock mutex, rc %d.\n", rc);
         return result;
@@ -92,7 +92,7 @@ struct vkd3d_nv_shader_extn d3d12_device_get_nv_shader_extn(struct d3d12_device 
     if (entry)
         result = entry->extn;
 
-    if ((rc = rwlock_unlock_read(&device->vendor_hacks.nv_shader.lock)))
+    if ((rc = pthread_mutex_unlock(&device->vendor_hacks.nv_shader.mutex)))
         ERR("Failed to unlock mutex, rc %d.\n", rc);
 
     return result;
@@ -555,7 +555,8 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     unsigned int key = local_thread ? vkd3d_get_current_thread_id() : 0;
-    struct vkd3d_nv_shader_extn_entry extn, *entry;
+    struct vkd3d_nv_shader_extn extn = { uav_slot, uav_space };
+    struct vkd3d_nv_shader_extn_entry e, *entry;
     int rc;
 
     TRACE("iface %p, uav_slot %"PRIu32", uav_space %"PRIu32", local_thread %i.\n", iface, uav_slot, uav_space, local_thread);
@@ -565,7 +566,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace
 
     device->vendor_hacks.nv_shader.enabled = true;
 
-    if ((rc = rwlock_lock_read(&device->vendor_hacks.nv_shader.lock)))
+    if ((rc = pthread_mutex_lock(&device->vendor_hacks.nv_shader.mutex)))
     {
         ERR("Failed to lock mutex, rc %d.\n", rc);
         return E_FAIL;
@@ -575,10 +576,9 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace
 
     if (entry)
     {
-        entry->extn.uav_slot = uav_slot;
-        entry->extn.uav_space = uav_space;
+        entry->extn = extn;
 
-        if ((rc = rwlock_unlock_read(&device->vendor_hacks.nv_shader.lock)))
+        if ((rc = pthread_mutex_unlock(&device->vendor_hacks.nv_shader.mutex)))
         {
             ERR("Failed to unlock mutex, rc %d.\n", rc);
             return E_FAIL;
@@ -587,24 +587,11 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace
         return S_OK;
     }
 
-    if ((rc = rwlock_unlock_read(&device->vendor_hacks.nv_shader.lock)))
-    {
-        ERR("Failed to unlock mutex, rc %d.\n", rc);
-        return E_FAIL;
-    }
+    e.thread_id = key;
+    entry = (void*)hash_map_insert(&device->vendor_hacks.nv_shader.map, &key, &e.entry);
+    entry->extn = extn;
 
-    if ((rc = rwlock_lock_write(&device->vendor_hacks.nv_shader.lock)))
-    {
-        ERR("Failed to lock mutex, rc %d.\n", rc);
-        return E_FAIL;
-    }
-
-    extn.thread_id = key;
-    entry = (void*)hash_map_insert(&device->vendor_hacks.nv_shader.map, &key, &extn.entry);
-    entry->extn.uav_slot = uav_slot;
-    entry->extn.uav_space = uav_space;
-
-    if ((rc = rwlock_unlock_write(&device->vendor_hacks.nv_shader.lock)))
+    if ((rc = pthread_mutex_unlock(&device->vendor_hacks.nv_shader.mutex)))
     {
         ERR("Failed to unlock mutex, rc %d.\n", rc);
         return E_FAIL;

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -33,6 +33,36 @@ bool vkd3d_nv_shader_extn_entry_compare(const void *key, const struct hash_map_e
     return *thread_id == extn->thread_id;
 }
 
+int vkd3d_nv_shader_init(struct d3d12_device *device)
+{
+    int rc = rwlock_init(&device->vendor_hacks.nv_shader.lock);
+
+    device->vendor_hacks.nv_shader.initialized = false;
+    device->vendor_hacks.nv_shader.enabled = false;
+
+    if (rc)
+        return rc;
+
+    hash_map_init(&device->vendor_hacks.nv_shader.map,
+        vkd3d_nv_shader_extn_entry_hash,
+        vkd3d_nv_shader_extn_entry_compare,
+        sizeof(struct vkd3d_nv_shader_extn_entry));
+
+    device->vendor_hacks.nv_shader.initialized = true;
+
+    return 0;
+}
+
+void vkd3d_nv_shader_cleanup(struct d3d12_device *device)
+{
+    if (!device->vendor_hacks.nv_shader.initialized)
+        return;
+
+    device->vendor_hacks.nv_shader.initialized = false;
+    hash_map_free(&device->vendor_hacks.nv_shader.map);
+    rwlock_destroy(&device->vendor_hacks.nv_shader.lock);
+}
+
 struct vkd3d_nv_shader_extn d3d12_device_get_nv_shader_extn(struct d3d12_device *device)
 {
     struct vkd3d_nv_shader_extn result = { UINT32_MAX, 0 };
@@ -40,29 +70,29 @@ struct vkd3d_nv_shader_extn d3d12_device_get_nv_shader_extn(struct d3d12_device 
     unsigned int key;
     int rc;
 
-    if (!device->has_nv_shader_extns)
+    if (!device->vendor_hacks.nv_shader.initialized || !device->vendor_hacks.nv_shader.enabled)
         return result;
 
     key = vkd3d_get_current_thread_id();
 
-    if ((rc = rwlock_lock_read(&device->nv_shader_lock)))
+    if ((rc = rwlock_lock_read(&device->vendor_hacks.nv_shader.lock)))
     {
         ERR("Failed to lock mutex, rc %d.\n", rc);
         return result;
     }
 
-    entry = (void*)hash_map_find(&device->nv_shader_extns, &key);
+    entry = (void*)hash_map_find(&device->vendor_hacks.nv_shader.map, &key);
 
     if (!entry || entry->extn.uav_slot == UINT32_MAX)
     {
         key = 0;
-        entry = (void*)hash_map_find(&device->nv_shader_extns, &key);
+        entry = (void*)hash_map_find(&device->vendor_hacks.nv_shader.map, &key);
     }
 
     if (entry)
         result = entry->extn;
 
-    if ((rc = rwlock_unlock_read(&device->nv_shader_lock)))
+    if ((rc = rwlock_unlock_read(&device->vendor_hacks.nv_shader.lock)))
         ERR("Failed to unlock mutex, rc %d.\n", rc);
 
     return result;
@@ -490,6 +520,9 @@ static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_IsNvShaderExtnOpCodeSupport
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
     TRACE("iface %p, op_code %"PRIu32".\n", iface, op_code);
 
+    if (!device->vendor_hacks.nv_shader.initialized)
+        return FALSE;
+
     switch (op_code)
     {
         case NV_EXTN_OP_HIT_OBJECT_TRACE_RAY:
@@ -527,22 +560,25 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace
 
     TRACE("iface %p, uav_slot %"PRIu32", uav_space %"PRIu32", local_thread %i.\n", iface, uav_slot, uav_space, local_thread);
 
-    device->has_nv_shader_extns = true;
+    if (!device->vendor_hacks.nv_shader.initialized)
+        return E_FAIL;
 
-    if ((rc = rwlock_lock_read(&device->nv_shader_lock)))
+    device->vendor_hacks.nv_shader.enabled = true;
+
+    if ((rc = rwlock_lock_read(&device->vendor_hacks.nv_shader.lock)))
     {
         ERR("Failed to lock mutex, rc %d.\n", rc);
         return E_FAIL;
     }
 
-    entry = (void*)hash_map_find(&device->nv_shader_extns, &key);
+    entry = (void*)hash_map_find(&device->vendor_hacks.nv_shader.map, &key);
 
     if (entry)
     {
         entry->extn.uav_slot = uav_slot;
         entry->extn.uav_space = uav_space;
 
-        if ((rc = rwlock_unlock_read(&device->nv_shader_lock)))
+        if ((rc = rwlock_unlock_read(&device->vendor_hacks.nv_shader.lock)))
         {
             ERR("Failed to unlock mutex, rc %d.\n", rc);
             return E_FAIL;
@@ -551,24 +587,24 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace
         return S_OK;
     }
 
-    if ((rc = rwlock_unlock_read(&device->nv_shader_lock)))
+    if ((rc = rwlock_unlock_read(&device->vendor_hacks.nv_shader.lock)))
     {
         ERR("Failed to unlock mutex, rc %d.\n", rc);
         return E_FAIL;
     }
 
-    if ((rc = rwlock_lock_write(&device->nv_shader_lock)))
+    if ((rc = rwlock_lock_write(&device->vendor_hacks.nv_shader.lock)))
     {
         ERR("Failed to lock mutex, rc %d.\n", rc);
         return E_FAIL;
     }
 
     extn.thread_id = key;
-    entry = (void*)hash_map_insert(&device->nv_shader_extns, &key, &extn.entry);
+    entry = (void*)hash_map_insert(&device->vendor_hacks.nv_shader.map, &key, &extn.entry);
     entry->extn.uav_slot = uav_slot;
     entry->extn.uav_space = uav_space;
 
-    if ((rc = rwlock_unlock_write(&device->nv_shader_lock)))
+    if ((rc = rwlock_unlock_write(&device->vendor_hacks.nv_shader.lock)))
     {
         ERR("Failed to unlock mutex, rc %d.\n", rc);
         return E_FAIL;

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -555,7 +555,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace
     return S_OK;
 }
 
-CONST_VTBL struct ID3D12DeviceExt3Vtbl d3d12_device_vkd3d_ext_vtbl =
+CONST_VTBL struct ID3D12DeviceExt4Vtbl d3d12_device_vkd3d_ext_vtbl =
 {
     /* IUnknown methods */
     d3d12_device_vkd3d_ext_QueryInterface,
@@ -584,6 +584,10 @@ CONST_VTBL struct ID3D12DeviceExt3Vtbl d3d12_device_vkd3d_ext_vtbl =
     /* ID3D12DeviceExt3 methods */
     d3d12_device_vkd3d_ext_SupportsAGSExtension,
     d3d12_device_vkd3d_ext_SetAGSUAVSlot,
+
+    /* ID3D12DeviceExt4 methods */
+    d3d12_device_vkd3d_ext_IsNvShaderExtnOpCodeSupported,
+    d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace,
 };
 
 static inline struct d3d12_device *d3d12_device_from_ID3D12DXVKInteropDevice(d3d12_dxvk_interop_device_iface *iface)

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -1880,6 +1880,7 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
         unsigned pipeline_variant_index,
         struct d3d12_rt_state_object_pipeline_data *data)
 {
+    struct vkd3d_nv_shader_extn nv_shader_extn = d3d12_device_get_nv_shader_extn(object->device);
     const struct vkd3d_vk_device_procs *vk_procs = &object->device->vk_procs;
     struct vkd3d_shader_interface_local_info shader_interface_local_info;
     VkRayTracingPipelineInterfaceCreateInfoKHR interface_create_info;
@@ -1926,6 +1927,9 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
         compile_args.driver_id = object->device->device_info.vulkan_1_2_properties.driverID;
         compile_args.driver_version = object->device->device_info.properties2.properties.driverVersion;
     }
+
+    compile_args.nv_shader_extn_uav_slot = nv_shader_extn.uav_slot;
+    compile_args.nv_shader_extn_uav_space = nv_shader_extn.uav_space;
 
     memset(&shader_interface_info, 0, sizeof(shader_interface_info));
     shader_interface_info.min_ssbo_alignment = d3d12_device_get_ssbo_alignment(object->device);

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2672,6 +2672,8 @@ static void d3d12_pipeline_state_init_compile_arguments(struct d3d12_pipeline_st
         struct d3d12_device *device, VkShaderStageFlagBits stage,
         struct vkd3d_shader_compile_arguments *compile_arguments)
 {
+    struct vkd3d_nv_shader_extn nv_shader_extn = d3d12_device_get_nv_shader_extn(device);
+
     memset(compile_arguments, 0, sizeof(*compile_arguments));
     compile_arguments->target = VKD3D_SHADER_TARGET_SPIRV_VULKAN_1_0;
     compile_arguments->target_extension_count = device->vk_info.shader_extension_count;
@@ -2690,6 +2692,9 @@ static void d3d12_pipeline_state_init_compile_arguments(struct d3d12_pipeline_st
 
     compile_arguments->parameter_count = state->graphics.cached_desc.shader_parameters_count;
     compile_arguments->parameters = state->graphics.cached_desc.shader_parameters;
+
+    compile_arguments->nv_shader_extn_uav_slot = nv_shader_extn.uav_slot;
+    compile_arguments->nv_shader_extn_uav_space = nv_shader_extn.uav_space;
 
     if (stage == VK_SHADER_STAGE_FRAGMENT_BIT)
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -209,6 +209,7 @@ struct vkd3d_vulkan_info
     bool NV_low_latency2;
     bool NV_raw_access_chains;
     bool NV_cooperative_matrix2;
+    bool NV_ray_tracing_invocation_reorder;
     /* VALVE extensions */
     bool VALVE_mutable_descriptor_type;
     bool VALVE_shader_mixed_float_dot_product;
@@ -5111,6 +5112,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDevicePresentId2FeaturesKHR present_id2_features;
     VkPhysicalDevicePresentWait2FeaturesKHR present_wait2_features;
     VkPhysicalDevicePresentTimingFeaturesEXT present_timing_features;
+    VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV ray_tracing_invocation_reorder_features_nv;
 
     VkPhysicalDeviceFeatures2 features2;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5224,7 +5224,7 @@ struct vkd3d_descriptor_qa_heap_buffer_data;
 struct vkd3d_timestamp_profiler;
 
 /* ID3D12DeviceExt */
-typedef ID3D12DeviceExt3 d3d12_device_vkd3d_ext_iface;
+typedef ID3D12DeviceExt4 d3d12_device_vkd3d_ext_iface;
 
 /* ID3D12DXVKInteropDevice */
 typedef ID3D12DXVKInteropDevice3 d3d12_dxvk_interop_device_iface;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5478,6 +5478,23 @@ struct vkd3d_null_rtas_allocation
     spinlock_t lock;
 };
 
+struct vkd3d_nv_shader_extn
+{
+    uint32_t uav_slot;
+    uint32_t uav_space;
+};
+
+struct vkd3d_nv_shader_extn_entry
+{
+    struct hash_map_entry entry;
+    unsigned int thread_id;
+    struct vkd3d_nv_shader_extn extn;
+};
+
+uint32_t vkd3d_nv_shader_extn_entry_hash(const void *key);
+bool vkd3d_nv_shader_extn_entry_compare(const void *key, const struct hash_map_entry *entry);
+struct vkd3d_nv_shader_extn d3d12_device_get_nv_shader_extn(struct d3d12_device *device);
+
 struct d3d12_device
 {
     d3d12_device_iface ID3D12Device_iface;
@@ -5515,6 +5532,10 @@ struct d3d12_device
     IUnknown *parent;
     LUID adapter_luid;
     D3DKMT_HANDLE kmt_local;
+
+    bool has_nv_shader_extns;
+    struct hash_map nv_shader_extns;
+    rwlock_t nv_shader_lock;
 
     struct vkd3d_private_store private_store;
     struct d3d_destruction_notifier destruction_notifier;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5493,8 +5493,18 @@ struct vkd3d_nv_shader_extn_entry
     struct vkd3d_nv_shader_extn extn;
 };
 
+struct vkd3d_nv_shader
+{
+    struct hash_map map;
+    rwlock_t lock;
+    bool initialized;
+    bool enabled;
+};
+
 uint32_t vkd3d_nv_shader_extn_entry_hash(const void *key);
 bool vkd3d_nv_shader_extn_entry_compare(const void *key, const struct hash_map_entry *entry);
+int vkd3d_nv_shader_init(struct d3d12_device *device);
+void vkd3d_nv_shader_cleanup(struct d3d12_device *device);
 struct vkd3d_nv_shader_extn d3d12_device_get_nv_shader_extn(struct d3d12_device *device);
 
 struct d3d12_device
@@ -5534,10 +5544,6 @@ struct d3d12_device
     IUnknown *parent;
     LUID adapter_luid;
     D3DKMT_HANDLE kmt_local;
-
-    bool has_nv_shader_extns;
-    struct hash_map nv_shader_extns;
-    rwlock_t nv_shader_lock;
 
     struct vkd3d_private_store private_store;
     struct d3d_destruction_notifier destruction_notifier;
@@ -5609,12 +5615,13 @@ struct d3d12_device
         bool tiler_suspend_resume_relax_load_store_op;
     } workarounds;
 
-#ifdef _WIN64
     struct
     {
+#ifdef _WIN64
         HMODULE amdxc64;
-    } vendor_hacks;
 #endif
+        struct vkd3d_nv_shader nv_shader;
+    } vendor_hacks;
 
     bool independent_device;
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5496,7 +5496,7 @@ struct vkd3d_nv_shader_extn_entry
 struct vkd3d_nv_shader
 {
     struct hash_map map;
-    rwlock_t lock;
+    pthread_mutex_t mutex;
     bool initialized;
     bool enabled;
 };


### PR DESCRIPTION
Since we're now doing AMD intrinsics too… The dxvk-nvapi side isn't wired up yet, but I'll deal with that soon.

I intend to keep this hidden behind an environment variable on nvapi side, with explicit opt-in for well-behaved titles, otherwise games like Cyberpunk 2077 will just break (it uses some atomic operations without checking if they're supported first :weary:), at least for as long as dxil-spirv has a problem with HitObjects used around Phi instructions.