### PR TITLE
Descriptor heap - Phase 3

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -14887,10 +14887,13 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearRenderTargetView(d3d12_com
 struct vkd3d_clear_uav_info
 {
     DXGI_FORMAT clear_dxgi_format;
-    bool has_view;
+    struct vkd3d_view *view;
+    uint32_t heap_index;
+    bool use_heap;
+
     union
     {
-        struct vkd3d_view *view;
+        struct vkd3d_descriptor_metadata_image_view image;
         struct vkd3d_descriptor_metadata_buffer_view buffer;
     } u;
 };
@@ -14904,6 +14907,7 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
     struct vkd3d_clear_uav_pipeline pipeline;
     struct vkd3d_clear_uav_args clear_args;
     VkDescriptorBufferInfo buffer_info;
+    const struct vkd3d_format *format;
     VkDescriptorImageInfo image_info;
     D3D12_RECT full_rect, curr_rect;
     VkWriteDescriptorSet write_set;
@@ -14940,24 +14944,36 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
     memset(&full_rect, 0, sizeof(full_rect));
 
+    format = vkd3d_get_format(list->device, args->clear_dxgi_format, false);
+
     if (d3d12_resource_is_texture(resource))
     {
-        assert(args->has_view);
+        /* TODO: This will change in heap. */
+        assert(args->view);
 
         image_info.sampler = VK_NULL_HANDLE;
-        image_info.imageView = args->u.view->vk_image_view;
+        image_info.imageView = args->view->vk_image_view;
         image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
         write_set.pImageInfo = &image_info;
 
-        view_extent = d3d12_resource_get_view_subresource_extent(resource, args->u.view);
+        if (args->view)
+        {
+            view_extent = d3d12_resource_get_view_subresource_extent(resource, args->view);
+        }
+        else
+        {
+            VkImageSubresourceLayers vk_subresource;
+            vk_subresource.aspectMask = format->vk_aspect_mask;
+            vk_subresource.mipLevel = args->u.image.mip_slice;
+            vk_subresource.baseArrayLayer = 0;
+            vk_subresource.layerCount = VK_REMAINING_ARRAY_LAYERS;
+            view_extent = d3d12_resource_desc_get_vk_subresource_extent(&resource->desc, format, &vk_subresource);
+        }
 
         full_rect.right = view_extent.width;
         full_rect.bottom = view_extent.height;
-
-        layer_count = args->u.view->info.texture.vk_view_type == VK_IMAGE_VIEW_TYPE_3D
-                ? view_extent.depth : args->u.view->info.texture.layer_count;
 
         if (sampler_feedback_clear)
         {
@@ -14966,33 +14982,32 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
             full_rect.bottom = padded.height;
         }
 
-        /* Robustness would take care of it, but no reason to spam more threads than needed. */
-        if (args->u.view->info.texture.vk_view_type == VK_IMAGE_VIEW_TYPE_3D)
+        if (resource->desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D)
         {
-            layer_count = min(layer_count - args->u.view->info.texture.w_offset, args->u.view->info.texture.w_size);
-            if (layer_count >= 0x80000000u)
-            {
-                ERR("3D slice out of bounds.\n");
-                layer_count = 0;
-            }
+            layer_count = min(resource->desc.DepthOrArraySize - args->u.image.first_array_slice, args->u.image.array_size);
+        }
+        else
+        {
+            layer_count = min(max(1, resource->desc.DepthOrArraySize >> args->u.image.mip_slice) -
+                              args->u.image.first_array_slice, args->u.image.array_size);
         }
 
         pipeline = vkd3d_meta_get_clear_image_uav_pipeline(
-                &list->device->meta_ops, args->u.view->info.texture.vk_view_type,
-                args->u.view->format->type == VKD3D_FORMAT_TYPE_UINT);
-        workgroup_size = vkd3d_meta_get_clear_image_uav_workgroup_size(args->u.view->info.texture.vk_view_type);
+                &list->device->meta_ops, args->u.image.vk_view_type,
+                format->type == VKD3D_FORMAT_TYPE_UINT);
+        workgroup_size = vkd3d_meta_get_clear_image_uav_workgroup_size(args->u.image.vk_view_type);
     }
     else
     {
         full_rect.bottom = 1;
 
-        if (args->has_view)
+        if (args->view)
         {
-            VkDeviceSize byte_count = args->u.view->format->byte_count;
-            full_rect.right = args->u.view->info.buffer.size / byte_count;
+            VkDeviceSize byte_count = args->view->format->byte_count;
+            full_rect.right = args->view->info.buffer.size / byte_count;
 
             write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
-            write_set.pTexelBufferView = &args->u.view->vk_buffer_view;
+            write_set.pTexelBufferView = &args->view->vk_buffer_view;
         }
         else
         {
@@ -15008,8 +15023,8 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
         layer_count = 1;
         pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops,
-                !args->has_view || args->u.view->format->type == VKD3D_FORMAT_TYPE_UINT,
-                !args->has_view);
+                !args->view || format->type == VKD3D_FORMAT_TYPE_UINT,
+                !args->view);
         workgroup_size = vkd3d_meta_get_clear_buffer_uav_workgroup_size();
     }
 
@@ -15081,6 +15096,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     unsigned int base_layer, layer_count, i, j;
     struct vkd3d_clear_uav_pipeline pipeline;
     struct vkd3d_scratch_allocation scratch;
+    VkImageSubresourceLayers vk_subresource;
     struct vkd3d_clear_uav_args clear_args;
     VkCopyBufferToImageInfo2 copy_info;
     VkDeviceSize scratch_buffer_size;
@@ -15102,10 +15118,14 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
     d3d12_command_list_update_descriptor_buffers(list);
 
-    assert(args->has_view);
+    assert(!args->view && !args->use_heap);
     assert(d3d12_resource_is_texture(resource));
 
-    view_extent = d3d12_resource_get_view_subresource_extent(resource, args->u.view);
+    vk_subresource.aspectMask = format->vk_aspect_mask;
+    vk_subresource.mipLevel = args->u.image.mip_slice;
+    vk_subresource.baseArrayLayer = 0;
+    vk_subresource.layerCount = VK_REMAINING_ARRAY_LAYERS;
+    view_extent = d3d12_resource_desc_get_vk_subresource_extent(&resource->desc, format, &vk_subresource);
 
     full_rect.left = 0;
     full_rect.right = view_extent.width;
@@ -15206,28 +15226,24 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     copy_region.bufferRowLength = 0;
     copy_region.bufferImageHeight = 0;
 
-    copy_region.imageSubresource = vk_subresource_layers_from_view(args->u.view);
+    base_layer = args->u.image.first_array_slice;
 
