### PR TITLE
Descriptor heap - Phase 2

### DIFF
--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -692,7 +692,7 @@ D3D12_GPU_VIRTUAL_ADDRESS vkd3d_get_null_rtas_va(struct d3d12_device *device)
     }
 
     if (FAILED(vkd3d_allocate_internal_buffer_memory(device, device->null_rtas_allocation.buffer,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &device->null_rtas_allocation.alloc)))
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0, &device->null_rtas_allocation.alloc)))
     {
         ERR("Failed to allocate empty RTAS memory.\n");
         goto end_unlock;

--- a/libs/vkd3d/breadcrumbs.c
+++ b/libs/vkd3d/breadcrumbs.c
@@ -190,7 +190,7 @@ HRESULT vkd3d_breadcrumb_tracer_init(struct vkd3d_breadcrumb_tracer *tracer, str
         }
 
         if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, tracer->host_buffer,
-                memory_props, &tracer->host_buffer_memory)))
+                memory_props, 0, &tracer->host_buffer_memory)))
         {
             goto err;
         }

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -24963,7 +24963,7 @@ static HRESULT d3d12_command_signature_init_patch_commands_buffer(struct d3d12_c
         return hr;
 
     if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, signature->state_template.dgc.buffer,
-            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, 0,
             &signature->state_template.dgc.memory)))
         return hr;
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -15145,7 +15145,8 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops, true, false);
     workgroup_size = vkd3d_meta_get_clear_buffer_uav_workgroup_size();
 
