### PR TITLE
Descriptor heap - Phase 5

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -1207,6 +1207,35 @@ bool vkd3d_shader_hash_range_parse_line(char *line,
         vkd3d_shader_hash_t *lo, vkd3d_shader_hash_t *hi,
         char **trail);
 
+/* In EXT_descriptor_heap, sets and bindings are non-physical concepts.
+ * Agree on a convention so that we can link SPIR-V to PSO creation. */
+enum
+{
+    VKD3D_SHADER_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE = 0, /* maximum 64 of these. binding encodes constant offset. */
+    VKD3D_SHADER_GLOBAL_HEAP_VIRTUAL_DESCRIPTOR_SET = 100,
+
+    /* Non-bindless bindings for global root signature */
+    VKD3D_SHADER_STATIC_SAMPLERS_VIRTUAL_DESCRIPTOR_SET = 101, /* bindings are allocated linearly */
+    VKD3D_SHADER_ROOT_CONSTANTS_VIRTUAL_DESCRIPTOR_SET = 102, /* Allows reading root parameters as a UBO */
+    VKD3D_SHADER_ROOT_DESCRIPTORS_VIRTUAL_DESCRIPTOR_SET = 103, /* binding = raw VA index */
+
+    /* Non-bindless bindings for local root signature */
+    VKD3D_SHADER_STATIC_LOCAL_SAMPLERS_VIRTUAL_DESCRIPTOR_SET = 104,
+    VKD3D_SHADER_LOCAL_ROOT_CONSTANTS_VIRTUAL_DESCRIPTOR_SET = 105,
+    VKD3D_SHADER_LOCAL_ROOT_DESCRIPTORS_VIRTUAL_DESCRIPTOR_SET = 106,
+
+    VKD3D_SHADER_LOCAL_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE = 200, /* Same as tables, but for shader records. */
+
+    /* Bindings within GLOBAL_HEAP set */
+    VKD3D_SHADER_GLOBAL_HEAP_BINDING = 0,
+
+    /* These are either plain SSBOs or magic UBOs. */
+    VKD3D_SHADER_GLOBAL_HEAP_BINDING_AUX_BINDINGS = 1,
+    VKD3D_SHADER_RAW_VIEW_GLOBAL_HEAP_BINDING = VKD3D_SHADER_GLOBAL_HEAP_BINDING_AUX_BINDINGS,
+    VKD3D_SHADER_GLOBAL_HEAP_SIZE_BINDING,
+    VKD3D_SHADER_GLOBAL_HEAP_BINDING_AUX_BINDINGS_COUNT = 4
+};
+
 #ifdef __cplusplus
 }
 #endif  /* __cplusplus */

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -13653,87 +13653,39 @@ static inline void d3d12_command_list_set_descriptor_table(struct d3d12_command_
     VKD3D_BREADCRUMB_COMMAND_STATE(ROOT_TABLE);
 }
 
-static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootDescriptorTable_embedded_64_16(
-        d3d12_command_list_iface *iface,
-        UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
-{
-    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-
-    TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n",
-            iface, root_parameter_index, base_descriptor.ptr);
-
-    d3d12_command_list_set_descriptor_table_embedded(list, &list->compute_bindings,
-            root_parameter_index, base_descriptor, 6, 4);
+/* Poor man's templates :V */
+#define DECLARE_ROOT_TABLE_VARIANT(variant, resource_log2, sampler_log2) \
+static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootDescriptorTable_##variant( \
+        d3d12_command_list_iface *iface, \
+        UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor) \
+{ \
+    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface); \
+ \
+    TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n", \
+            iface, root_parameter_index, base_descriptor.ptr); \
+ \
+    d3d12_command_list_set_descriptor_table_embedded(list, &list->compute_bindings, \
+            root_parameter_index, base_descriptor, resource_log2, sampler_log2); \
+} \
+static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootDescriptorTable_##variant( \
+        d3d12_command_list_iface *iface, \
+        UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor) \
+{ \
+    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface); \
+ \
+    TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n", \
+            iface, root_parameter_index, base_descriptor.ptr); \
+ \
+    d3d12_command_list_set_descriptor_table_embedded(list, &list->graphics_bindings, \
+            root_parameter_index, base_descriptor, resource_log2, sampler_log2); \
 }
