### PR TITLE
Descriptor heap - Phase 4

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -8304,53 +8304,55 @@ HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
     return hresult_from_vk_result(vr);
 }
 
-static HRESULT d3d12_create_sampler(struct d3d12_device *device,
-        const D3D12_SAMPLER_DESC2 *desc, VkSampler *vk_sampler)
+struct vkd3d_sampler_view_create_info
 {
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkSamplerCustomBorderColorCreateInfoEXT border_color_info;
+    VkSamplerCustomBorderColorIndexCreateInfoEXT index_create_info;
     VkSamplerReductionModeCreateInfoEXT reduction_desc;
     VkSamplerCreateInfo sampler_desc;
+};
+
+static void d3d12_setup_sampler_info(struct d3d12_device *device,
+        const D3D12_SAMPLER_DESC2 *desc, struct vkd3d_sampler_view_create_info *info)
+{
     uint32_t num_live_objects;
-    VkResult vr;
 
-    border_color_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT;
-    border_color_info.pNext = NULL;
-    memcpy(border_color_info.customBorderColor.uint32, desc->UintBorderColor,
-            sizeof(border_color_info.customBorderColor.uint32));
-    border_color_info.format = VK_FORMAT_UNDEFINED;
+    memset(info, 0, sizeof(*info));
 
-    reduction_desc.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT;
-    reduction_desc.pNext = NULL;
-    reduction_desc.reductionMode = vk_reduction_mode_from_d3d12(D3D12_DECODE_FILTER_REDUCTION(desc->Filter));
+    info->border_color_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT;
+    memcpy(info->border_color_info.customBorderColor.uint32, desc->UintBorderColor,
+            sizeof(info->border_color_info.customBorderColor.uint32));
+    info->border_color_info.format = VK_FORMAT_UNDEFINED;
 
-    sampler_desc.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_desc.pNext = NULL;
-    sampler_desc.flags = 0;
-    sampler_desc.magFilter = vk_filter_from_d3d12(D3D12_DECODE_MAG_FILTER(desc->Filter));
-    sampler_desc.minFilter = vk_filter_from_d3d12(D3D12_DECODE_MIN_FILTER(desc->Filter));
-    sampler_desc.mipmapMode = vk_mipmap_mode_from_d3d12(D3D12_DECODE_MIP_FILTER(desc->Filter));
-    sampler_desc.addressModeU = vk_address_mode_from_d3d12(desc->AddressU);
-    sampler_desc.addressModeV = vk_address_mode_from_d3d12(desc->AddressV);
-    sampler_desc.addressModeW = vk_address_mode_from_d3d12(desc->AddressW);
-    sampler_desc.mipLodBias = desc->MipLODBias;
-    sampler_desc.anisotropyEnable = D3D12_DECODE_IS_ANISOTROPIC_FILTER(desc->Filter);
-    sampler_desc.maxAnisotropy = desc->MaxAnisotropy;
-    sampler_desc.compareEnable = D3D12_DECODE_IS_COMPARISON_FILTER(desc->Filter);
-    sampler_desc.compareOp = sampler_desc.compareEnable ? vk_compare_op_from_d3d12(desc->ComparisonFunc) : 0;
-    sampler_desc.minLod = desc->MinLOD;
-    sampler_desc.maxLod = desc->MaxLOD;
-    sampler_desc.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
-    sampler_desc.unnormalizedCoordinates = !!(desc->Flags & D3D12_SAMPLER_FLAG_NON_NORMALIZED_COORDINATES);
+    info->reduction_desc.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT;
+    info->reduction_desc.reductionMode = vk_reduction_mode_from_d3d12(D3D12_DECODE_FILTER_REDUCTION(desc->Filter));
 
-    if (sampler_desc.maxAnisotropy < 1.0f)
-        sampler_desc.anisotropyEnable = VK_FALSE;
+    info->sampler_desc.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    info->sampler_desc.flags = 0;
+    info->sampler_desc.magFilter = vk_filter_from_d3d12(D3D12_DECODE_MAG_FILTER(desc->Filter));
+    info->sampler_desc.minFilter = vk_filter_from_d3d12(D3D12_DECODE_MIN_FILTER(desc->Filter));
+    info->sampler_desc.mipmapMode = vk_mipmap_mode_from_d3d12(D3D12_DECODE_MIP_FILTER(desc->Filter));
+    info->sampler_desc.addressModeU = vk_address_mode_from_d3d12(desc->AddressU);
+    info->sampler_desc.addressModeV = vk_address_mode_from_d3d12(desc->AddressV);
+    info->sampler_desc.addressModeW = vk_address_mode_from_d3d12(desc->AddressW);
+    info->sampler_desc.mipLodBias = desc->MipLODBias;
+    info->sampler_desc.anisotropyEnable = D3D12_DECODE_IS_ANISOTROPIC_FILTER(desc->Filter);
+    info->sampler_desc.maxAnisotropy = desc->MaxAnisotropy;
+    info->sampler_desc.compareEnable = D3D12_DECODE_IS_COMPARISON_FILTER(desc->Filter);
+    info->sampler_desc.compareOp = info->sampler_desc.compareEnable ? vk_compare_op_from_d3d12(desc->ComparisonFunc) : 0;
+    info->sampler_desc.minLod = desc->MinLOD;
+    info->sampler_desc.maxLod = desc->MaxLOD;
+    info->sampler_desc.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    info->sampler_desc.unnormalizedCoordinates = !!(desc->Flags & D3D12_SAMPLER_FLAG_NON_NORMALIZED_COORDINATES);
 
-    if (sampler_desc.anisotropyEnable)
-        sampler_desc.maxAnisotropy = min(16.0f, sampler_desc.maxAnisotropy);
+    if (info->sampler_desc.maxAnisotropy < 1.0f)
+        info->sampler_desc.anisotropyEnable = VK_FALSE;
+
+    if (info->sampler_desc.anisotropyEnable)
+        info->sampler_desc.maxAnisotropy = min(16.0f, info->sampler_desc.maxAnisotropy);
 
     if (d3d12_sampler_needs_border_color(desc->AddressU, desc->AddressV, desc->AddressW))
-        sampler_desc.borderColor = vk_border_color_from_d3d12(device, desc->UintBorderColor, desc->Flags);
+        info->sampler_desc.borderColor = vk_border_color_from_d3d12(device, desc->UintBorderColor, desc->Flags);
 
     if (vkd3d_atomic_uint32_load_explicit(&device->sampler_map.live_object_count, vkd3d_memory_order_relaxed) <
         device->device_info.properties2.properties.limits.maxSamplerAllocationCount)
@@ -8367,49 +8369,87 @@ static HRESULT d3d12_create_sampler(struct d3d12_device *device,
     if (num_live_objects > device->device_info.properties2.properties.limits.maxSamplerAllocationCount)
         FIXME_ONCE("Trying to create a sampler, but device limits are exhausted. Creation may fail.\n");
 
-    if (sampler_desc.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT ||
-            sampler_desc.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT)
+    if (info->sampler_desc.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT ||
+            info->sampler_desc.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT)
     {
-        uint32_t num_border_colors;
+        uint32_t num_legacy_border_colors = 0;
+        bool exhausted_limits = false;
 
-        /* Once a sampler is created, we keep it alive forever.
-         * There's a theoretical false positive here if samplers are created in parallel before they are inserted
-         * into the hashmaps. Some samplers may be destroyed right away,
-         * and we don't decrement the counters in that scenario, but the chance of this causing issues in the wild are nil. */
-        if (vkd3d_atomic_uint32_load_explicit(&device->sampler_map.custom_border_color_count, vkd3d_memory_order_relaxed) <
-            device->device_info.custom_border_color_properties.maxCustomBorderColorSamplers)
+        if (d3d12_device_use_descriptor_heap(device))
         {
-            /* Avoid theoretical situation where the counter wraps around. */
-            num_border_colors = vkd3d_atomic_uint32_increment(&device->sampler_map.custom_border_color_count,
-                    vkd3d_memory_order_relaxed);
+            info->index_create_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_INDEX_CREATE_INFO_EXT;
+            info->index_create_info.index = vkd3d_sampler_state_register_custom_border_color(
+                    device, &device->sampler_state, info->sampler_desc.borderColor, &info->border_color_info);
+
+            if (info->index_create_info.index == UINT32_MAX)
+                exhausted_limits = true;
+            else
+                vk_prepend_struct(&info->sampler_desc, &info->index_create_info);
         }
         else
         {
-            num_border_colors = UINT32_MAX;
+            /* Once a sampler is created, we keep it alive forever.
+             * There's a theoretical false positive here if samplers are created in parallel before they are inserted
+             * into the hashmaps. Some samplers may be destroyed right away,
+             * and we don't decrement the counters in that scenario, but the chance of this causing issues in the wild are nil. */
+            if (vkd3d_atomic_uint32_load_explicit(&device->sampler_map.legacy_custom_border_color_count, vkd3d_memory_order_relaxed) <
+                device->device_info.custom_border_color_properties.maxCustomBorderColorSamplers)
+            {
+                /* Avoid theoretical situation where the counter wraps around. */
+                num_legacy_border_colors = vkd3d_atomic_uint32_increment(&device->sampler_map.legacy_custom_border_color_count,
+                        vkd3d_memory_order_relaxed);
+            }
+            else
+            {
+                exhausted_limits = true;
+            }
         }
 
-        if (num_border_colors > device->device_info.custom_border_color_properties.maxCustomBorderColorSamplers)
+        if (exhausted_limits || num_legacy_border_colors > device->device_info.custom_border_color_properties.maxCustomBorderColorSamplers)
         {
             FIXME_ONCE("Trying to create custom border color, but device limits are exhausted, replacing with TRANSPARENT_BLACK.\n");
-            if (sampler_desc.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT)
-                sampler_desc.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+            if (info->sampler_desc.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT)
+                info->sampler_desc.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
             else
-                sampler_desc.borderColor = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
+                info->sampler_desc.borderColor = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
         }
         else
         {
-            vk_prepend_struct(&sampler_desc, &border_color_info);
+            vk_prepend_struct(&info->sampler_desc, &info->border_color_info);
         }
     }
 
-    if (reduction_desc.reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE &&
+    if (info->reduction_desc.reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE &&
             device->device_info.vulkan_1_2_features.samplerFilterMinmax)
-        vk_prepend_struct(&sampler_desc, &reduction_desc);
+        vk_prepend_struct(&info->sampler_desc, &info->reduction_desc);
+}
 
-    if ((vr = VK_CALL(vkCreateSampler(device->vk_device, &sampler_desc, NULL, vk_sampler))) < 0)
+static HRESULT d3d12_create_sampler(struct d3d12_device *device,
+        const D3D12_SAMPLER_DESC2 *desc, VkSampler *vk_sampler)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct vkd3d_sampler_view_create_info info;
+    VkResult vr;
+
+    d3d12_setup_sampler_info(device, desc, &info);
+
+    if ((vr = VK_CALL(vkCreateSampler(device->vk_device, &info.sampler_desc, NULL, vk_sampler))) < 0)
         WARN("Failed to create Vulkan sampler, vr %d.\n", vr);
 
     return hresult_from_vk_result(vr);
+}
+
+void d3d12_desc_create_sampler_heap(vkd3d_cpu_descriptor_va_t desc_va,
+        struct d3d12_device *device, const D3D12_SAMPLER_DESC2 *desc)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct vkd3d_sampler_view_create_info info;
+    VkHostAddressRangeEXT desc_range;
+
+    d3d12_setup_sampler_info(device, desc, &info);
+    desc_range.address = (void *)desc_va;
+    desc_range.size = device->bindless_state.sampler_size;
+    VK_CALL(vkWriteSamplerDescriptorsEXT(device->vk_device, 1, &info.sampler_desc, &desc_range));
 }
 
 void d3d12_desc_create_sampler_embedded(vkd3d_cpu_descriptor_va_t desc_va,

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5857,6 +5857,49 @@ static void d3d12_descriptor_heap_write_null_descriptor_template(vkd3d_cpu_descr
                     VKD3D_DESCRIPTOR_QA_TYPE_RT_ACCELERATION_STRUCTURE_BIT, vkd3d_null_cookie());
 }
 