-    if (args->u.view->info.texture.vk_view_type == VK_IMAGE_VIEW_TYPE_3D)
+    copy_region.imageSubresource.aspectMask = format->vk_aspect_mask;
+    copy_region.imageSubresource.mipLevel = args->u.image.mip_slice;
+    copy_region.imageSubresource.baseArrayLayer = base_layer;
+    copy_region.imageOffset.z = 0;
+    copy_region.imageExtent.depth = 1;
+    copy_region.imageSubresource.layerCount = 1;
+
+    if (resource->desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D)
     {
-        base_layer = args->u.view->info.texture.w_offset;
-        layer_count = view_extent.depth;
-        layer_count = min(layer_count - args->u.view->info.texture.w_offset, args->u.view->info.texture.w_size);
-        if (layer_count >= 0x80000000u)
-        {
-            ERR("3D slice out of bounds.\n");
-            layer_count = 0;
-        }
+        layer_count = min(resource->desc.DepthOrArraySize - args->u.image.first_array_slice, args->u.image.array_size);
     }
     else
     {
-        copy_region.imageOffset.z = 0;
-        base_layer = copy_region.imageSubresource.baseArrayLayer;
-        layer_count = copy_region.imageSubresource.layerCount;
+        layer_count = min(max(1, resource->desc.DepthOrArraySize >> args->u.image.mip_slice) -
+                          args->u.image.first_array_slice, args->u.image.array_size);
     }
-
-    copy_region.imageExtent.depth = 1;
-    copy_region.imageSubresource.layerCount = 1;
 
     copy_info.sType = VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2;
     copy_info.pNext = NULL;
@@ -15339,20 +15355,23 @@ static const struct vkd3d_format *vkd3d_clear_uav_find_uint_format(struct d3d12_
 }
 
 static inline bool vkd3d_clear_uav_info_from_metadata(struct vkd3d_clear_uav_info *args,
-        struct d3d12_desc_split_metadata metadata)
+        const struct vkd3d_descriptor_metadata_view *metadata)
 {
-    if (metadata.view->info.flags & VKD3D_DESCRIPTOR_FLAG_IMAGE_VIEW)
+    args->view = NULL;
+    args->use_heap = false;
+    args->heap_index = UINT32_MAX;
+
+    if (metadata->info.flags & VKD3D_DESCRIPTOR_FLAG_IMAGE_VIEW)
     {
-        args->has_view = true;
-        args->u.view = metadata.view->info.image.view;
-        args->clear_dxgi_format = metadata.view->info.image.view->format->dxgi_format;
+        args->u.image = metadata->info.image;
+        args->view = metadata->info.image.view;
+        args->clear_dxgi_format = metadata->info.image.dxgi_format;
         return true;
     }
-    else if (metadata.view->info.flags & VKD3D_DESCRIPTOR_FLAG_BUFFER_VA_RANGE)
+    else if (metadata->info.flags & VKD3D_DESCRIPTOR_FLAG_BUFFER_VA_RANGE)
     {
-        args->u.buffer = metadata.view->info.buffer;
-        args->has_view = false;
-        args->clear_dxgi_format = metadata.view->info.buffer.dxgi_format;
+        args->u.buffer = metadata->info.buffer;
+        args->clear_dxgi_format = metadata->info.buffer.dxgi_format;
         return true;
     }
     else
@@ -15444,6 +15463,37 @@ static bool vkd3d_clear_uav_synthesize_buffer_view(struct d3d12_command_list *li
     return true;
 }
 
+static void vkd3d_texture_view_desc_convert_from_metadata(
+        struct d3d12_resource *resource,
+        const struct vkd3d_format *format,
+        struct vkd3d_texture_view_desc *desc,
+        const struct vkd3d_descriptor_metadata_image_view *meta)
+{
+    memset(desc, 0, sizeof(*desc));
+
+    desc->image = resource->res.vk_image;
+    desc->format = format;
+    desc->aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, meta->plane_slice);
+    desc->image_usage = VK_IMAGE_USAGE_STORAGE_BIT;
+    desc->miplevel_count = 1;
+    desc->layer_count = 1;
+    desc->w_size = 1;
+    desc->allowed_swizzle = false;
+    desc->view_type = meta->vk_view_type;
+    desc->miplevel_idx = meta->mip_slice;
+
+    if (meta->vk_view_type == VK_IMAGE_VIEW_TYPE_3D)
+    {
+        desc->w_offset = meta->first_array_slice;
+        desc->w_size = meta->array_size;
+    }
+    else
+    {
+        desc->layer_idx = meta->first_array_slice;
+        desc->layer_count = meta->array_size;
+    }
+}
+
 static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3d12_command_list_iface *iface,
         D3D12_GPU_DESCRIPTOR_HANDLE gpu_handle, D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle, ID3D12Resource *resource,
         const UINT values[4], UINT rect_count, const D3D12_RECT *rects)
@@ -15473,14 +15523,18 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
     if (!resource_impl || !metadata.view)
         return;
 
-    if (!vkd3d_clear_uav_info_from_metadata(&args, metadata))
+    if (!vkd3d_clear_uav_info_from_metadata(&args, metadata.view))
         return;
 
-    if (d3d12_resource_is_texture(resource_impl) && !args.has_view)
+    if (d3d12_resource_is_texture(resource_impl) && !(args.u.image.flags & VKD3D_DESCRIPTOR_FLAG_IMAGE_VIEW))
     {
-        /* Theoretically possibly for buggy application that tries to clear a buffer view with a texture resource.
-         * Safeguard against crash. */
-        WARN("Attempted to clear buffer with image resource.\n");
+        WARN("Image clear mismatch.\n");
+        return;
+    }
+
+    if (d3d12_resource_is_buffer(resource_impl) && !(args.u.buffer.flags & VKD3D_DESCRIPTOR_FLAG_BUFFER_VA_RANGE))
+    {
+        WARN("Buffer clear mismatch.\n");
         return;
     }
 
@@ -15491,28 +15545,34 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
 
     /* Handle formatted buffer clears.
      * Always defer creating the VkBufferView until this time. */
