### PR TITLE
vkd3d: Fix wrong Vulkan enum for mesh stage check in graphics pipeline state initialization

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -5363,7 +5363,7 @@ static HRESULT d3d12_pipeline_state_init_graphics_create_info(struct d3d12_pipel
     vkd3d_shader_free_shader_signature(&pc_output_signature);
     vkd3d_shader_free_shader_signature(&io_output_signature);
 
-    graphics->attribute_count = (graphics->stage_flags & VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT)
+    graphics->attribute_count = (graphics->stage_flags & VK_SHADER_STAGE_MESH_BIT_EXT)
             ? 0 : desc->input_layout.NumElements;
 
     if (graphics->attribute_count > ARRAY_SIZE(graphics->attributes))


### PR DESCRIPTION
graphics->stage_flags is populated with VkShaderStageFlagBits, but the mesh pipeline check uses VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT (0x400000) instead of VK_SHADER_STAGE_MESH_BIT_EXT (0x80). The bitwise AND always evaluates to zero, so the check never matches.

As a result, mesh pipelines fall through into the input-layout path with attribute_count = NumElements instead of being set to 0. Mesh shaders do not use the input assembler, so this path should be skipped.

This appears to be an enum mix-up: every other stage_flags check in this function uses VK_SHADER_STAGE_*, including the mesh-based pipeline_type decision earlier in the same function.