### PR TITLE
Descriptor heap - Phase 7

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2513,7 +2513,7 @@ static void d3d12_command_list_begin_new_sequence(struct d3d12_command_list *lis
 
     d3d12_command_list_invalidate_all_state(list);
     /* Extra special consideration since we're starting a fresh command buffer. */
-    list->descriptor_heap.buffers.heap_dirty = true;
+    list->descriptor_heap.buffers.global_heap_dirty = true;
     d3d12_command_list_debug_mark_label(list, "Split", 0.0f, 0.0f, 0.0f, 1.0f);
 }
 
@@ -7100,12 +7100,19 @@ bool d3d12_command_list_reset_query(struct d3d12_command_list *list,
 
 static void d3d12_command_list_init_default_descriptor_buffers(struct d3d12_command_list *list)
 {
-    if (d3d12_device_uses_descriptor_buffers(list->device))
+    if (d3d12_device_use_descriptor_heap(list->device))
     {
-        list->descriptor_heap.buffers.heap_va_resource = list->device->global_descriptor_buffer.resource.va;
-        list->descriptor_heap.buffers.heap_va_sampler = list->device->global_descriptor_buffer.sampler.va;
-        list->descriptor_heap.buffers.vk_buffer_resource = list->device->global_descriptor_buffer.resource.vk_buffer;
-        list->descriptor_heap.buffers.heap_dirty = true;
+        /* By default, don't bind descriptor heap unless it's actually needed.
+         * Drivers are able to inherit across command buffer boundary if they have a design
+         * that cares about it. */
+        list->descriptor_heap.buffers.global_heap_dirty = false;
+    }
+    else if (d3d12_device_uses_descriptor_buffers(list->device))
+    {
+        list->descriptor_heap.buffers.db.heap_va_resource = list->device->global_descriptor_buffer.resource.va;
+        list->descriptor_heap.buffers.db.heap_va_sampler = list->device->global_descriptor_buffer.sampler.va;
+        list->descriptor_heap.buffers.db.vk_buffer_resource = list->device->global_descriptor_buffer.resource.vk_buffer;
+        list->descriptor_heap.buffers.global_heap_dirty = true;
     }
 }
 
@@ -7750,37 +7757,69 @@ static void vk_write_descriptor_set_from_scratch_push_ubo(VkWriteDescriptorSet *
 }
 
 /* This is a big stall on some GPUs so need to track this separately. */
-void d3d12_command_list_update_descriptor_buffers(struct d3d12_command_list *list)
+void d3d12_command_list_update_global_descriptor_heap(struct d3d12_command_list *list)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkDescriptorBufferBindingPushDescriptorBufferHandleEXT buffer_handle;
     VkDescriptorBufferBindingInfoEXT global_buffers[2];
+    VkBindHeapInfoEXT resource_heap_info;
 
-    if (d3d12_device_uses_descriptor_buffers(list->device) &&
-            list->descriptor_heap.buffers.heap_dirty)
+    /* global_heap_dirty is part of a union and only okay to touch if we use DB or heaps. */
+
+    if (d3d12_device_use_descriptor_heap(list->device) &&
+            list->descriptor_heap.buffers.global_heap_dirty)
+    {
+        memset(&resource_heap_info, 0, sizeof(resource_heap_info));
+        resource_heap_info.sType = VK_STRUCTURE_TYPE_BIND_HEAP_INFO_EXT;
+
+        /* Do not bind dummy heap. */
+        if (list->descriptor_heap.buffers.resource.va)
+        {
+            resource_heap_info.heapRange.address = list->descriptor_heap.buffers.resource.va;
+            resource_heap_info.heapRange.size = list->descriptor_heap.buffers.resource.size;
+            resource_heap_info.reservedRangeOffset = list->descriptor_heap.buffers.resource.reserved_offset;
+            resource_heap_info.reservedRangeSize =
+                    list->device->device_info.descriptor_heap_properties.minResourceHeapReservedRange;
+            VK_CALL(vkCmdBindResourceHeapEXT(list->cmd.vk_command_buffer, &resource_heap_info));
+        }
+
+        if (list->descriptor_heap.buffers.sampler.va)
+        {
+            resource_heap_info.heapRange.address = list->descriptor_heap.buffers.sampler.va;
+            resource_heap_info.heapRange.size = list->descriptor_heap.buffers.sampler.size;
+            resource_heap_info.reservedRangeOffset = list->descriptor_heap.buffers.sampler.reserved_offset;
+            resource_heap_info.reservedRangeSize =
+                    list->device->device_info.descriptor_heap_properties.minSamplerHeapReservedRangeWithEmbedded;
+            VK_CALL(vkCmdBindSamplerHeapEXT(list->cmd.vk_command_buffer, &resource_heap_info));
+        }
+
+        list->descriptor_heap.buffers.global_heap_dirty = false;
+    }
+    else if (d3d12_device_uses_descriptor_buffers(list->device) &&
+            list->descriptor_heap.buffers.global_heap_dirty)
     {
         global_buffers[0].sType = VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT;
         global_buffers[0].pNext = NULL;
         global_buffers[0].usage = list->device->global_descriptor_buffer.resource.usage;
-        global_buffers[0].address = list->descriptor_heap.buffers.heap_va_resource;
+        global_buffers[0].address = list->descriptor_heap.buffers.db.heap_va_resource;
 
         if (global_buffers[0].usage & VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT)
         {
             global_buffers[0].pNext = &buffer_handle;
             buffer_handle.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_PUSH_DESCRIPTOR_BUFFER_HANDLE_EXT;
             buffer_handle.pNext = NULL;
-            buffer_handle.buffer = list->descriptor_heap.buffers.vk_buffer_resource;
+            buffer_handle.buffer = list->descriptor_heap.buffers.db.vk_buffer_resource;
         }
 
         global_buffers[1].sType = VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT;
         global_buffers[1].pNext = NULL;
         global_buffers[1].usage = list->device->global_descriptor_buffer.sampler.usage;
-        global_buffers[1].address = list->descriptor_heap.buffers.heap_va_sampler;
+        global_buffers[1].address = list->descriptor_heap.buffers.db.heap_va_sampler;
 
         VK_CALL(vkCmdBindDescriptorBuffersEXT(list->cmd.vk_command_buffer,
                 ARRAY_SIZE(global_buffers), global_buffers));
 
-        list->descriptor_heap.buffers.heap_dirty = false;
+        list->descriptor_heap.buffers.global_heap_dirty = false;
     }
 }
 