-    if (!args.has_view && args.clear_dxgi_format)
+    if (d3d12_resource_is_buffer(resource_impl))
     {
-        uint_format = vkd3d_clear_uav_find_uint_format(list->device, args.clear_dxgi_format);
-        if (!uint_format)
+        if (args.clear_dxgi_format)
         {
-            ERR("Unhandled format %d.\n", clear_format->dxgi_format);
-            return;
+            uint_format = vkd3d_clear_uav_find_uint_format(list->device, args.clear_dxgi_format);
+            if (!uint_format)
+            {
+                ERR("Unhandled format %d.\n", clear_format->dxgi_format);
+                return;
+            }
+
+            color = vkd3d_fixup_clear_uav_uint_color(list->device, clear_format->dxgi_format, color);
+            color = vkd3d_fixup_clear_uav_swizzle(list->device, clear_format, color);
+            vkd3d_mask_uint_clear_color(color.uint32, uint_format->vk_format);
+        }
+        else
+        {
+            /* Structured buffer UAV clears are not allowed, so if it's raw, it's BAB, which is R32_UINT centric. */
+            uint_format = vkd3d_get_format(list->device, DXGI_FORMAT_R32_UINT, false);
         }
 
-        color = vkd3d_fixup_clear_uav_uint_color(list->device, clear_format->dxgi_format, color);
-        color = vkd3d_fixup_clear_uav_swizzle(list->device, clear_format, color);
-        vkd3d_mask_uint_clear_color(color.uint32, uint_format->vk_format);
-
+        args.clear_dxgi_format = uint_format->dxgi_format;
         if (!vkd3d_clear_uav_synthesize_buffer_view(list, resource_impl, &args, uint_format, &inline_view))
             return;
-
-        args.u.view = inline_view;
-        args.has_view = true;
+        args.view = inline_view;
     }
     else if (d3d12_resource_is_texture(resource_impl) && clear_format->type != VKD3D_FORMAT_TYPE_UINT)
     {
-        const struct vkd3d_view *base_view = metadata.view->info.image.view;
         uint_format = vkd3d_clear_uav_find_uint_format(list->device, clear_format->dxgi_format);
         color = vkd3d_fixup_clear_uav_uint_color(list->device, clear_format->dxgi_format, color);
         color = vkd3d_fixup_clear_uav_swizzle(list->device, clear_format, color);
@@ -15525,48 +15585,47 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
 
         vkd3d_mask_uint_clear_color(color.uint32, uint_format->vk_format);
 
-        if (d3d12_resource_view_format_is_compatible(resource_impl, uint_format))
+        /* If the clear color is 0, we can safely use the existing view to perform the
+         * clear since the bit pattern will not change. Otherwise, fill a scratch buffer
+         * with the packed clear value and perform a buffer to image copy.
+         * We have no SINT clear variant, and SINT is always compatible with UINT due to flexible casting rules in D3D12. */
+        if (clear_format->type != VKD3D_FORMAT_TYPE_SINT &&
+                !color.uint32[0] && !color.uint32[1] && !color.uint32[2] && !color.uint32[3])
+            uint_format = clear_format;
+
+        if (!d3d12_resource_view_format_is_compatible(resource_impl, uint_format))
+        {
+            /* We'll synthesize a custom buffer view here. */
+            args.view = NULL;
+
+            d3d12_command_list_clear_uav_with_copy(list, resource_impl,
+                    &args, &color, uint_format, rect_count, rects);
+            return;
+        }
+
+        args.clear_dxgi_format = uint_format->dxgi_format;
+        clear_format = uint_format;
+    }
+    else if (d3d12_resource_is_texture(resource_impl))
+    {
+        vkd3d_mask_uint_clear_color(color.uint32, clear_format->vk_format);
+    }
+
+    if (d3d12_resource_is_texture(resource_impl))
+    {
+        if (!args.view || args.view->format != clear_format)
         {
             struct vkd3d_texture_view_desc view_desc;
-            memset(&view_desc, 0, sizeof(view_desc));
+            vkd3d_texture_view_desc_convert_from_metadata(resource_impl, clear_format, &view_desc, &args.u.image);
 
-            view_desc.image = resource_impl->res.vk_image;
-            view_desc.view_type = base_view->info.texture.vk_view_type;
-            view_desc.format = uint_format;
-            view_desc.miplevel_idx = base_view->info.texture.miplevel_idx;
-            view_desc.miplevel_count = 1;
-            view_desc.layer_idx = base_view->info.texture.layer_idx;
-            view_desc.layer_count = base_view->info.texture.layer_count;
-            view_desc.w_offset = base_view->info.texture.w_offset;
-            view_desc.w_size = base_view->info.texture.w_size;
-            view_desc.aspect_mask = base_view->info.texture.aspect_mask;
-            view_desc.image_usage = VK_IMAGE_USAGE_STORAGE_BIT;
-            view_desc.allowed_swizzle = false;
-
-            if (!vkd3d_create_texture_view(list->device, &view_desc, &args.u.view))
+            if (!vkd3d_create_texture_view(list->device, &view_desc, &inline_view))
             {
                 ERR("Failed to create image view.\n");
                 return;
             }
 
-            inline_view = args.u.view;
+            args.view = inline_view;
         }
-        else
-        {
-            /* If the clear color is 0, we can safely use the existing view to perform the
-             * clear since the bit pattern will not change. Otherwise, fill a scratch buffer
-             * with the packed clear value and perform a buffer to image copy. */
-            if (color.uint32[0] || color.uint32[1] || color.uint32[2] || color.uint32[3])
-            {
-                d3d12_command_list_clear_uav_with_copy(list, resource_impl,
-                        &args, &color, uint_format, rect_count, rects);
-                return;
-            }
-        }
-    }
-    else if (args.has_view)
-    {
-        vkd3d_mask_uint_clear_color(color.uint32, clear_format->vk_format);
     }
 
     d3d12_command_list_clear_uav(list, resource_impl, &args, &color, rect_count, rects);
@@ -15604,14 +15663,18 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewFloat(d
     if (!resource_impl || !metadata.view)
         return;
 
-    if (!vkd3d_clear_uav_info_from_metadata(&args, metadata))
+    if (!vkd3d_clear_uav_info_from_metadata(&args, metadata.view))
         return;
 
-    if (d3d12_resource_is_texture(resource_impl) && !args.has_view)
+    if (d3d12_resource_is_texture(resource_impl) && !(args.u.image.flags & VKD3D_DESCRIPTOR_FLAG_IMAGE_VIEW))
     {
-        /* Theoretically possibly for buggy application that tries to clear a buffer view with a texture resource.
-         * Safeguard against crash. */
-        WARN("Attempted to clear buffer with image resource.\n");
+        WARN("Image clear mismatch.\n");
+        return;
+    }
+
+    if (d3d12_resource_is_buffer(resource_impl) && !(args.u.buffer.flags & VKD3D_DESCRIPTOR_FLAG_BUFFER_VA_RANGE))
+    {
+        WARN("Buffer clear mismatch.\n");
         return;
     }
 
@@ -15623,16 +15686,31 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewFloat(d
     }
     else
     {
-        memset(&color, 0, sizeof(color));
+        WARN("Attempting to clear float UAV without format.\n");
+        return;
     }
 
-    if (!args.has_view && args.clear_dxgi_format)
+    if (d3d12_resource_is_texture(resource_impl))
     {
-        if (!vkd3d_clear_uav_synthesize_buffer_view(list, resource_impl, &args, NULL, &inline_view))
-            return;
+        if (!args.view)
+        {
+            struct vkd3d_texture_view_desc view_desc;
+            vkd3d_texture_view_desc_convert_from_metadata(resource_impl, clear_format, &view_desc, &args.u.image);
 
-        args.u.view = inline_view;
-        args.has_view = true;
+            if (!vkd3d_create_texture_view(list->device, &view_desc, &inline_view))
+            {
+                ERR("Failed to create image view.\n");
+                return;
+            }
+
+            args.view = inline_view;
+        }
+    }
+    else
+    {
+        if (!vkd3d_clear_uav_synthesize_buffer_view(list, resource_impl, &args, clear_format, &inline_view))
+            return;
+        args.view = inline_view;
     }
 
     d3d12_command_list_clear_uav(list, resource_impl, &args, &color, rect_count, rects);

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -6452,18 +6452,16 @@ static void vkd3d_texture_view_desc_fixup(struct d3d12_device *device, struct vk
     }
 }
 