-
-static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootDescriptorTable_embedded_64_16(
-        d3d12_command_list_iface *iface,
-        UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
-{
-    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-
-    TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n",
-            iface, root_parameter_index, base_descriptor.ptr);
-
-    d3d12_command_list_set_descriptor_table_embedded(list, &list->graphics_bindings,
-            root_parameter_index, base_descriptor, 6, 4);
-}
-
-static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootDescriptorTable_embedded_32_16(
-        d3d12_command_list_iface *iface,
-        UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
-{
-    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-
-    TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n",
-            iface, root_parameter_index, base_descriptor.ptr);
-
-    d3d12_command_list_set_descriptor_table_embedded(list, &list->compute_bindings,
-            root_parameter_index, base_descriptor, 5, 4);
-}
-
-static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootDescriptorTable_embedded_32_16(
-        d3d12_command_list_iface *iface,
-        UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
-{
-    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-
-    TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n",
-            iface, root_parameter_index, base_descriptor.ptr);
-
-    d3d12_command_list_set_descriptor_table_embedded(list, &list->graphics_bindings,
-            root_parameter_index, base_descriptor, 5, 4);
-}
-
-static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootDescriptorTable_embedded_default(
-        d3d12_command_list_iface *iface,
-        UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
-{
-    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-
-    TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n",
-            iface, root_parameter_index, base_descriptor.ptr);
-
-    d3d12_command_list_set_descriptor_table_embedded(list, &list->compute_bindings,
-            root_parameter_index, base_descriptor,
-            list->device->bindless_state.cbv_srv_uav_size_log2,
-            list->device->bindless_state.sampler_size_log2);
-}
-
-static void STDMETHODCALLTYPE d3d12_command_list_SetGraphicsRootDescriptorTable_embedded_default(
-        d3d12_command_list_iface *iface,
-        UINT root_parameter_index, D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
-{
-    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-
-    TRACE("iface %p, root_parameter_index %u, base_descriptor %#"PRIx64".\n",
-            iface, root_parameter_index, base_descriptor.ptr);
-
-    d3d12_command_list_set_descriptor_table_embedded(list, &list->graphics_bindings,
-            root_parameter_index, base_descriptor,
-            list->device->bindless_state.cbv_srv_uav_size_log2,
-            list->device->bindless_state.sampler_size_log2);
-}
+DECLARE_ROOT_TABLE_VARIANT(embedded_64_16, 6, 4)
+DECLARE_ROOT_TABLE_VARIANT(embedded_32_16, 5, 4)
+DECLARE_ROOT_TABLE_VARIANT(embedded_32_32, 5, 5)
+DECLARE_ROOT_TABLE_VARIANT(embedded_128_32, 7, 5)
+DECLARE_ROOT_TABLE_VARIANT(embedded_default,
+    list->device->bindless_state.cbv_srv_uav_size_log2,
+    list->device->bindless_state.sampler_size_log2)
 
 static void STDMETHODCALLTYPE d3d12_command_list_SetComputeRootDescriptorTable_default(
         d3d12_command_list_iface *iface,
@@ -21342,6 +21294,8 @@ static CONST_VTBL struct ID3D12GraphicsCommandList10Vtbl d3d12_command_list_vtbl
 VKD3D_DECLARE_D3D12_GRAPHICS_COMMAND_LIST_VARIANT(default, default);
 VKD3D_DECLARE_D3D12_GRAPHICS_COMMAND_LIST_VARIANT(embedded_64_16, embedded_64_16);
 VKD3D_DECLARE_D3D12_GRAPHICS_COMMAND_LIST_VARIANT(embedded_32_16, embedded_32_16);
+VKD3D_DECLARE_D3D12_GRAPHICS_COMMAND_LIST_VARIANT(embedded_32_32, embedded_32_32);
+VKD3D_DECLARE_D3D12_GRAPHICS_COMMAND_LIST_VARIANT(embedded_128_32, embedded_128_32);
 VKD3D_DECLARE_D3D12_GRAPHICS_COMMAND_LIST_VARIANT(embedded_default, embedded_default);
 
 #ifdef VKD3D_ENABLE_PROFILING
@@ -21422,6 +21376,16 @@ static HRESULT d3d12_command_list_init(struct d3d12_command_list *list, struct d
             {
                 list->ID3D12GraphicsCommandList_iface.lpVtbl = &d3d12_command_list_vtbl_embedded_32_16;
             }
+            else if (device->bindless_state.cbv_srv_uav_size == 32 &&
+                    device->bindless_state.sampler_size == 32)
+            {
+                list->ID3D12GraphicsCommandList_iface.lpVtbl = &d3d12_command_list_vtbl_embedded_32_32;
+            }
+            else if (device->bindless_state.cbv_srv_uav_size == 128 &&
+                    device->bindless_state.sampler_size == 32)
+            {
+                list->ID3D12GraphicsCommandList_iface.lpVtbl = &d3d12_command_list_vtbl_embedded_128_32;
+            }
             else
             {
                 list->ID3D12GraphicsCommandList_iface.lpVtbl = &d3d12_command_list_vtbl_embedded_default;
@@ -21491,7 +21455,9 @@ struct d3d12_command_list *d3d12_command_list_from_iface(ID3D12CommandList *ifac
     is_valid |=
             iface->lpVtbl == (struct ID3D12CommandListVtbl *)&d3d12_command_list_vtbl_default ||
             iface->lpVtbl == (struct ID3D12CommandListVtbl *)&d3d12_command_list_vtbl_embedded_64_16 ||
+            iface->lpVtbl == (struct ID3D12CommandListVtbl *)&d3d12_command_list_vtbl_embedded_32_32 ||
             iface->lpVtbl == (struct ID3D12CommandListVtbl *)&d3d12_command_list_vtbl_embedded_32_16 ||
+            iface->lpVtbl == (struct ID3D12CommandListVtbl *)&d3d12_command_list_vtbl_embedded_128_32 ||
             iface->lpVtbl == (struct ID3D12CommandListVtbl *)&d3d12_command_list_vtbl_embedded_default;
 
     if (!is_valid)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -6152,6 +6152,16 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateRootSignature(d3d12_device_i
             &IID_ID3D12RootSignature, riid, root_signature);
 }
 
+static void STDMETHODCALLTYPE d3d12_device_CreateConstantBufferView_heap(d3d12_device_iface *iface,
+        const D3D12_CONSTANT_BUFFER_VIEW_DESC *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
+{
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+
+    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+
+    d3d12_desc_create_cbv_heap(descriptor.ptr, device, desc);
+}
+
 static void STDMETHODCALLTYPE d3d12_device_CreateConstantBufferView_embedded(d3d12_device_iface *iface,
         const D3D12_CONSTANT_BUFFER_VIEW_DESC *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
 {
@@ -6170,6 +6180,18 @@ static void STDMETHODCALLTYPE d3d12_device_CreateConstantBufferView_default(d3d1
     TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
 
     d3d12_desc_create_cbv(descriptor.ptr, device, desc);
+}
+
+static void STDMETHODCALLTYPE d3d12_device_CreateShaderResourceView_heap(d3d12_device_iface *iface,
+        ID3D12Resource *resource, const D3D12_SHADER_RESOURCE_VIEW_DESC *desc,
+        D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
+{
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+
+    TRACE("iface %p, resource %p, desc %p, descriptor %#lx.\n",
+            iface, resource, desc, descriptor.ptr);
+
+    d3d12_desc_create_srv_heap(descriptor.ptr, device, impl_from_ID3D12Resource(resource), desc);
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CreateShaderResourceView_embedded(d3d12_device_iface *iface,
@@ -6194,6 +6216,22 @@ static void STDMETHODCALLTYPE d3d12_device_CreateShaderResourceView_default(d3d1
             iface, resource, desc, descriptor.ptr);
 
     d3d12_desc_create_srv(descriptor.ptr, device, impl_from_ID3D12Resource(resource), desc);
+}
+
+static void STDMETHODCALLTYPE d3d12_device_CreateUnorderedAccessView_heap(d3d12_device_iface *iface,
+        ID3D12Resource *resource, ID3D12Resource *counter_resource,
+        const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
+{
+    struct d3d12_resource *d3d12_resource_ = impl_from_ID3D12Resource(resource);
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+    TRACE("iface %p, resource %p, counter_resource %p, desc %p, descriptor %#lx.\n",
+            iface, resource, counter_resource, desc, descriptor.ptr);
+
+    d3d12_desc_create_uav_heap(descriptor.ptr,
+            device, d3d12_resource_,
+            impl_from_ID3D12Resource(counter_resource), desc);
+
+    /* TODO: Plumb d3d12_uav_info through later. */
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CreateUnorderedAccessView_embedded(d3d12_device_iface *iface,
@@ -6286,6 +6324,19 @@ static void STDMETHODCALLTYPE d3d12_device_CreateDepthStencilView(d3d12_device_i
             impl_from_ID3D12Device(iface), impl_from_ID3D12Resource(resource), desc);
 }
 
+static void STDMETHODCALLTYPE d3d12_device_CreateSampler_heap(d3d12_device_iface *iface,
+        const D3D12_SAMPLER_DESC *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
+{
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+    D3D12_SAMPLER_DESC2 desc2;
+
+    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+
+    memcpy(&desc2, desc, sizeof(*desc));
+    desc2.Flags = D3D12_SAMPLER_FLAG_NONE;
+    d3d12_desc_create_sampler_heap(descriptor.ptr, device, &desc2);
+}
+
 static void STDMETHODCALLTYPE d3d12_device_CreateSampler_embedded(d3d12_device_iface *iface,
         const D3D12_SAMPLER_DESC *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
 {
@@ -6310,6 +6361,16 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSampler_default(d3d12_device_if
     memcpy(&desc2, desc, sizeof(*desc));
     desc2.Flags = D3D12_SAMPLER_FLAG_NONE;
     d3d12_desc_create_sampler(descriptor.ptr, device, &desc2);
+}
+
+static void STDMETHODCALLTYPE d3d12_device_CreateSampler2_heap(d3d12_device_iface *iface,
+        const D3D12_SAMPLER_DESC2 *desc, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
+{
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+
+    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+
+    d3d12_desc_create_sampler_heap(descriptor.ptr, device, desc);
 }
 
 static void STDMETHODCALLTYPE d3d12_device_CreateSampler2_embedded(d3d12_device_iface *iface,
@@ -6789,6 +6850,92 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_embedded_32_16_
                     (void *)dst_descriptor_range_offset.ptr,
                     (const void *)src_descriptor_range_offset.ptr,
                     16 * descriptor_count);
+        }
+    }
+    else
+    {
+        device = unsafe_impl_from_ID3D12Device(iface);
+        d3d12_device_copy_descriptors(device,
+                1, &dst_descriptor_range_offset, &descriptor_count,
+                1, &src_descriptor_range_offset, &descriptor_count,
+                descriptor_heap_type);
+    }
+}
+
+static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_embedded_32_32_planar(d3d12_device_iface *iface,
+        UINT descriptor_count, const D3D12_CPU_DESCRIPTOR_HANDLE dst_descriptor_range_offset,
+        const D3D12_CPU_DESCRIPTOR_HANDLE src_descriptor_range_offset,
+        D3D12_DESCRIPTOR_HEAP_TYPE descriptor_heap_type)
+{
+    struct d3d12_device *device;
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
+          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+            iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
+            descriptor_heap_type);
+
+    if (VKD3D_EXPECT_TRUE(descriptor_heap_type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV ||
+            descriptor_heap_type == D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER))
+    {
+        if (VKD3D_EXPECT_TRUE(descriptor_count == 1))
+        {
+            /* Expected path. */
+            d3d12_desc_copy_embedded_resource_single_32(
+                    dst_descriptor_range_offset.ptr,
+                    src_descriptor_range_offset.ptr);
+        }
+        else
+        {
+            /* Rare path. */
+            d3d12_desc_copy_embedded_resource(
+                    dst_descriptor_range_offset.ptr,
+                    src_descriptor_range_offset.ptr,
+                    32 * descriptor_count);
+        }
+    }
+    else
+    {
+        device = unsafe_impl_from_ID3D12Device(iface);
+        d3d12_device_copy_descriptors(device,
+                1, &dst_descriptor_range_offset, &descriptor_count,
+                1, &src_descriptor_range_offset, &descriptor_count,
+                descriptor_heap_type);
+    }
+}
+
+static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_embedded_128_32_planar(d3d12_device_iface *iface,
+        UINT descriptor_count, const D3D12_CPU_DESCRIPTOR_HANDLE dst_descriptor_range_offset,
+        const D3D12_CPU_DESCRIPTOR_HANDLE src_descriptor_range_offset,
+        D3D12_DESCRIPTOR_HEAP_TYPE descriptor_heap_type)
+{
+    struct d3d12_device *device;
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
+          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+            iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
+            descriptor_heap_type);
+
+    if (VKD3D_EXPECT_TRUE(descriptor_heap_type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV))
+    {
+        d3d12_desc_copy_embedded_resource(
+                dst_descriptor_range_offset.ptr,
+                src_descriptor_range_offset.ptr,
+                128 * descriptor_count);
+    }
+    else if (descriptor_heap_type == D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)
+    {
+        if (VKD3D_EXPECT_TRUE(descriptor_count == 1))
+        {
+            /* Expected path. */
+            vkd3d_memcpy_aligned_32_cached(
+                    (void *)dst_descriptor_range_offset.ptr,
+                    (const void *)src_descriptor_range_offset.ptr);
+        }
+        else
+        {
+            /* Rare path. */
+            vkd3d_memcpy_aligned_cached(
+                    (void *)dst_descriptor_range_offset.ptr,
+                    (const void *)src_descriptor_range_offset.ptr,
+                    32 * descriptor_count);
         }
     }
     else
@@ -8567,6 +8714,25 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSamplerFeedbackUnorderedAccessV
     d3d12_desc_create_uav_embedded(descriptor.ptr, device, feedback, NULL, &uav_desc);
 }
 
+static void STDMETHODCALLTYPE d3d12_device_CreateSamplerFeedbackUnorderedAccessView_heap(d3d12_device_iface *iface,
+        ID3D12Resource *target_resource, ID3D12Resource *feedback_resource, D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
+{
+    struct d3d12_resource *feedback = impl_from_ID3D12Resource(feedback_resource);
+    struct d3d12_device *device = impl_from_ID3D12Device(iface);
+    D3D12_UNORDERED_ACCESS_VIEW_DESC uav_desc;
+
+    TRACE("iface %p, target_resource %p, feedback_resource %p, descriptor %#lx\n",
+            iface, target_resource, feedback_resource, descriptor.ptr);
+
+    /* NULL paired resource means NULL descriptor.
+     * https://microsoft.github.io/DirectX-Specs/d3d/SamplerFeedback.html#null-feedback-map-binding-is-permitted */
+    if (!target_resource)
+        feedback = NULL;
+
+    d3d12_device_create_sampler_feedback_desc(&uav_desc, feedback);
+    d3d12_desc_create_uav_heap(descriptor.ptr, device, feedback, NULL, &uav_desc);
+}
+
 static void STDMETHODCALLTYPE d3d12_device_GetCopyableFootprints1(d3d12_device_iface *iface,
         const D3D12_RESOURCE_DESC1 *desc, UINT first_sub_resource, UINT sub_resource_count,
         UINT64 base_offset, D3D12_PLACED_SUBRESOURCE_FOOTPRINT *layouts, UINT *row_counts,
@@ -8963,9 +9129,20 @@ CONST_VTBL struct ID3D12Device12Vtbl d3d12_device_vtbl_##name = \
 }
 
 VKD3D_DECLARE_D3D12_DEVICE_VARIANT(default, default, default);
-VKD3D_DECLARE_D3D12_DEVICE_VARIANT(embedded_64_16_packed, embedded, embedded_64_16_packed);
-VKD3D_DECLARE_D3D12_DEVICE_VARIANT(embedded_32_16_planar, embedded, embedded_32_16_planar);
+
+/* Descriptor heap paths. Create one optimized copy variant per known vendor config. */
+VKD3D_DECLARE_D3D12_DEVICE_VARIANT(heap_64_16_packed, heap, embedded_64_16_packed); /* RDNA2 */
+VKD3D_DECLARE_D3D12_DEVICE_VARIANT(heap_32_16_planar, heap, embedded_32_16_planar); /* RDNA3+ */
+VKD3D_DECLARE_D3D12_DEVICE_VARIANT(heap_32_32_planar, heap, embedded_32_32_planar); /* NV */
+VKD3D_DECLARE_D3D12_DEVICE_VARIANT(heap_128_32_planar, heap, embedded_128_32_planar); /* Intel */
+VKD3D_DECLARE_D3D12_DEVICE_VARIANT(heap_generic, heap, embedded_generic);
+
+/* Descriptor buffer with embedded mutable */
+VKD3D_DECLARE_D3D12_DEVICE_VARIANT(embedded_64_16_packed, embedded, embedded_64_16_packed); /* RDNA2 */
+VKD3D_DECLARE_D3D12_DEVICE_VARIANT(embedded_32_16_planar, embedded, embedded_32_16_planar); /* RDNA3+ */
 VKD3D_DECLARE_D3D12_DEVICE_VARIANT(embedded_generic, embedded, embedded_generic);
+
+/* Optimized descriptor buffer paths. */
 VKD3D_DECLARE_D3D12_DEVICE_VARIANT(descriptor_buffer_16_16_4, default, descriptor_buffer_16_16_4);
 VKD3D_DECLARE_D3D12_DEVICE_VARIANT(descriptor_buffer_64_64_32, default, descriptor_buffer_64_64_32);
 
@@ -10454,7 +10631,43 @@ static void d3d12_device_replace_vtable(struct d3d12_device *device)
     /* Don't bother modifying CopyDescriptors path, its main overhead is chasing other pointers anyway,
      * and that code path handles embedded mutable descriptors. */
 
-    if (d3d12_device_use_embedded_mutable_descriptors(device))
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        if ((device->bindless_state.flags & VKD3D_BINDLESS_MUTABLE_EMBEDDED_PACKED_METADATA) &&
+                device->bindless_state.cbv_srv_uav_size == 64 &&
+                device->bindless_state.sampler_size == 16)
+        {
+            /* RDNA2 */
+            device->ID3D12Device_iface.lpVtbl = &d3d12_device_vtbl_heap_64_16_packed;
+        }
+        else if (!(device->bindless_state.flags & VKD3D_BINDLESS_MUTABLE_EMBEDDED_PACKED_METADATA) &&
+                device->bindless_state.cbv_srv_uav_size == 32 &&
+                device->bindless_state.sampler_size == 16)
+        {
+            /* RDNA3+ */
+            device->ID3D12Device_iface.lpVtbl = &d3d12_device_vtbl_heap_32_16_planar;
+        }
+        else if (!(device->bindless_state.flags & VKD3D_BINDLESS_MUTABLE_EMBEDDED_PACKED_METADATA) &&
+                device->bindless_state.cbv_srv_uav_size == 32 &&
+                device->bindless_state.sampler_size == 32)
+        {
+            /* NV */
+            device->ID3D12Device_iface.lpVtbl = &d3d12_device_vtbl_heap_32_32_planar;
+        }
+        else if (!(device->bindless_state.flags & VKD3D_BINDLESS_MUTABLE_EMBEDDED_PACKED_METADATA) &&
+                device->bindless_state.cbv_srv_uav_size == 128 &&
+                device->bindless_state.sampler_size == 32)
+        {
+            /* Intel. If we can find a way to properly alias SSBO + Texel buffer and stuff UAV counter
+             * somewhere, we can probably do 64_32. */
+            device->ID3D12Device_iface.lpVtbl = &d3d12_device_vtbl_heap_128_32_planar;
+        }
+        else
+        {
+            device->ID3D12Device_iface.lpVtbl = &d3d12_device_vtbl_heap_generic;
+        }
+    }
+    else if (d3d12_device_use_embedded_mutable_descriptors(device))
     {
         if ((device->bindless_state.flags & VKD3D_BINDLESS_MUTABLE_EMBEDDED_PACKED_METADATA) &&
                 device->bindless_state.cbv_srv_uav_size == 64 &&

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -8266,50 +8266,57 @@ static VkBorderColor vk_border_color_from_d3d12(struct d3d12_device *device, con
     return uint_border ? VK_BORDER_COLOR_INT_CUSTOM_EXT : VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
 }
 
+void d3d12_setup_static_sampler_info(struct d3d12_device *device,
+        const D3D12_STATIC_SAMPLER_DESC1 *desc,
+        struct d3d12_root_signature_static_sampler_vk_desc *vk_desc)
+{
+    VkSamplerReductionModeCreateInfo *reduction = &vk_desc->reduction;
+    VkSamplerCreateInfo *sampler_desc = &vk_desc->desc;
+
+    memset(vk_desc, 0, sizeof(*vk_desc));
+    reduction->sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT;
+    reduction->reductionMode = vk_reduction_mode_from_d3d12(D3D12_DECODE_FILTER_REDUCTION(desc->Filter));
+
+    sampler_desc->sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    sampler_desc->magFilter = vk_filter_from_d3d12(D3D12_DECODE_MAG_FILTER(desc->Filter));
+    sampler_desc->minFilter = vk_filter_from_d3d12(D3D12_DECODE_MIN_FILTER(desc->Filter));
+    sampler_desc->mipmapMode = vk_mipmap_mode_from_d3d12(D3D12_DECODE_MIP_FILTER(desc->Filter));
+    sampler_desc->addressModeU = vk_address_mode_from_d3d12(desc->AddressU);
+    sampler_desc->addressModeV = vk_address_mode_from_d3d12(desc->AddressV);
+    sampler_desc->addressModeW = vk_address_mode_from_d3d12(desc->AddressW);
+    sampler_desc->mipLodBias = desc->MipLODBias;
+    sampler_desc->anisotropyEnable = D3D12_DECODE_IS_ANISOTROPIC_FILTER(desc->Filter);
+    sampler_desc->maxAnisotropy = desc->MaxAnisotropy;
+    sampler_desc->compareEnable = D3D12_DECODE_IS_COMPARISON_FILTER(desc->Filter);
+    sampler_desc->compareOp = sampler_desc->compareEnable ? vk_compare_op_from_d3d12(desc->ComparisonFunc) : 0;
+    sampler_desc->minLod = desc->MinLOD;
+    sampler_desc->maxLod = desc->MaxLOD;
+    sampler_desc->borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    sampler_desc->unnormalizedCoordinates = !!(desc->Flags & D3D12_SAMPLER_FLAG_NON_NORMALIZED_COORDINATES);
+
+    if (sampler_desc->maxAnisotropy < 1.0f)
+        sampler_desc->anisotropyEnable = VK_FALSE;
+
+    if (sampler_desc->anisotropyEnable)
+        sampler_desc->maxAnisotropy = min(16.0f, sampler_desc->maxAnisotropy);
+
+    if (d3d12_sampler_needs_border_color(desc->AddressU, desc->AddressV, desc->AddressW))
+        sampler_desc->borderColor = vk_static_border_color_from_d3d12(desc->BorderColor);
+
+    if (reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE &&
+            device->device_info.vulkan_1_2_features.samplerFilterMinmax)
+        vk_prepend_struct(sampler_desc, reduction);
+}
+
 HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
         const D3D12_STATIC_SAMPLER_DESC1 *desc, VkSampler *vk_sampler)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    VkSamplerReductionModeCreateInfoEXT reduction_desc;
-    VkSamplerCreateInfo sampler_desc;
+    struct d3d12_root_signature_static_sampler_vk_desc vk_desc;
     uint32_t num_live_objects;
     VkResult vr;
 
-    reduction_desc.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT;
-    reduction_desc.pNext = NULL;
-    reduction_desc.reductionMode = vk_reduction_mode_from_d3d12(D3D12_DECODE_FILTER_REDUCTION(desc->Filter));
-
-    sampler_desc.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_desc.pNext = NULL;
-    sampler_desc.flags = 0;
-    sampler_desc.magFilter = vk_filter_from_d3d12(D3D12_DECODE_MAG_FILTER(desc->Filter));
-    sampler_desc.minFilter = vk_filter_from_d3d12(D3D12_DECODE_MIN_FILTER(desc->Filter));
-    sampler_desc.mipmapMode = vk_mipmap_mode_from_d3d12(D3D12_DECODE_MIP_FILTER(desc->Filter));
-    sampler_desc.addressModeU = vk_address_mode_from_d3d12(desc->AddressU);
-    sampler_desc.addressModeV = vk_address_mode_from_d3d12(desc->AddressV);
-    sampler_desc.addressModeW = vk_address_mode_from_d3d12(desc->AddressW);
-    sampler_desc.mipLodBias = desc->MipLODBias;
-    sampler_desc.anisotropyEnable = D3D12_DECODE_IS_ANISOTROPIC_FILTER(desc->Filter);
-    sampler_desc.maxAnisotropy = desc->MaxAnisotropy;
-    sampler_desc.compareEnable = D3D12_DECODE_IS_COMPARISON_FILTER(desc->Filter);
-    sampler_desc.compareOp = sampler_desc.compareEnable ? vk_compare_op_from_d3d12(desc->ComparisonFunc) : 0;
-    sampler_desc.minLod = desc->MinLOD;
-    sampler_desc.maxLod = desc->MaxLOD;
-    sampler_desc.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
-    sampler_desc.unnormalizedCoordinates = !!(desc->Flags & D3D12_SAMPLER_FLAG_NON_NORMALIZED_COORDINATES);
-
-    if (sampler_desc.maxAnisotropy < 1.0f)
-        sampler_desc.anisotropyEnable = VK_FALSE;
-
-    if (sampler_desc.anisotropyEnable)
-        sampler_desc.maxAnisotropy = min(16.0f, sampler_desc.maxAnisotropy);
-
-    if (d3d12_sampler_needs_border_color(desc->AddressU, desc->AddressV, desc->AddressW))
-        sampler_desc.borderColor = vk_static_border_color_from_d3d12(desc->BorderColor);
-
-    if (reduction_desc.reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE &&
-            device->device_info.vulkan_1_2_features.samplerFilterMinmax)
-        vk_prepend_struct(&sampler_desc, &reduction_desc);
+    d3d12_setup_static_sampler_info(device, desc, &vk_desc);
 
     if (vkd3d_atomic_uint32_load_explicit(&device->sampler_map.live_object_count, vkd3d_memory_order_relaxed) <
         device->device_info.properties2.properties.limits.maxSamplerAllocationCount)
@@ -8326,7 +8333,7 @@ HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
     if (num_live_objects > device->device_info.properties2.properties.limits.maxSamplerAllocationCount)
         FIXME_ONCE("Trying to create a sampler, but device limits are exhausted. Creation may fail.\n");
 
-    if ((vr = VK_CALL(vkCreateSampler(device->vk_device, &sampler_desc, NULL, vk_sampler))) < 0)
+    if ((vr = VK_CALL(vkCreateSampler(device->vk_device, &vk_desc.desc, NULL, vk_sampler))) < 0)
         WARN("Failed to create Vulkan sampler, vr %d.\n", vr);
 
     return hresult_from_vk_result(vr);

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1261,31 +1261,66 @@ static HRESULT d3d12_root_signature_init_static_samplers(struct d3d12_root_signa
         const D3D12_ROOT_SIGNATURE_DESC2 *desc, struct vkd3d_descriptor_set_context *context,
         VkDescriptorSetLayout *vk_set_layout)
 {
-    VkDescriptorSetLayoutBinding *vk_binding_info, *vk_binding;
+    bool heap = d3d12_device_use_descriptor_heap(root_signature->device);
+    VkDescriptorSetLayoutBinding *vk_binding_info = NULL;
+    VkDescriptorSetAndBindingMappingEXT *vk_mapping;
     struct vkd3d_shader_resource_binding *binding;
+    VkDescriptorSetLayoutBinding *vk_binding;
     unsigned int i;
     HRESULT hr;
 
     if (!desc->NumStaticSamplers)
         return S_OK;
 
-    if (!(vk_binding_info = vkd3d_malloc(desc->NumStaticSamplers * sizeof(*vk_binding_info))))
+    if (!heap && !(vk_binding_info = vkd3d_malloc(desc->NumStaticSamplers * sizeof(*vk_binding_info))))
         return E_OUTOFMEMORY;
+
+    if (heap)
+    {
+        context->vk_set = VKD3D_SHADER_STATIC_SAMPLERS_VIRTUAL_DESCRIPTOR_SET;
+
+        if (!vkd3d_array_reserve((void **)&root_signature->heap.mappings, &root_signature->heap.mappings_size,
+                root_signature->heap.mappings_count + desc->NumStaticSamplers,
+                sizeof(*root_signature->heap.mappings)))
+            return E_OUTOFMEMORY;
+
+        root_signature->heap.vk_static_samplers_desc = vkd3d_calloc(
+            desc->NumStaticSamplers, sizeof(*root_signature->heap.vk_static_samplers_desc));
+        if (!root_signature->heap.vk_static_samplers_desc)
+            return E_OUTOFMEMORY;
+    }
 
     for (i = 0; i < desc->NumStaticSamplers; ++i)
     {
         const D3D12_STATIC_SAMPLER_DESC1 *s = &desc->pStaticSamplers[i];
 
-        if (FAILED(hr = vkd3d_sampler_state_create_static_sampler(&root_signature->device->sampler_state,
-                root_signature->device, s, &root_signature->static_samplers[i])))
-            goto cleanup;
+        if (heap)
+        {
+            d3d12_setup_static_sampler_info(root_signature->device, s, &root_signature->heap.vk_static_samplers_desc[i]);
 
-        vk_binding = &vk_binding_info[i];
-        vk_binding->binding = context->vk_binding;
-        vk_binding->descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
-        vk_binding->descriptorCount = 1;
-        vk_binding->stageFlags = vkd3d_vk_stage_flags_from_visibility(s->ShaderVisibility);
-        vk_binding->pImmutableSamplers = &root_signature->static_samplers[i];
+            vk_mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+            memset(vk_mapping, 0, sizeof(*vk_mapping));
+            vk_mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+            vk_mapping->descriptorSet = context->vk_set;
+            vk_mapping->firstBinding = context->vk_binding;
+            vk_mapping->bindingCount = 1;
+            vk_mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_SAMPLER_BIT_EXT;
+            vk_mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+            vk_mapping->sourceData.constantOffset.pEmbeddedSampler = &root_signature->heap.vk_static_samplers_desc[i].desc;
+        }
+        else
+        {
+            vk_binding = &vk_binding_info[i];
+            vk_binding->binding = context->vk_binding;
+            vk_binding->descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+            vk_binding->descriptorCount = 1;
+            vk_binding->stageFlags = vkd3d_vk_stage_flags_from_visibility(s->ShaderVisibility);
+            vk_binding->pImmutableSamplers = &root_signature->static_samplers[i];
+
+            if (FAILED(hr = vkd3d_sampler_state_create_static_sampler(&root_signature->device->sampler_state,
+                    root_signature->device, s, &root_signature->static_samplers[i])))
+                goto cleanup;
+        }
 
         binding = &root_signature->bindings[context->binding_index];
         binding->type = VKD3D_SHADER_DESCRIPTOR_TYPE_SAMPLER;
@@ -1303,22 +1338,25 @@ static HRESULT d3d12_root_signature_init_static_samplers(struct d3d12_root_signa
         context->vk_binding += 1;
     }
 
-    if (FAILED(hr = vkd3d_create_descriptor_set_layout(root_signature->device, 0,
-            desc->NumStaticSamplers, vk_binding_info,
-            VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
-                    VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT,
-            &root_signature->vk_sampler_descriptor_layout)))
-        goto cleanup;
+    hr = S_OK;
 
-    /* With descriptor buffers we can implicitly bind immutable samplers, and no descriptors are necessary. */
-    if (!d3d12_device_uses_descriptor_buffers(root_signature->device))
+    if (!heap)
     {
-        hr = vkd3d_sampler_state_allocate_descriptor_set(&root_signature->device->sampler_state,
-                root_signature->device, root_signature->vk_sampler_descriptor_layout,
-                &root_signature->vk_sampler_set, &root_signature->vk_sampler_pool);
+        if (FAILED(hr = vkd3d_create_descriptor_set_layout(root_signature->device, 0,
+                desc->NumStaticSamplers, vk_binding_info,
+                VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
+                        VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT,
+                vk_set_layout)))
+            goto cleanup;
+
+        /* With descriptor buffers we can implicitly bind immutable samplers, and no descriptors are necessary. */
+        if (!d3d12_device_uses_descriptor_buffers(root_signature->device))
+        {
+            hr = vkd3d_sampler_state_allocate_descriptor_set(&root_signature->device->sampler_state,
+                    root_signature->device, *vk_set_layout,
+                    &root_signature->vk_sampler_set, &root_signature->vk_sampler_pool);
+        }
     }
-    else
-        hr = S_OK;
 
 cleanup:
     vkd3d_free(vk_binding_info);

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -94,6 +94,8 @@ static void d3d12_root_signature_cleanup(struct d3d12_root_signature *root_signa
     vkd3d_free(root_signature->static_samplers_desc);
     vkd3d_free(root_signature->root_parameter_mappings);
     vkd3d_free(root_signature->root_signature_blob);
+    vkd3d_free(root_signature->heap.mappings);
+    vkd3d_free(root_signature->heap.vk_static_samplers_desc);
 }
 
 void d3d12_root_signature_inc_ref(struct d3d12_root_signature *root_signature)
@@ -1399,6 +1401,145 @@ static void d3d12_root_signature_update_bind_point_layout(struct d3d12_bind_poin
         layout->push_constant_range = *push_range;
 }
 
+static HRESULT d3d12_root_signature_init_global_mappings(struct d3d12_root_signature *root_signature,
+        const struct d3d12_root_signature_info *info)
+{
+    VkDescriptorSetAndBindingMappingEXT *mapping;
+
+    if (!vkd3d_array_reserve((void**)&root_signature->heap.mappings, &root_signature->heap.mappings_size,
+            root_signature->heap.mappings_count + 8, sizeof(*root_signature->heap.mappings)))
+        return E_OUTOFMEMORY;
+
+    /* SM 6.6 image heap mapping. */
+    {
+        mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+        memset(mapping, 0, sizeof(*mapping));
+        mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+        mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_SAMPLED_IMAGE_BIT_EXT |
+                VK_SPIRV_RESOURCE_TYPE_READ_ONLY_IMAGE_BIT_EXT |
+                VK_SPIRV_RESOURCE_TYPE_READ_WRITE_IMAGE_BIT_EXT;
+        mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+        mapping->descriptorSet = VKD3D_SHADER_GLOBAL_HEAP_VIRTUAL_DESCRIPTOR_SET;
+        mapping->firstBinding = 0;
+        mapping->bindingCount = 1;
+        mapping->sourceData.constantOffset.heapOffset = root_signature->device->bindless_state.heap.redzone_size;
+        mapping->sourceData.constantOffset.heapArrayStride =
+                root_signature->device->bindless_state.cbv_srv_uav_size;
+    }
+
+    /* SM 6.6 buffer heap mapping */
+    {
+        mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+        memset(mapping, 0, sizeof(*mapping));
+        mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+        mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT |
+                VK_SPIRV_RESOURCE_TYPE_READ_ONLY_STORAGE_BUFFER_BIT_EXT |
+                VK_SPIRV_RESOURCE_TYPE_READ_WRITE_STORAGE_BUFFER_BIT_EXT;
+        if (d3d12_device_supports_ray_tracing_tier_1_0(root_signature->device))
+            mapping->resourceMask |= VK_SPIRV_RESOURCE_TYPE_ACCELERATION_STRUCTURE_BIT_EXT;
+        mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+        mapping->descriptorSet = VKD3D_SHADER_GLOBAL_HEAP_VIRTUAL_DESCRIPTOR_SET;
+        mapping->firstBinding = 0;
+        mapping->bindingCount = 1;
+        mapping->sourceData.constantOffset.heapOffset =
+                root_signature->device->bindless_state.heap.redzone_size +
+                root_signature->device->bindless_state.packed_raw_buffer_offset;
+        mapping->sourceData.constantOffset.heapArrayStride =
+                root_signature->device->bindless_state.cbv_srv_uav_size;
+    }
+
+    /* SM 6.6 sampler heap mapping */
+    {
+        mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+        memset(mapping, 0, sizeof(*mapping));
+        mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+        mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_SAMPLER_BIT_EXT;
+        mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+        mapping->descriptorSet = VKD3D_SHADER_GLOBAL_HEAP_VIRTUAL_DESCRIPTOR_SET;
+        mapping->firstBinding = 0;
+        mapping->bindingCount = 1;
+        mapping->sourceData.constantOffset.heapOffset = 0;
+        mapping->sourceData.constantOffset.heapArrayStride = root_signature->device->bindless_state.sampler_size;
+    }
+
+    /* Global root parameter mapping when read as a UBO. */
+    {
+        mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+        memset(mapping, 0, sizeof(*mapping));
+        mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+        mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT;
+        mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT;
+        mapping->descriptorSet = VKD3D_SHADER_ROOT_CONSTANTS_VIRTUAL_DESCRIPTOR_SET;
+        mapping->firstBinding = 0;
+        mapping->bindingCount = 1;
+        mapping->sourceData.pushDataOffset = 0;
+    }
+
+    /* Global mapping when reading heap meta descriptors. */
+    {
+        mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+        memset(mapping, 0, sizeof(*mapping));
+        mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+        mapping->resourceMask =
+                VK_SPIRV_RESOURCE_TYPE_READ_ONLY_STORAGE_BUFFER_BIT_EXT |
+                VK_SPIRV_RESOURCE_TYPE_READ_WRITE_STORAGE_BUFFER_BIT_EXT;
+        mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+        mapping->descriptorSet = VKD3D_SHADER_GLOBAL_HEAP_VIRTUAL_DESCRIPTOR_SET;
+        mapping->firstBinding = VKD3D_SHADER_GLOBAL_HEAP_BINDING_AUX_BINDINGS;
+        mapping->bindingCount = VKD3D_SHADER_GLOBAL_HEAP_BINDING_AUX_BINDINGS_COUNT;
+        mapping->sourceData.constantOffset.heapOffset = 0;
+        mapping->sourceData.constantOffset.heapArrayStride =
+                align(root_signature->device->device_info.descriptor_heap_properties.bufferDescriptorSize,
+                    root_signature->device->device_info.descriptor_heap_properties.bufferDescriptorAlignment);
+    }
+
+    root_signature->heap.redzone_style = VKD3D_ROOT_SIGNATURE_HEAP_REDZONE_STYLE_NONE;
+
+    if (root_signature->device->bindless_state.heap.redzone_size)
+    {
+        /* We need to access the heap somehow in shaders. This gets more annoying than it should be ... */
+        if (info->cost <= 60)
+        {
+            root_signature->heap.redzone_style = VKD3D_ROOT_SIGNATURE_HEAP_REDZONE_STYLE_INLINE;
+            root_signature->heap.redzone_inline_heap_offset =
+                    align(info->cost * sizeof(uint32_t), sizeof(VkDeviceAddress));
+
+            /* We can store the data inline. The shaders are expected to have a plain UBO
+             * of (set = VIRTUAL_DESCRIPTOR_SET, binding = B) uniform UBO { uint size; } or VkDeviceAddress.
+             * This is much simpler than rejigging a ton of code in dxil-spirv
+             * to support fetching them from root constant block.
+             */
+            mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+            memset(mapping, 0, sizeof(*mapping));
+            mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+            mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT;
+            mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT;
+            mapping->descriptorSet = VKD3D_SHADER_GLOBAL_HEAP_VIRTUAL_DESCRIPTOR_SET;
+            mapping->firstBinding = VKD3D_SHADER_RAW_VIEW_GLOBAL_HEAP_BINDING;
+            mapping->bindingCount = 1;
+            mapping->sourceData.pushDataOffset = root_signature->heap.redzone_inline_heap_offset;
+
+            mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+            memset(mapping, 0, sizeof(*mapping));
+            mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+            mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT;
+            mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT;
+            mapping->descriptorSet = VKD3D_SHADER_GLOBAL_HEAP_VIRTUAL_DESCRIPTOR_SET;
+            mapping->firstBinding = VKD3D_SHADER_GLOBAL_HEAP_SIZE_BINDING;
+            mapping->bindingCount = 1;
+            mapping->sourceData.pushDataOffset = root_signature->heap.redzone_inline_heap_offset + sizeof(VkDeviceAddress);
+        }
+        else
+        {
+            root_signature->heap.redzone_style = VKD3D_ROOT_SIGNATURE_HEAP_REDZONE_STYLE_DESCRIPTOR;
+            /* Refer to AUX descriptors. Can use a single SSBO here which covers both size + payloads.
+             * Slower, but it will always work. */
+        }
+    }
+
+    return S_OK;
+}
+
 static HRESULT d3d12_root_signature_init_global(struct d3d12_root_signature *root_signature,
         struct d3d12_device *device, const D3D12_ROOT_SIGNATURE_DESC2 *desc)
 {
@@ -1514,63 +1655,71 @@ static HRESULT d3d12_root_signature_init_global(struct d3d12_root_signature *roo
     if (FAILED(hr = d3d12_root_signature_init_root_descriptor_tables(root_signature, desc, &info, &context)))
         return hr;
 
-    /* Select push UBO style or push constants on a per-pipeline type basis. */
-    d3d12_root_signature_update_bind_point_layout(&root_signature->graphics,
-            &push_constant_range, &context, &info);
-    d3d12_root_signature_update_bind_point_layout(&root_signature->mesh,
-            &push_constant_range, &context, &info);
-    d3d12_root_signature_update_bind_point_layout(&root_signature->compute,
-            &push_constant_range, &context, &info);
-    d3d12_root_signature_update_bind_point_layout(&root_signature->raygen,
-            &push_constant_range, &context, &info);
-
-    /* If we need to use restricted entry_points in vkCmdPushConstants,
-     * we are unfortunately required to do it like this
-     * since stageFlags in vkCmdPushConstants must cover at least all entry_points in the layout.
-     *
-     * We can pick the appropriate layout to use in PSO creation.
-     * In set_root_signature we can bind the appropriate layout as well.
-     *
-     * For graphics we can generally rely on visibility mask, but not so for compute and raygen,
-     * since they use ALL visibility. */
-
-    if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
-            device, root_signature->graphics.num_set_layouts, root_signature->set_layouts,
-            &root_signature->graphics.push_constant_range,
-            VK_SHADER_STAGE_ALL_GRAPHICS, &root_signature->graphics)))
-        return hr;
-
-    if (device->device_info.mesh_shader_features.meshShader && device->device_info.mesh_shader_features.taskShader)
+    if (d3d12_device_use_descriptor_heap(device))
     {
-        mesh_shader_stages = VK_SHADER_STAGE_MESH_BIT_EXT |
-                VK_SHADER_STAGE_TASK_BIT_EXT |
-                VK_SHADER_STAGE_FRAGMENT_BIT;
-
-        if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
-                device, root_signature->mesh.num_set_layouts, root_signature->set_layouts,
-                &root_signature->mesh.push_constant_range,
-                mesh_shader_stages, &root_signature->mesh)))
+        if (FAILED(hr = d3d12_root_signature_init_global_mappings(root_signature, &info)))
             return hr;
     }
-
-    if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
-            device, root_signature->compute.num_set_layouts, root_signature->set_layouts,
-            &root_signature->compute.push_constant_range,
-            VK_SHADER_STAGE_COMPUTE_BIT, &root_signature->compute)))
-        return hr;
-
-    if (d3d12_device_supports_ray_tracing_tier_1_0(device))
+    else
     {
+        /* Select push UBO style or push constants on a per-pipeline type basis. */
+        d3d12_root_signature_update_bind_point_layout(&root_signature->graphics,
+                &push_constant_range, &context, &info);
+        d3d12_root_signature_update_bind_point_layout(&root_signature->mesh,
+                &push_constant_range, &context, &info);
+        d3d12_root_signature_update_bind_point_layout(&root_signature->compute,
+                &push_constant_range, &context, &info);
+        d3d12_root_signature_update_bind_point_layout(&root_signature->raygen,
+                &push_constant_range, &context, &info);
+
+        /* If we need to use restricted entry_points in vkCmdPushConstants,
+         * we are unfortunately required to do it like this
+         * since stageFlags in vkCmdPushConstants must cover at least all entry_points in the layout.
+         *
+         * We can pick the appropriate layout to use in PSO creation.
+         * In set_root_signature we can bind the appropriate layout as well.
+         *
+         * For graphics we can generally rely on visibility mask, but not so for compute and raygen,
+         * since they use ALL visibility. */
+
         if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
-                device, root_signature->raygen.num_set_layouts, root_signature->set_layouts,
-                &root_signature->raygen.push_constant_range,
-                VK_SHADER_STAGE_RAYGEN_BIT_KHR |
-                VK_SHADER_STAGE_MISS_BIT_KHR |
-                VK_SHADER_STAGE_INTERSECTION_BIT_KHR |
-                VK_SHADER_STAGE_CALLABLE_BIT_KHR |
-                VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
-                VK_SHADER_STAGE_ANY_HIT_BIT_KHR, &root_signature->raygen)))
+                device, root_signature->graphics.num_set_layouts, root_signature->set_layouts,
+                &root_signature->graphics.push_constant_range,
+                VK_SHADER_STAGE_ALL_GRAPHICS, &root_signature->graphics)))
             return hr;
+
+        if (device->device_info.mesh_shader_features.meshShader && device->device_info.mesh_shader_features.taskShader)
+        {
+            mesh_shader_stages = VK_SHADER_STAGE_MESH_BIT_EXT |
+                    VK_SHADER_STAGE_TASK_BIT_EXT |
+                    VK_SHADER_STAGE_FRAGMENT_BIT;
+
+            if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
+                    device, root_signature->mesh.num_set_layouts, root_signature->set_layouts,
+                    &root_signature->mesh.push_constant_range,
+                    mesh_shader_stages, &root_signature->mesh)))
+                return hr;
+        }
+
+        if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
+                device, root_signature->compute.num_set_layouts, root_signature->set_layouts,
+                &root_signature->compute.push_constant_range,
+                VK_SHADER_STAGE_COMPUTE_BIT, &root_signature->compute)))
+            return hr;
+
+        if (d3d12_device_supports_ray_tracing_tier_1_0(device))
+        {
+            if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
+                    device, root_signature->raygen.num_set_layouts, root_signature->set_layouts,
+                    &root_signature->raygen.push_constant_range,
+                    VK_SHADER_STAGE_RAYGEN_BIT_KHR |
+                    VK_SHADER_STAGE_MISS_BIT_KHR |
+                    VK_SHADER_STAGE_INTERSECTION_BIT_KHR |
+                    VK_SHADER_STAGE_CALLABLE_BIT_KHR |
+                    VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
+                    VK_SHADER_STAGE_ANY_HIT_BIT_KHR, &root_signature->raygen)))
+                return hr;
+        }
     }
 
     return S_OK;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1478,6 +1478,17 @@ void d3d12_desc_create_uav_embedded(vkd3d_cpu_descriptor_va_t descriptor, struct
 void d3d12_desc_create_sampler_embedded(vkd3d_cpu_descriptor_va_t sampler,
         struct d3d12_device *device, const D3D12_SAMPLER_DESC2 *desc);
 
+void d3d12_desc_create_cbv_heap(vkd3d_cpu_descriptor_va_t descriptor,
+        struct d3d12_device *device, const D3D12_CONSTANT_BUFFER_VIEW_DESC *desc);
+void d3d12_desc_create_srv_heap(vkd3d_cpu_descriptor_va_t descriptor,
+        struct d3d12_device *device, struct d3d12_resource *resource,
+        const D3D12_SHADER_RESOURCE_VIEW_DESC *desc);
+void d3d12_desc_create_uav_heap(vkd3d_cpu_descriptor_va_t descriptor, struct d3d12_device *device,
+        struct d3d12_resource *resource, struct d3d12_resource *counter_resource,
+        const D3D12_UNORDERED_ACCESS_VIEW_DESC *desc);
+void d3d12_desc_create_sampler_heap(vkd3d_cpu_descriptor_va_t sampler,
+        struct d3d12_device *device, const D3D12_SAMPLER_DESC2 *desc);
+
 bool vkd3d_create_vk_buffer_view(struct d3d12_device *device,
         VkBuffer vk_buffer, const struct vkd3d_format *format,
         VkDeviceSize offset, VkDeviceSize range, VkBufferUsageFlags2 usage, VkBufferView *vk_view);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1946,6 +1946,13 @@ struct vkd3d_descriptor_hoist_info
     unsigned int num_desc;
 };
 
