### PR TITLE
Descriptor heap - Phase 6

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -1224,7 +1224,9 @@ enum
     VKD3D_SHADER_LOCAL_ROOT_CONSTANTS_VIRTUAL_DESCRIPTOR_SET = 105,
     VKD3D_SHADER_LOCAL_ROOT_DESCRIPTORS_VIRTUAL_DESCRIPTOR_SET = 106,
 
-    VKD3D_SHADER_LOCAL_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE = 200, /* Same as tables, but for shader records. */
+    /* Same as tables, but for shader records. Maximum number of these would be 4096 / sizeof(u64) = 512,
+     * so the numbering scheme is sound. */
+    VKD3D_SHADER_LOCAL_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE = 200,
 
     /* Bindings within GLOBAL_HEAP set */
     VKD3D_SHADER_GLOBAL_HEAP_BINDING = 0,

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1029,13 +1029,17 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
         const VkPushConstantRange *push_constant_range, struct vkd3d_descriptor_set_context *context,
         VkDescriptorSetLayout *vk_set_layout)
 {
+    bool local_root_signature = !!(desc->Flags & D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE);
+    bool heap = d3d12_device_use_descriptor_heap(root_signature->device);
     VkDescriptorSetLayoutBinding *vk_binding, *vk_binding_info = NULL;
+    VkDescriptorSetAndBindingMappingEXT *vk_mapping;
     struct vkd3d_descriptor_hoist_desc *hoist_desc;
     struct vkd3d_shader_resource_binding *binding;
     struct vkd3d_shader_root_parameter *param;
     uint32_t raw_va_root_descriptor_count = 0;
     unsigned int hoisted_parameter_index;
     const D3D12_DESCRIPTOR_RANGE1 *range;
+    uint32_t local_root_size = 0;
     unsigned int i, j, k;
     HRESULT hr = S_OK;
     uint32_t or_flags;
@@ -1056,6 +1060,13 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
         return S_OK;
     }
 
+    if (heap)
+    {
+        context->vk_set = local_root_signature
+                ? VKD3D_SHADER_LOCAL_ROOT_DESCRIPTORS_VIRTUAL_DESCRIPTOR_SET
+                : VKD3D_SHADER_ROOT_DESCRIPTORS_VIRTUAL_DESCRIPTOR_SET;
+    }
+
     hoisted_parameter_index = desc->NumParameters;
 
     for (i = 0, j = 0; i < desc->NumParameters; ++i)
@@ -1063,8 +1074,7 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
         const D3D12_ROOT_PARAMETER1 *p = &desc->pParameters[i];
         bool raw_va;
 