-static struct vkd3d_view *vkd3d_create_texture_uav_view(struct d3d12_device *device,
-        struct d3d12_resource *resource, const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
+static bool vkd3d_setup_texture_uav_view(struct d3d12_device *device,
+        struct d3d12_resource *resource, const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc,
+        struct vkd3d_texture_view_desc *texture)
 {
-    struct vkd3d_view_key key;
-    key.view_type = VKD3D_VIEW_TYPE_IMAGE;
+    if (!init_default_texture_view_desc(texture, resource, desc ? desc->Format : 0))
+        return false;
 
-    if (!init_default_texture_view_desc(&key.u.texture, resource, desc ? desc->Format : 0))
-        return NULL;
+    texture->image_usage = VK_IMAGE_USAGE_STORAGE_BIT;
 
-    key.u.texture.image_usage = VK_IMAGE_USAGE_STORAGE_BIT;
-
-    if (vkd3d_format_is_compressed(key.u.texture.format))
+    if (vkd3d_format_is_compressed(texture->format))
     {
         WARN("UAVs cannot be created for compressed formats.\n");
         return NULL;
@@ -6474,47 +6472,47 @@ static struct vkd3d_view *vkd3d_create_texture_uav_view(struct d3d12_device *dev
         switch (desc->ViewDimension)
         {
             case D3D12_UAV_DIMENSION_TEXTURE1D:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_1D;
-                key.u.texture.miplevel_idx = desc->Texture1D.MipSlice;
-                key.u.texture.layer_count = 1;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_1D;
+                texture->miplevel_idx = desc->Texture1D.MipSlice;
+                texture->layer_count = 1;
                 break;
             case D3D12_UAV_DIMENSION_TEXTURE1DARRAY:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
-                key.u.texture.miplevel_idx = desc->Texture1DArray.MipSlice;
-                key.u.texture.layer_idx = desc->Texture1DArray.FirstArraySlice;
-                key.u.texture.layer_count = desc->Texture1DArray.ArraySize;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+                texture->miplevel_idx = desc->Texture1DArray.MipSlice;
+                texture->layer_idx = desc->Texture1DArray.FirstArraySlice;
+                texture->layer_count = desc->Texture1DArray.ArraySize;
                 break;
             case D3D12_UAV_DIMENSION_TEXTURE2D:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_2D;
-                key.u.texture.miplevel_idx = desc->Texture2D.MipSlice;
-                key.u.texture.layer_count = 1;
-                key.u.texture.aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2D.PlaneSlice);
+                texture->view_type = VK_IMAGE_VIEW_TYPE_2D;
+                texture->miplevel_idx = desc->Texture2D.MipSlice;
+                texture->layer_count = 1;
+                texture->aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2D.PlaneSlice);
                 break;
             case D3D12_UAV_DIMENSION_TEXTURE2DMS:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_2D;
-                key.u.texture.miplevel_idx = 0;
-                key.u.texture.layer_count = 1;
-                key.u.texture.aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2D.PlaneSlice);
+                texture->view_type = VK_IMAGE_VIEW_TYPE_2D;
+                texture->miplevel_idx = 0;
+                texture->layer_count = 1;
+                texture->aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2D.PlaneSlice);
                 break;
             case D3D12_UAV_DIMENSION_TEXTURE2DARRAY:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-                key.u.texture.miplevel_idx = desc->Texture2DArray.MipSlice;
-                key.u.texture.layer_idx = desc->Texture2DArray.FirstArraySlice;
-                key.u.texture.layer_count = desc->Texture2DArray.ArraySize;
-                key.u.texture.aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2DArray.PlaneSlice);
+                texture->view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+                texture->miplevel_idx = desc->Texture2DArray.MipSlice;
+                texture->layer_idx = desc->Texture2DArray.FirstArraySlice;
+                texture->layer_count = desc->Texture2DArray.ArraySize;
+                texture->aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2DArray.PlaneSlice);
                 break;
             case D3D12_UAV_DIMENSION_TEXTURE2DMSARRAY:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-                key.u.texture.miplevel_idx = 0;
-                key.u.texture.layer_idx = desc->Texture2DMSArray.FirstArraySlice;
-                key.u.texture.layer_count = desc->Texture2DMSArray.ArraySize;
-                key.u.texture.aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, 0);
+                texture->view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+                texture->miplevel_idx = 0;
+                texture->layer_idx = desc->Texture2DMSArray.FirstArraySlice;
+                texture->layer_count = desc->Texture2DMSArray.ArraySize;
+                texture->aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, 0);
                 break;
             case D3D12_UAV_DIMENSION_TEXTURE3D:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_3D;