+void d3d12_desc_create_cbv_heap(vkd3d_cpu_descriptor_va_t desc_va,
+        struct d3d12_device *device, const D3D12_CONSTANT_BUFFER_VIEW_DESC *desc)
+{
+    DECLSPEC_ALIGN(8) uint8_t stack_payload[VKD3D_MAX_DESCRIPTOR_SIZE];
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    VkResourceDescriptorInfoEXT desc_info;
+    struct d3d12_desc_split_embedded d;
+    VkDeviceAddressRangeEXT addr_range;
+    VkHostAddressRangeEXT desc_range;
+
+    if (!desc)
+    {
+        WARN("Constant buffer desc is NULL.\n");
+        return;
+    }
+
+    if (desc->SizeInBytes & (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1))
+    {
+        WARN("Size is not %u bytes aligned.\n", D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+        return;
+    }
+
+    d = d3d12_desc_decode_embedded_resource_va(desc_va);
+
+    memset(&desc_info, 0, sizeof(desc_info));
+    desc_info.sType = VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT;
+    desc_info.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+
+    if (desc->BufferLocation)
+    {
+        desc_info.data.pAddressRange = &addr_range;
+        addr_range.address = desc->BufferLocation;
+        addr_range.size = desc->SizeInBytes;
+    }
+
+    memset(stack_payload, 0, device->bindless_state.cbv_srv_uav_size);
+
+    desc_range.address = stack_payload + device->bindless_state.packed_raw_buffer_offset;
+    desc_range.size = device->bindless_state.heap.ubo_size;
+    VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+    memcpy(d.payload, stack_payload, device->bindless_state.cbv_srv_uav_size);
+}
+
 void d3d12_desc_create_cbv_embedded(vkd3d_cpu_descriptor_va_t desc_va,
         struct d3d12_device *device, const D3D12_CONSTANT_BUFFER_VIEW_DESC *desc)
 {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -1695,6 +1695,13 @@ HRESULT vkd3d_sampler_state_init(struct vkd3d_sampler_state *state,
         return hresult_from_errno(rc);
 
     hash_map_init(&state->map, &vkd3d_sampler_entry_hash, &vkd3d_sampler_entry_compare, sizeof(struct vkd3d_sampler_entry));
+
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        state->border_color_bank_size = min(4096, device->device_info.custom_border_color_properties.maxCustomBorderColorSamplers);
+        state->border_colors = vkd3d_calloc(state->border_color_bank_size, sizeof(*state->border_colors));
+    }
+
     return S_OK;
 }
 
@@ -1719,7 +1726,68 @@ void vkd3d_sampler_state_cleanup(struct vkd3d_sampler_state *state,
 
     hash_map_free(&state->map);
 
+    vkd3d_free(state->border_colors);
     pthread_mutex_destroy(&state->mutex);
+}
+
+uint32_t vkd3d_sampler_state_register_custom_border_color(
+        struct d3d12_device *device,
+        struct vkd3d_sampler_state *state, VkBorderColor border_color,
+        const VkSamplerCustomBorderColorCreateInfoEXT *info)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    uint32_t i;
+
+    pthread_mutex_lock(&state->mutex);
+
+    if (state->noop_registration)
+    {
+        i = state->noop_registration_index;
+        goto unlock;
+    }
+
+    for (i = 0; i < state->border_color_count; i++)
+    {
+        if (state->border_colors[i].border_color == border_color &&
+            memcmp(&state->border_colors[i].color, &info->customBorderColor, sizeof(VkClearColorValue)) == 0)
+        {
+            i = state->border_colors[i].index;
+            goto unlock;
+        }
+    }
+
+    if (state->border_color_count == state->border_color_bank_size)
+    {
+        i = UINT32_MAX;
+        goto unlock;
+    }
+
+    if (VK_CALL(vkRegisterCustomBorderColorEXT(device->vk_device, info, VK_FALSE, &i)) != VK_SUCCESS)
+    {
+        ERR("Failed to allocate custom border color index.\n");
+        i = UINT32_MAX;
+    }
+
+    /* Some drivers (e.g. NVIDIA) simply do not care about custom border colors and will just return the same value indefinitely.
+     * If we detect that drivers don't care, just skip the registration in the future.
+     * If we need to, we can reserve indices ourselves and OOM when maxCustomBorderColors is reached,
+     * and ignore the fact that drivers do this weirdness,
+     * but it means we won't be able to pass a test that native can pass. */
+    if (state->border_color_count == 1 && i == state->border_colors[0].index)
+    {
+        state->noop_registration = true;
+        state->noop_registration_index = i;
+        goto unlock;
+    }
+
+    state->border_colors[state->border_color_count].border_color = border_color;
+    state->border_colors[state->border_color_count].color = info->customBorderColor;
+    state->border_colors[state->border_color_count].index = i;
+    state->border_color_count++;
+
+unlock:
+    pthread_mutex_unlock(&state->mutex);
+    return i;
 }
 
 HRESULT d3d12_create_static_sampler(struct d3d12_device *device,

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -7255,6 +7255,160 @@ VkDeviceAddress vkd3d_get_acceleration_structure_device_address(struct d3d12_dev
     return VK_CALL(vkGetAccelerationStructureDeviceAddressKHR(device->vk_device, &address_info));
 }
 
+static void vkd3d_create_buffer_uav_heap(vkd3d_cpu_descriptor_va_t desc_va, struct d3d12_device *device,
+        struct d3d12_resource *resource, struct d3d12_resource *counter_resource,
+        const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
+{
+    const struct vkd3d_bindless_state *bindless = &device->bindless_state;
+    DECLSPEC_ALIGN(8) uint8_t stack_payload[VKD3D_MAX_DESCRIPTOR_SIZE];
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct vkd3d_descriptor_metadata_buffer_view view;
+    VkTexelBufferDescriptorInfoEXT texel_buffer_info;
+    VkResourceDescriptorInfoEXT desc_info;
+    struct d3d12_desc_split_embedded d;
+    VkDeviceAddressRangeEXT ssbo_range;
+    VkHostAddressRangeEXT desc_range;
+    bool can_emit_sibling_typed;
+    bool can_emit_sibling_raw;
+    bool emit_typed;
+    bool is_typed;
+    bool emit_raw;
+
+    if (!desc)
+    {
+        FIXME("Default buffer UAV not supported.\n");
+        return;
+    }
+
+    if (desc->ViewDimension != D3D12_UAV_DIMENSION_BUFFER)
+    {
+        WARN("Unexpected view dimension %#x.\n", desc->ViewDimension);
+        return;
+    }
+
+    memset(&desc_info, 0, sizeof(desc_info));
+    desc_info.sType = VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT;
+
+    d = d3d12_desc_decode_embedded_resource_va_with_metadata(desc_va,
+            device->bindless_state.packed_metadata_offset, stack_payload);
+
+    if (resource)
+    {
+        vkd3d_get_metadata_buffer_view_for_resource_heap(device, resource,
+                desc->Format, desc->Buffer.FirstElement, desc->Buffer.NumElements,
+                desc->Buffer.StructureByteStride, (desc->Buffer.Flags & D3D12_BUFFER_UAV_FLAG_RAW) != 0,
+                &view);
+    }
+    else
+    {
+        memset(&view, 0, sizeof(view));
+    }
+
+    is_typed = desc->Format && !(desc->Buffer.Flags & D3D12_BUFFER_UAV_FLAG_RAW);
+
+    can_emit_sibling_typed =
+        bindless->packed_raw_buffer_offset >= bindless->heap.storage_texel_buffer_size && !counter_resource;
+    can_emit_sibling_raw = bindless->packed_raw_buffer_offset >= bindless->heap.storage_texel_buffer_size;
+
+    if (!is_typed && !d3d12_resource_desc_supports_heap_raw_uav_ssbo(device, desc))
+    {
+        is_typed = true;
+        view.dxgi_format = DXGI_FORMAT_R32_UINT;
+    }
+
+    /* TODO: Check max range for typed? */
+    emit_typed = is_typed || can_emit_sibling_typed;
+    emit_raw = !is_typed || can_emit_sibling_raw;
+
+    /* With ReBAR in play, it's been suggested by at least one IHV that fusing the writes is a good thing. */
+    memset(stack_payload, 0, bindless->cbv_srv_uav_size);
+
+    if (emit_typed)
+    {
+        desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+        if (resource)
+        {
+            memset(&texel_buffer_info, 0, sizeof(texel_buffer_info));
+            texel_buffer_info.sType = VK_STRUCTURE_TYPE_TEXEL_BUFFER_DESCRIPTOR_INFO_EXT;
+            texel_buffer_info.addressRange.address = view.va;
+            texel_buffer_info.addressRange.size = view.range;
+            texel_buffer_info.format = vkd3d_internal_get_vk_format(device, view.dxgi_format);
+            if (texel_buffer_info.format == VK_FORMAT_UNDEFINED)
+            {
+                if (desc->Buffer.Flags & D3D12_BUFFER_UAV_FLAG_RAW)
+                {
+                    texel_buffer_info.format = VK_FORMAT_R32_UINT;
+                }
+                else
+                {
+                    texel_buffer_info.format = vkd3d_internal_get_vk_format(device,
+                        vkd3d_structured_uav_to_texel_buffer_dxgi_format(desc->Buffer.StructureByteStride));
+                }
+            }
+
+            if (texel_buffer_info.format != VK_FORMAT_UNDEFINED)
+                desc_info.data.pTexelBuffer = &texel_buffer_info;
+        }
+
+        desc_range.address = stack_payload;
+        desc_range.size = device->bindless_state.heap.storage_texel_buffer_size;
+        VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+    }
+
+    if (emit_raw)
+    {
+        desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+
+        if (resource)
+        {
+            ssbo_range.address = view.va;
+            ssbo_range.size = view.range;
+            desc_info.data.pAddressRange = &ssbo_range;
+        }
+        else
+        {
+            desc_info.data.pAddressRange = NULL;
+        }
+
+        desc_range.address = stack_payload + bindless->packed_raw_buffer_offset;
+        desc_range.size = device->device_info.descriptor_heap_properties.bufferDescriptorSize;
+        VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+    }
+
+    if (counter_resource && desc->Buffer.StructureByteStride != 0)
+    {
+        desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+        desc_info.data.pTexelBuffer = &texel_buffer_info;
+
+        /* Could use SSBO here, but texel buffer is more convenient w.r.t. heap mappings and
+         * descriptor buffer path uses texel buffers too. */
+        memset(&texel_buffer_info, 0, sizeof(texel_buffer_info));
+        texel_buffer_info.sType = VK_STRUCTURE_TYPE_TEXEL_BUFFER_DESCRIPTOR_INFO_EXT;
+        texel_buffer_info.addressRange.address = counter_resource->res.va + desc->Buffer.CounterOffsetInBytes;
+        texel_buffer_info.addressRange.size = sizeof(uint32_t);
+        texel_buffer_info.format = VK_FORMAT_R32_UINT;
+        desc_range.address = stack_payload;
+        desc_range.size = device->device_info.descriptor_heap_properties.bufferDescriptorSize;
+
+        if (bindless->heap.uav_counter_embedded_offset == 0)
+        {
+            VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+        }
+        else
+        {
+            /* Ugly hackery. Place UAV counter BDA at end of payload. */
+            memcpy(stack_payload + bindless->heap.uav_counter_embedded_offset,
+                    &texel_buffer_info.addressRange.address, sizeof(VkDeviceAddress));
+        }
+    }
+
+    /* The metadata write may be redirected to stack payload memory. */
+    if (d.metadata)
+        d.metadata->info.buffer = view;
+
+    memcpy(d.payload, stack_payload, bindless->cbv_srv_uav_size);
+}
+
 static void vkd3d_create_buffer_uav_embedded(vkd3d_cpu_descriptor_va_t desc_va, struct d3d12_device *device,
         struct d3d12_resource *resource, struct d3d12_resource *counter_resource,
         const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
@@ -7637,6 +7791,57 @@ static void vkd3d_descriptor_metadata_setup_image_view(struct vkd3d_descriptor_m
         meta->plane_slice = 0;
 }
 
+static void vkd3d_create_texture_uav_heap(vkd3d_cpu_descriptor_va_t desc_va,
+        struct d3d12_device *device, struct d3d12_resource *resource,
+        const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
+{
+    DECLSPEC_ALIGN(8) uint8_t stack_payload[VKD3D_MAX_DESCRIPTOR_SIZE];
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct vkd3d_texture_view_create_info create_info;
+    VkResourceDescriptorInfoEXT desc_info;
+    struct vkd3d_texture_view_desc info;
+    VkImageDescriptorInfoEXT image_info;
+    struct d3d12_desc_split_embedded d;
+    VkHostAddressRangeEXT desc_range;
+
+    d = d3d12_desc_decode_embedded_resource_va_with_metadata(desc_va,
+            device->bindless_state.packed_metadata_offset, stack_payload);
+
+    memset(&desc_info, 0, sizeof(desc_info));
+    desc_info.sType = VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT;
+    desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+
+    memset(stack_payload, 0, device->bindless_state.cbv_srv_uav_size);
+
+    if (resource && vkd3d_setup_texture_uav_view(device, resource, desc, &info) &&
+        vkd3d_setup_texture_view(device, &info, &create_info))
+    {
+        desc_info.data.pImage = &image_info;
+        memset(&image_info, 0, sizeof(image_info));
+        image_info.sType = VK_STRUCTURE_TYPE_IMAGE_DESCRIPTOR_INFO_EXT;
+        image_info.layout = VK_IMAGE_LAYOUT_GENERAL;
+        image_info.pView = &create_info.view_desc;
+
+        /* Setup metadata if the resource is used as clear UAV, and we have to do fallback views. */
+        if (d.metadata)
+        {
+            struct vkd3d_descriptor_metadata_image_view *image = &d.metadata->info.image;
+            vkd3d_descriptor_metadata_setup_image_view(&d.metadata->info.image,
+                create_info.view_desc.viewType, &create_info.view_desc.subresourceRange, resource, desc);
+            image->view = NULL;
+        }
+    }
+    else if (d.metadata)
+    {
+        memset(&d.metadata->info.image, 0, sizeof(d.metadata->info.image));
+    }
+
+    desc_range.address = stack_payload;
+    desc_range.size = device->bindless_state.heap.storage_image_size;
+    VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+    memcpy(d.payload, stack_payload, device->bindless_state.cbv_srv_uav_size);
+}
+
 static void vkd3d_create_texture_uav_embedded(vkd3d_cpu_descriptor_va_t desc_va,
         struct d3d12_device *device, struct d3d12_resource *resource,
         const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
@@ -7791,6 +7996,35 @@ static void vkd3d_create_texture_uav(vkd3d_cpu_descriptor_va_t desc_va,
     vkd3d_descriptor_debug_write_descriptor(d.heap->descriptor_heap_info.host_ptr,
             d.heap->cookie, d.offset,
             VKD3D_DESCRIPTOR_QA_TYPE_STORAGE_IMAGE_BIT, d.view->qa_cookie);
+}
+
+void d3d12_desc_create_uav_heap(vkd3d_cpu_descriptor_va_t desc_va, struct d3d12_device *device,
+        struct d3d12_resource *resource, struct d3d12_resource *counter_resource,
+        const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
+{
+    bool is_buffer;
+
+    if (resource)
+    {
+        is_buffer = d3d12_resource_is_buffer(resource);
+    }
+    else if (desc)
+    {
+        is_buffer = desc->ViewDimension == D3D12_UAV_DIMENSION_BUFFER;
+    }
+    else
+    {
+        WARN("Description required for NULL UAV.\n");
+        return;
+    }
+
+    if (counter_resource && (!resource || !is_buffer))
+        FIXME("Ignoring counter resource %p.\n", counter_resource);
+
+    if (is_buffer)
+        vkd3d_create_buffer_uav_heap(desc_va, device, resource, counter_resource, desc);
+    else
+        vkd3d_create_texture_uav_heap(desc_va, device, resource, desc);
 }
 
 void d3d12_desc_create_uav_embedded(vkd3d_cpu_descriptor_va_t desc_va, struct d3d12_device *device,

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -6221,6 +6221,166 @@ static bool vkd3d_buffer_view_get_aligned_view(
     return true;
 }
 
+static bool d3d12_resource_desc_supports_heap_raw_ssbo(struct d3d12_device *device,
+        uint32_t stride, bool raw)
+{
+    assert(stride || raw);
+    if (stride)
+        return (stride & (device->bindless_state.heap.min_ssbo_alignment - 1)) == 0;
+    else
+        return device->bindless_state.heap.supports_universal_byte_address_ssbo;
+}
+
+static bool d3d12_resource_desc_supports_heap_raw_srv_ssbo(
+        struct d3d12_device *device, const D3D12_SHADER_RESOURCE_VIEW_DESC *desc)
+{
+    return d3d12_resource_desc_supports_heap_raw_ssbo(device,
+            desc->Buffer.StructureByteStride,
+            (desc->Buffer.Flags & D3D12_BUFFER_SRV_FLAG_RAW) != 0);
+}
+
+static bool d3d12_resource_desc_supports_heap_raw_uav_ssbo(
+        struct d3d12_device *device, const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc)
+{
+    return d3d12_resource_desc_supports_heap_raw_ssbo(device,
+            desc->Buffer.StructureByteStride,
+            (desc->Buffer.Flags & D3D12_BUFFER_UAV_FLAG_RAW) != 0);
+}
+
+static void vkd3d_create_buffer_srv_heap(vkd3d_cpu_descriptor_va_t desc_va,
+        struct d3d12_device *device, struct d3d12_resource *resource,
+        const D3D12_SHADER_RESOURCE_VIEW_DESC *desc)
+{
+    const struct vkd3d_bindless_state *bindless = &device->bindless_state;
+    DECLSPEC_ALIGN(8) uint8_t stack_payload[VKD3D_MAX_DESCRIPTOR_SIZE];
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct vkd3d_descriptor_metadata_buffer_view view;
+    VkTexelBufferDescriptorInfoEXT texel_buffer_info;
+    VkResourceDescriptorInfoEXT desc_info;
+    struct d3d12_desc_split_embedded d;
+    VkDeviceAddressRangeEXT ssbo_range;
+    VkHostAddressRangeEXT desc_range;
+
+    if (!desc)
+    {
+        FIXME("Default buffer SRV not supported.\n");
+        return;
+    }
+
+    d = d3d12_desc_decode_embedded_resource_va(desc_va);
+
+    memset(&desc_info, 0, sizeof(desc_info));
+    desc_info.sType = VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT;
+
+    memset(stack_payload, 0, bindless->cbv_srv_uav_size);
+
+    if (desc->ViewDimension == D3D12_SRV_DIMENSION_RAYTRACING_ACCELERATION_STRUCTURE)
+    {
+        desc_info.type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
+        if (desc->RaytracingAccelerationStructure.Location)
+        {
+            ssbo_range.address = desc->RaytracingAccelerationStructure.Location;
+            ssbo_range.size = 0; /* 0 size is allowed by spec. */
+            desc_info.data.pAddressRange = &ssbo_range;
+        }
+
+        desc_range.address = stack_payload + device->bindless_state.packed_raw_buffer_offset;
+        desc_range.size = device->device_info.descriptor_heap_properties.bufferDescriptorSize;
+        VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+    }
+    else if (desc->ViewDimension == D3D12_SRV_DIMENSION_BUFFER)
+    {
+        bool can_emit_sibling_typed_raw;
+        bool emit_typed;
+        bool is_typed;
+        bool emit_raw;
+
+        /* Ignore metadata for SRV. */
+        if (resource)
+        {
+            vkd3d_get_metadata_buffer_view_for_resource_heap(device, resource,
+                    desc->Format, desc->Buffer.FirstElement, desc->Buffer.NumElements,
+                    desc->Buffer.StructureByteStride, (desc->Buffer.Flags & D3D12_BUFFER_SRV_FLAG_RAW) != 0,
+                    &view);
+        }
+        else
+        {
+            memset(&view, 0, sizeof(view));
+        }
+
+        is_typed = desc->Format && !(desc->Buffer.Flags & D3D12_BUFFER_SRV_FLAG_RAW);
+
+        can_emit_sibling_typed_raw = bindless->packed_raw_buffer_offset >= bindless->heap.uniform_texel_buffer_size;
+
+        if (!is_typed && !d3d12_resource_desc_supports_heap_raw_srv_ssbo(device, desc))
+        {
+            is_typed = true;
+            view.dxgi_format = DXGI_FORMAT_R32_UINT;
+        }
+
+        /* TODO: Check max range for typed? */
+        emit_typed = is_typed || can_emit_sibling_typed_raw;
+        emit_raw = !is_typed || can_emit_sibling_typed_raw;
+
+        if (emit_typed)
+        {
+            desc_info.type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+            if (resource)
+            {
+                memset(&texel_buffer_info, 0, sizeof(texel_buffer_info));
+                texel_buffer_info.sType = VK_STRUCTURE_TYPE_TEXEL_BUFFER_DESCRIPTOR_INFO_EXT;
+                texel_buffer_info.addressRange.address = view.va;
+                texel_buffer_info.addressRange.size = view.range;
+                texel_buffer_info.format = vkd3d_internal_get_vk_format(device, view.dxgi_format);
+                if (texel_buffer_info.format == VK_FORMAT_UNDEFINED)
+                {
+                    if (desc->Buffer.Flags & D3D12_BUFFER_SRV_FLAG_RAW)
+                    {
+                        texel_buffer_info.format = VK_FORMAT_R32_UINT;
+                    }
+                    else
+                    {
+                        texel_buffer_info.format = vkd3d_internal_get_vk_format(device,
+                            vkd3d_structured_srv_to_texel_buffer_dxgi_format(desc->Buffer.StructureByteStride));
+                    }
+                }
+
+                if (texel_buffer_info.format != VK_FORMAT_UNDEFINED)
+                    desc_info.data.pTexelBuffer = &texel_buffer_info;
+            }
+
+            desc_range.address = stack_payload;
+            desc_range.size = device->bindless_state.heap.uniform_texel_buffer_size;
+            VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+        }
+
+        if (emit_raw)
+        {
+            desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            if (resource)
+            {
+                ssbo_range.address = view.va;
+                ssbo_range.size = view.range;
+                desc_info.data.pAddressRange = &ssbo_range;
+            }
+            else
+            {
+                desc_info.data.pAddressRange = NULL;
+            }
+
+            desc_range.address = stack_payload + bindless->packed_raw_buffer_offset;
+            desc_range.size = device->device_info.descriptor_heap_properties.bufferDescriptorSize;
+            VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+        }
+    }
+    else
+    {
+        WARN("Unexpected view dimension %#x.\n", desc->ViewDimension);
+    }
+
+    memcpy(d.payload, stack_payload, bindless->cbv_srv_uav_size);
+}
+
 static void vkd3d_create_buffer_srv_embedded(vkd3d_cpu_descriptor_va_t desc_va,
         struct d3d12_device *device, struct d3d12_resource *resource,
         const D3D12_SHADER_RESOURCE_VIEW_DESC *desc)
@@ -6845,6 +7005,44 @@ static void vkd3d_create_texture_srv_embedded(vkd3d_cpu_descriptor_va_t desc_va,
             d.payload));
 }
 
+static void vkd3d_create_texture_srv_heap(vkd3d_cpu_descriptor_va_t desc_va,
+        struct d3d12_device *device, struct d3d12_resource *resource,
+        const D3D12_SHADER_RESOURCE_VIEW_DESC *desc)
+{
+    DECLSPEC_ALIGN(8) uint8_t stack_payload[VKD3D_MAX_DESCRIPTOR_SIZE];
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct vkd3d_texture_view_create_info create_info;
+    VkResourceDescriptorInfoEXT desc_info;
+    struct vkd3d_texture_view_desc info;
+    VkImageDescriptorInfoEXT image_info;
+    struct d3d12_desc_split_embedded d;
+    VkHostAddressRangeEXT desc_range;
+
+    d = d3d12_desc_decode_embedded_resource_va(desc_va);
+
+    memset(&desc_info, 0, sizeof(desc_info));
+    desc_info.sType = VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT;
+    desc_info.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+
+    memset(stack_payload, 0, device->bindless_state.cbv_srv_uav_size);
+
+    /* Ignore metadata. */
+    if (resource && vkd3d_setup_texture_srv_view(device, resource, desc, &info) &&
+        vkd3d_setup_texture_view(device, &info, &create_info))
+    {
+        desc_info.data.pImage = &image_info;
+        memset(&image_info, 0, sizeof(image_info));
+        image_info.sType = VK_STRUCTURE_TYPE_IMAGE_DESCRIPTOR_INFO_EXT;
+        image_info.layout = d3d12_resource_pick_layout(resource, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        image_info.pView = &create_info.view_desc;
+    }
+
+    desc_range.address = stack_payload;
+    desc_range.size = device->bindless_state.heap.sampled_image_size;
+    VK_CALL(vkWriteResourceDescriptorsEXT(device->vk_device, 1, &desc_info, &desc_range));
+    memcpy(d.payload, stack_payload, device->bindless_state.cbv_srv_uav_size);
+}
+
 static void vkd3d_create_texture_srv(vkd3d_cpu_descriptor_va_t desc_va,
         struct d3d12_device *device, struct d3d12_resource *resource,
         const D3D12_SHADER_RESOURCE_VIEW_DESC *desc)
@@ -6940,6 +7138,33 @@ static void vkd3d_create_texture_srv(vkd3d_cpu_descriptor_va_t desc_va,
     vkd3d_descriptor_debug_write_descriptor(d.heap->descriptor_heap_info.host_ptr,
             d.heap->cookie, d.offset,
             VKD3D_DESCRIPTOR_QA_TYPE_SAMPLED_IMAGE_BIT, d.view->qa_cookie);
+}
+
+void d3d12_desc_create_srv_heap(vkd3d_cpu_descriptor_va_t desc_va,
+        struct d3d12_device *device, struct d3d12_resource *resource,
+        const D3D12_SHADER_RESOURCE_VIEW_DESC *desc)
+{
+    bool is_buffer;
+
+    if (resource)
+    {
+        is_buffer = d3d12_resource_is_buffer(resource);
+    }
+    else if (desc)
+    {
+        is_buffer = desc->ViewDimension == D3D12_SRV_DIMENSION_BUFFER ||
+                desc->ViewDimension == D3D12_SRV_DIMENSION_RAYTRACING_ACCELERATION_STRUCTURE;
+    }
+    else
+    {
+        WARN("Description required for NULL SRV.\n");
+        return;
+    }
+
+    if (is_buffer)
+        vkd3d_create_buffer_srv_heap(desc_va, device, resource, desc);
+    else
+        vkd3d_create_texture_srv_heap(desc_va, device, resource, desc);
 }
 
 void d3d12_desc_create_srv_embedded(vkd3d_cpu_descriptor_va_t desc_va,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1098,7 +1098,7 @@ struct vkd3d_view_map
 struct vkd3d_sampler_view_map
 {
     struct vkd3d_view_map map;
-    uint32_t custom_border_color_count;
+    uint32_t legacy_custom_border_color_count;
     uint32_t live_object_count;
 };
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3860,6 +3860,13 @@ static inline struct d3d12_command_signature *impl_from_ID3D12CommandSignature(I
     return CONTAINING_RECORD(iface, struct d3d12_command_signature, ID3D12CommandSignature_iface);
 }
 
+struct vkd3d_sampler_custom_border_color
+{
+    VkBorderColor border_color;
+    VkClearColorValue color;
+    uint32_t index;
+};
+
 /* Static samplers */
 struct vkd3d_sampler_state
 {
@@ -3869,7 +3876,18 @@ struct vkd3d_sampler_state
     VkDescriptorPool *vk_descriptor_pools;
     size_t vk_descriptor_pools_size;
     size_t vk_descriptor_pool_count;
+
+    struct vkd3d_sampler_custom_border_color *border_colors;
+    size_t border_color_bank_size;
+    size_t border_color_count;
+    bool noop_registration;
+    uint32_t noop_registration_index;
 };
+
+uint32_t vkd3d_sampler_state_register_custom_border_color(
+        struct d3d12_device *device,
+        struct vkd3d_sampler_state *state, VkBorderColor border_color,
+        const VkSamplerCustomBorderColorCreateInfoEXT *info);
 
 struct vkd3d_shader_debug_ring
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -61,7 +61,7 @@
 /* The above plus one push descriptor set + static sampler set + static sampler set for local root signatures. */
 #define VKD3D_MAX_DESCRIPTOR_SETS (VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS + 3u)
 #define VKD3D_MAX_MUTABLE_DESCRIPTOR_TYPES 6u
-#define VKD3D_MAX_DESCRIPTOR_SIZE 256u /* Maximum allowed value in VK_EXT_descriptor_buffer. */
+#define VKD3D_MAX_DESCRIPTOR_SIZE 256u /* Maximum allowed value in VK_EXT_descriptor_buffer/heap. */
 
 #define VKD3D_MIN_VIEW_DESCRIPTOR_COUNT (1000000u)
 #define VKD3D_MIN_SAMPLER_DESCRIPTOR_COUNT (2048u)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1696,6 +1696,24 @@ static inline struct d3d12_desc_split_embedded d3d12_desc_decode_embedded_resour
     return split;
 }
 
+static inline struct d3d12_desc_split_embedded d3d12_desc_decode_embedded_resource_va_with_metadata(
+        vkd3d_cpu_descriptor_va_t va, uint32_t packed_metadata_offset, void *stack_payload)
+{
+    struct d3d12_desc_split_embedded split = d3d12_desc_decode_embedded_resource_va(va);
+
+    /* Only fish out metadata for host descriptor heap. */
+    if (!split.metadata && (va & VKD3D_RESOURCE_EMBEDDED_METADATA_OFFSET_LOG2_MASK) == VKD3D_RESOURCE_EMBEDDED_CACHED_MASK)
+    {
+        /* If we have a stack payload, it should be written there rather than getting double write on write-combined memory. */
+        if (stack_payload)
+            split.metadata = void_ptr_offset(stack_payload, packed_metadata_offset);
+        else
+            split.metadata = void_ptr_offset(split.payload, packed_metadata_offset);
+    }
+
+    return split;
+}
+
 static inline void d3d12_desc_copy_embedded_resource(vkd3d_cpu_descriptor_va_t dst_va,
         vkd3d_cpu_descriptor_va_t src_va, size_t size)
 {


### PR DESCRIPTION
This series focuses on creating descriptors on the heap. It's very similar to descriptor buffer embedded path.

Major difference is some details around how texel buffer <-> SSBO aliasing is done. We can support SSBO alignment > 4 here by dynamically falling back to texel buffer based on the stride. The shader mapping deals with this difference later. StructuredBuffer and BAB cannot reliably alias each other on native drivers, so it's probably fine. It might help enable heap on more drivers down the line.

Another difference is that we finally emit "proper" RTAS descriptors now, so no weird jank with embedded raw VAs, etc.

Samplers hit different paths for custom border colors as with heap we need explicit reservation.

Otherwise it should be fairly straight forward.