@@ -7796,7 +7835,7 @@ static void d3d12_command_list_update_descriptor_heaps(struct d3d12_command_list
 
     if (d3d12_device_uses_descriptor_buffers(list->device))
     {
-        d3d12_command_list_update_descriptor_buffers(list);
+        d3d12_command_list_update_global_descriptor_heap(list);
 
         /* Prefer binding everything in one go. There is no risk of null descriptor sets here. */
         if (bindings->descriptor_heap_dirty_mask)
@@ -7804,7 +7843,7 @@ static void d3d12_command_list_update_descriptor_heaps(struct d3d12_command_list
             VK_CALL(vkCmdSetDescriptorBufferOffsetsEXT(list->cmd.vk_command_buffer, vk_bind_point,
                     layout, 0, bindless_state->legacy.set_count,
                     bindless_state->legacy.vk_descriptor_buffer_indices,
-                    list->descriptor_heap.buffers.vk_offsets));
+                    list->descriptor_heap.buffers.db.vk_offsets));
             bindings->descriptor_heap_dirty_mask = 0;
         }
     }
@@ -9809,7 +9848,7 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
 
         d3d12_command_list_invalidate_current_pipeline(list, true);
         d3d12_command_list_invalidate_root_parameters(list, &list->graphics_bindings, true, &list->compute_bindings);
-        d3d12_command_list_update_descriptor_buffers(list);
+        d3d12_command_list_update_global_descriptor_heap(list);
 
         memset(&dst_view_desc, 0, sizeof(dst_view_desc));
         dst_view_desc.image = dst_resource->res.vk_image;