-                key.u.texture.miplevel_idx = desc->Texture3D.MipSlice;
-                key.u.texture.w_offset = desc->Texture3D.FirstWSlice;
-                key.u.texture.w_size = desc->Texture3D.WSize;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_3D;
+                texture->miplevel_idx = desc->Texture3D.MipSlice;
+                texture->w_offset = desc->Texture3D.FirstWSlice;
+                texture->w_size = desc->Texture3D.WSize;
                 if (!device->device_info.image_sliced_view_of_3d_features.imageSlicedViewOf3D)
                 {
                     if (desc->Texture3D.FirstWSlice ||
@@ -6531,23 +6529,31 @@ static struct vkd3d_view *vkd3d_create_texture_uav_view(struct d3d12_device *dev
         }
     }
 
-    vkd3d_texture_view_desc_fixup(device, &key.u.texture);
+    vkd3d_texture_view_desc_fixup(device, texture);
+    return true;
+}
+
+static struct vkd3d_view *vkd3d_create_texture_uav_view(struct d3d12_device *device,
+        struct d3d12_resource *resource, const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
+{
+    struct vkd3d_view_key key;
+    key.view_type = VKD3D_VIEW_TYPE_IMAGE;
+    if (!vkd3d_setup_texture_uav_view(device, resource, desc, &key.u.texture))
+        return NULL;
 
     return vkd3d_view_map_create_view(&resource->view_map, device, &key);
 }
 
-static struct vkd3d_view *vkd3d_create_texture_srv_view(struct d3d12_device *device,
-        struct d3d12_resource *resource, const D3D12_SHADER_RESOURCE_VIEW_DESC *desc)
+static bool vkd3d_setup_texture_srv_view(struct d3d12_device *device,
+        struct d3d12_resource *resource, const D3D12_SHADER_RESOURCE_VIEW_DESC *desc,
+        struct vkd3d_texture_view_desc *texture)
 {
-    struct vkd3d_view_key key;
+    if (!init_default_texture_view_desc(texture, resource, desc ? desc->Format : 0))
+        return false;
 
-    if (!init_default_texture_view_desc(&key.u.texture, resource, desc ? desc->Format : 0))
-        return NULL;
-
-    key.view_type = VKD3D_VIEW_TYPE_IMAGE;
-    key.u.texture.miplevel_count = VK_REMAINING_MIP_LEVELS;
-    key.u.texture.allowed_swizzle = true;
-    key.u.texture.image_usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    texture->miplevel_count = VK_REMAINING_MIP_LEVELS;
+    texture->allowed_swizzle = true;
+    texture->image_usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     if (desc)
     {
@@ -6556,84 +6562,94 @@ static struct vkd3d_view *vkd3d_create_texture_srv_view(struct d3d12_device *dev
             TRACE("Component mapping %s for format %#x.\n",
                     debug_d3d12_shader_component_mapping(desc->Shader4ComponentMapping), desc->Format);
 
-            vk_component_mapping_from_d3d12(&key.u.texture.components, desc->Shader4ComponentMapping);
+            vk_component_mapping_from_d3d12(&texture->components, desc->Shader4ComponentMapping);
         }
 
         switch (desc->ViewDimension)
         {
             case D3D12_SRV_DIMENSION_TEXTURE1D:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_1D;
-                key.u.texture.miplevel_idx = desc->Texture1D.MostDetailedMip;
-                key.u.texture.miplevel_count = desc->Texture1D.MipLevels;
-                key.u.texture.miplevel_clamp = desc->Texture1D.ResourceMinLODClamp;
-                key.u.texture.layer_count = 1;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_1D;
+                texture->miplevel_idx = desc->Texture1D.MostDetailedMip;
+                texture->miplevel_count = desc->Texture1D.MipLevels;
+                texture->miplevel_clamp = desc->Texture1D.ResourceMinLODClamp;
+                texture->layer_count = 1;
                 break;
             case D3D12_SRV_DIMENSION_TEXTURE1DARRAY:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
-                key.u.texture.miplevel_idx = desc->Texture1DArray.MostDetailedMip;
-                key.u.texture.miplevel_count = desc->Texture1DArray.MipLevels;
-                key.u.texture.miplevel_clamp = desc->Texture1DArray.ResourceMinLODClamp;
-                key.u.texture.layer_idx = desc->Texture1DArray.FirstArraySlice;
-                key.u.texture.layer_count = desc->Texture1DArray.ArraySize;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+                texture->miplevel_idx = desc->Texture1DArray.MostDetailedMip;
+                texture->miplevel_count = desc->Texture1DArray.MipLevels;
+                texture->miplevel_clamp = desc->Texture1DArray.ResourceMinLODClamp;
+                texture->layer_idx = desc->Texture1DArray.FirstArraySlice;
+                texture->layer_count = desc->Texture1DArray.ArraySize;
                 break;
             case D3D12_SRV_DIMENSION_TEXTURE2D:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_2D;
-                key.u.texture.miplevel_idx = desc->Texture2D.MostDetailedMip;
-                key.u.texture.miplevel_count = desc->Texture2D.MipLevels;
-                key.u.texture.miplevel_clamp = desc->Texture2D.ResourceMinLODClamp;
-                key.u.texture.layer_count = 1;
-                key.u.texture.aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2D.PlaneSlice);
+                texture->view_type = VK_IMAGE_VIEW_TYPE_2D;
+                texture->miplevel_idx = desc->Texture2D.MostDetailedMip;
+                texture->miplevel_count = desc->Texture2D.MipLevels;
+                texture->miplevel_clamp = desc->Texture2D.ResourceMinLODClamp;
+                texture->layer_count = 1;
+                texture->aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2D.PlaneSlice);
                 break;
             case D3D12_SRV_DIMENSION_TEXTURE2DARRAY:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-                key.u.texture.miplevel_idx = desc->Texture2DArray.MostDetailedMip;
-                key.u.texture.miplevel_count = desc->Texture2DArray.MipLevels;
-                key.u.texture.miplevel_clamp = desc->Texture2DArray.ResourceMinLODClamp;
-                key.u.texture.layer_idx = desc->Texture2DArray.FirstArraySlice;
-                key.u.texture.layer_count = desc->Texture2DArray.ArraySize;
-                key.u.texture.aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2DArray.PlaneSlice);
+                texture->view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+                texture->miplevel_idx = desc->Texture2DArray.MostDetailedMip;
+                texture->miplevel_count = desc->Texture2DArray.MipLevels;
+                texture->miplevel_clamp = desc->Texture2DArray.ResourceMinLODClamp;
+                texture->layer_idx = desc->Texture2DArray.FirstArraySlice;
+                texture->layer_count = desc->Texture2DArray.ArraySize;
+                texture->aspect_mask = vk_image_aspect_flags_from_d3d12(resource->format, desc->Texture2DArray.PlaneSlice);
                 break;
             case D3D12_SRV_DIMENSION_TEXTURE2DMS:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_2D;
-                key.u.texture.layer_count = 1;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_2D;
+                texture->layer_count = 1;
                 break;
             case D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-                key.u.texture.layer_idx = desc->Texture2DMSArray.FirstArraySlice;
-                key.u.texture.layer_count = desc->Texture2DMSArray.ArraySize;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+                texture->layer_idx = desc->Texture2DMSArray.FirstArraySlice;
+                texture->layer_count = desc->Texture2DMSArray.ArraySize;
                 break;
             case D3D12_SRV_DIMENSION_TEXTURE3D:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_3D;
-                key.u.texture.miplevel_idx = desc->Texture3D.MostDetailedMip;
-                key.u.texture.miplevel_count = desc->Texture3D.MipLevels;
-                key.u.texture.miplevel_clamp = desc->Texture3D.ResourceMinLODClamp;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_3D;
+                texture->miplevel_idx = desc->Texture3D.MostDetailedMip;
+                texture->miplevel_count = desc->Texture3D.MipLevels;
+                texture->miplevel_clamp = desc->Texture3D.ResourceMinLODClamp;
                 break;
             case D3D12_SRV_DIMENSION_TEXTURECUBE:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_CUBE;
-                key.u.texture.miplevel_idx = desc->TextureCube.MostDetailedMip;
-                key.u.texture.miplevel_count = desc->TextureCube.MipLevels;
-                key.u.texture.miplevel_clamp = desc->TextureCube.ResourceMinLODClamp;
-                key.u.texture.layer_count = 6;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_CUBE;
+                texture->miplevel_idx = desc->TextureCube.MostDetailedMip;
+                texture->miplevel_count = desc->TextureCube.MipLevels;
+                texture->miplevel_clamp = desc->TextureCube.ResourceMinLODClamp;
+                texture->layer_count = 6;
                 break;
             case D3D12_SRV_DIMENSION_TEXTURECUBEARRAY:
-                key.u.texture.view_type = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
-                key.u.texture.miplevel_idx = desc->TextureCubeArray.MostDetailedMip;
-                key.u.texture.miplevel_count = desc->TextureCubeArray.MipLevels;
-                key.u.texture.miplevel_clamp = desc->TextureCubeArray.ResourceMinLODClamp;
-                key.u.texture.layer_idx = desc->TextureCubeArray.First2DArrayFace;
-                key.u.texture.layer_count = desc->TextureCubeArray.NumCubes;
-                if (key.u.texture.layer_count != VK_REMAINING_ARRAY_LAYERS)
-                    key.u.texture.layer_count *= 6;
+                texture->view_type = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
+                texture->miplevel_idx = desc->TextureCubeArray.MostDetailedMip;
+                texture->miplevel_count = desc->TextureCubeArray.MipLevels;
+                texture->miplevel_clamp = desc->TextureCubeArray.ResourceMinLODClamp;
+                texture->layer_idx = desc->TextureCubeArray.First2DArrayFace;
+                texture->layer_count = desc->TextureCubeArray.NumCubes;
+                if (texture->layer_count != VK_REMAINING_ARRAY_LAYERS)
+                    texture->layer_count *= 6;
                 break;
             default:
                 FIXME("Unhandled view dimension %#x.\n", desc->ViewDimension);
         }
     }
 