-        if (!(desc->Flags & D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE) &&
-                p->ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
+        if (!local_root_signature && p->ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
         {
             unsigned int range_descriptor_offset = 0;
             for (k = 0; k < p->DescriptorTable.NumDescriptorRanges && info->hoist_descriptor_count; k++)
@@ -1119,8 +1129,15 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
         if (p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_CBV
                 && p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_SRV
                 && p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_UAV)
+        {
+            if (p->ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
+                local_root_size = align(local_root_size + sizeof(VkDeviceAddress), sizeof(VkDeviceAddress));
+            else
+                local_root_size += p->Constants.Num32BitValues * sizeof(uint32_t);
             continue;
+        }
 
+        local_root_size = align(local_root_size, sizeof(VkDeviceAddress));
         raw_va = d3d12_root_signature_parameter_is_raw_va(root_signature, p->ParameterType);
 
         if (!raw_va)
@@ -1155,6 +1172,32 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
         else if (vk_binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
             binding->flags |= VKD3D_SHADER_BINDING_FLAG_RAW_SSBO;
 
+        if (heap)
+        {
+            vkd3d_array_reserve((void **)&root_signature->heap.mappings, &root_signature->heap.mappings_size,
+                    root_signature->heap.mappings_count + 1,
+                    sizeof(*root_signature->heap.mappings));
+
+            vk_mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+            memset(vk_mapping, 0, sizeof(*vk_mapping));
+            vk_mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+            vk_mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_ALL_EXT;
+            vk_mapping->descriptorSet = context->vk_set;
+            vk_mapping->firstBinding = raw_va_root_descriptor_count;
+            vk_mapping->bindingCount = 1;
+
+            if (local_root_signature)
+            {
+                vk_mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_ADDRESS_EXT;
+                vk_mapping->sourceData.shaderRecordAddressOffset = local_root_size;
+            }
+            else
+            {
+                vk_mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT;
+                vk_mapping->sourceData.pushAddressOffset = raw_va_root_descriptor_count * sizeof(VkDeviceAddress);
+            }
+        }
+
         param = &root_signature->parameters[i];
         param->parameter_type = p->ParameterType;
         param->descriptor.binding = binding;
@@ -1166,6 +1209,8 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
             raw_va_root_descriptor_count += 1;
         else
             context->vk_binding += 1;
+
+        local_root_size += sizeof(VkDeviceAddress);
     }
 
     if (or_flags & VKD3D_ROOT_SIGNATURE_USE_PUSH_CONSTANT_UNIFORM_BLOCK)

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -416,10 +416,18 @@ static bool d3d12_descriptor_range_can_hoist_cbv_descriptor(
 }
 
 static void d3d12_root_signature_info_count_srv_uav_table(struct d3d12_root_signature_info *info,
-        struct d3d12_device *device)
+        struct d3d12_device *device, D3D12_DESCRIPTOR_RANGE_TYPE range_type)
 {
-    /* separate image + buffer descriptors + aux buffer descriptor. */
-    info->binding_count += 3;
+    /* Separate image + buffer descriptors + (most likely) aux buffer descriptor.
+     * Needs to match d3d12_root_signature_init_srv_uav_binding. */
+    bool can_skip_rtas_binding = d3d12_device_use_descriptor_heap(device) && range_type == D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    info->binding_count += 2;
+
+    /* For UAV we always need an extra binding for the UAV counter.
+     * This UAV counter is either a texel buffer or a raw VA binding.
+     * For SRV we can map to RTAS. */
+    if (!can_skip_rtas_binding)
+        info->binding_count += 1;
 
     if (device->bindless_state.flags & VKD3D_BINDLESS_RAW_SSBO)
         info->binding_count += 1;
@@ -447,7 +455,7 @@ static HRESULT d3d12_root_signature_info_count_descriptors(struct d3d12_root_sig
     {
         case D3D12_DESCRIPTOR_RANGE_TYPE_SRV:
         case D3D12_DESCRIPTOR_RANGE_TYPE_UAV:
-            d3d12_root_signature_info_count_srv_uav_table(info, device);
+            d3d12_root_signature_info_count_srv_uav_table(info, device, range->RangeType);
             break;
         case D3D12_DESCRIPTOR_RANGE_TYPE_CBV:
             if (!(desc->Flags & D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE) &&
@@ -494,8 +502,8 @@ static HRESULT d3d12_root_signature_info_from_desc(struct d3d12_root_signature_i
     if (d3d12_root_signature_may_require_global_heap_binding(device) ||
             (desc->Flags & D3D12_ROOT_SIGNATURE_FLAG_CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED))
     {
-        d3d12_root_signature_info_count_srv_uav_table(info, device);
-        d3d12_root_signature_info_count_srv_uav_table(info, device);
+        d3d12_root_signature_info_count_srv_uav_table(info, device, D3D12_DESCRIPTOR_RANGE_TYPE_SRV);
+        d3d12_root_signature_info_count_srv_uav_table(info, device, D3D12_DESCRIPTOR_RANGE_TYPE_UAV);
         d3d12_root_signature_info_count_cbv_table(info);
     }
 
@@ -763,6 +771,8 @@ static void d3d12_root_signature_init_srv_uav_binding(struct d3d12_root_signatur
         struct vkd3d_shader_resource_binding *binding,
         struct vkd3d_shader_resource_binding *out_bindings_base, uint32_t *out_index)
 {
+    /* Always true if not using heap */
+    bool uses_typed_uav_counter = root_signature->device->bindless_state.heap.uav_counter_embedded_offset == 0;
     struct vkd3d_bindless_state *bindless_state = &root_signature->device->bindless_state;
     enum vkd3d_bindless_set_flag range_flag;
 
@@ -770,7 +780,7 @@ static void d3d12_root_signature_init_srv_uav_binding(struct d3d12_root_signatur
     binding->flags = VKD3D_SHADER_BINDING_FLAG_BINDLESS | VKD3D_SHADER_BINDING_FLAG_AUX_BUFFER;
 
     if (d3d12_device_use_embedded_mutable_descriptors(root_signature->device) &&
-            range_type == D3D12_DESCRIPTOR_RANGE_TYPE_UAV)
+            uses_typed_uav_counter && range_type == D3D12_DESCRIPTOR_RANGE_TYPE_UAV)
     {
         /* If we're relying on embedded mutable descriptors we have to be a bit careful with aliasing raw VAs.
          * With application bugs in play, it's somewhat easy to end up aliasing a true texel buffer
@@ -783,9 +793,10 @@ static void d3d12_root_signature_init_srv_uav_binding(struct d3d12_root_signatur
         if (vkd3d_bindless_state_find_binding(bindless_state, range_flag | VKD3D_BINDLESS_SET_BUFFER, &binding->binding))
             out_bindings_base[(*out_index)++] = *binding;
     }
-    else
+    else if (range_type == D3D12_DESCRIPTOR_RANGE_TYPE_UAV || !d3d12_device_use_descriptor_heap(root_signature->device))
     {
-        /* Use raw VA for both RTAS and UAV counters. */
+        /* Use raw VA for both RTAS and UAV counters.
+         * On heap, we use proper descriptors for RTAS, so skip this path for SRV. We'll pick up the normal buffer bindings. */
         binding->flags |= VKD3D_SHADER_BINDING_FLAG_RAW_VA;
         binding->binding = root_signature->raw_va_aux_buffer_binding;
         out_bindings_base[(*out_index)++] = *binding;
@@ -891,6 +902,9 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
 
         table->binding_count = 0;
         table->first_binding = &root_signature->bindings[context->binding_index];
+
+        /* TODO: Add mappings for proper tables. For now, keep manual lowering.
+         * The lowering path is necessary for descriptor heap robustness down the line. */
 
         for (j = 0; j < range_count; ++j)
         {
@@ -8038,6 +8052,18 @@ bool vkd3d_bindless_state_find_binding(const struct vkd3d_bindless_state *bindle
         uint32_t flags, struct vkd3d_shader_descriptor_binding *binding)
 {
     unsigned int i;
+
+    if (bindless_state->flags & VKD3D_BINDLESS_HEAP)
+    {
+        /* Mapping struct takes care of typing.
+         * TODO: For QA buffers, we'll have to adjust the binding. */
+        binding->set = VKD3D_SHADER_GLOBAL_HEAP_VIRTUAL_DESCRIPTOR_SET;
+        if (flags & VKD3D_BINDLESS_SET_EXTRA_RAW_VA_AUX_BUFFER)
+            binding->binding = VKD3D_SHADER_RAW_VIEW_GLOBAL_HEAP_BINDING;
+        else
+            binding->binding = VKD3D_SHADER_GLOBAL_HEAP_BINDING;
+        return true;
+    }
 
     for (i = 0; i < bindless_state->legacy.set_count; i++)
     {

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -679,6 +679,9 @@ static HRESULT d3d12_root_signature_init_push_constants(struct d3d12_root_signat
         if (p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS)
             continue;
 
+        /* Even heap path keeps the lowering to uints. The way CBVs work in DXIL won't interact too well
+         * with robustness most likely. */
+
         d3d12_root_signature_add_root_parameter_mapping(root_signature, i, push_constant_range->size);
         root_signature->root_constant_mask |= 1ull << i;
 
@@ -699,23 +702,20 @@ static HRESULT d3d12_root_signature_init_push_constants(struct d3d12_root_signat
     }
 
     /* Append one 32-bit push constant for each descriptor table offset */
-    if (root_signature->device->bindless_state.flags)
+    root_signature->descriptor_table_offset = push_constant_range->size;
+
+    for (i = 0; i < desc->NumParameters; ++i)
     {
-        root_signature->descriptor_table_offset = push_constant_range->size;
+        const D3D12_ROOT_PARAMETER1 *p = &desc->pParameters[i];
 
-        for (i = 0; i < desc->NumParameters; ++i)
-        {
-            const D3D12_ROOT_PARAMETER1 *p = &desc->pParameters[i];
+        if (p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
+            continue;
 
-            if (p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
-                continue;
+        d3d12_root_signature_add_root_parameter_mapping(root_signature, i, push_constant_range->size);
+        root_signature->descriptor_table_count += 1;
 
-            d3d12_root_signature_add_root_parameter_mapping(root_signature, i, push_constant_range->size);
-            root_signature->descriptor_table_count += 1;
-
-            push_constant_range->stageFlags |= vkd3d_vk_stage_flags_from_visibility(p->ShaderVisibility);
-            push_constant_range->size += sizeof(uint32_t);
-        }
+        push_constant_range->stageFlags |= vkd3d_vk_stage_flags_from_visibility(p->ShaderVisibility);
+        push_constant_range->size += sizeof(uint32_t);
     }
 
     return S_OK;
@@ -1663,9 +1663,11 @@ static HRESULT d3d12_root_signature_init_global(struct d3d12_root_signature *roo
             &push_constant_range)))
         return hr;
 
-    /* If we cannot contain the push constants, fall back to push UBO everywhere. */
-    if (push_constant_range.size > vk_device_properties->limits.maxPushConstantsSize)
-        d3d12_root_signature_add_common_flags(root_signature, VKD3D_ROOT_SIGNATURE_USE_PUSH_CONSTANT_UNIFORM_BLOCK);
+    /* If we cannot contain the push constants, fall back to push UBO everywhere.
+     * This is a nonissue on heap, since it's pushDataSize and it's guaranteed to be at least 256. */
+    if (!d3d12_device_use_descriptor_heap(device))
+        if (push_constant_range.size > vk_device_properties->limits.maxPushConstantsSize)
+            d3d12_root_signature_add_common_flags(root_signature, VKD3D_ROOT_SIGNATURE_USE_PUSH_CONSTANT_UNIFORM_BLOCK);
 
     d3d12_root_signature_init_extra_bindings(root_signature, &info);
 


### PR DESCRIPTION
Completes the initial bringup of root signature model.

Root constants still use root parameter lowering. The main reason for this is that DXIL likes to load full uvec4s even if onle a few uints are actually used (and valid to use) and we have no good way to ensure robustness in the usual CBV path in dxil-spirv. It's possible to rewrite a few things in dxil-spirv to make it work by unrolling, but that's yet another code path that has to be tested, etc, and it's not really worth it given we have to support the legacy model for years to come.

Root descriptors use the new proper interface (the biggest win). The strategy for root SSBO on drivers with large SSBO alignment will be that dxil.c can replace the virtual root descriptor set back to old school BDA on demand, since we have the binding, which translates directly to a "root descriptor index" in the dxil.c interface API.

Root table mappings use the legacy model for now, except they map to the global virtual set instead of the more "physical" sets which we set up in descriptor buffer. The plan is for a future commit in the series to add extra mappings for direct table mappings that dxil.c can opt into when the explicit lowering is not needed. E.g. descriptor heap robustness will force the existing explicit lowering since we need to compute the final heap index in the shader. In the vastly common case, we will be able to translate the old school model into a proper set/binding without descriptor indexing though.