### PR TITLE
vkd3d: Emit null descriptor as texel buffer fallback for stride of 1.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5217,7 +5217,12 @@ static DXGI_FORMAT vkd3d_structured_srv_to_texel_buffer_dxgi_format(unsigned int
 
     /* It's a bit unclear what happens with strides 2 and 6.
      * This basically never comes up in practice, so just pick something safe-ish. */
-    return DXGI_FORMAT_R16_UINT;
+    if ((stride & 1) == 0)
+        return DXGI_FORMAT_R16_UINT;
+
+    /* A structured stride of 1 is not useful, and texel buffer aliasing is basically
+     * broken on native drivers. Do not try to emit a descriptor in this case. */
+    return DXGI_FORMAT_UNKNOWN;
 }
 
 static DXGI_FORMAT vkd3d_structured_uav_to_texel_buffer_dxgi_format(unsigned int stride)
@@ -5230,8 +5235,11 @@ static DXGI_FORMAT vkd3d_structured_uav_to_texel_buffer_dxgi_format(unsigned int
      * Just keep it simple here. */
     if ((stride & 3) == 0)
         return DXGI_FORMAT_R32_UINT;
-    else
+
+    if ((stride & 1) == 0)
         return DXGI_FORMAT_R16_UINT;
+
+    return DXGI_FORMAT_UNKNOWN;
 }
 
 static bool vkd3d_create_buffer_view_for_resource(struct d3d12_device *device,
@@ -6134,6 +6142,12 @@ static void vkd3d_create_buffer_srv_embedded(vkd3d_cpu_descriptor_va_t desc_va,
         {
             addr_info.format = vkd3d_internal_get_vk_format(device,
                     vkd3d_structured_srv_to_texel_buffer_dxgi_format(desc->Buffer.StructureByteStride));
+
+            if (!addr_info.format)
+            {
+                addr_info.address = 0u;
+                addr_info.range = VK_WHOLE_SIZE;
+            }
         }
     }
     VK_CALL(vkGetDescriptorEXT(device->vk_device, &get_info,
@@ -6328,6 +6342,12 @@ static void vkd3d_create_buffer_srv(vkd3d_cpu_descriptor_va_t desc_va,
                 {
                     addr_info.format = vkd3d_internal_get_vk_format(device,
                             vkd3d_structured_srv_to_texel_buffer_dxgi_format(desc->Buffer.StructureByteStride));
+
+                    if (!addr_info.format)
+                    {
+                        addr_info.address = 0u;
+                        addr_info.range = VK_WHOLE_SIZE;
+                    }
                 }
             }
             payload = d3d12_descriptor_heap_get_mapped_payload(d.heap, binding.set, d.offset);
@@ -6917,6 +6937,12 @@ static void vkd3d_create_buffer_uav_embedded(vkd3d_cpu_descriptor_va_t desc_va, 
             {
                 addr_info.format = vkd3d_internal_get_vk_format(device,
                         vkd3d_structured_uav_to_texel_buffer_dxgi_format(desc->Buffer.StructureByteStride));
+
+                if (!addr_info.format)
+                {
+                    addr_info.address = 0u;
+                    addr_info.range = VK_WHOLE_SIZE;
+                }
             }
         }
     }
@@ -7086,6 +7112,12 @@ static void vkd3d_create_buffer_uav(vkd3d_cpu_descriptor_va_t desc_va, struct d3
                 {
                     addr_info.format = vkd3d_internal_get_vk_format(device,
                             vkd3d_structured_uav_to_texel_buffer_dxgi_format(desc->Buffer.StructureByteStride));
+
+                    if (!addr_info.format)
+                    {
+                        addr_info.address = 0u;
+                        addr_info.range = VK_WHOLE_SIZE;
+                    }
                 }
             }
 


### PR DESCRIPTION
This is UB and actually super broken on native. Should fix #2968, but probably need to consider this for Heap as well.

FWIW, NV native still seems to sort-of map this to R16, which is technically implementable, but gets rather cursed w.r.t padding while staying in bounds of the containing resource. The game works fine anyway. AMD crashes and WARP apparently just behaves as-if stride was 4 or something.

I have a somewhat unfinished test [here](https://github.com/doitsujin/vkd3d/commit/13107b3c069240eb409528cc525e0b4bafec6d61), not sure what to do with it though given that this is turbo-UB.