-    if (key.u.texture.miplevel_count == VK_REMAINING_MIP_LEVELS)
-        key.u.texture.miplevel_count = resource->desc.MipLevels - key.u.texture.miplevel_idx;
+    if (texture->miplevel_count == VK_REMAINING_MIP_LEVELS)
+        texture->miplevel_count = resource->desc.MipLevels - texture->miplevel_idx;
 
-    vkd3d_texture_view_desc_fixup(device, &key.u.texture);
+    vkd3d_texture_view_desc_fixup(device, texture);
+    return true;
+}
+
+static struct vkd3d_view *vkd3d_create_texture_srv_view(struct d3d12_device *device,
+        struct d3d12_resource *resource, const D3D12_SHADER_RESOURCE_VIEW_DESC *desc)
+{
+    struct vkd3d_view_key key;
+    key.view_type = VKD3D_VIEW_TYPE_IMAGE;
+    if (!vkd3d_setup_texture_srv_view(device, resource, desc, &key.u.texture))
+        return false;
 
     if ((vkd3d_config_flags & VKD3D_CONFIG_FLAG_PREALLOCATE_SRV_MIP_CLAMPS) &&
             desc->ViewDimension != D3D12_SRV_DIMENSION_TEXTURE2DMS &&

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5198,7 +5198,23 @@ bool vkd3d_create_opacity_micromap_view(struct d3d12_device *device, const struc
 #define VKD3D_VIEW_RAW_BUFFER 0x1
 #define VKD3D_VIEW_BUFFER_SRV 0x2
 
-static void vkd3d_get_metadata_buffer_view_for_resource(struct d3d12_device *device,
+static void vkd3d_get_metadata_buffer_view_for_resource_heap(struct d3d12_device *device,
+        struct d3d12_resource *resource, DXGI_FORMAT view_format,
+        VkDeviceSize offset, VkDeviceSize size, VkDeviceSize structure_stride,
+        bool raw, struct vkd3d_descriptor_metadata_buffer_view *view)
+{
+    VkDeviceSize element_size;
+
+    element_size = view_format == DXGI_FORMAT_UNKNOWN
+            ? structure_stride : vkd3d_get_format(device, view_format, false)->byte_count;
+
+    view->va = resource->res.va + offset * element_size;
+    view->range = size * element_size;
+    view->dxgi_format = raw ? DXGI_FORMAT_UNKNOWN : view_format;
+    view->flags = VKD3D_DESCRIPTOR_FLAG_BUFFER_VA_RANGE | VKD3D_DESCRIPTOR_FLAG_NON_NULL;
+}
+
+static void vkd3d_get_metadata_buffer_view_for_resource_legacy(struct d3d12_device *device,
         struct d3d12_resource *resource, DXGI_FORMAT view_format,
         VkDeviceSize offset, VkDeviceSize size, VkDeviceSize structure_stride,
         struct vkd3d_descriptor_metadata_buffer_view *view)
@@ -6140,7 +6156,7 @@ static void vkd3d_create_buffer_srv_embedded(vkd3d_cpu_descriptor_va_t desc_va,
     }
 
     /* Ignore metadata for SRV. */
-    vkd3d_get_metadata_buffer_view_for_resource(device, resource,
+    vkd3d_get_metadata_buffer_view_for_resource_legacy(device, resource,
             desc->Format, desc->Buffer.FirstElement, desc->Buffer.NumElements,
             desc->Buffer.StructureByteStride, &view);
 
@@ -6283,7 +6299,7 @@ static void vkd3d_create_buffer_srv(vkd3d_cpu_descriptor_va_t desc_va,
     }
 
     d.types->set_info_mask = 0;
-    vkd3d_get_metadata_buffer_view_for_resource(device, resource,
+    vkd3d_get_metadata_buffer_view_for_resource_legacy(device, resource,
             desc->Format, desc->Buffer.FirstElement, desc->Buffer.NumElements,
             desc->Buffer.StructureByteStride, &d.view->info.buffer);
 
@@ -6937,7 +6953,7 @@ static void vkd3d_create_buffer_uav_embedded(vkd3d_cpu_descriptor_va_t desc_va, 
     d = d3d12_desc_decode_embedded_resource_va(desc_va);
     m = d3d12_desc_decode_metadata(device, desc_va);
 
-    vkd3d_get_metadata_buffer_view_for_resource(device, resource,
+    vkd3d_get_metadata_buffer_view_for_resource_legacy(device, resource,
             desc->Format, desc->Buffer.FirstElement, desc->Buffer.NumElements,
             desc->Buffer.StructureByteStride, &view);
 
@@ -7069,7 +7085,7 @@ static void vkd3d_create_buffer_uav(vkd3d_cpu_descriptor_va_t desc_va, struct d3
     /* Handle UAV itself */
     d.types->set_info_mask = 0;
 
-    vkd3d_get_metadata_buffer_view_for_resource(device, resource,
+    vkd3d_get_metadata_buffer_view_for_resource_legacy(device, resource,
             desc->Format, desc->Buffer.FirstElement, desc->Buffer.NumElements,
             desc->Buffer.StructureByteStride, &d.view->info.buffer);
     d.view->info.buffer.flags |= VKD3D_DESCRIPTOR_FLAG_RAW_VA_AUX_BUFFER;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -7257,11 +7257,56 @@ static void vkd3d_create_buffer_uav(vkd3d_cpu_descriptor_va_t desc_va, struct d3
     VK_CALL(vkUpdateDescriptorSets(device->vk_device, vk_write_count, vk_write, 0, NULL));
 }
 
+static void vkd3d_descriptor_metadata_setup_image_view(struct vkd3d_descriptor_metadata_image_view *meta,
+        VkImageViewType vk_view_type, const VkImageSubresourceRange *vk_subresource_range,
+        struct d3d12_resource *resource, const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
+{
+    /* Encodes sideband data that allows implementation to reconstruct a fresh image view
+     * should the need arise. This will always happen in descriptor heap path. */
+    meta->flags = VKD3D_DESCRIPTOR_FLAG_IMAGE_VIEW | VKD3D_DESCRIPTOR_FLAG_NON_NULL;
+
+    if (desc && desc->Format)
+        meta->dxgi_format = desc->Format;
+    else
+        meta->dxgi_format = resource->format->dxgi_format;
+
+    meta->mip_slice = vk_subresource_range->baseMipLevel;
+
+    if (vk_view_type == VK_IMAGE_VIEW_TYPE_3D)
+    {
+        if (desc)
+        {
+            meta->first_array_slice = desc->Texture3D.FirstWSlice;
+            meta->array_size = desc->Texture3D.WSize;
+        }
+        else
+        {
+            /* This gets clamped in ClearUAV anyway. */
+            meta->first_array_slice = 0;
+            meta->array_size = UINT16_MAX;
+        }
+    }
+    else
+    {
+        meta->first_array_slice = vk_subresource_range->baseArrayLayer;
+        meta->array_size = vk_subresource_range->layerCount;
+    }
+
+    meta->vk_view_type = vk_view_type;
+    if (desc && desc->ViewDimension == D3D12_UAV_DIMENSION_TEXTURE2D)
+        meta->plane_slice = desc->Texture2D.PlaneSlice;
+    else if (desc && desc->ViewDimension == D3D12_UAV_DIMENSION_TEXTURE2DARRAY)
+        meta->plane_slice = desc->Texture2DArray.PlaneSlice;
+    else
+        meta->plane_slice = 0;
+}
+
 static void vkd3d_create_texture_uav_embedded(vkd3d_cpu_descriptor_va_t desc_va,
         struct d3d12_device *device, struct d3d12_resource *resource,
         const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    VkImageSubresourceRange vk_subresource_range;
     struct d3d12_desc_split_embedded d;
     struct d3d12_desc_split_metadata m;
     VkDescriptorGetInfoEXT get_info;
@@ -7285,8 +7330,10 @@ static void vkd3d_create_texture_uav_embedded(vkd3d_cpu_descriptor_va_t desc_va,
 
     if (m.view)
     {
+        vk_subresource_range = vk_subresource_range_from_view(view);
         m.view->info.image.view = view;
-        m.view->info.image.flags = VKD3D_DESCRIPTOR_FLAG_IMAGE_VIEW;
+        vkd3d_descriptor_metadata_setup_image_view(&m.view->info.image,
+            view->info.texture.vk_view_type, &vk_subresource_range, resource, desc);
     }
 
     get_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT;
@@ -7317,6 +7364,7 @@ static void vkd3d_create_texture_uav(vkd3d_cpu_descriptor_va_t desc_va,
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     union vkd3d_descriptor_info null_descriptor_info;
+    VkImageSubresourceRange vk_subresource_range;
     union vkd3d_descriptor_info descriptor_info;
     struct vkd3d_descriptor_binding binding;
     VkWriteDescriptorSet vk_writes[2];
@@ -7347,7 +7395,9 @@ static void vkd3d_create_texture_uav(vkd3d_cpu_descriptor_va_t desc_va,
     binding = vkd3d_bindless_state_binding_from_info_index(&device->bindless_state, info_index);
 
     d.view->info.image.view = view;
-    d.view->info.image.flags = VKD3D_DESCRIPTOR_FLAG_IMAGE_VIEW | VKD3D_DESCRIPTOR_FLAG_NON_NULL;
+    vk_subresource_range = vk_subresource_range_from_view(view);
+    vkd3d_descriptor_metadata_setup_image_view(&d.view->info.image,
+            view->info.texture.vk_view_type, &vk_subresource_range, resource, desc);
     d.types->set_info_mask = 1u << info_index;
     d.types->single_binding = binding;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5504,35 +5504,29 @@ static bool init_default_texture_view_desc(struct vkd3d_texture_view_desc *desc,
     return true;
 }
 
-bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_texture_view_desc *desc, struct vkd3d_view **view)
+bool vkd3d_setup_texture_view(struct d3d12_device *device,
+        const struct vkd3d_texture_view_desc *desc,
+        struct vkd3d_texture_view_create_info *info)
 {
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    VkImageViewUsageCreateInfo image_usage_create_info;
     const struct vkd3d_format *format = desc->format;
-    VkImageViewMinLodCreateInfoEXT min_lod_desc;
-    VkImageViewSlicedCreateInfoEXT sliced_desc;
-    VkImageView vk_view = VK_NULL_HANDLE;
-    VkImageViewCreateInfo view_desc;
     int32_t miplevel_clamp_fixed;
-    struct vkd3d_view *object;
     uint32_t clamp_base_level;
     uint32_t end_level;
-    VkResult vr;
 
-    view_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    view_desc.pNext = NULL;
-    view_desc.flags = 0;
-    view_desc.image = desc->image;
-    view_desc.viewType = desc->view_type;
-    view_desc.format = format->vk_format;
-    vkd3d_set_view_swizzle_for_format(&view_desc.components, format, desc->allowed_swizzle);
+    memset(info, 0, sizeof(*info));
+    info->view_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    info->view_desc.flags = 0;
+    info->view_desc.image = desc->image;
+    info->view_desc.viewType = desc->view_type;
+    info->view_desc.format = format->vk_format;
+    vkd3d_set_view_swizzle_for_format(&info->view_desc.components, format, desc->allowed_swizzle);
     if (desc->allowed_swizzle)
-        vk_component_mapping_compose(&view_desc.components, &desc->components);
-    view_desc.subresourceRange.aspectMask = desc->aspect_mask;
-    view_desc.subresourceRange.baseMipLevel = desc->miplevel_idx;
-    view_desc.subresourceRange.levelCount = desc->miplevel_count;
-    view_desc.subresourceRange.baseArrayLayer = desc->layer_idx;
-    view_desc.subresourceRange.layerCount = desc->layer_count;
+        vk_component_mapping_compose(&info->view_desc.components, &desc->components);
+    info->view_desc.subresourceRange.aspectMask = desc->aspect_mask;
+    info->view_desc.subresourceRange.baseMipLevel = desc->miplevel_idx;
+    info->view_desc.subresourceRange.levelCount = desc->miplevel_count;
+    info->view_desc.subresourceRange.baseArrayLayer = desc->layer_idx;
+    info->view_desc.subresourceRange.layerCount = desc->layer_count;
 
     /* If the clamp is defined such that it would only access mip levels
      * outside the view range, don't make a view and use a NULL descriptor.
@@ -5546,10 +5540,9 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
             if (device->device_info.image_view_min_lod_features.minLod)
             {
                 /* Clamp minLod the highest accessed mip level to stay within spec */
-                min_lod_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT;
-                min_lod_desc.pNext = NULL;
-                min_lod_desc.minLod = vkd3d_fixed_24_8_to_float(miplevel_clamp_fixed);
-                vk_prepend_struct(&view_desc, &min_lod_desc);
+                info->min_lod_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT;
+                info->min_lod_desc.minLod = vkd3d_fixed_24_8_to_float(miplevel_clamp_fixed);
+                vk_prepend_struct(&info->view_desc, &info->min_lod_desc);
             }
             else
             {
@@ -5557,29 +5550,46 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
                 /* This is not correct, but it's the best we can do without VK_EXT_image_view_min_lod.
                  * It should at least avoid a scenario where implicit LOD fetches from invalid levels. */
                 clamp_base_level = (uint32_t)desc->miplevel_clamp;
-                end_level = view_desc.subresourceRange.baseMipLevel + view_desc.subresourceRange.levelCount;
-                view_desc.subresourceRange.levelCount = end_level - clamp_base_level;
-                view_desc.subresourceRange.baseMipLevel = clamp_base_level;
+                end_level = info->view_desc.subresourceRange.baseMipLevel + info->view_desc.subresourceRange.levelCount;
+                info->view_desc.subresourceRange.levelCount = end_level - clamp_base_level;
+                info->view_desc.subresourceRange.baseMipLevel = clamp_base_level;
             }
         }
 
-        image_usage_create_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO;
-        image_usage_create_info.pNext = NULL;
-        image_usage_create_info.usage = desc->image_usage;
-        vk_prepend_struct(&view_desc, &image_usage_create_info);
+        info->image_usage_create_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO;
+        info->image_usage_create_info.usage = desc->image_usage;
+        vk_prepend_struct(&info->view_desc, &info->image_usage_create_info);
 
         if (desc->view_type == VK_IMAGE_VIEW_TYPE_3D &&
                 (desc->w_offset != 0 || desc->w_size != VK_REMAINING_3D_SLICES_EXT) &&
                 device->device_info.image_sliced_view_of_3d_features.imageSlicedViewOf3D)
         {
-            sliced_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT;
-            sliced_desc.pNext = NULL;
-            sliced_desc.sliceOffset = desc->w_offset;
-            sliced_desc.sliceCount = desc->w_size;
-            vk_prepend_struct(&view_desc, &sliced_desc);
+            info->sliced_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT;
+            info->sliced_desc.pNext = NULL;
+            info->sliced_desc.sliceOffset = desc->w_offset;
+            info->sliced_desc.sliceCount = desc->w_size;
+            vk_prepend_struct(&info->view_desc, &info->sliced_desc);
         }
 
-        if ((vr = VK_CALL(vkCreateImageView(device->vk_device, &view_desc, NULL, &vk_view))) < 0)
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_texture_view_desc *desc, struct vkd3d_view **view)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct vkd3d_texture_view_create_info info;
+    VkImageView vk_view = VK_NULL_HANDLE;
+    struct vkd3d_view *object;
+    VkResult vr;
+
+    if (vkd3d_setup_texture_view(device, desc, &info))
+    {
+        if ((vr = VK_CALL(vkCreateImageView(device->vk_device, &info.view_desc, NULL, &vk_view))) < 0)
         {
             WARN("Failed to create Vulkan image view, vr %d.\n", vr);
             return false;
@@ -5593,7 +5603,7 @@ bool vkd3d_create_texture_view(struct d3d12_device *device, const struct vkd3d_t
     }
 
     object->vk_image_view = vk_view;
-    object->format = format;
+    object->format = desc->format;
     object->info.texture.vk_view_type = desc->view_type;
     object->info.texture.aspect_mask = desc->aspect_mask;
     object->info.texture.miplevel_idx = desc->miplevel_idx;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -6580,6 +6580,18 @@ static inline unsigned int d3d12_resource_get_sub_resource_count(const struct d3
             (resource->format ? vkd3d_popcount(resource->format->vk_aspect_mask) : 1);
 }
 
+struct vkd3d_texture_view_create_info
+{
+    VkImageViewUsageCreateInfo image_usage_create_info;
+    VkImageViewMinLodCreateInfoEXT min_lod_desc;
+    VkImageViewSlicedCreateInfoEXT sliced_desc;
+    VkImageViewCreateInfo view_desc;
+};
+
+bool vkd3d_setup_texture_view(struct d3d12_device *device,
+        const struct vkd3d_texture_view_desc *desc,
+        struct vkd3d_texture_view_create_info *info);
+
 static inline uint32_t d3d12_resource_desc_default_alignment(const D3D12_RESOURCE_DESC1 *desc)
 {
     return desc->SampleDesc.Count > 1 ?

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1410,11 +1410,19 @@ struct vkd3d_descriptor_metadata_buffer_view
     VkDeviceAddress va;
 };
 
+/* Tightly pack this to fit in 16 bytes. */
 struct vkd3d_descriptor_metadata_image_view
 {
     uint8_t flags;
-    struct vkd3d_view *view;
+    uint8_t dxgi_format;
+    uint8_t mip_slice;
+    uint8_t vk_view_type : 4;
+    uint8_t plane_slice : 4;
+    uint16_t first_array_slice;
+    uint16_t array_size;
+    struct vkd3d_view *view; /* Only used in legacy paths. */
 };
+STATIC_ASSERT(sizeof(struct vkd3d_descriptor_metadata_image_view) <= 16);
 
 struct vkd3d_descriptor_metadata_view
 {


### PR DESCRIPTION
Refactors out image view creation to setup of info structs and the creation. For heap, we will need to only extract the creation info when creating descriptors.

The last commit reworks the meta struct to encode all relevant view info in 8 bytes. This allows us to keep the existing view for legacy paths, but also allow heap path to work well. Technically, the legacy paths could have gone through the re-materialization path, but that's a bit silly and would be a minor perf regression in theory, so don't. There's no reason to squeeze the info struct below 16 bytes since it unions with the buffer one, which is also 16 byte.