-    if (!vkd3d_create_vk_buffer_view(list->device, scratch.buffer, format, scratch.offset, scratch_buffer_size, &vk_buffer_view))
+    if (!vkd3d_create_vk_buffer_view(list->device, scratch.buffer, format, scratch.offset, scratch_buffer_size,
+            VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, &vk_buffer_view))
     {
         ERR("Failed to create buffer view for UAV clear.\n");
         return;
@@ -15432,6 +15433,7 @@ static bool vkd3d_clear_uav_synthesize_buffer_view(struct d3d12_command_list *li
     view_desc.size = args->u.buffer.range;
     view_desc.format = override_format ? override_format :
             vkd3d_get_format(list->device, args->clear_dxgi_format, false);
+    view_desc.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
 
     if (!view_desc.format || !vkd3d_create_buffer_view(list->device, &view_desc, inline_view))
     {
@@ -17603,6 +17605,7 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
         src_buffer_view_desc.size = extent.width * extent.height;
         src_buffer_view_desc.offset = src->mem.offset;
         src_buffer_view_desc.buffer = src->res.vk_buffer;
+        src_buffer_view_desc.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
         if (!vkd3d_create_buffer_view(list->device, &src_buffer_view_desc, &src_view))
             goto cleanup;
@@ -17962,6 +17965,7 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
         dst_buffer_view_desc.size = extent.width * extent.height;
         dst_buffer_view_desc.offset = dst->mem.offset;
         dst_buffer_view_desc.buffer = dst->res.vk_buffer;
+        dst_buffer_view_desc.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
 
         if (!vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
             goto cleanup;

--- a/libs/vkd3d/debug_ring.c
+++ b/libs/vkd3d/debug_ring.c
@@ -405,7 +405,7 @@ HRESULT vkd3d_shader_debug_ring_init(struct vkd3d_shader_debug_ring *ring,
 #endif
 
     if (FAILED(vkd3d_allocate_internal_buffer_memory(device, ring->host_buffer,
-            memory_props, &ring->host_buffer_memory)))
+            memory_props, 0, &ring->host_buffer_memory)))
         goto err_free_buffers;
 
     resource_desc.Width = ring->control_block_size;
@@ -425,7 +425,7 @@ HRESULT vkd3d_shader_debug_ring_init(struct vkd3d_shader_debug_ring *ring,
 #endif
 
     if (FAILED(vkd3d_allocate_internal_buffer_memory(device, ring->device_atomic_buffer,
-            memory_props, &ring->device_atomic_buffer_memory)))
+            memory_props, 0, &ring->device_atomic_buffer_memory)))
         goto err_free_buffers;
 
     if (VK_CALL(vkMapMemory(device->vk_device, ring->host_buffer_memory.vk_memory,

--- a/libs/vkd3d/descriptor_debug.c
+++ b/libs/vkd3d/descriptor_debug.c
@@ -453,7 +453,7 @@ static HRESULT vkd3d_descriptor_debug_alloc_global_info_instructions(
 #endif
 
     if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, global_info->vk_payload_buffer,
-            memory_properties, &global_info->payload_device_allocation)))
+            memory_properties, 0, &global_info->payload_device_allocation)))
     {
         vkd3d_descriptor_debug_free_global_info(global_info, device);
         return hr;
@@ -511,7 +511,7 @@ static HRESULT vkd3d_descriptor_debug_alloc_global_info_instructions(
 #endif
 
     if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, global_info->vk_control_buffer,
-            memory_properties, &global_info->control_device_allocation)))
+            memory_properties, 0, &global_info->control_device_allocation)))
     {
         vkd3d_descriptor_debug_free_global_info(global_info, device);
         return hr;
@@ -669,7 +669,7 @@ static HRESULT vkd3d_descriptor_debug_alloc_global_info_descriptors(
 #endif
 
     if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, global_info->vk_payload_buffer,
-            memory_properties,
+            memory_properties, 0,
             &global_info->payload_device_allocation)))
     {
         vkd3d_descriptor_debug_free_global_info(global_info, device);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -9327,10 +9327,49 @@ uint32_t d3d12_device_get_max_descriptor_heap_size(struct d3d12_device *device, 
     switch (heap_type)
     {
         case D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV:
-            return VKD3D_MIN_VIEW_DESCRIPTOR_COUNT;
+            /* Only expose very large descriptor heaps if we have ReBAR available.
+             * Otherwise we risk spilling to sysmem. */
+            if (d3d12_device_use_descriptor_heap(device) && device->memory_info.has_gpu_upload_heap)
+            {
+                VkDeviceSize useable_size =
+                    device->device_info.descriptor_heap_properties.maxResourceHeapSize -
+                    device->device_info.descriptor_heap_properties.minResourceHeapReservedRange;
+                uint32_t count;
+
+                /* Reserve at start of heap. */
+                useable_size -= device->bindless_state.heap.redzone_size;
+                /* Dummy NULL descriptor. */
+                useable_size -= device->bindless_state.cbv_srv_uav_size;
+                /* Meta reservation. */
+                useable_size -= VKD3D_DESCRIPTOR_HEAP_META_DESCRIPTOR_COUNT * device->bindless_state.cbv_srv_uav_size;
+
+                /* Don't report ridiculously large numbers here for safety. Limit the number of descriptors. */
+                count = min(16000000, useable_size >> device->bindless_state.cbv_srv_uav_size_log2);
+                assert(count >= VKD3D_MIN_VIEW_DESCRIPTOR_COUNT);
+                return count;
+            }
+            else
+            {
+                return VKD3D_MIN_VIEW_DESCRIPTOR_COUNT;
+            }
 
         case D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER:
-            return VKD3D_MIN_SAMPLER_DESCRIPTOR_COUNT;
+            if (d3d12_device_use_descriptor_heap(device) && device->memory_info.has_gpu_upload_heap)
+            {
+                /* Meta shaders need embedded samplers in some cases, so we cannot potentially expose the larger limits. */
+                VkDeviceSize useable_size =
+                    device->device_info.descriptor_heap_properties.maxSamplerHeapSize -
+                    device->device_info.descriptor_heap_properties.minSamplerHeapReservedRangeWithEmbedded;
+
+                /* Don't report ridiculously large numbers here for safety. Limit the number of descriptors. */
+                uint32_t count = min(1000000, useable_size >> device->bindless_state.sampler_size_log2);
+                assert(count >= VKD3D_MIN_SAMPLER_DESCRIPTOR_COUNT);
+                return count;
+            }
+            else
+            {
+                return VKD3D_MIN_SAMPLER_DESCRIPTOR_COUNT;
+            }
 
         default:
             WARN("Unhandled descriptor heap type %u.\n", heap_type);

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -2216,7 +2216,7 @@ HRESULT vkd3d_allocate_heap_memory(struct d3d12_device *device, struct vkd3d_mem
 }
 
 HRESULT vkd3d_allocate_internal_buffer_memory(struct d3d12_device *device, VkBuffer vk_buffer,
-        VkMemoryPropertyFlags type_flags,
+        VkMemoryPropertyFlags type_flags, VkMemoryAllocateFlags allocate_flags,
         struct vkd3d_device_memory_allocation *allocation)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
@@ -2228,7 +2228,7 @@ HRESULT vkd3d_allocate_internal_buffer_memory(struct d3d12_device *device, VkBuf
 
     flags_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
     flags_info.pNext = NULL;
-    flags_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    flags_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT | allocate_flags;
 
     VK_CALL(vkGetBufferMemoryRequirements(device->vk_device, vk_buffer, &memory_requirements));
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -215,6 +215,8 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
             | VK_BUFFER_USAGE_TRANSFER_DST_BIT
             | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
             | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+            | VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT
+            | VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT
             | VK_BUFFER_USAGE_INDEX_BUFFER_BIT
             | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
             | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
@@ -256,12 +258,6 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
     }
 
     buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-
-    if (desc->Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
-        buffer_info.usage |= VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
-
-    if (!(desc->Flags & D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE))
-        buffer_info.usage |= VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
     /* Buffers always have properties of D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS. */
     if (desc->Flags & D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS)

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -8324,14 +8324,6 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_heap(struct d3d12_descrip
             alloc_size = align64(alloc_size, device->device_info.descriptor_heap_properties.resourceHeapAlignment);
             descriptor_heap->descriptor_buffer.reserved_offset = alloc_size;
             alloc_size += device->device_info.descriptor_heap_properties.minResourceHeapReservedRange;
-
-            if (alloc_size > device->device_info.descriptor_heap_properties.maxResourceHeapSize)
-            {
-                /* Should not happen. */
-                ERR("Resource heap is allocated with too large size, %"PRIu64" > %"PRIu64".\n",
-                        alloc_size, device->device_info.descriptor_heap_properties.maxResourceHeapSize);
-                return E_OUTOFMEMORY;
-            }
         }
     }
     else
@@ -8344,14 +8336,6 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_heap(struct d3d12_descrip
             alloc_size = align64(alloc_size, device->device_info.descriptor_heap_properties.samplerHeapAlignment);
             descriptor_heap->descriptor_buffer.reserved_offset = alloc_size;
             alloc_size += device->device_info.descriptor_heap_properties.minSamplerHeapReservedRangeWithEmbedded;
-
-            if (alloc_size > device->device_info.descriptor_heap_properties.maxSamplerHeapSize)
-            {
-                /* Should not happen. */
-                ERR("Sampler heap is allocated with too large size, %"PRIu64" > %"PRIu64".\n",
-                        alloc_size, device->device_info.descriptor_heap_properties.maxSamplerHeapSize);
-                return E_OUTOFMEMORY;
-            }
         }
     }
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -1360,6 +1360,8 @@ static uint32_t vkd3d_view_entry_hash(const void *key)
             hash = hash_combine(hash, hash_uint64(k->u.buffer.offset));
             hash = hash_combine(hash, hash_uint64(k->u.buffer.size));
             hash = hash_combine(hash, (uintptr_t)k->u.buffer.format);
+            /* The only interesting usage flags are 32-bit. */
+            hash = hash_combine(hash, (VkBufferUsageFlags)k->u.buffer.usage);
             break;
 
         case VKD3D_VIEW_TYPE_IMAGE:
@@ -1425,7 +1427,8 @@ static bool vkd3d_view_entry_compare(const void *key, const struct hash_map_entr
             return k->u.buffer.buffer == e->key.u.buffer.buffer &&
                     k->u.buffer.format == e->key.u.buffer.format &&
                     k->u.buffer.offset == e->key.u.buffer.offset &&
-                    k->u.buffer.size == e->key.u.buffer.size;
+                    k->u.buffer.size == e->key.u.buffer.size &&
+                    k->u.buffer.usage == e->key.u.buffer.usage;
 
         case VKD3D_VIEW_TYPE_IMAGE:
             return k->u.texture.image == e->key.u.texture.image &&
@@ -5023,11 +5026,13 @@ bool vkd3d_create_raw_r32ui_vk_buffer_view(struct d3d12_device *device,
         VkBuffer vk_buffer, VkDeviceSize offset, VkDeviceSize range, VkBufferView *vk_view)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    struct VkBufferViewCreateInfo view_desc;
+    VkBufferViewCreateInfo view_desc;
     VkResult vr;
 
     if (offset % 4)
         FIXME("Offset %#"PRIx64" violates the required alignment 4.\n", offset);
+
+    /* R32UI is always supported with uniform/storage. */
 
     view_desc.sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO;
     view_desc.pNext = NULL;
@@ -5043,10 +5048,11 @@ bool vkd3d_create_raw_r32ui_vk_buffer_view(struct d3d12_device *device,
 
 bool vkd3d_create_vk_buffer_view(struct d3d12_device *device,
         VkBuffer vk_buffer, const struct vkd3d_format *format,
-        VkDeviceSize offset, VkDeviceSize range, VkBufferView *vk_view)
+        VkDeviceSize offset, VkDeviceSize range, VkBufferUsageFlags2 usage, VkBufferView *vk_view)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    struct VkBufferViewCreateInfo view_desc;
+    VkBufferUsageFlags2CreateInfo flags2;
+    VkBufferViewCreateInfo view_desc;
     VkResult vr;
 
     if (vkd3d_format_is_compressed(format))
@@ -5062,6 +5068,15 @@ bool vkd3d_create_vk_buffer_view(struct d3d12_device *device,
     view_desc.format = format->vk_format;
     view_desc.offset = offset;
     view_desc.range = range;
+
+    if (device->device_info.maintenance_5_features.maintenance5)
+    {
+        memset(&flags2, 0, sizeof(flags2));
+        flags2.sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO;
+        flags2.usage = usage;
+        vk_prepend_struct(&view_desc, &flags2);
+    }
+
     if ((vr = VK_CALL(vkCreateBufferView(device->vk_device, &view_desc, NULL, vk_view))) < 0)
         WARN("Failed to create Vulkan buffer view, vr %d.\n", vr);
     return vr == VK_SUCCESS;
@@ -5073,7 +5088,7 @@ bool vkd3d_create_buffer_view(struct d3d12_device *device, const struct vkd3d_bu
     struct vkd3d_view *object;
     VkBufferView vk_view;
 
-    if (!vkd3d_create_vk_buffer_view(device, desc->buffer, desc->format, desc->offset, desc->size, &vk_view))
+    if (!vkd3d_create_vk_buffer_view(device, desc->buffer, desc->format, desc->offset, desc->size, desc->usage, &vk_view))
         return false;
 
     if (!(object = vkd3d_view_create(VKD3D_VIEW_TYPE_BUFFER)))
@@ -5289,6 +5304,10 @@ static bool vkd3d_create_buffer_view_for_resource(struct d3d12_device *device,
     key.u.buffer.format = format;
     key.u.buffer.offset = resource->mem.offset + offset * element_size;
     key.u.buffer.size = size * element_size;
+    if (flags & VKD3D_VIEW_BUFFER_SRV)
+        key.u.buffer.usage = VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT;
+    else
+        key.u.buffer.usage = VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT;
 
     return !!(*view = vkd3d_view_map_create_view(&resource->view_map, device, &key));
 }

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -8216,6 +8216,7 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_heap(struct d3d12_descrip
 {
     const struct vkd3d_vk_device_procs *vk_procs = &descriptor_heap->device->vk_procs;
     struct d3d12_device *device = descriptor_heap->device;
+    VkMemoryAllocateFlags allocate_flags = 0;
     VkMemoryPropertyFlags property_flags;
     VkDeviceSize descriptor_count;
     VkBufferUsageFlags2KHR usage;
@@ -8311,8 +8312,14 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_heap(struct d3d12_descrip
 
         property_flags = device->memory_info.descriptor_heap_memory_properties;
 
+        /* A freshly initialized descriptor buffer is undefined.
+         * For sake of best-effort robustness, make sure it gets zero-cleared,
+         * but don't go beyond that. */
+        if (device->device_info.zero_initialize_device_memory_features.zeroInitializeDeviceMemory)
+            allocate_flags |= VK_MEMORY_ALLOCATE_ZERO_INITIALIZE_BIT_EXT;
+
         if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, descriptor_heap->descriptor_buffer.vk_buffer,
-                property_flags,
+                property_flags, allocate_flags,
                 &descriptor_heap->descriptor_buffer.device_allocation)))
         {
             VK_CALL(vkDestroyBuffer(device->vk_device, descriptor_heap->descriptor_buffer.vk_buffer, NULL));
@@ -8343,6 +8350,8 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_heap(struct d3d12_descrip
             ERR("Failed to allocate host descriptor buffer.\n");
             return E_OUTOFMEMORY;
         }
+
+        memset(descriptor_heap->descriptor_buffer.host_allocation, 0, alloc_size);
     }
 
     descriptor_heap->descriptor_buffer.size = alloc_size;
@@ -8477,7 +8486,7 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_buffer(struct d3d12_descr
         property_flags = device->memory_info.descriptor_heap_memory_properties;
 
         if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, descriptor_heap->descriptor_buffer.vk_buffer,
-                property_flags,
+                property_flags, 0,
                 &descriptor_heap->descriptor_buffer.device_allocation)))
         {
             VK_CALL(vkDestroyBuffer(device->vk_device, descriptor_heap->descriptor_buffer.vk_buffer, NULL));
@@ -8827,7 +8836,7 @@ static HRESULT d3d12_descriptor_heap_init_data_buffer(struct d3d12_descriptor_he
         property_flags = device->memory_info.descriptor_heap_memory_properties;
 
         if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, descriptor_heap->vk_buffer,
-                property_flags, &descriptor_heap->device_allocation)))
+                property_flags, 0, &descriptor_heap->device_allocation)))
             return hr;
 
         if ((vr = VK_CALL(vkMapMemory(device->vk_device, descriptor_heap->device_allocation.vk_memory,
@@ -9711,7 +9720,7 @@ HRESULT d3d12_query_heap_create(struct d3d12_device *device, const D3D12_QUERY_H
         }
 
         if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, object->vk_buffer,
-                VK_MEMORY_HEAP_DEVICE_LOCAL_BIT, &object->device_allocation)))
+                VK_MEMORY_HEAP_DEVICE_LOCAL_BIT, 0, &object->device_allocation)))
         {
             VK_CALL(vkDestroyBuffer(device->vk_device, object->vk_buffer, NULL));
             vkd3d_free(object);
@@ -10230,7 +10239,7 @@ HRESULT vkd3d_global_descriptor_buffer_init(struct vkd3d_global_descriptor_buffe
     }
 
     if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, global_descriptor_buffer->resource.vk_buffer,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0,
             &global_descriptor_buffer->resource.device_allocation)))
     {
         vkd3d_global_descriptor_buffer_cleanup(global_descriptor_buffer, device);
@@ -10250,7 +10259,7 @@ HRESULT vkd3d_global_descriptor_buffer_init(struct vkd3d_global_descriptor_buffe
     }
 
     if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, global_descriptor_buffer->sampler.vk_buffer,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0,
             &global_descriptor_buffer->sampler.device_allocation)))
     {
         vkd3d_global_descriptor_buffer_cleanup(global_descriptor_buffer, device);

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -8212,6 +8212,144 @@ CONST_VTBL struct ID3D12DescriptorHeapVtbl d3d12_descriptor_heap_vtbl =
     d3d12_descriptor_heap_GetGPUDescriptorHandleForHeapStart,
 };
 
