### PR TITLE
vkd3d: Fix dst subresource comparison in resolve barrier deduplication

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -18692,7 +18692,7 @@ static void d3d12_command_list_resolve_render_pass_attachments(struct d3d12_comm
             for (k = 0; k < j && (!found_src || !found_dst); k++)
             {
                 found_src = found_src || !memcmp(&regions[j].srcSubresource, &regions[k].srcSubresource, sizeof(regions[j].srcSubresource));
-                found_dst = found_dst || !memcmp(&regions[j].srcSubresource, &regions[k].dstSubresource, sizeof(regions[j].dstSubresource));
+                found_dst = found_dst || !memcmp(&regions[j].dstSubresource, &regions[k].dstSubresource, sizeof(regions[j].dstSubresource));
             }
 
             if (!found_src)


### PR DESCRIPTION
In d3d12_command_list_resolve_render_pass_attachments(), barrier deduplication for resolve destinations uses an incorrect subresource comparison.

Current code:

    found_dst = found_dst || !memcmp(&regions[j].srcSubresource,
        &regions[k].dstSubresource, sizeof(regions[j].dstSubresource));

This compares srcSubresource (region j) against dstSubresource (region k), which is inconsistent with the deduplication intent for destination barriers. The first argument must be regions[j].dstSubresource:

    found_dst = found_dst || !memcmp(&regions[j].dstSubresource,
        &regions[k].dstSubresource, sizeof(regions[j].dstSubresource));

As a result of the bug:
1. Required dst barriers may be skipped when src/dst subresources happen to cross-match.
2. Duplicate dst barriers may be emitted when dst subresources actually match but the buggy check fails to detect it.

This fixes the destination subresource comparison used by resolve barrier deduplication.