@@ -11592,7 +11631,7 @@ static void d3d12_command_list_execute_resolve(struct d3d12_command_list *list,
     {
         d3d12_command_list_invalidate_current_pipeline(list, true);
         d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
-        d3d12_command_list_update_descriptor_buffers(list);
+        d3d12_command_list_update_global_descriptor_heap(list);
 
         vk_format = d3d12_command_list_get_resolve_format(list, dst_resource, src_resource, format);
 
@@ -11705,7 +11744,7 @@ cleanup_compute:
     {
         d3d12_command_list_invalidate_current_pipeline(list, true);
         d3d12_command_list_invalidate_root_parameters(list, &list->graphics_bindings, true, &list->compute_bindings);
-        d3d12_command_list_update_descriptor_buffers(list);
+        d3d12_command_list_update_global_descriptor_heap(list);
 
         vk_format = d3d12_command_list_get_resolve_format(list, dst_resource, src_resource, format);
 
@@ -13449,6 +13488,54 @@ static void vkd3d_pipeline_bindings_set_dirty_sets(struct vkd3d_pipeline_binding
     bindings->dirty_flags |= VKD3D_PIPELINE_DIRTY_HOISTED_DESCRIPTORS;
 }
 
+static void d3d12_command_list_set_descriptor_heaps(struct d3d12_command_list *list,
+        unsigned int heap_count, ID3D12DescriptorHeap *const *heaps)
+{
+    VkDeviceAddress current_resource_va, current_sampler_va;
+    unsigned int i;
+
+    current_resource_va = list->descriptor_heap.buffers.resource.va;
+    current_sampler_va = list->descriptor_heap.buffers.sampler.va;
+
+    list->descriptor_heap.buffers.resource.heap = NULL;
+    list->descriptor_heap.buffers.sampler.heap = NULL;
+
+    for (i = 0; i < heap_count; i++)
+    {
+        struct d3d12_descriptor_heap *heap = impl_from_ID3D12DescriptorHeap(heaps[i]);
+
+        if (!heap)
+            continue;
+
+        if (heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
+        {
+            list->descriptor_heap.buffers.resource.va = heap->descriptor_buffer.va;
+            list->descriptor_heap.buffers.resource.size = heap->descriptor_buffer.size;
+            list->descriptor_heap.buffers.resource.reserved_offset = heap->descriptor_buffer.reserved_offset;
+            list->descriptor_heap.buffers.resource.heap = heap;
+
+            /* We might need to push new redzone inline data for example. */
+            d3d12_command_list_invalidate_root_parameters(list, &list->graphics_bindings, false, NULL);
+            d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, false, NULL);
+        }
+        else if (heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)
+        {
+            list->descriptor_heap.buffers.sampler.va = heap->descriptor_buffer.va;
+            list->descriptor_heap.buffers.sampler.size = heap->descriptor_buffer.size;
+            list->descriptor_heap.buffers.sampler.reserved_offset = heap->descriptor_buffer.reserved_offset;
+            list->descriptor_heap.buffers.sampler.heap = heap;
+        }
+    }
+
+    if (current_resource_va == list->descriptor_heap.buffers.resource.va &&
+            current_sampler_va == list->descriptor_heap.buffers.sampler.va)
+        return;
+
+    /* Immediately bind the heap. This allows e.g. metacommands to more aggressively use the heap as intended. */
+    list->descriptor_heap.buffers.global_heap_dirty = true;
+    d3d12_command_list_update_global_descriptor_heap(list);
+}
+
 static void d3d12_command_list_set_descriptor_heaps_buffers(struct d3d12_command_list *list,
         unsigned int heap_count, ID3D12DescriptorHeap *const *heaps)
 {
@@ -13457,8 +13544,8 @@ static void d3d12_command_list_set_descriptor_heaps_buffers(struct d3d12_command
     struct d3d12_desc_split d;
     unsigned int i, j;
 
-    current_resource_va = list->descriptor_heap.buffers.heap_va_resource;
-    current_sampler_va = list->descriptor_heap.buffers.heap_va_sampler;
+    current_resource_va = list->descriptor_heap.buffers.db.heap_va_resource;
+    current_sampler_va = list->descriptor_heap.buffers.db.heap_va_sampler;
 
     for (i = 0; i < heap_count; i++)
     {
@@ -13470,8 +13557,8 @@ static void d3d12_command_list_set_descriptor_heaps_buffers(struct d3d12_command
 
         if (heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
         {
-            list->descriptor_heap.buffers.heap_va_resource = heap->descriptor_buffer.va;
-            list->descriptor_heap.buffers.vk_buffer_resource = heap->descriptor_buffer.vk_buffer;
+            list->descriptor_heap.buffers.db.heap_va_resource = heap->descriptor_buffer.va;
+            list->descriptor_heap.buffers.db.vk_buffer_resource = heap->descriptor_buffer.vk_buffer;
 
             if (!d3d12_device_use_embedded_mutable_descriptors(list->device))
             {
@@ -13482,19 +13569,19 @@ static void d3d12_command_list_set_descriptor_heaps_buffers(struct d3d12_command
         }
         else if (heap->desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)
         {
-            list->descriptor_heap.buffers.heap_va_sampler = heap->descriptor_buffer.va;
+            list->descriptor_heap.buffers.db.heap_va_sampler = heap->descriptor_buffer.va;
         }
 
         for (j = 0; j < bindless_state->legacy.set_count; j++)
             if (bindless_state->legacy.set_info[j].heap_type == heap->desc.Type)
-                list->descriptor_heap.buffers.vk_offsets[j] = heap->descriptor_buffer.offsets[set_index++];
+                list->descriptor_heap.buffers.db.vk_offsets[j] = heap->descriptor_buffer.offsets[set_index++];
     }
 
-    if (current_resource_va == list->descriptor_heap.buffers.heap_va_resource &&
-            current_sampler_va == list->descriptor_heap.buffers.heap_va_sampler)
+    if (current_resource_va == list->descriptor_heap.buffers.db.heap_va_resource &&
+            current_sampler_va == list->descriptor_heap.buffers.db.heap_va_sampler)
         return;
 
-    list->descriptor_heap.buffers.heap_dirty = true;
+    list->descriptor_heap.buffers.global_heap_dirty = true;
     /* Invalidation is a bit more aggressive for descriptor buffers.
      * We also need to invalidate any push descriptors. */
     d3d12_command_list_invalidate_root_parameters(list, &list->graphics_bindings, true, NULL);
@@ -13560,7 +13647,9 @@ static void STDMETHODCALLTYPE d3d12_command_list_SetDescriptorHeaps(d3d12_comman
         }
     }
 
-    if (d3d12_device_uses_descriptor_buffers(list->device))
+    if (d3d12_device_use_descriptor_heap(list->device))
+        d3d12_command_list_set_descriptor_heaps(list, heap_count, heaps);
+    else if (d3d12_device_uses_descriptor_buffers(list->device))
         d3d12_command_list_set_descriptor_heaps_buffers(list, heap_count, heaps);
     else
         d3d12_command_list_set_descriptor_heaps_sets(list, heap_count, heaps);
@@ -14877,7 +14966,7 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
     d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
-    d3d12_command_list_update_descriptor_buffers(list);
+    d3d12_command_list_update_global_descriptor_heap(list);
 
     sampler_feedback_clear = d3d12_resource_desc_is_sampler_feedback(&resource->desc);
 
@@ -15072,7 +15161,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
     d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
-    d3d12_command_list_update_descriptor_buffers(list);
+    d3d12_command_list_update_global_descriptor_heap(list);
 
     assert(!args->view && !args->use_heap);
     assert(d3d12_resource_is_texture(resource));
@@ -17560,7 +17649,7 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
         return;
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_update_descriptor_buffers(list);
+    d3d12_command_list_update_global_descriptor_heap(list);
     d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
     d3d12_command_list_debug_mark_begin_region(list, "SamplerFeedbackEncode");
 
@@ -17908,7 +17997,7 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
         return;
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_update_descriptor_buffers(list);
+    d3d12_command_list_update_global_descriptor_heap(list);
     d3d12_command_list_debug_mark_begin_region(list, "SamplerFeedbackDecode");
     if (dst->desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
         d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6234,7 +6234,7 @@ static void d3d12_command_list_invalidate_push_constants(struct vkd3d_pipeline_b
 }
 
 void d3d12_command_list_invalidate_root_parameters(struct d3d12_command_list *list,
-        struct vkd3d_pipeline_bindings *bindings, bool invalidate_descriptor_heaps,
+        struct vkd3d_pipeline_bindings *bindings, bool invalidate_legacy_descriptor_sets,
         struct vkd3d_pipeline_bindings *sibling_push_domain)
 {
     /* For scenarios where we're emitting push constants to one bind point in meta shaders,
@@ -6256,10 +6256,11 @@ void d3d12_command_list_invalidate_root_parameters(struct d3d12_command_list *li
 
     d3d12_command_list_invalidate_push_constants(bindings);
 
-    if (invalidate_descriptor_heaps)
+    /* This is relevant if the pipeline layout changes, but it's irrelevant for EXT_descriptor_heap. */
+    if (invalidate_legacy_descriptor_sets)
     {
         struct d3d12_device *device = bindings->root_signature->device;
-        bindings->descriptor_heap_dirty_mask = (1ull << device->bindless_state.legacy.set_count) - 1;
+        bindings->legacy_descriptor_set_dirty_mask = (1ull << device->bindless_state.legacy.set_count) - 1;
     }
 }
 
@@ -7830,7 +7831,14 @@ static void d3d12_command_list_update_descriptor_heaps(struct d3d12_command_list
     const struct vkd3d_bindless_state *bindless_state = &list->device->bindless_state;
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
 
-    if (!bindings->descriptor_heap_dirty_mask)
+    if (d3d12_device_use_descriptor_heap(list->device))
+    {
+        /* We don't bind legacy sets. */
+        d3d12_command_list_update_global_descriptor_heap(list);
+        return;
+    }
+
+    if (!bindings->legacy_descriptor_set_dirty_mask)
         return;
 
     if (d3d12_device_uses_descriptor_buffers(list->device))
@@ -7838,20 +7846,20 @@ static void d3d12_command_list_update_descriptor_heaps(struct d3d12_command_list
         d3d12_command_list_update_global_descriptor_heap(list);
 
         /* Prefer binding everything in one go. There is no risk of null descriptor sets here. */
-        if (bindings->descriptor_heap_dirty_mask)
+        if (bindings->legacy_descriptor_set_dirty_mask)
         {
             VK_CALL(vkCmdSetDescriptorBufferOffsetsEXT(list->cmd.vk_command_buffer, vk_bind_point,
                     layout, 0, bindless_state->legacy.set_count,
                     bindless_state->legacy.vk_descriptor_buffer_indices,
                     list->descriptor_heap.buffers.db.vk_offsets));
-            bindings->descriptor_heap_dirty_mask = 0;
+            bindings->legacy_descriptor_set_dirty_mask = 0;
         }
     }
     else
     {
-        while (bindings->descriptor_heap_dirty_mask)
+        while (bindings->legacy_descriptor_set_dirty_mask)
         {
-            unsigned int heap_index = vkd3d_bitmask_iter64(&bindings->descriptor_heap_dirty_mask);
+            unsigned int heap_index = vkd3d_bitmask_iter64(&bindings->legacy_descriptor_set_dirty_mask);
 
             if (list->descriptor_heap.sets.vk_sets[heap_index])
             {
@@ -8161,8 +8169,7 @@ static void d3d12_command_list_update_descriptors(struct d3d12_command_list *lis
 
     vk_bind_point = vk_bind_point_from_pipeline_type(list->active_pipeline_type);
 
-    if (bindings->descriptor_heap_dirty_mask)
-        d3d12_command_list_update_descriptor_heaps(list, bindings, vk_bind_point, layout);
+    d3d12_command_list_update_descriptor_heaps(list, bindings, vk_bind_point, layout);
 
     if (bindings->dirty_flags & VKD3D_PIPELINE_DIRTY_STATIC_SAMPLER_SET)
         d3d12_command_list_update_static_samplers(list, bindings, vk_bind_point, layout);
@@ -13484,7 +13491,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ExecuteBundle(d3d12_command_lis
 
 static void vkd3d_pipeline_bindings_set_dirty_sets(struct vkd3d_pipeline_bindings *bindings, uint64_t dirty_mask)
 {
-    bindings->descriptor_heap_dirty_mask = dirty_mask;
+    bindings->legacy_descriptor_set_dirty_mask = dirty_mask;
     bindings->dirty_flags |= VKD3D_PIPELINE_DIRTY_HOISTED_DESCRIPTORS;
 }
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1634,6 +1634,10 @@ static HRESULT d3d12_root_signature_init_global_mappings(struct d3d12_root_signa
         }
     }
 
+    root_signature->heap.mapping_info.sType = VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT;
+    root_signature->heap.mapping_info.mappingCount = root_signature->heap.mappings_count;
+    root_signature->heap.mapping_info.pMappings = root_signature->heap.mappings;
+
     return S_OK;
 }
 
@@ -2968,13 +2972,13 @@ static void d3d12_pipeline_state_init_compile_arguments(struct d3d12_pipeline_st
 static HRESULT vkd3d_setup_shader_stage(struct d3d12_pipeline_state *state, struct d3d12_device *device,
         VkPipelineShaderStageCreateInfo *stage_desc, VkShaderStageFlagBits stage,
         VkPipelineShaderStageRequiredSubgroupSizeCreateInfo *required_subgroup_size_info,
-        const VkPipelineShaderStageModuleIdentifierCreateInfoEXT *identifier_create_info,
+        VkPipelineShaderStageModuleIdentifierCreateInfoEXT *identifier_create_info,
         const struct vkd3d_shader_code *spirv_code)
 {
     bool override_subgroup_size = false;
 
     stage_desc->sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stage_desc->pNext = NULL;
+    stage_desc->pNext = d3d12_device_use_descriptor_heap(device) ? &state->root_signature->heap.mapping_info : NULL;
     stage_desc->flags = 0;
     stage_desc->stage = stage;
     stage_desc->pName = "main";
@@ -2985,7 +2989,7 @@ static HRESULT vkd3d_setup_shader_stage(struct d3d12_pipeline_state *state, stru
         return E_INVALIDARG;
 
     if (!spirv_code->size && identifier_create_info && identifier_create_info->identifierSize)
-        stage_desc->pNext = identifier_create_info;
+        vk_prepend_struct(stage_desc, identifier_create_info);
 
     if ((spirv_code->meta.flags & VKD3D_SHADER_META_FLAG_USES_SUBGROUP_OPERATIONS) ||
             spirv_code->meta.cs_wave_size_min)
@@ -2996,7 +3000,7 @@ static HRESULT vkd3d_setup_shader_stage(struct d3d12_pipeline_state *state, stru
         if (required_subgroup_size_info)
         {
             required_subgroup_size_info->sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
-            required_subgroup_size_info->pNext = (void*)stage_desc->pNext;
+            required_subgroup_size_info->pNext = NULL;
 
             /* [WaveSize(min,max,preferred)] in SM 6.8, or [WaveSize(N)] in SM 6.6. */
             if (spirv_code->meta.cs_wave_size_preferred &&
@@ -3053,11 +3057,13 @@ static HRESULT vkd3d_setup_shader_stage(struct d3d12_pipeline_state *state, stru
         {
             /* If min == max, we can still support WaveSize in a dummy kind of way. */
             if (device->device_info.vulkan_1_3_properties.requiredSubgroupSizeStages & stage)
-                stage_desc->pNext = required_subgroup_size_info;
+                vk_prepend_struct(stage_desc, required_subgroup_size_info);
 
             stage_desc->flags &= ~VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT;
         }
     }
+
+    assert(state->root_signature->heap.mapping_info.pNext == NULL);
 
     if (spirv_code->size)
         return d3d12_pipeline_state_create_shader_module(device, &stage_desc->module, spirv_code);

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3297,6 +3297,7 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     struct vkd3d_queue_timeline_trace_cookie cookie;
     VkPipelineCreationFeedbackEXT feedbacks[1];
     VkComputePipelineCreateInfo pipeline_info;
+    VkPipelineCreateFlags2CreateInfo flags2;
     struct vkd3d_shader_spec_info spec_info;
     VkPipelineCreationFeedbackEXT feedback;
     struct vkd3d_shader_code *spirv_code;
@@ -3354,11 +3355,11 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     if (VKD3D_CONFIG_FLAG_IS_SET(PIPELINE_LIBRARY_LOG))
     {
         feedback_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO;
-        feedback_info.pNext = pipeline_info.pNext;
+        feedback_info.pNext = NULL;
         feedback_info.pPipelineStageCreationFeedbacks = feedbacks;
         feedback_info.pipelineStageCreationFeedbackCount = 1;
         feedback_info.pPipelineCreationFeedback = &feedback;
-        pipeline_info.pNext = &feedback_info;
+        vk_prepend_struct(&pipeline_info, &feedback_info);
     }
     else
         feedback_info.pipelineStageCreationFeedbackCount = 0;
@@ -3366,13 +3367,24 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     if (pipeline_info.stage.module == VK_NULL_HANDLE)
         pipeline_info.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
-    if (d3d12_device_uses_descriptor_buffers(device))
-        pipeline_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-
     if (state->compute.code.meta.flags & VKD3D_SHADER_META_FLAG_DISABLE_OPTIMIZATIONS)
         pipeline_info.flags |= VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&device->queue_timeline_trace);
+
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        memset(&flags2, 0, sizeof(flags2));
+        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        vk_prepend_struct(&pipeline_info, &flags2);
+        flags2.flags = pipeline_info.flags;
+        pipeline_info.flags = 0;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+    }
+    else if (d3d12_device_uses_descriptor_buffers(device))
+    {
+        pipeline_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     vr = VK_CALL(vkCreateComputePipelines(device->vk_device,
             vk_cache, 1, &pipeline_info, NULL, &state->compute.vk_pipeline));
@@ -3414,6 +3426,7 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     if (vr == VK_PIPELINE_COMPILE_REQUIRED)
     {
         pipeline_info.flags &= ~VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+        flags2.flags &= ~VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
         if (FAILED(hr = vkd3d_compile_shader_stage(state, device,
                 VK_SHADER_STAGE_COMPUTE_BIT, code, spirv_code, spirv_code_debug)))
@@ -4300,6 +4313,7 @@ VkPipeline vkd3d_vertex_input_pipeline_create(struct d3d12_device *device,
     VkGraphicsPipelineLibraryCreateInfoEXT library_create_info;
     struct vkd3d_vertex_input_pipeline_desc desc_copy = *desc;
     VkGraphicsPipelineCreateInfo create_info;
+    VkPipelineCreateFlags2CreateInfo flags2;
     VkPipeline vk_pipeline;
     VkResult vr;
 
@@ -4311,15 +4325,27 @@ VkPipeline vkd3d_vertex_input_pipeline_create(struct d3d12_device *device,
 
     memset(&create_info, 0, sizeof(create_info));
     create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    create_info.pNext = &library_create_info;
     create_info.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
     create_info.pInputAssemblyState = &desc_copy.ia_info;
     create_info.pVertexInputState = &desc_copy.vi_info;
     create_info.pDynamicState = &desc_copy.dy_info;
     create_info.basePipelineIndex = -1;
 
-    if (d3d12_device_uses_descriptor_buffers(device))
+    vk_prepend_struct(&create_info, &library_create_info);
+
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        memset(&flags2, 0, sizeof(flags2));
+        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        vk_prepend_struct(&create_info, &flags2);
+        flags2.flags = create_info.flags;
+        create_info.flags = 0;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+    }
+    else if (d3d12_device_uses_descriptor_buffers(device))
+    {
         create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     if ((vr = VK_CALL(vkCreateGraphicsPipelines(device->vk_device,
             VK_NULL_HANDLE, 1, &create_info, NULL, &vk_pipeline))))
@@ -4450,6 +4476,7 @@ VkPipeline vkd3d_fragment_output_pipeline_create(struct d3d12_device *device,
     struct vkd3d_fragment_output_pipeline_desc desc_copy = *desc;
     VkGraphicsPipelineLibraryCreateInfoEXT library_create_info;
     VkGraphicsPipelineCreateInfo create_info;
+    VkPipelineCreateFlags2CreateInfo flags2;
     VkPipeline vk_pipeline;
     VkResult vr;
 
@@ -4457,20 +4484,32 @@ VkPipeline vkd3d_fragment_output_pipeline_create(struct d3d12_device *device,
 
     memset(&library_create_info, 0, sizeof(library_create_info));
     library_create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT;
-    library_create_info.pNext = &desc_copy.rt_info;
     library_create_info.flags = VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT;
 
     memset(&create_info, 0, sizeof(create_info));
     create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    create_info.pNext = &library_create_info;
     create_info.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
     create_info.pColorBlendState = &desc_copy.cb_info;
     create_info.pMultisampleState = &desc_copy.ms_info;
     create_info.pDynamicState = &desc_copy.dy_info;
     create_info.basePipelineIndex = -1;
 
-    if (d3d12_device_uses_descriptor_buffers(device))
+    vk_prepend_struct(&create_info, &desc_copy.rt_info);
+    vk_prepend_struct(&create_info, &library_create_info);
+
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        memset(&flags2, 0, sizeof(flags2));
+        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        vk_prepend_struct(&create_info, &flags2);
+        flags2.flags = create_info.flags;
+        create_info.flags = 0;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+    }
+    else if (d3d12_device_uses_descriptor_buffers(device))
+    {
         create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     if ((vr = VK_CALL(vkCreateGraphicsPipelines(device->vk_device,
             VK_NULL_HANDLE, 1, &create_info, NULL, &vk_pipeline))))
@@ -6499,6 +6538,7 @@ static VkResult d3d12_pipeline_state_link_pipeline_variant(struct d3d12_pipeline
     struct vkd3d_queue_timeline_trace_cookie cookie;
     VkPipelineLibraryCreateInfoKHR library_info;
     VkGraphicsPipelineCreateInfo create_info;
+    VkPipelineCreateFlags2CreateInfo flags2;
     VkPipeline vk_libraries[3];
     uint32_t library_count = 0;
     VkResult vr;
@@ -6526,13 +6566,11 @@ static VkResult d3d12_pipeline_state_link_pipeline_variant(struct d3d12_pipeline
 
     memset(&create_info, 0, sizeof(create_info));
     create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    create_info.pNext = &library_info;
     create_info.flags = graphics->library_create_flags;
     create_info.layout = graphics->pipeline_layout;
     create_info.basePipelineIndex = -1;
 
-    if (d3d12_device_uses_descriptor_buffers(state->device))
-        create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    vk_prepend_struct(&create_info, &library_info);
 
     if (graphics->disable_optimization)
         create_info.flags |= VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
@@ -6544,6 +6582,19 @@ static VkResult d3d12_pipeline_state_link_pipeline_variant(struct d3d12_pipeline
         create_info.flags |= VK_PIPELINE_CREATE_LINK_TIME_OPTIMIZATION_BIT_EXT;
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&state->device->queue_timeline_trace);
+
+    if (d3d12_device_use_descriptor_heap(state->device))
+    {
+        memset(&flags2, 0, sizeof(flags2));
+        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        flags2.flags = create_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+        create_info.flags = 0;
+        vk_prepend_struct(&create_info, &flags2);
+    }
+    else if (d3d12_device_uses_descriptor_buffers(state->device))
+    {
+        create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     vr = VK_CALL(vkCreateGraphicsPipelines(state->device->vk_device,
             vk_cache, 1, &create_info, NULL, vk_pipeline));
@@ -6585,6 +6636,7 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
     struct d3d12_device *device = state->device;
     VkGraphicsPipelineCreateInfo pipeline_desc;
     VkPipelineViewportStateCreateInfo vp_desc;
+    VkPipelineCreateFlags2CreateInfo flags2;
     VkPipelineCreationFeedbackEXT feedback;
     uint32_t stages_module_dup_mask = 0;
     VkPipeline vk_pipeline;
@@ -6634,7 +6686,6 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
 
     memset(&pipeline_desc, 0, sizeof(pipeline_desc));
     pipeline_desc.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    pipeline_desc.pNext = &fragment_output_desc.rt_info;
     pipeline_desc.stageCount = graphics->stage_count;
     pipeline_desc.pStages = graphics->stages;
     pipeline_desc.pViewportState = &vp_desc;
@@ -6643,6 +6694,8 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
     pipeline_desc.pDynamicState = &dynamic_create_info;
     pipeline_desc.layout = graphics->pipeline_layout;
     pipeline_desc.basePipelineIndex = -1;
+
+    vk_prepend_struct(&pipeline_desc, &fragment_output_desc.rt_info);
 
     if (d3d12_device_supports_variable_shading_rate_tier_2(device))
         pipeline_desc.flags |= VK_PIPELINE_CREATE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
@@ -6674,11 +6727,10 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
         TRACE("Compiling pipeline library for %p with flags %#x.\n", state, library_flags);
 
         library_create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT;
-        /* Explicit cast to silence a constness warning, this seems to be a Vulkan header bug */
-        library_create_info.pNext = (void*)pipeline_desc.pNext;
+        library_create_info.pNext = NULL;
         library_create_info.flags = library_flags;
+        vk_prepend_struct(&pipeline_desc, &library_create_info);
 
-        pipeline_desc.pNext = &library_create_info;
         pipeline_desc.flags |= VK_PIPELINE_CREATE_LIBRARY_BIT_KHR |
                 VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
 
@@ -6729,9 +6781,6 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
         if (pipeline_desc.pStages[i].module == VK_NULL_HANDLE)
             pipeline_desc.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
-    if (d3d12_device_uses_descriptor_buffers(device))
-        pipeline_desc.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-
     if (graphics->disable_optimization)
         pipeline_desc.flags |= VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
 
@@ -6740,16 +6789,30 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
     if (VKD3D_CONFIG_FLAG_IS_SET(PIPELINE_LIBRARY_LOG))
     {
         feedback_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT;
-        feedback_info.pNext = pipeline_desc.pNext;
+        feedback_info.pNext = NULL;
         feedback_info.pPipelineStageCreationFeedbacks = feedbacks;
         feedback_info.pipelineStageCreationFeedbackCount = pipeline_desc.stageCount;
         feedback_info.pPipelineCreationFeedback = &feedback;
-        pipeline_desc.pNext = &feedback_info;
+        vk_prepend_struct(&pipeline_desc, &feedback_info);
     }
     else
         feedback_info.pipelineStageCreationFeedbackCount = 0;
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&device->queue_timeline_trace);
+
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        memset(&flags2, 0, sizeof(flags2));
+        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        vk_prepend_struct(&pipeline_desc, &flags2);
+        flags2.flags = pipeline_desc.flags;
+        pipeline_desc.flags = 0;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+    }
+    else if (d3d12_device_uses_descriptor_buffers(device))
+    {
+        pipeline_desc.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     vr = VK_CALL(vkCreateGraphicsPipelines(device->vk_device, vk_cache, 1, &pipeline_desc, NULL, &vk_pipeline));
 
@@ -6796,6 +6859,8 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
         }
 
         pipeline_desc.flags &= ~VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+        flags2.flags &= ~VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+
         /* Internal modules are known to be non-null now. */
         pipeline_desc.pStages = state->graphics.stages;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3101,12 +3101,23 @@ union vkd3d_descriptor_heap_state
 {
     struct
     {
-        VkDeviceAddress heap_va_resource;
-        VkDeviceAddress heap_va_sampler;
-        VkBuffer vk_buffer_resource;
-        bool heap_dirty;
+        struct
+        {
+            VkDeviceAddress heap_va_resource;
+            VkDeviceAddress heap_va_sampler;
+            VkBuffer vk_buffer_resource;
+            VkDeviceSize vk_offsets[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
+        } db;
 
-        VkDeviceSize vk_offsets[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
+        struct
+        {
+            struct d3d12_descriptor_heap *heap;
+            VkDeviceAddress va;
+            VkDeviceSize size;
+            VkDeviceSize reserved_offset;
+        } resource, sampler;
+
+        bool global_heap_dirty;
     } buffers;
 
     struct
@@ -3453,7 +3464,7 @@ void d3d12_command_list_invalidate_current_pipeline(struct d3d12_command_list *l
 void d3d12_command_list_invalidate_root_parameters(struct d3d12_command_list *list,
         struct vkd3d_pipeline_bindings *bindings, bool invalidate_descriptor_heaps,
         struct vkd3d_pipeline_bindings *sibling_push_domain);
-void d3d12_command_list_update_descriptor_buffers(struct d3d12_command_list *list);
+void d3d12_command_list_update_global_descriptor_heap(struct d3d12_command_list *list);
 void d3d12_command_list_flush_dgc_batch(struct d3d12_command_list *list);
 
 union vkd3d_root_parameter_data

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2801,7 +2801,7 @@ struct vkd3d_pipeline_bindings
     uint32_t dirty_flags; /* vkd3d_pipeline_dirty_flags */
 
     uint32_t descriptor_tables[D3D12_MAX_ROOT_COST];
-    uint64_t descriptor_heap_dirty_mask;
+    uint64_t legacy_descriptor_set_dirty_mask;
 
     /* Needed when VK_KHR_push_descriptor is not available. */
     struct vkd3d_root_descriptor_info root_descriptors[D3D12_MAX_ROOT_COST];
@@ -3462,7 +3462,7 @@ void d3d12_command_list_debug_mark_end_region(struct d3d12_command_list *list);
 
 void d3d12_command_list_invalidate_current_pipeline(struct d3d12_command_list *list, bool meta_shader);
 void d3d12_command_list_invalidate_root_parameters(struct d3d12_command_list *list,
-        struct vkd3d_pipeline_bindings *bindings, bool invalidate_descriptor_heaps,
+        struct vkd3d_pipeline_bindings *bindings, bool invalidate_legacy_descriptor_sets,
         struct vkd3d_pipeline_bindings *sibling_push_domain);
 void d3d12_command_list_update_global_descriptor_heap(struct d3d12_command_list *list);
 void d3d12_command_list_flush_dgc_batch(struct d3d12_command_list *list);

--- a/libs/vkd3d/workgraphs.c
+++ b/libs/vkd3d/workgraphs.c
@@ -2589,7 +2589,7 @@ static void d3d12_command_list_workgraph_bind_resources(struct d3d12_command_lis
         VK_CALL(vkCmdSetDescriptorBufferOffsetsEXT(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                 module->vk_pipeline_layout, 0, bindless_state->legacy.set_count,
                 bindless_state->legacy.vk_descriptor_buffer_indices,
-                list->descriptor_heap.buffers.vk_offsets));
+                list->descriptor_heap.buffers.db.vk_offsets));
     }
     else
     {
@@ -3451,7 +3451,7 @@ void d3d12_command_list_workgraph_dispatch(struct d3d12_command_list *list, cons
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
     d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
-    d3d12_command_list_update_descriptor_buffers(list);
+    d3d12_command_list_update_global_descriptor_heap(list);
 
     d3d12_command_list_workgraph_barrier(list,
             VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,


### PR DESCRIPTION
Binds the descriptor heap. Unlike DB there is no "dummy" fallback heap, since we rely on drivers linking together the heaps properly on the drivers that care.

Also, sets up PSO properly.

Refactor some struct members to mark them as only being relevant for legacy model.