+static HRESULT d3d12_descriptor_heap_create_descriptor_heap(struct d3d12_descriptor_heap *descriptor_heap)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &descriptor_heap->device->vk_procs;
+    struct d3d12_device *device = descriptor_heap->device;
+    VkMemoryPropertyFlags property_flags;
+    VkDeviceSize descriptor_count;
+    VkBufferUsageFlags2KHR usage;
+    VkDeviceSize alloc_size;
+    VkResult vr;
+    HRESULT hr;
+
+    if (descriptor_heap->desc.Type != D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
+            descriptor_heap->desc.Type != D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)
+        return S_OK;
+
+    descriptor_count = descriptor_heap->desc.NumDescriptors;
+
+    /* Sampler heap layout is trivial:
+     * Lower 2k bank for samplers.
+     * Upper 2k bank for reserved embedded. */
+
+    /* Shader visible resource heap is a bit more complex:
+     * - Redzone of up to 4 SSBOs. Stores SSBO pointing to own heap.
+     * - N descriptors. (heapOffset is used in root signature to shift out of redzone)
+     * - 1 dummy descriptor to serve as universal NULL descriptor for robustness hackery.
+     * - Reservation region
+     */
+
+    if (descriptor_heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
+    {
+        alloc_size = device->bindless_state.cbv_srv_uav_size * descriptor_count;
+
+        if (!(descriptor_heap->desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE))
+        {
+            if (device->bindless_state.packed_metadata_offset == 0)
+            {
+                /* Need to store planar metadata. */
+                alloc_size += device->bindless_state.cbv_srv_uav_size *
+                    (1u << vkd3d_log2i_ceil(max(1u, descriptor_count)));
+            }
+        }
+        else
+        {
+            /* At the beginning of the heap, store some magic. */
+            alloc_size += device->bindless_state.heap.redzone_size;
+
+            alloc_size = align64(alloc_size, device->bindless_state.cbv_srv_uav_size);
+
+            /* Allocate some space for clamped NULL descriptor
+             * (only relevant if we're doing some form of workaround or QA checks). */
+            alloc_size += device->bindless_state.cbv_srv_uav_size;
+
+            /* Align for start of reservation region. */
+            alloc_size = align64(alloc_size, device->device_info.descriptor_heap_properties.resourceHeapAlignment);
+            descriptor_heap->descriptor_buffer.reserved_offset = alloc_size;
+            alloc_size += device->device_info.descriptor_heap_properties.minResourceHeapReservedRange;
+
+            if (alloc_size > device->device_info.descriptor_heap_properties.maxResourceHeapSize)
+            {
+                /* Should not happen. */
+                ERR("Resource heap is allocated with too large size, %"PRIu64" > %"PRIu64".\n",
+                        alloc_size, device->device_info.descriptor_heap_properties.maxResourceHeapSize);
+                return E_OUTOFMEMORY;
+            }
+        }
+    }
+    else
+    {
+        alloc_size = device->bindless_state.sampler_size;
+        alloc_size *= descriptor_count;
+
+        if (descriptor_heap->desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
+        {
+            alloc_size = align64(alloc_size, device->device_info.descriptor_heap_properties.samplerHeapAlignment);
+            descriptor_heap->descriptor_buffer.reserved_offset = alloc_size;
+            alloc_size += device->device_info.descriptor_heap_properties.minSamplerHeapReservedRangeWithEmbedded;
+
+            if (alloc_size > device->device_info.descriptor_heap_properties.maxSamplerHeapSize)
+            {
+                /* Should not happen. */
+                ERR("Sampler heap is allocated with too large size, %"PRIu64" > %"PRIu64".\n",
+                        alloc_size, device->device_info.descriptor_heap_properties.maxSamplerHeapSize);
+                return E_OUTOFMEMORY;
+            }
+        }
+    }
+
+    if (descriptor_heap->desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
+    {
+        usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT;
+        if (device->bindless_state.heap.redzone_size)
+            usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+        if (FAILED(hr = vkd3d_create_buffer_explicit_usage(device, usage, alloc_size,
+                "descriptor-buffer", &descriptor_heap->descriptor_buffer.vk_buffer)))
+            return hr;
+
+        property_flags = device->memory_info.descriptor_heap_memory_properties;
+
+        if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, descriptor_heap->descriptor_buffer.vk_buffer,
+                property_flags,
+                &descriptor_heap->descriptor_buffer.device_allocation)))
+        {
+            VK_CALL(vkDestroyBuffer(device->vk_device, descriptor_heap->descriptor_buffer.vk_buffer, NULL));
+            descriptor_heap->descriptor_buffer.vk_buffer = VK_NULL_HANDLE;
+            return hr;
+        }
+
+        descriptor_heap->descriptor_buffer.va =
+                vkd3d_get_buffer_device_address(device, descriptor_heap->descriptor_buffer.vk_buffer);
+
+        if ((vr = VK_CALL(vkMapMemory(device->vk_device,
+                descriptor_heap->descriptor_buffer.device_allocation.vk_memory,
+                0, VK_WHOLE_SIZE, 0, (void**)&descriptor_heap->descriptor_buffer.host_allocation))))
+        {
+            ERR("Failed to map descriptor set memory.\n");
+            vkd3d_free_device_memory(device, &descriptor_heap->descriptor_buffer.device_allocation);
+            VK_CALL(vkDestroyBuffer(device->vk_device, descriptor_heap->descriptor_buffer.vk_buffer, NULL));
+            return hresult_from_vk_result(vr);
+        }
+    }
+    else
+    {
+        descriptor_heap->descriptor_buffer.host_allocation = vkd3d_malloc_aligned(alloc_size,
+                device->device_info.properties2.properties.limits.nonCoherentAtomSize);
+
+        if (!descriptor_heap->descriptor_buffer.host_allocation)
+        {
+            ERR("Failed to allocate host descriptor buffer.\n");
+            return E_OUTOFMEMORY;
+        }
+    }
+
+    descriptor_heap->descriptor_buffer.size = alloc_size;
+
+    return S_OK;
+}
+
 static HRESULT d3d12_descriptor_heap_create_descriptor_buffer(struct d3d12_descriptor_heap *descriptor_heap)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &descriptor_heap->device->vk_procs;
