### PR TITLE
vkd3d: Restore missing RTAS barrier workaround for Witcher 3

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -19681,6 +19681,29 @@ static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
     d3d12_command_list_end_current_render_pass(list, true);
     d3d12_command_list_end_transfer_batch(list);
 
+    if (list->device->workarounds.synchronize_compute_blas &&
+            rtas_batch->build_type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
+    {
+        VkMemoryBarrier2 vk_memory_barrier;
+        VkDependencyInfo dep_info;
+
+        memset(&vk_memory_barrier, 0, sizeof(vk_memory_barrier));
+        memset(&dep_info, 0, sizeof(dep_info));
+
+        dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        dep_info.memoryBarrierCount = 1;
+        dep_info.pMemoryBarriers = &vk_memory_barrier;
+
+        vk_memory_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
+        vk_memory_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+        vk_memory_barrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
+        vk_memory_barrier.dstStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
+        /* Inputs to BLAS build are SHADER_READ_BIT. */
+        vk_memory_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
+
+        VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
+    }
+
     if (rtas_batch->build_info_count)
         VK_CALL(vkCmdBuildAccelerationStructuresKHR(list->cmd.vk_command_buffer,
                 rtas_batch->build_info_count, rtas_batch->build_infos, rtas_batch->range_ptrs));

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -583,6 +583,7 @@ enum vkd3d_application_feature_override
     VKD3D_APPLICATION_FEATURE_DISABLE_ANTI_LAG = 1 << 4,
     VKD3D_APPLICATION_FEATURE_RDNA1_COMPATIBILITY = 1 << 5,
     VKD3D_APPLICATION_FEATURE_VIEW_INSTANCING = 1 << 6,
+    VKD3D_APPLICATION_FEATURE_SYNCHRONIZE_COMPUTE_BLAS = 1 << 7,
 };
 
 static enum vkd3d_application_feature_override vkd3d_application_feature_override;
@@ -650,7 +651,9 @@ static const struct vkd3d_instance_application_meta application_override[] = {
     /* Dead Space (2023) (1693980) */
     { VKD3D_STRING_COMPARE_EXACT, "Dead Space.exe", VKD3D_CONFIG_FLAG_FORCE_DEDICATED_IMAGE_ALLOCATION, 0 },
     /* Witcher 3 (2023) (292030) */
-    { VKD3D_STRING_COMPARE_EXACT, "witcher3.exe", VKD3D_CONFIG_FLAG_DISABLE_SIMULTANEOUS_UAV_COMPRESSION, 0 },
+    { VKD3D_STRING_COMPARE_EXACT, "witcher3.exe",
+            VKD3D_CONFIG_FLAG_DISABLE_SIMULTANEOUS_UAV_COMPRESSION, 0,
+            VKD3D_APPLICATION_FEATURE_SYNCHRONIZE_COMPUTE_BLAS },
     /* Age of Wonders 4 (1669000). Extremely stuttery performance with ReBAR. */
     { VKD3D_STRING_COMPARE_EXACT, "AOW4.exe", VKD3D_CONFIG_FLAG_NO_UPLOAD_HVV, 0 },
     /* Red Dead Redemption (2668510). Inconsistent performance with ReBAR at cutscenes of the game. */
@@ -10094,6 +10097,12 @@ static void d3d12_device_caps_override_application(struct d3d12_device *device)
         INFO("Disabling AMD anti-lag.\n");
         device->vk_info.AMD_anti_lag = false;
         device->device_info.anti_lag_amd.antiLag = VK_FALSE;
+    }
+
+    if (vkd3d_application_feature_override & VKD3D_APPLICATION_FEATURE_SYNCHRONIZE_COMPUTE_BLAS)
+    {
+        INFO("Enabling compute to BLAS barrier synchronization.\n");
+        device->workarounds.synchronize_compute_blas = true;
     }
 }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5673,6 +5673,7 @@ struct d3d12_device
         bool tiler_renderpass_barriers;
         bool tiler_suspend_resume;
         bool tiler_suspend_resume_relax_load_store_op;
+        bool synchronize_compute_blas;
     } workarounds;
 
     struct


### PR DESCRIPTION
The workaround from commit `c21121a4` was lost during the RTAS batching refactor that added OMM support. When DXR was enabled by default in commit `1a049c66`, Witcher 3 started using ray tracing and triggers a missing synchronization between compute shader writes and BLAS builds.

Without this barrier, the game deadlocks when opening menus.

Fixes #2880.

Instead of reusing the old config flag (all bits are now occupied), use the application feature override mechanism.