+enum vkd3d_root_signature_heap_redzone_style
+{
+    VKD3D_ROOT_SIGNATURE_HEAP_REDZONE_STYLE_NONE = 0,
+    VKD3D_ROOT_SIGNATURE_HEAP_REDZONE_STYLE_INLINE,
+    VKD3D_ROOT_SIGNATURE_HEAP_REDZONE_STYLE_DESCRIPTOR
+};
+
 struct d3d12_root_signature
 {
     ID3D12RootSignature ID3D12RootSignature_iface;
@@ -2005,6 +2012,19 @@ struct d3d12_root_signature
     unsigned int static_sampler_count;
     D3D12_STATIC_SAMPLER_DESC1 *static_samplers_desc;
     VkSampler *static_samplers;
+
+    struct
+    {
+        VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info;
+        VkDescriptorSetAndBindingMappingEXT *mappings;
+        size_t mappings_size;
+        size_t mappings_count;
+
+        struct d3d12_root_signature_static_sampler_vk_desc *vk_static_samplers_desc;
+        enum vkd3d_root_signature_heap_redzone_style redzone_style;
+        /* Ideal: Push descriptor heap VA + descriptor heap size straight into PushData. */
+        uint32_t redzone_inline_heap_offset;
+    } heap;
 
     struct vkd3d_descriptor_hoist_info hoist_info;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1497,6 +1497,16 @@ bool vkd3d_create_raw_buffer_view(struct d3d12_device *device,
 HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
         const D3D12_STATIC_SAMPLER_DESC1 *desc, VkSampler *vk_sampler);
 
+struct d3d12_root_signature_static_sampler_vk_desc
+{
+    VkSamplerCreateInfo desc;
+    VkSamplerReductionModeCreateInfoEXT reduction;
+};
+
+void d3d12_setup_static_sampler_info(struct d3d12_device *device,
+        const D3D12_STATIC_SAMPLER_DESC1 *desc,
+        struct d3d12_root_signature_static_sampler_vk_desc *vk_desc);
+
 #define D3D12_DESC_ALIGNMENT 32
 struct d3d12_rtv_desc
 {


### PR DESCRIPTION
First, sets up the optimized vtables for copying descriptors around. Similar idea to the things we have already, except expanded for more cases. (C++ templates sure would help here ...).

Afterwards, the process to implement ID3D12RootSignature is begun with the simpler parts to warm up for Phase 6.

The root signature implementation involves building up a DescriptorSetAndBinding mapping create info struct rather than creating a pipeline layout which is the biggest win of descriptor heap from a usability PoV.

The heap redzone layout is also introduced here.