@@ -8923,34 +9061,40 @@ static void d3d12_descriptor_heap_add_null_descriptor_template_descriptors(
     descriptor_heap->null_descriptor_template.set_info_mask |= 1u << set_info_index;
 }
 
-static HRESULT d3d12_descriptor_heap_init(struct d3d12_descriptor_heap *descriptor_heap,
+static void d3d12_descriptor_heap_write_redzone_descriptors(
+        struct d3d12_descriptor_heap *descriptor_heap, struct d3d12_device *device)
+{
+    uint8_t *host_memory = descriptor_heap->descriptor_buffer.host_allocation;
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    VkResourceDescriptorInfoEXT desc_info;
+    VkDeviceAddressRangeEXT ssbo_range;
+    VkHostAddressRangeEXT desc_range;
+
+    /* If we don't need redzone descriptors, just skip it. */
+    if (!device->bindless_state.heap.redzone_size)
+        return;
+
+    memset(&desc_info, 0, sizeof(desc_info));
+    desc_info.sType = VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT;
+    desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    desc_info.data.pAddressRange = &ssbo_range;
+
+    ssbo_range.address = descriptor_heap->descriptor_buffer.va + device->bindless_state.heap.redzone_size;
+    ssbo_range.size = descriptor_heap->desc.NumDescriptors * device->bindless_state.cbv_srv_uav_size;
+    desc_range.address = host_memory;
+    desc_range.size = device->device_info.descriptor_heap_properties.bufferDescriptorSize;
+
+    VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+
+    /* TODO: Can write QA descriptors here as well. For now we fallback to legacy path if we need pure debug options. */
+}
+
+static HRESULT d3d12_descriptor_heap_init_legacy(struct d3d12_descriptor_heap *descriptor_heap,
         struct d3d12_device *device, const D3D12_DESCRIPTOR_HEAP_DESC *desc)
 {
     uint32_t fast_bank_pointer_index = 0;
     unsigned int i;
     HRESULT hr;
-
-    memset(descriptor_heap, 0, sizeof(*descriptor_heap));
-    descriptor_heap->ID3D12DescriptorHeap_iface.lpVtbl = &d3d12_descriptor_heap_vtbl;
-    descriptor_heap->refcount = 1;
-    descriptor_heap->internal_refcount = 1;
-    descriptor_heap->device = device;
-    descriptor_heap->desc = *desc;
-
-    if (desc->Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
-        descriptor_heap->gpu_va = d3d12_device_get_descriptor_heap_gpu_va(device, desc->Type);
-
-    if (d3d12_device_uses_descriptor_buffers(device))
-    {
-        if (FAILED(hr = d3d12_descriptor_heap_create_descriptor_buffer(descriptor_heap)))
-            goto fail;
-    }
-    else
-    {
-        if (FAILED(hr = d3d12_descriptor_heap_create_descriptor_pool(descriptor_heap,
-                &descriptor_heap->vk_descriptor_pool)))
-            goto fail;
-    }
 
     if (desc->Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV ||
             desc->Type == D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)
@@ -8965,7 +9109,7 @@ static HRESULT d3d12_descriptor_heap_init(struct d3d12_descriptor_heap *descript
                 {
                     if (FAILED(hr = d3d12_descriptor_heap_create_descriptor_set(descriptor_heap,
                             set_info, &descriptor_heap->sets[set_info->set_index].vk_descriptor_set)))
-                        goto fail;
+                        return hr;
                 }
 
                 d3d12_descriptor_heap_get_host_mapping(descriptor_heap, set_info, set_info->set_index);
@@ -8992,13 +9136,59 @@ static HRESULT d3d12_descriptor_heap_init(struct d3d12_descriptor_heap *descript
     }
 
     if (FAILED(hr = d3d12_descriptor_heap_init_data_buffer(descriptor_heap, device, desc)))
-        goto fail;
+        return hr;
 
     if (desc->Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
         descriptor_heap->fast_pointer_bank[fast_bank_pointer_index++] = descriptor_heap->raw_va_aux_buffer.host_ptr;
 
     if (desc->Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
         d3d12_descriptor_heap_update_extra_bindings(descriptor_heap, device);
+
+    return S_OK;
+}
+
+static HRESULT d3d12_descriptor_heap_init(struct d3d12_descriptor_heap *descriptor_heap,
+        struct d3d12_device *device, const D3D12_DESCRIPTOR_HEAP_DESC *desc)
+{
+    HRESULT hr;
+
+    memset(descriptor_heap, 0, sizeof(*descriptor_heap));
+    descriptor_heap->ID3D12DescriptorHeap_iface.lpVtbl = &d3d12_descriptor_heap_vtbl;
+    descriptor_heap->refcount = 1;
+    descriptor_heap->internal_refcount = 1;
+    descriptor_heap->device = device;
+    descriptor_heap->desc = *desc;
+
+    if (desc->Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
+        descriptor_heap->gpu_va = d3d12_device_get_descriptor_heap_gpu_va(device, desc->Type);
+
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        if (FAILED(hr = d3d12_descriptor_heap_create_descriptor_heap(descriptor_heap)))
+            goto fail;
+    }
+    else if (d3d12_device_uses_descriptor_buffers(device))
+    {
+        if (FAILED(hr = d3d12_descriptor_heap_create_descriptor_buffer(descriptor_heap)))
+            goto fail;
+    }
+    else
+    {
+        if (FAILED(hr = d3d12_descriptor_heap_create_descriptor_pool(descriptor_heap,
+                &descriptor_heap->vk_descriptor_pool)))
+            goto fail;
+    }
+
+    /* Legacy junk that deals with mapping sets to the descriptor buffer. */
+    if (!d3d12_device_use_descriptor_heap(device))
+        if (FAILED(hr = d3d12_descriptor_heap_init_legacy(descriptor_heap, device, desc)))
+            goto fail;
+
+    if (d3d12_device_use_descriptor_heap(device) && desc->Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
+        (desc->Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE))
+    {
+        d3d12_descriptor_heap_write_redzone_descriptors(descriptor_heap, device);
+    }
 
     if (FAILED(hr = vkd3d_private_store_init(&descriptor_heap->private_store)))
         goto fail;
@@ -9176,11 +9366,21 @@ HRESULT d3d12_descriptor_heap_create(struct d3d12_device *device,
     {
         if (d3d12_device_use_embedded_mutable_descriptors(device))
         {
-            /* Need to guarantee that this offset is aligned to 32 byte.
-             * We're guaranteed the base allocation is aligned, but to align the mutable descriptor binding itself,
-             * we might need to get creative.
-             * We can tweak the descriptor set layout such that we get an aligned offset, however. */
-            object->cpu_va.ptr = (SIZE_T)object->sets[0].mapped_set;
+            if (d3d12_device_use_descriptor_heap(device))
+            {
+                object->cpu_va.ptr = (SIZE_T)object->descriptor_buffer.host_allocation;
+                if (desc->Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV && (desc->Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE))
+                    object->cpu_va.ptr += device->bindless_state.heap.redzone_size;
+            }
+            else
+            {
+                /* Need to guarantee that this offset is aligned to 32 byte.
+                 * We're guaranteed the base allocation is aligned, but to align the mutable descriptor binding itself,
+                 * we might need to get creative.
+                 * We can tweak the descriptor set layout such that we get an aligned offset, however. */
+                object->cpu_va.ptr = (SIZE_T)object->sets[0].mapped_set;
+            }
+
             assert(!(object->cpu_va.ptr & VKD3D_RESOURCE_EMBEDDED_METADATA_OFFSET_LOG2_MASK));
 
             if (!(desc->Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) &&

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -8114,6 +8114,33 @@ void d3d12_descriptor_heap_dec_ref(struct d3d12_descriptor_heap *heap)
     }
 }
 
+uint32_t d3d12_descriptor_heap_allocate_meta_index(struct d3d12_descriptor_heap *heap)
+{
+    uint32_t index = UINT32_MAX;
+    pthread_mutex_lock(&heap->meta_descriptor_lock);
+
+    if (heap->meta_descriptor_index_count == 0)
+        goto unlock;
+
+    index = heap->meta_descriptor_indices[--heap->meta_descriptor_index_count];
+    d3d12_descriptor_heap_inc_ref(heap);
+
+unlock:
+    pthread_mutex_unlock(&heap->meta_descriptor_lock);
+    return index;
+}
+
+void d3d12_descriptor_heap_free_meta_index(struct d3d12_descriptor_heap *heap, uint32_t index)
+{
+    assert(heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
+        (heap->desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE));
+    pthread_mutex_lock(&heap->meta_descriptor_lock);
+    assert(heap->meta_descriptor_index_count < VKD3D_DESCRIPTOR_HEAP_META_DESCRIPTOR_COUNT);
+    heap->meta_descriptor_indices[heap->meta_descriptor_index_count++] = index;
+    pthread_mutex_unlock(&heap->meta_descriptor_lock);
+    d3d12_descriptor_heap_dec_ref(heap);
+}
+
 static ULONG STDMETHODCALLTYPE d3d12_descriptor_heap_Release(ID3D12DescriptorHeap *iface)
 {
     struct d3d12_descriptor_heap *heap = impl_from_ID3D12DescriptorHeap(iface);
@@ -8238,6 +8265,7 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_heap(struct d3d12_descrip
     VkDeviceSize alloc_size;
     VkResult vr;
     HRESULT hr;
+    size_t i;
 
     if (descriptor_heap->desc.Type != D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
             descriptor_heap->desc.Type != D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)
@@ -8279,6 +8307,18 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_heap(struct d3d12_descrip
             /* Allocate some space for clamped NULL descriptor
              * (only relevant if we're doing some form of workaround or QA checks). */
             alloc_size += device->bindless_state.cbv_srv_uav_size;
+
+            /* Allocate space for meta descriptors. */
+            pthread_mutex_init(&descriptor_heap->meta_descriptor_lock, NULL);
+            descriptor_heap->meta_descriptor_indices = vkd3d_malloc(
+                VKD3D_DESCRIPTOR_HEAP_META_DESCRIPTOR_COUNT * sizeof(uint32_t));
+            for (i = 0; i < VKD3D_DESCRIPTOR_HEAP_META_DESCRIPTOR_COUNT; i++)
+            {
+                /* All meta shaders use a simple stride from base. */
+                descriptor_heap->meta_descriptor_indices[i] = alloc_size >> device->bindless_state.cbv_srv_uav_size_log2;
+                alloc_size += device->bindless_state.cbv_srv_uav_size;
+            }
+            descriptor_heap->meta_descriptor_index_count = VKD3D_DESCRIPTOR_HEAP_META_DESCRIPTOR_COUNT;
 
             /* Align for start of reservation region. */
             alloc_size = align64(alloc_size, device->device_info.descriptor_heap_properties.resourceHeapAlignment);
@@ -9485,6 +9525,21 @@ void d3d12_descriptor_heap_cleanup(struct d3d12_descriptor_heap *descriptor_heap
         vkd3d_free_aligned(descriptor_heap->descriptor_buffer.host_allocation);
     vkd3d_free_device_memory(device, &descriptor_heap->descriptor_buffer.device_allocation);
     VK_CALL(vkDestroyBuffer(device->vk_device, descriptor_heap->descriptor_buffer.vk_buffer, NULL));
+
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        if (descriptor_heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
+            (descriptor_heap->desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE))
+        {
+            if (descriptor_heap->meta_descriptor_index_count != VKD3D_DESCRIPTOR_HEAP_META_DESCRIPTOR_COUNT)
+            {
+                FIXME("Mismatch in meta descriptors. Expected VKD3D_DESCRIPTOR_HEAP_META_DESCRIPTOR_COUNT, got %zu.\n",
+                        descriptor_heap->meta_descriptor_index_count);
+            }
+            pthread_mutex_destroy(&descriptor_heap->meta_descriptor_lock);
+            vkd3d_free(descriptor_heap->meta_descriptor_indices);
+        }
+    }
 
     vkd3d_descriptor_debug_unregister_heap(descriptor_heap->cookie);
 }

--- a/libs/vkd3d/va_map.c
+++ b/libs/vkd3d/va_map.c
@@ -273,6 +273,7 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
     key.u.buffer.offset = va - resource->va;
     key.u.buffer.size = resource->size - key.u.buffer.offset;
     key.u.buffer.format = NULL;
+    key.u.buffer.usage = 0;
 
     view = vkd3d_view_map_get_view(view_map, device, &key);
     if (!view)
@@ -334,6 +335,7 @@ static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
     key.u.buffer.offset = va - resource->va;
     key.u.buffer.size = resource->size - key.u.buffer.offset;
     key.u.buffer.format = NULL;
+    key.u.buffer.usage = 0;
 
     view = vkd3d_view_map_create_view2(view_map, device, &key, rtas_is_omm);
     if (!view)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1263,7 +1263,7 @@ HRESULT vkd3d_allocate_device_memory(struct d3d12_device *device,
 void vkd3d_free_device_memory(struct d3d12_device *device,
         const struct vkd3d_device_memory_allocation *allocation);
 HRESULT vkd3d_allocate_internal_buffer_memory(struct d3d12_device *device, VkBuffer vk_buffer,
-        VkMemoryPropertyFlags type_flags,
+        VkMemoryPropertyFlags type_flags, VkMemoryAllocateFlags allocate_flags,
         struct vkd3d_device_memory_allocation *allocation);
 HRESULT vkd3d_create_buffer(struct d3d12_device *device,
         const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1615,6 +1615,13 @@ struct d3d12_descriptor_heap
     struct vkd3d_private_store private_store;
     struct d3d_destruction_notifier destruction_notifier;
 
+    /* For descriptor heap, command allocator can borrow single descriptors from the heap
+     * which is required in order to execute meta commands. */
+#define VKD3D_DESCRIPTOR_HEAP_META_DESCRIPTOR_COUNT 4096
+    pthread_mutex_t meta_descriptor_lock;
+    uint32_t *meta_descriptor_indices;
+    size_t meta_descriptor_index_count;
+
     /* Here we pack metadata data structures for CBV_SRV_UAV and SAMPLER.
      * For RTV/DSV heaps, we just encode rtv_desc structs inline. */
     DECLSPEC_ALIGN(D3D12_DESC_ALIGNMENT) BYTE descriptors[];
@@ -1626,6 +1633,9 @@ void d3d12_descriptor_heap_cleanup(struct d3d12_descriptor_heap *descriptor_heap
 bool d3d12_descriptor_heap_require_padding_descriptors(struct d3d12_device *device);
 void d3d12_descriptor_heap_inc_ref(struct d3d12_descriptor_heap *heap);
 void d3d12_descriptor_heap_dec_ref(struct d3d12_descriptor_heap *heap);
+
+uint32_t d3d12_descriptor_heap_allocate_meta_index(struct d3d12_descriptor_heap *heap);
+void d3d12_descriptor_heap_free_meta_index(struct d3d12_descriptor_heap *heap, uint32_t index);
 
 static inline struct d3d12_descriptor_heap *impl_from_ID3D12DescriptorHeap(ID3D12DescriptorHeap *iface)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1328,6 +1328,7 @@ struct vkd3d_buffer_view_desc
     const struct vkd3d_format *format;
     VkDeviceSize offset;
     VkDeviceSize size;
+    VkBufferUsageFlags2 usage;
 };
 
 struct vkd3d_texture_view_desc
@@ -1471,7 +1472,7 @@ void d3d12_desc_create_sampler_embedded(vkd3d_cpu_descriptor_va_t sampler,
 
 bool vkd3d_create_vk_buffer_view(struct d3d12_device *device,
         VkBuffer vk_buffer, const struct vkd3d_format *format,
-        VkDeviceSize offset, VkDeviceSize range, VkBufferView *vk_view);
+        VkDeviceSize offset, VkDeviceSize range, VkBufferUsageFlags2 usage, VkBufferView *vk_view);
 bool vkd3d_create_raw_buffer_view(struct d3d12_device *device,
         D3D12_GPU_VIRTUAL_ADDRESS gpu_address, VkBufferView *vk_buffer_view);
 HRESULT d3d12_create_static_sampler(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1586,6 +1586,8 @@ struct d3d12_descriptor_heap
     {
         VkBuffer vk_buffer;
         VkDeviceAddress va;
+        VkDeviceSize size;
+        VkDeviceSize reserved_offset;
         struct vkd3d_device_memory_allocation device_allocation;
         uint8_t *host_allocation;
         VkDeviceSize offsets[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];

--- a/libs/vkd3d/workgraphs.c
+++ b/libs/vkd3d/workgraphs.c
@@ -1184,7 +1184,7 @@ static HRESULT d3d12_wg_state_object_allocate_ring(struct d3d12_wg_state_object_
     }
 
     if (FAILED(hr = vkd3d_allocate_internal_buffer_memory(device, ring->vk_buffer,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0,
             &ring->allocation)))
     {
         return hr;


### PR DESCRIPTION
Focuses on allocating the descriptor heap buffers.
Also adds the interface for a command allocator to temporarily borrow a resource index from the heap for use in e.g. meta shaders, since swapping the heap is a bad time for real this time.