### PR TITLE
vkd3d: Fix subresource layer range merging

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4865,6 +4865,7 @@ static void d3d12_command_list_update_subresource_data(struct d3d12_command_list
 {
     struct vkd3d_subresource_tracking *entry;
     VkImageAspectFlags aspect, aspect_mask;
+    uint32_t merged_end;
     uint32_t i;
     bool skip;
 
@@ -4893,9 +4894,10 @@ static void d3d12_command_list_update_subresource_data(struct d3d12_command_list
                 else if (entry->subresource.baseArrayLayer <= subresource.baseArrayLayer + subresource.layerCount &&
                             entry->subresource.baseArrayLayer + entry->subresource.layerCount >= subresource.baseArrayLayer)
                 {
+					merged_end = max(entry->subresource.baseArrayLayer + entry->subresource.layerCount,
+                            subresource.baseArrayLayer + subresource.layerCount);
                     subresource.baseArrayLayer = min(entry->subresource.baseArrayLayer, subresource.baseArrayLayer);
-                    subresource.layerCount = max(entry->subresource.baseArrayLayer + entry->subresource.layerCount,
-                            subresource.baseArrayLayer - subresource.layerCount) - entry->subresource.baseArrayLayer;
+                    subresource.layerCount = merged_end - subresource.baseArrayLayer;
                     *entry = list->subresource_tracking[--list->subresource_tracking_count];
                     continue;
                 }


### PR DESCRIPTION
d3d12_command_list_update_subresource_data() tracks which image subresource layers have been modified so they can later be copied back to the linear staging buffer.

When a new update overlaps an existing tracked entry, the two layer ranges are merged. The old merge calculation updated baseArrayLayer before computing the end of the merged range, and used subtraction instead of addition when deriving that end.

This could produce an incorrect merged layerCount: either too small, missing layers from the update, or very large due to unsigned underflow. In both cases the tracking list would be wrong, and modified layers could be left out of the copy back to the staging buffer.

The fix computes the merged end layer before overwriting baseArrayLayer, then derives the new layerCount from the merged start.