### PR TITLE
vkd3d: Fix formatting warnings.

### DIFF
--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -59,7 +59,9 @@ static inline size_t align(size_t addr, size_t alignment)
 }
 
 #ifdef __GNUC__
-# define VKD3D_PRINTF_FUNC(fmt, args) __attribute__((format(printf, fmt, args)))
+/* Normal printf needlessly warns on %zu since it targets ancient msvcrt.dll.
+ * This is not relevant anymore. */
+# define VKD3D_PRINTF_FUNC(fmt, args) __attribute__((format(gnu_printf, fmt, args)))
 # define VKD3D_UNUSED __attribute__((unused))
 #else
 # define VKD3D_PRINTF_FUNC(fmt, args)

--- a/include/private/vkd3d_native_sync_handle.h
+++ b/include/private/vkd3d_native_sync_handle.h
@@ -72,7 +72,7 @@ static inline int vkd3d_native_sync_handle_release(vkd3d_native_sync_handle hand
             /* Failing to release semaphore is expected if the counter exceeds the maximum limit.
              * If the application does not wait for the semaphore once per present, this
              * will eventually happen. */
-            TRACE("Failed to release semaphore (#%x).\n", GetLastError());
+            TRACE("Failed to release semaphore (#%x).\n", (int)GetLastError());
             prev = -1;
         }
         return prev;
@@ -81,7 +81,7 @@ static inline int vkd3d_native_sync_handle_release(vkd3d_native_sync_handle hand
     {
         if (!SetEvent(handle.handle))
         {
-            ERR("Failed to set event %p (#%x).\n", handle.handle, GetLastError());
+            ERR("Failed to set event %p (#%x).\n", handle.handle, (int)GetLastError());
             return -1;
         }
         return 0;

--- a/libs/d3d12/main.c
+++ b/libs/d3d12/main.c
@@ -47,6 +47,8 @@
 #define DLLEXPORT
 #endif
 
+#include <inttypes.h>
+
 static pthread_once_t library_once = PTHREAD_ONCE_INIT;
 
 static vkd3d_module_t d3d12core_module = NULL;
@@ -152,7 +154,7 @@ HRESULT WINAPI DLLEXPORT D3D12CreateDevice(IUnknown *adapter, D3D_FEATURE_LEVEL 
 HRESULT WINAPI DLLEXPORT D3D12CreateRootSignatureDeserializer(const void *data, SIZE_T data_size,
         REFIID iid, void **deserializer)
 {
-    TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
+    TRACE("data %p, data_size %zu, iid %s, deserializer %p.\n",
             data, data_size, debugstr_guid(iid), deserializer);
 
     if (!load_d3d12core())
@@ -174,7 +176,7 @@ HRESULT WINAPI DLLEXPORT D3D12SerializeRootSignature(const D3D12_ROOT_SIGNATURE_
 HRESULT WINAPI DLLEXPORT D3D12CreateVersionedRootSignatureDeserializer(const void *data, SIZE_T data_size,
         REFIID iid, void **deserializer)
 {
-    TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
+    TRACE("data %p, data_size %zu, iid %s, deserializer %p.\n",
             data, data_size, debugstr_guid(iid), deserializer);
 
     if (!load_d3d12core())

--- a/libs/d3d12core/debug.c
+++ b/libs/d3d12core/debug.c
@@ -54,7 +54,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_dred_settings_QueryInterface(
 static ULONG STDMETHODCALLTYPE d3d12_dred_settings_AddRef(d3d12_dred_settings_iface *iface)
 {
     struct d3d12_dred_settings *dred_settings = impl_from_ID3D12DeviceRemovedExtendedDataSettings(iface);
-    ULONG refcount = InterlockedIncrement(&dred_settings->refcount);
+    unsigned int refcount = InterlockedIncrement(&dred_settings->refcount);
 
     TRACE("%p increasing refcount to %u.\n", dred_settings, refcount);
 
@@ -64,7 +64,7 @@ static ULONG STDMETHODCALLTYPE d3d12_dred_settings_AddRef(d3d12_dred_settings_if
 static ULONG STDMETHODCALLTYPE d3d12_dred_settings_Release(d3d12_dred_settings_iface *iface)
 {
     struct d3d12_dred_settings *dred_settings = impl_from_ID3D12DeviceRemovedExtendedDataSettings(iface);
-    ULONG refcount;
+    unsigned int refcount;
 
     pthread_mutex_lock(&debug_singleton_lock);
     refcount = InterlockedDecrement(&dred_settings->refcount);

--- a/libs/d3d12core/main.c
+++ b/libs/d3d12core/main.c
@@ -44,6 +44,8 @@
 #define DLLEXPORT
 #endif
 
+#include <inttypes.h>
+
 typedef IVKD3DCoreInterface d3d12core_interface;
 HRESULT WINAPI DLLEXPORT D3D12GetInterface(REFCLSID rcslid, REFIID iid, void** debug);
 
@@ -71,12 +73,12 @@ static BOOL wait_vr_key(HKEY vr_key)
     size = sizeof(value);
     if ((status = RegQueryValueExA(vr_key, "state", NULL, &type, (BYTE *)&value, &size)))
     {
-        ERR("OpenVR: could not query value, status %d.\n", status);
+        ERR("OpenVR: could not query value, status %d.\n", (int)status);
         return false;
     }
     if (type != REG_DWORD)
     {
-        ERR("OpenVR: unexpected value type %d.\n", type);
+        ERR("OpenVR: unexpected value type %d.\n", (int)type);
         return false;
     }
 
@@ -100,7 +102,7 @@ static BOOL wait_vr_key(HKEY vr_key)
         size = sizeof(value);
         if ((status = RegQueryValueExA(vr_key, "state", NULL, &type, (BYTE *)&value, &size)))
         {
-            ERR("OpenVR: could not query value, status %d.\n", status);
+            ERR("OpenVR: could not query value, status %d.\n", (int)status);
             break;
         }
         if (value)
@@ -109,13 +111,13 @@ static BOOL wait_vr_key(HKEY vr_key)
 
         while ((wait_status = WaitForSingleObject(event, 1000)) == WAIT_TIMEOUT && max_retry)
         {
-            WARN("VR state wait timeout (retries left %u).\n", max_retry);
+            WARN("VR state wait timeout (retries left %u).\n", (int)max_retry);
             max_retry--;
         }
 
         if (wait_status != WAIT_OBJECT_0 && wait_status != WAIT_TIMEOUT)
         {
-            ERR("Got unexpected wait status %u.\n", wait_status);
+            ERR("Got unexpected wait status %u.\n", (int)wait_status);
             break;
         }
     }
@@ -134,7 +136,7 @@ static char *openvr_instance_extensions()
 
     if (status != ERROR_SUCCESS)
     {
-        WARN("Failed to open VR registry key, status %d.\n", status);
+        WARN("Failed to open VR registry key, status %d.\n", (int)status);
         return NULL;
     }
     if (!wait_vr_key(vr_key))
@@ -147,13 +149,13 @@ static char *openvr_instance_extensions()
     status = RegQueryValueExA(vr_key, "openvr_vulkan_instance_extensions", NULL, &type, NULL, &len);
     if (status != ERROR_SUCCESS)
     {
-        WARN("Failed to query VR instance extensions, status %d.\n", status);
+        WARN("Failed to query VR instance extensions, status %d.\n", (int)status);
         RegCloseKey(vr_key);
         return NULL;
     }
     if (type != REG_SZ)
     {
-        WARN("Unexpected VR instance extensions type %d.\n", type);
+        WARN("Unexpected VR instance extensions type %d.\n", (int)type);
         RegCloseKey(vr_key);
         return NULL;
     }
@@ -161,7 +163,7 @@ static char *openvr_instance_extensions()
     status = RegQueryValueExA(vr_key, "openvr_vulkan_instance_extensions", NULL, &type, (BYTE *)openvr_instance_extensions, &len);
     if (status != ERROR_SUCCESS)
     {
-        WARN("Failed to query VR instance extensions, status %d.\n", status);
+        WARN("Failed to query VR instance extensions, status %d.\n", (int)status);
         vkd3d_free(openvr_instance_extensions);
         openvr_instance_extensions = NULL;
     }
@@ -180,7 +182,7 @@ static char *openvr_device_extensions(DXGI_ADAPTER_DESC *desc)
 
     if (status != ERROR_SUCCESS)
     {
-        WARN("Failed to open VR registry key, status %d.\n", status);
+        WARN("Failed to open VR registry key, status %d.\n", (int)status);
         return NULL;
     }
     if (!wait_vr_key(vr_key))
@@ -195,13 +197,13 @@ static char *openvr_device_extensions(DXGI_ADAPTER_DESC *desc)
     status = RegQueryValueExA(vr_key, key_name, NULL, &type, NULL, &len);
     if (status != ERROR_SUCCESS)
     {
-        WARN("Failed to query VR instance extensions, status %d.\n", status);
+        WARN("Failed to query VR instance extensions, status %d.\n", (int)status);
         RegCloseKey(vr_key);
         return NULL;
     }
     if (type != REG_SZ)
     {
-        WARN("Unexpected VR instance extensions type %d.\n", type);
+        WARN("Unexpected VR instance extensions type %d.\n", (int)type);
         RegCloseKey(vr_key);
         return NULL;
     }
@@ -209,7 +211,7 @@ static char *openvr_device_extensions(DXGI_ADAPTER_DESC *desc)
     status = RegQueryValueExA(vr_key, key_name, NULL, &type, (BYTE *)openvr_device_extensions, &len);
     if (status != ERROR_SUCCESS)
     {
-        WARN("Failed to query VR instance extensions, status %d.\n", status);
+        WARN("Failed to query VR instance extensions, status %d.\n", (int)status);
         vkd3d_free(openvr_device_extensions);
         openvr_device_extensions = NULL;
     }
@@ -380,13 +382,13 @@ static HRESULT d3d12_get_adapter(IDXGIAdapter **dxgi_adapter, IUnknown *adapter)
     {
         if (FAILED(hr = CreateDXGIFactory1(&IID_IDXGIFactory4, (void **)&factory)))
         {
-            WARN("Failed to create DXGI factory, hr %#x.\n", hr);
+            WARN("Failed to create DXGI factory, hr %#x.\n", (int)hr);
             goto done;
         }
 
         if (FAILED(hr = IDXGIFactory4_EnumAdapters(factory, 0, dxgi_adapter)))
         {
-            WARN("Failed to enumerate primary adapter, hr %#x.\n", hr);
+            WARN("Failed to enumerate primary adapter, hr %#x.\n", (int)hr);
             goto done;
         }
     }
@@ -398,12 +400,12 @@ static HRESULT d3d12_get_adapter(IDXGIAdapter **dxgi_adapter, IUnknown *adapter)
 
         if (FAILED(hr = IDXCoreAdapter_GetProperty(dxcore_adapter, InstanceLuid, sizeof(luid), &luid)))
         {
-            WARN("Failed to get InstanceLuid property from dxcore adapter, hr %#x.\n", hr);
+            WARN("Failed to get InstanceLuid property from dxcore adapter, hr %#x.\n", (int)hr);
             goto done;
         }
         if (FAILED(hr = CreateDXGIFactory1(&IID_IDXGIFactory4, (void **)&factory)))
         {
-            WARN("Failed to create DXGI factory, hr %#x.\n", hr);
+            WARN("Failed to create DXGI factory, hr %#x.\n", (int)hr);
             goto done;
         }
         for (i = 0; SUCCEEDED(IDXGIFactory4_EnumAdapters(factory, i, dxgi_adapter)); ++i)
@@ -427,7 +429,7 @@ static HRESULT d3d12_get_adapter(IDXGIAdapter **dxgi_adapter, IUnknown *adapter)
     {
         if (FAILED(hr = IUnknown_QueryInterface(adapter, &IID_IDXGIAdapter, (void **)dxgi_adapter)))
         {
-            WARN("Invalid adapter %p, hr %#x.\n", adapter, hr);
+            WARN("Invalid adapter %p, hr %#x.\n", adapter, (int)hr);
             goto done;
         }
     }
@@ -507,7 +509,8 @@ static VkPhysicalDevice d3d12_find_physical_device(struct vkd3d_instance *instan
 
             if (vk_physical_device)
             {
-                WARN("Multiple adapters found with LUID %#x%x.\n", adapter_desc->AdapterLuid.HighPart, adapter_desc->AdapterLuid.LowPart);
+                WARN("Multiple adapters found with LUID %#x%x.\n",
+                        (int)adapter_desc->AdapterLuid.HighPart, (int)adapter_desc->AdapterLuid.LowPart);
 
                 match = properties2.properties.deviceID == adapter_desc->DeviceId &&
                         properties2.properties.vendorID == adapter_desc->VendorId;
@@ -625,7 +628,7 @@ static HRESULT vkd3d_create_instance_global(struct vkd3d_instance **out_instance
 #endif
 
     if (FAILED(hr = vkd3d_create_instance(&instance_create_info, out_instance)))
-        WARN("Failed to create vkd3d instance, hr %#x.\n", hr);
+        WARN("Failed to create vkd3d instance, hr %#x.\n", (int)hr);
 
 #ifdef _WIN32
     if (instance_create_info.instance_extensions != instance_extensions)
@@ -673,7 +676,7 @@ static HRESULT STDMETHODCALLTYPE d3d12core_CreateDeviceFromFactory(
 
     if (FAILED(hr = IDXGIAdapter_GetDesc(dxgi_adapter, &adapter_desc)))
     {
-        WARN("Failed to get adapter desc, hr %#x.\n", hr);
+        WARN("Failed to get adapter desc, hr %#x.\n", (int)hr);
         goto out_release_adapter;
     }
 
@@ -745,7 +748,7 @@ static HRESULT STDMETHODCALLTYPE d3d12core_CreateDevice(d3d12core_interface *cor
 HRESULT STDMETHODCALLTYPE d3d12core_CreateRootSignatureDeserializer(d3d12core_interface *core,
         const void *data, SIZE_T data_size, REFIID iid, void **deserializer)
 {
-    TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
+    TRACE("data %p, data_size %zu, iid %s, deserializer %p.\n",
             data, data_size, debugstr_guid(iid), deserializer);
 
     return vkd3d_create_root_signature_deserializer(data, data_size, iid, deserializer);
@@ -763,7 +766,7 @@ HRESULT STDMETHODCALLTYPE d3d12core_SerializeRootSignature(d3d12core_interface *
 HRESULT STDMETHODCALLTYPE d3d12core_CreateVersionedRootSignatureDeserializer(d3d12core_interface *core,
         const void *data, SIZE_T data_size, REFIID iid, void **deserializer)
 {
-    TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
+    TRACE("data %p, data_size %zu, iid %s, deserializer %p.\n",
             data, data_size, debugstr_guid(iid), deserializer);
 
     return vkd3d_create_versioned_root_signature_deserializer(data, data_size, iid, deserializer);

--- a/libs/vkd3d-shader/dxbc.c
+++ b/libs/vkd3d-shader/dxbc.c
@@ -72,7 +72,7 @@ static void skip_dword_unknown(const char **ptr, unsigned int count)
     for (i = 0; i < count; ++i)
     {
         read_dword(ptr, &d);
-        WARN("\t0x%08x\n", d);
+        WARN("\t0x%08x\n", (int)d);
     }
 }
 
@@ -82,7 +82,7 @@ static const char *shader_get_string(const char *data, size_t data_size, DWORD o
 
     if (offset >= data_size)
     {
-        WARN("Invalid offset %#x (data size %#lx).\n", offset, (long)data_size);
+        WARN("Invalid offset %#x (data size %#lx).\n", (int)offset, (long)data_size);
         return NULL;
     }
 
@@ -113,7 +113,7 @@ static int parse_dxbc(const char *data, size_t data_size,
     }
 
     read_dword(&ptr, &tag);
-    TRACE("tag: %#x.\n", tag);
+    TRACE("tag: %#x.\n", (int)tag);
 
     if (tag != TAG_DXBC)
     {
@@ -125,18 +125,18 @@ static int parse_dxbc(const char *data, size_t data_size,
     skip_dword_unknown(&ptr, 4);
 
     read_dword(&ptr, &version);
-    TRACE("version: %#x.\n", version);
+    TRACE("version: %#x.\n", (int)version);
     if (version != 0x00000001)
     {
-        WARN("Got unexpected DXBC version %#x.\n", version);
+        WARN("Got unexpected DXBC version %#x.\n", (int)version);
         return VKD3D_ERROR_INVALID_ARGUMENT;
     }
 
     read_dword(&ptr, &total_size);
-    TRACE("total size: %#x\n", total_size);
+    TRACE("total size: %#x\n", (int)total_size);
 
     read_dword(&ptr, &chunk_count);
-    TRACE("chunk count: %#x\n", chunk_count);
+    TRACE("chunk count: %#x\n", (int)chunk_count);
 
     for (i = 0; i < chunk_count; ++i)
     {
@@ -145,11 +145,11 @@ static int parse_dxbc(const char *data, size_t data_size,
         DWORD chunk_offset;
 
         read_dword(&ptr, &chunk_offset);
-        TRACE("chunk %u at offset %#x\n", i, chunk_offset);
+        TRACE("chunk %u at offset %#x\n", i, (int)chunk_offset);
 
         if (chunk_offset >= data_size || !require_space(chunk_offset, 2, sizeof(DWORD), data_size))
         {
-            WARN("Invalid chunk offset %#x (data size %zu).\n", chunk_offset, data_size);
+            WARN("Invalid chunk offset %#x (data size %zu).\n", (int)chunk_offset, data_size);
             return VKD3D_ERROR_INVALID_ARGUMENT;
         }
 
@@ -161,7 +161,7 @@ static int parse_dxbc(const char *data, size_t data_size,
         if (!require_space(chunk_ptr - data, 1, chunk_size, data_size))
         {
             WARN("Invalid chunk size %#x (data size %zu, chunk offset %#x).\n",
-                    chunk_size, data_size, chunk_offset);
+                    (int)chunk_size, data_size, (int)chunk_offset);
             return VKD3D_ERROR_INVALID_ARGUMENT;
         }
 
@@ -183,18 +183,18 @@ static int shader_parse_signature(DWORD tag, const char *data, DWORD data_size,
 
     if (!require_space(0, 2, sizeof(DWORD), data_size))
     {
-        WARN("Invalid data size %#x.\n", data_size);
+        WARN("Invalid data size %#x.\n", (int)data_size);
         return VKD3D_ERROR_INVALID_ARGUMENT;
     }
 
     read_dword(&ptr, &count);
-    TRACE("%u elements.\n", count);
+    TRACE("%u elements.\n", (unsigned int)count);
 
     skip_dword_unknown(&ptr, 1); /* It seems to always be 0x00000008. */
 
     if (!require_space(ptr - data, count, 6 * sizeof(DWORD), data_size))
     {
-        WARN("Invalid count %#x (data size %#x).\n", count, data_size);
+        WARN("Invalid count %#x (data size %#x).\n", (int)count, (int)data_size);
         return VKD3D_ERROR_INVALID_ARGUMENT;
     }
 
@@ -219,7 +219,7 @@ static int shader_parse_signature(DWORD tag, const char *data, DWORD data_size,
         read_dword(&ptr, &name_offset);
         if (!(e[i].semantic_name = shader_get_string(data, data_size, name_offset)))
         {
-            WARN("Invalid name offset %#x (data size %#x).\n", name_offset, data_size);
+            WARN("Invalid name offset %#x (data size %#x).\n", (int)name_offset, (int)data_size);
             vkd3d_free(e);
             return VKD3D_ERROR_INVALID_ARGUMENT;
         }
@@ -629,7 +629,7 @@ static int shader_parse_root_parameters1(struct root_signature_parser_context *c
 
     if (!require_space(offset, 3 * count, sizeof(DWORD), context->data_size))
     {
-        WARN("Invalid data size %#x (offset %u, count %u).\n", context->data_size, offset, count);
+        WARN("Invalid data size %#x (offset %u, count %u).\n", context->data_size, (unsigned int)offset, (unsigned int)count);
         return VKD3D_ERROR_INVALID_ARGUMENT;
     }
     ptr = &context->data[offset];

--- a/libs/vkd3d/breadcrumbs.c
+++ b/libs/vkd3d/breadcrumbs.c
@@ -970,9 +970,9 @@ void vkd3d_breadcrumb_tracer_register_placed_resource(struct d3d12_heap *heap,
                     msg = "Attempting to place opaque resource on heap, placement aliases with other resources.";
 
                 d3d12_resource_report_parameters(report_buffer, sizeof(report_buffer), resource);
-                INFO("\n%s (heap %p)\n  New placement: resource cookie = %"PRIu64", offset = %"PRIu64", size = %"PRIu64", VA = %"PRIx64"\n\t%s\n",
+                INFO("\n%s (heap %p)\n  New placement: resource cookie = %u, offset = %"PRIu64", size = %"PRIu64", VA = %"PRIx64"\n\t%s\n",
                         msg, heap,
-                        resource->res.cookie,
+                        resource->res.cookie.index,
                         heap_offset, required_size, resource->res.va,
                         report_buffer);
 
@@ -980,8 +980,8 @@ void vkd3d_breadcrumb_tracer_register_placed_resource(struct d3d12_heap *heap,
             }
 
             d3d12_resource_report_parameters(report_buffer, sizeof(report_buffer), placement->resource);
-            INFO("\n   Existing aliasing resource : cookie = %"PRIu64", offset = %"PRIu64", size = %"PRIu64".\n\t\t%s\n",
-                    placement->resource->res.cookie, placement->heap_offset, placement->size,
+            INFO("\n   Existing aliasing resource : cookie = %u, offset = %"PRIu64", size = %"PRIu64".\n\t\t%s\n",
+                    placement->resource->res.cookie.index, placement->heap_offset, placement->size,
                     report_buffer);
         }
     }
@@ -989,9 +989,9 @@ void vkd3d_breadcrumb_tracer_register_placed_resource(struct d3d12_heap *heap,
     if (!has_alias)
     {
         d3d12_resource_report_parameters(report_buffer, sizeof(report_buffer), resource);
-        INFO("\nPlacing non-aliased resource (heap %p)\n New placement: resource cookie = %"PRIu64", offset = %"PRIu64", size = %"PRIu64", VA = %"PRIx64"\n\t%s\n",
+        INFO("\nPlacing non-aliased resource (heap %p)\n New placement: resource cookie = %u, offset = %"PRIu64", size = %"PRIu64", VA = %"PRIx64"\n\t%s\n",
                 heap,
-                resource->res.cookie,
+                resource->res.cookie.index,
                 heap_offset, required_size, resource->res.va,
                 report_buffer);
     }

--- a/libs/vkd3d/bundle.c
+++ b/libs/vkd3d/bundle.c
@@ -107,7 +107,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_bundle_allocator_QueryInterface(ID3D12Com
 static ULONG STDMETHODCALLTYPE d3d12_bundle_allocator_AddRef(ID3D12CommandAllocator *iface)
 {
     struct d3d12_bundle_allocator *allocator = impl_from_ID3D12CommandAllocator(iface);
-    ULONG refcount = InterlockedIncrement(&allocator->refcount);
+    unsigned int refcount = InterlockedIncrement(&allocator->refcount);
 
     TRACE("%p increasing refcount to %u.\n", allocator, refcount);
 
@@ -117,7 +117,7 @@ static ULONG STDMETHODCALLTYPE d3d12_bundle_allocator_AddRef(ID3D12CommandAlloca
 static ULONG STDMETHODCALLTYPE d3d12_bundle_allocator_Release(ID3D12CommandAllocator *iface)
 {
     struct d3d12_bundle_allocator *allocator = impl_from_ID3D12CommandAllocator(iface);
-    ULONG refcount = InterlockedDecrement(&allocator->refcount);
+    unsigned int refcount = InterlockedDecrement(&allocator->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", allocator, refcount);
 
@@ -313,7 +313,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_bundle_QueryInterface(d3d12_command_list_
 static ULONG STDMETHODCALLTYPE d3d12_bundle_AddRef(d3d12_command_list_iface *iface)
 {
     struct d3d12_bundle *bundle = impl_from_ID3D12GraphicsCommandList(iface);
-    ULONG refcount = InterlockedIncrement(&bundle->refcount);
+    unsigned int refcount = InterlockedIncrement(&bundle->refcount);
 
     TRACE("%p increasing refcount to %u.\n", bundle, refcount);
 
@@ -323,7 +323,7 @@ static ULONG STDMETHODCALLTYPE d3d12_bundle_AddRef(d3d12_command_list_iface *ifa
 static ULONG STDMETHODCALLTYPE d3d12_bundle_Release(d3d12_command_list_iface *iface)
 {
     struct d3d12_bundle *bundle = impl_from_ID3D12GraphicsCommandList(iface);
-    ULONG refcount = InterlockedDecrement(&bundle->refcount);
+    unsigned int refcount = InterlockedDecrement(&bundle->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", bundle, refcount);
 
@@ -1162,31 +1162,31 @@ static void STDMETHODCALLTYPE d3d12_bundle_ClearDepthStencilView(d3d12_command_l
         D3D12_CPU_DESCRIPTOR_HANDLE dsv, D3D12_CLEAR_FLAGS flags, float depth, UINT8 stencil,
         UINT rect_count, const D3D12_RECT *rects)
 {
-    WARN("iface %p, dsv %#lx, flags %#x, depth %.8e, stencil 0x%02x, rect_count %u, rects %p ignored!\n",
-            iface, dsv.ptr, flags, depth, stencil, rect_count, rects);
+    WARN("iface %p, dsv %zx, flags %#x, depth %.8e, stencil 0x%02x, rect_count %u, rects %p ignored!\n",
+            iface, (size_t)dsv.ptr, flags, depth, stencil, rect_count, rects);
 }
 
 static void STDMETHODCALLTYPE d3d12_bundle_ClearRenderTargetView(d3d12_command_list_iface *iface,
         D3D12_CPU_DESCRIPTOR_HANDLE rtv, const FLOAT color[4], UINT rect_count, const D3D12_RECT *rects)
 {
-    WARN("iface %p, rtv %#lx, color %p, rect_count %u, rects %p ignored!\n",
-            iface, rtv.ptr, color, rect_count, rects);
+    WARN("iface %p, rtv %zx, color %p, rect_count %u, rects %p ignored!\n",
+            iface, (size_t)rtv.ptr, color, rect_count, rects);
 }
 
 static void STDMETHODCALLTYPE d3d12_bundle_ClearUnorderedAccessViewUint(d3d12_command_list_iface *iface,
         D3D12_GPU_DESCRIPTOR_HANDLE gpu_handle, D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle, ID3D12Resource *resource,
         const UINT values[4], UINT rect_count, const D3D12_RECT *rects)
 {
-    WARN("iface %p, gpu_handle %#"PRIx64", cpu_handle %lx, resource %p, values %p, rect_count %u, rects %p ignored!\n",
-            iface, gpu_handle.ptr, cpu_handle.ptr, resource, values, rect_count, rects);
+    WARN("iface %p, gpu_handle %"PRIx64", cpu_handle %zx, resource %p, values %p, rect_count %u, rects %p ignored!\n",
+            iface, gpu_handle.ptr, (size_t)cpu_handle.ptr, resource, values, rect_count, rects);
 }
 
 static void STDMETHODCALLTYPE d3d12_bundle_ClearUnorderedAccessViewFloat(d3d12_command_list_iface *iface,
         D3D12_GPU_DESCRIPTOR_HANDLE gpu_handle, D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle, ID3D12Resource *resource,
         const float values[4], UINT rect_count, const D3D12_RECT *rects)
 {
-    WARN("iface %p, gpu_handle %#"PRIx64", cpu_handle %lx, resource %p, values %p, rect_count %u, rects %p ignored!\n",
-            iface, gpu_handle.ptr, cpu_handle.ptr, resource, values, rect_count, rects);
+    WARN("iface %p, gpu_handle %"PRIx64", cpu_handle %zx, resource %p, values %p, rect_count %u, rects %p ignored!\n",
+            iface, gpu_handle.ptr, (size_t)cpu_handle.ptr, resource, values, rect_count, rects);
 }
 
 static void STDMETHODCALLTYPE d3d12_bundle_DiscardResource(d3d12_command_list_iface *iface,
@@ -1514,15 +1514,15 @@ static void STDMETHODCALLTYPE d3d12_bundle_EndRenderPass(d3d12_command_list_ifac
 static void STDMETHODCALLTYPE d3d12_bundle_InitializeMetaCommand(d3d12_command_list_iface *iface,
         ID3D12MetaCommand *meta_command, const void *parameter_data, SIZE_T parameter_size)
 {
-    WARN("iface %p, meta_command %p, parameter_data %p, parameter_size %lu ignored!\n",
-            iface, meta_command, parameter_data, parameter_size);
+    WARN("iface %p, meta_command %p, parameter_data %p, parameter_size %zu ignored!\n",
+            iface, meta_command, parameter_data, (size_t)parameter_size);
 }
 
 static void STDMETHODCALLTYPE d3d12_bundle_ExecuteMetaCommand(d3d12_command_list_iface *iface,
         ID3D12MetaCommand *meta_command, const void *parameter_data, SIZE_T parameter_size)
 {
-    WARN("iface %p, meta_command %p, parameter_data %p, parameter_size %lu ignored!\n",
-            iface, meta_command, parameter_data, parameter_size);
+    WARN("iface %p, meta_command %p, parameter_data %p, parameter_size %zu ignored!\n",
+            iface, meta_command, parameter_data, (size_t)parameter_size);
 }
 
 static void STDMETHODCALLTYPE d3d12_bundle_BuildRaytracingAccelerationStructure(d3d12_command_list_iface *iface,

--- a/libs/vkd3d/cache.c
+++ b/libs/vkd3d/cache.c
@@ -1507,7 +1507,7 @@ void d3d12_pipeline_library_dec_ref(struct d3d12_pipeline_library *pipeline_libr
 
 ULONG d3d12_pipeline_library_inc_public_ref(struct d3d12_pipeline_library *pipeline_library)
 {
-    ULONG refcount = InterlockedIncrement(&pipeline_library->refcount);
+    unsigned int refcount = InterlockedIncrement(&pipeline_library->refcount);
     if (refcount == 1)
         d3d12_device_add_ref(pipeline_library->device);
     TRACE("%p increasing refcount to %u.\n", pipeline_library, refcount);
@@ -1517,7 +1517,7 @@ ULONG d3d12_pipeline_library_inc_public_ref(struct d3d12_pipeline_library *pipel
 ULONG d3d12_pipeline_library_dec_public_ref(struct d3d12_pipeline_library *pipeline_library)
 {
     struct d3d12_device *device = pipeline_library->device;
-    ULONG refcount = InterlockedDecrement(&pipeline_library->refcount);
+    unsigned int refcount = InterlockedDecrement(&pipeline_library->refcount);
     TRACE("%p decreasing refcount to %u.\n", pipeline_library, refcount);
     if (!refcount)
     {
@@ -2982,7 +2982,7 @@ static void vkd3d_pipeline_library_disk_cache_merge(struct vkd3d_pipeline_librar
     if (FAILED(hr = d3d12_pipeline_library_validate_stream_format_header(cache->library,
             cache->library->device, mapped_write_cache.mapped, mapped_write_cache.mapped_size)))
     {
-        INFO("Write cache is invalid (hr #%x), nuking it.\n", hr);
+        INFO("Write cache is invalid (hr #%x), nuking it.\n", (int)hr);
         goto out;
     }
 
@@ -3198,7 +3198,7 @@ static void vkd3d_pipeline_library_disk_cache_initial_setup(struct vkd3d_pipelin
         else if (hr == D3D12_ERROR_ADAPTER_NOT_FOUND)
             INFO("Cannot load existing on-disk cache due to driver version mismatch.\n");
         else if (FAILED(hr))
-            INFO("Failed to load driver cache with hr #%x, falling back to empty cache.\n", hr);
+            INFO("Failed to load driver cache with hr #%x, falling back to empty cache.\n", (int)hr);
     }
 
     /* When we add new internal blobs from this point,
@@ -3481,7 +3481,7 @@ static void *vkd3d_pipeline_library_disk_thread_main(void *userarg)
             {
                 /* INVALIDARG is expected for duplicates. */
                 if (hr != E_INVALIDARG)
-                    ERR("Failed to serialize pipeline to disk cache, hr #%x.\n", hr);
+                    ERR("Failed to serialize pipeline to disk cache, hr #%x.\n", (int)hr);
             }
             else if (!dirty)
             {
@@ -3522,7 +3522,7 @@ static void *vkd3d_pipeline_library_disk_thread_main(void *userarg)
         {
             /* INVALIDARG is expected for duplicates. */
             if (hr != E_INVALIDARG)
-                ERR("Failed to serialize pipeline to disk cache, hr #%x.\n", hr);
+                ERR("Failed to serialize pipeline to disk cache, hr #%x.\n", (int)hr);
         }
         else
             dirty = true;
@@ -3536,7 +3536,7 @@ static void *vkd3d_pipeline_library_disk_thread_main(void *userarg)
         {
             /* INVALIDARG is expected for duplicates. */
             if (hr != E_INVALIDARG)
-                ERR("Failed to serialize pipeline to disk cache, hr #%x.\n", hr);
+                ERR("Failed to serialize pipeline to disk cache, hr #%x.\n", (int)hr);
         }
         else
             dirty = true;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -713,7 +713,7 @@ static void vkd3d_waiting_fence_signal_fence(struct vkd3d_fence_worker *worker,
         TRACE("Signaling fence %p to virtual value %"PRIu64".\n", info->fence, info->virtual_value);
 
         if (FAILED(hr = d3d12_fence_signal(info->fence, worker, info->update_count)))
-            ERR("Failed to signal D3D12 fence, hr %#x.\n", hr);
+            ERR("Failed to signal D3D12 fence, hr %#x.\n", (int)hr);
     }
 
     d3d12_fence_dec_ref(info->fence);
@@ -1135,7 +1135,7 @@ static HRESULT vkd3d_waiting_event_signal(struct d3d12_device *device, struct vk
     hr = vkd3d_native_sync_handle_signal(event->handle);
 
     if (FAILED(hr))
-        ERR("Failed to signal event, hr #%x.\n", hr);
+        ERR("Failed to signal event, hr #%x.\n", (int)hr);
 
     return hr;
 }
@@ -1476,7 +1476,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_fence_QueryInterface(d3d12_fence_iface *i
 static ULONG STDMETHODCALLTYPE d3d12_fence_AddRef(d3d12_fence_iface *iface)
 {
     struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
-    ULONG refcount = InterlockedIncrement(&fence->refcount);
+    unsigned int refcount = InterlockedIncrement(&fence->refcount);
 
     TRACE("%p increasing refcount to %u.\n", fence, refcount);
 
@@ -1486,7 +1486,7 @@ static ULONG STDMETHODCALLTYPE d3d12_fence_AddRef(d3d12_fence_iface *iface)
 static ULONG STDMETHODCALLTYPE d3d12_fence_Release(d3d12_fence_iface *iface)
 {
     struct d3d12_fence *fence = impl_from_ID3D12Fence1(iface);
-    ULONG refcount = InterlockedDecrement(&fence->refcount);
+    unsigned int refcount = InterlockedDecrement(&fence->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", fence, refcount);
 
@@ -1826,7 +1826,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_shared_fence_QueryInterface(d3d12_fence_i
 static ULONG STDMETHODCALLTYPE d3d12_shared_fence_AddRef(d3d12_fence_iface *iface)
 {
     struct d3d12_shared_fence *fence = shared_impl_from_ID3D12Fence1(iface);
-    ULONG refcount = InterlockedIncrement(&fence->refcount);
+    unsigned int refcount = InterlockedIncrement(&fence->refcount);
 
     TRACE("%p increasing refcount to %u.\n", fence, refcount);
 
@@ -1883,7 +1883,7 @@ static void d3d12_shared_fence_dec_ref(struct d3d12_shared_fence *fence)
 static ULONG STDMETHODCALLTYPE d3d12_shared_fence_Release(d3d12_fence_iface *iface)
 {
     struct d3d12_shared_fence *fence = shared_impl_from_ID3D12Fence1(iface);
-    ULONG refcount = InterlockedDecrement(&fence->refcount);
+    unsigned int refcount = InterlockedDecrement(&fence->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", fence, refcount);
 
@@ -2927,7 +2927,7 @@ static ULONG d3d12_command_allocator_inc_ref(struct d3d12_command_allocator *all
 static ULONG STDMETHODCALLTYPE d3d12_command_allocator_AddRef(ID3D12CommandAllocator *iface)
 {
     struct d3d12_command_allocator *allocator = impl_from_ID3D12CommandAllocator(iface);
-    ULONG refcount = InterlockedIncrement(&allocator->refcount);
+    unsigned int refcount = InterlockedIncrement(&allocator->refcount);
 
     TRACE("%p increasing refcount to %u.\n", allocator, refcount);
 
@@ -3046,7 +3046,7 @@ static ULONG d3d12_command_allocator_dec_ref(struct d3d12_command_allocator *all
 static ULONG STDMETHODCALLTYPE d3d12_command_allocator_Release(ID3D12CommandAllocator *iface)
 {
     struct d3d12_command_allocator *allocator = impl_from_ID3D12CommandAllocator(iface);
-    ULONG refcount = InterlockedDecrement(&allocator->refcount);
+    unsigned int refcount = InterlockedDecrement(&allocator->refcount);
     unsigned int pending;
 
     TRACE("%p decreasing refcount to %u.\n", allocator, refcount);
@@ -6798,7 +6798,7 @@ HRESULT STDMETHODCALLTYPE d3d12_command_list_QueryInterface(d3d12_command_list_i
 ULONG STDMETHODCALLTYPE d3d12_command_list_AddRef(d3d12_command_list_iface *iface)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    ULONG refcount = InterlockedIncrement(&list->refcount);
+    unsigned int refcount = InterlockedIncrement(&list->refcount);
 
     TRACE("%p increasing refcount to %u.\n", list, refcount);
 
@@ -6808,7 +6808,7 @@ ULONG STDMETHODCALLTYPE d3d12_command_list_AddRef(d3d12_command_list_iface *ifac
 ULONG STDMETHODCALLTYPE d3d12_command_list_Release(d3d12_command_list_iface *iface)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    ULONG refcount = InterlockedDecrement(&list->refcount);
+    unsigned int refcount = InterlockedDecrement(&list->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", list, refcount);
 
@@ -15135,7 +15135,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearDepthStencilView(d3d12_com
     const struct d3d12_rtv_desc *dsv_desc = d3d12_rtv_desc_from_cpu_handle(dsv);
     VkImageAspectFlags clear_aspects = 0;
 
-    TRACE("iface %p, dsv %#lx, flags %#x, depth %.8e, stencil 0x%02x, rect_count %u, rects %p.\n",
+    TRACE("iface %p, dsv %zx, flags %#x, depth %.8e, stencil 0x%02x, rect_count %u, rects %p.\n",
             iface, dsv.ptr, flags, depth, stencil, rect_count, rects);
 
     d3d12_command_list_check_render_pass_validation(list, "ClearDepthStencilView called within a render pass.\n", true);
@@ -15269,7 +15269,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearRenderTargetView(d3d12_com
     VkClearValue clear_value;
     int i;
 
-    TRACE("iface %p, rtv %#lx, color %p, rect_count %u, rects %p.\n",
+    TRACE("iface %p, rtv %zx, color %p, rect_count %u, rects %p.\n",
             iface, rtv.ptr, color, rect_count, rects);
 
     d3d12_command_list_check_render_pass_validation(list, "ClearRenderTargetView called within a render pass.\n", true);
@@ -16000,7 +16000,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
     struct vkd3d_clear_uav_info args;
     VkClearColorValue color;
 
-    TRACE("iface %p, gpu_handle %#"PRIx64", cpu_handle %lx, resource %p, values %p, rect_count %u, rects %p.\n",
+    TRACE("iface %p, gpu_handle %#"PRIx64", cpu_handle %zx, resource %p, values %p, rect_count %u, rects %p.\n",
             iface, gpu_handle.ptr, cpu_handle.ptr, resource, values, rect_count, rects);
 
     d3d12_command_list_check_render_pass_validation(list, "ClearUnorderedAccessViewUint called within a render pass.\n", true);
@@ -16162,7 +16162,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewFloat(d
     struct vkd3d_clear_uav_info args;
     VkClearColorValue color;
 
-    TRACE("iface %p, gpu_handle %#"PRIx64", cpu_handle %lx, resource %p, values %p, rect_count %u, rects %p.\n",
+    TRACE("iface %p, gpu_handle %#"PRIx64", cpu_handle %zx, resource %p, values %p, rect_count %u, rects %p.\n",
             iface, gpu_handle.ptr, cpu_handle.ptr, resource, values, rect_count, rects);
 
     d3d12_command_list_check_render_pass_validation(list, "ClearUnorderedAccessViewFloat called within a render pass.\n", true);
@@ -20176,7 +20176,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_InitializeMetaCommand(d3d12_com
     struct d3d12_meta_command *meta_command_object = impl_from_ID3D12MetaCommand(meta_command);
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
 
-    TRACE("iface %p, meta_command %p, parameter_data %p, parameter_size %lu.\n",
+    TRACE("iface %p, meta_command %p, parameter_data %p, parameter_size %zu.\n",
             iface, meta_command, parameter_data, parameter_size);
 
     /* Not all meta commands require initialization */
@@ -20198,7 +20198,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_ExecuteMetaCommand(d3d12_comman
     struct d3d12_meta_command *meta_command_object = impl_from_ID3D12MetaCommand(meta_command);
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
 
-    TRACE("iface %p, meta_command %p, parameter_data %p, parameter_size %lu.\n",
+    TRACE("iface %p, meta_command %p, parameter_data %p, parameter_size %zu.\n",
             iface, meta_command, parameter_data, parameter_size);
 
     list->cmd.estimated_cost += VKD3D_COMMAND_COST_HIGH;
@@ -22467,7 +22467,7 @@ HRESULT STDMETHODCALLTYPE d3d12_command_queue_QueryInterface(ID3D12CommandQueue 
 ULONG STDMETHODCALLTYPE d3d12_command_queue_AddRef(ID3D12CommandQueue *iface)
 {
     struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
-    ULONG refcount = InterlockedIncrement(&command_queue->refcount);
+    unsigned int refcount = InterlockedIncrement(&command_queue->refcount);
 
     TRACE("%p increasing refcount to %u.\n", command_queue, refcount);
 
@@ -22477,7 +22477,7 @@ ULONG STDMETHODCALLTYPE d3d12_command_queue_AddRef(ID3D12CommandQueue *iface)
 ULONG STDMETHODCALLTYPE d3d12_command_queue_Release(ID3D12CommandQueue *iface)
 {
     struct d3d12_command_queue *command_queue = impl_from_ID3D12CommandQueue(iface);
-    ULONG refcount = InterlockedDecrement(&command_queue->refcount);
+    unsigned int refcount = InterlockedDecrement(&command_queue->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", command_queue, refcount);
 
@@ -23661,7 +23661,7 @@ static void d3d12_command_queue_push_fence_waits_to_worker(struct d3d12_command_
         fence_wait->fence = NULL;
 
         if (FAILED(hr = vkd3d_enqueue_timeline_semaphore(worker, &fence_info, &cookie)))
-            ERR("Failed to enqueue timeline semaphore, hr %#x.\n", hr);
+            ERR("Failed to enqueue timeline semaphore, hr %#x.\n", (int)hr);
     }
 }
 
@@ -23891,7 +23891,7 @@ static void d3d12_command_queue_ensure_fence_signal_order(
     d3d12_fence_inc_ref(fence);
 
     if (FAILED(hr = vkd3d_enqueue_timeline_semaphore(&command_queue->fence_worker, &fence_info, NULL)))
-        ERR("Failed to enqueue timeline semaphore, hr %#x.\n", hr);
+        ERR("Failed to enqueue timeline semaphore, hr %#x.\n", (int)hr);
 }
 
 static void d3d12_command_queue_wait(struct d3d12_command_queue *command_queue,
@@ -23997,7 +23997,7 @@ static void d3d12_command_queue_signal(struct d3d12_command_queue *command_queue
     d3d12_fence_inc_ref(signal_info->fence);
 
     if (FAILED(hr = vkd3d_enqueue_timeline_semaphore(&command_queue->fence_worker, &fence_info, &cookie)))
-        ERR("Failed to enqueue timeline semaphore, hr #%x.\n", hr);
+        ERR("Failed to enqueue timeline semaphore, hr #%x.\n", (int)hr);
 
     d3d12_fence_update_pending_value_locked_and_broadcast(fence);
     d3d12_fence_unlock(fence);
@@ -24104,7 +24104,7 @@ static void d3d12_command_queue_signal_shared(struct d3d12_command_queue *comman
 
     if (FAILED(hr = vkd3d_enqueue_timeline_semaphore(&command_queue->fence_worker, &fence_info, NULL)))
     {
-        ERR("Failed to enqueue timeline semaphore, hr #%x.\n", hr);
+        ERR("Failed to enqueue timeline semaphore, hr #%x.\n", (int)hr);
     }
 
     /* We should probably trigger DEVICE_REMOVED if we hit any errors in the submission thread. */
@@ -25569,7 +25569,7 @@ static HRESULT d3d12_command_queue_init(struct d3d12_command_queue *queue,
     hr = d3d12_device_removed_reason(device);
     if (hr != S_OK)
     {
-        WARN("Device %p is removed (reason %#x).\n", device, hr);
+        WARN("Device %p is removed (reason %#x).\n", device, (int)hr);
         return DXGI_ERROR_DEVICE_REMOVED;
     }
 
@@ -25818,7 +25818,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_signature_QueryInterface(ID3D12Co
 static ULONG STDMETHODCALLTYPE d3d12_command_signature_AddRef(ID3D12CommandSignature *iface)
 {
     struct d3d12_command_signature *signature = impl_from_ID3D12CommandSignature(iface);
-    ULONG refcount = InterlockedIncrement(&signature->refcount);
+    unsigned int refcount = InterlockedIncrement(&signature->refcount);
 
     TRACE("%p increasing refcount to %u.\n", signature, refcount);
 
@@ -25852,7 +25852,7 @@ static void d3d12_command_signature_cleanup(struct d3d12_command_signature *sign
 static ULONG STDMETHODCALLTYPE d3d12_command_signature_Release(ID3D12CommandSignature *iface)
 {
     struct d3d12_command_signature *signature = impl_from_ID3D12CommandSignature(iface);
-    ULONG refcount = InterlockedDecrement(&signature->refcount);
+    unsigned int refcount = InterlockedDecrement(&signature->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", signature, refcount);
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1346,7 +1346,7 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
 
     if (FAILED(hr = vkd3d_init_vk_global_procs(instance, create_info->pfn_vkGetInstanceProcAddr)))
     {
-        ERR("Failed to initialize Vulkan global procs, hr %#x.\n", hr);
+        ERR("Failed to initialize Vulkan global procs, hr %#x.\n", (int)hr);
         return hr;
     }
 
@@ -1459,7 +1459,7 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
 
     if (FAILED(hr = vkd3d_load_vk_instance_procs(&instance->vk_procs, vk_global_procs, vk_instance)))
     {
-        ERR("Failed to load instance procs, hr %#x.\n", hr);
+        ERR("Failed to load instance procs, hr %#x.\n", (int)hr);
         vkd3d_free((void *)extensions);
         if (instance->vk_procs.vkDestroyInstance)
             instance->vk_procs.vkDestroyInstance(vk_instance, NULL);
@@ -1560,7 +1560,7 @@ static void vkd3d_destroy_instance(struct vkd3d_instance *instance)
 
 ULONG vkd3d_instance_incref(struct vkd3d_instance *instance)
 {
-    ULONG refcount = InterlockedIncrement(&instance->refcount);
+    unsigned int refcount = InterlockedIncrement(&instance->refcount);
 
     TRACE("%p increasing refcount to %u.\n", instance, refcount);
 
@@ -1569,7 +1569,7 @@ ULONG vkd3d_instance_incref(struct vkd3d_instance *instance)
 
 ULONG vkd3d_instance_decref(struct vkd3d_instance *instance)
 {
-    ULONG refcount;
+    unsigned int refcount;
 
     /* The device singleton is more advanced, since it uses a CAS loop.
      * Device references are lowered constantly, but instance references only release
@@ -4096,7 +4096,7 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
 
     if (FAILED(hr = vkd3d_load_vk_device_procs(&device->vk_procs, vk_procs, vk_device)))
     {
-        ERR("Failed to load device procs, hr %#x.\n", hr);
+        ERR("Failed to load device procs, hr %#x.\n", (int)hr);
         if (device->vk_procs.vkDestroyDevice)
             device->vk_procs.vkDestroyDevice(vk_device, NULL);
         return hr;
@@ -4106,7 +4106,7 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
 
     if (FAILED(hr = d3d12_device_create_vkd3d_queues(device, &device_queue_info)))
     {
-        ERR("Failed to create queues, hr %#x.\n", hr);
+        ERR("Failed to create queues, hr %#x.\n", (int)hr);
         device->vk_procs.vkDestroyDevice(vk_device, NULL);
         return hr;
     }
@@ -4680,7 +4680,7 @@ ULONG d3d12_device_release_common(struct d3d12_device *device)
 static ULONG STDMETHODCALLTYPE d3d12_device_AddRef(d3d12_device_iface *iface)
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
-    ULONG refcount = d3d12_device_add_ref_common(device);
+    unsigned int refcount = d3d12_device_add_ref_common(device);
     TRACE("%p increasing refcount to %u.\n", device, refcount);
     return refcount;
 }
@@ -4688,7 +4688,7 @@ static ULONG STDMETHODCALLTYPE d3d12_device_AddRef(d3d12_device_iface *iface)
 static ULONG STDMETHODCALLTYPE d3d12_device_Release(d3d12_device_iface *iface)
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
-    UINT refcount = d3d12_device_release_common(device);
+    unsigned int refcount = d3d12_device_release_common(device);
     TRACE("%p decreasing refcount to %u.\n", device, refcount);
     return refcount;
 }
@@ -6187,7 +6187,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateRootSignature(d3d12_device_i
     struct d3d12_root_signature *object;
     HRESULT hr;
 
-    TRACE("iface %p, node_mask 0x%08x, bytecode %p, bytecode_length %lu, riid %s, root_signature %p.\n",
+    TRACE("iface %p, node_mask 0x%08x, bytecode %p, bytecode_length %zu, riid %s, root_signature %p.\n",
             iface, node_mask, bytecode, bytecode_length, debugstr_guid(riid), root_signature);
 
     debug_ignored_node_mask(node_mask);
@@ -6204,7 +6204,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateConstantBufferView_heap(d3d12_d
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     d3d12_desc_create_cbv_heap(descriptor.ptr, device, desc);
 }
@@ -6214,7 +6214,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateConstantBufferView_embedded(d3d
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     d3d12_desc_create_cbv_embedded(descriptor.ptr, device, desc);
 }
@@ -6224,7 +6224,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateConstantBufferView_default(d3d1
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     d3d12_desc_create_cbv(descriptor.ptr, device, desc);
 }
@@ -6235,7 +6235,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateShaderResourceView_heap(d3d12_d
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, resource %p, desc %p, descriptor %#lx.\n",
+    TRACE("iface %p, resource %p, desc %p, descriptor %#zx.\n",
             iface, resource, desc, descriptor.ptr);
 
     d3d12_desc_create_srv_heap(descriptor.ptr, device, impl_from_ID3D12Resource(resource), desc);
@@ -6247,7 +6247,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateShaderResourceView_embedded(d3d
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, resource %p, desc %p, descriptor %#lx.\n",
+    TRACE("iface %p, resource %p, desc %p, descriptor %#zx.\n",
             iface, resource, desc, descriptor.ptr);
 
     d3d12_desc_create_srv_embedded(descriptor.ptr, device, impl_from_ID3D12Resource(resource), desc);
@@ -6259,7 +6259,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateShaderResourceView_default(d3d1
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, resource %p, desc %p, descriptor %#lx.\n",
+    TRACE("iface %p, resource %p, desc %p, descriptor %#zx.\n",
             iface, resource, desc, descriptor.ptr);
 
     d3d12_desc_create_srv(descriptor.ptr, device, impl_from_ID3D12Resource(resource), desc);
@@ -6273,7 +6273,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateUnorderedAccessView_heap(d3d12_
 {
     struct d3d12_resource *d3d12_resource_ = impl_from_ID3D12Resource(resource);
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
-    TRACE("iface %p, resource %p, counter_resource %p, desc %p, descriptor %#lx.\n",
+    TRACE("iface %p, resource %p, counter_resource %p, desc %p, descriptor %#zx.\n",
             iface, resource, counter_resource, desc, descriptor.ptr);
 
     d3d12_desc_create_uav_heap(descriptor.ptr,
@@ -6316,7 +6316,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateUnorderedAccessView_embedded(d3
 {
     struct d3d12_resource *d3d12_resource_ = impl_from_ID3D12Resource(resource);
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
-    TRACE("iface %p, resource %p, counter_resource %p, desc %p, descriptor %#lx.\n",
+    TRACE("iface %p, resource %p, counter_resource %p, desc %p, descriptor %#zx.\n",
             iface, resource, counter_resource, desc, descriptor.ptr);
 
     d3d12_desc_create_uav_embedded(descriptor.ptr,
@@ -6334,7 +6334,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateUnorderedAccessView_default(d3d
     VkResult vr;
     struct d3d12_resource *d3d12_resource_ = impl_from_ID3D12Resource(resource);
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
-    TRACE("iface %p, resource %p, counter_resource %p, desc %p, descriptor %#lx.\n",
+    TRACE("iface %p, resource %p, counter_resource %p, desc %p, descriptor %#zx.\n",
             iface, resource, counter_resource, desc, descriptor.ptr);
 
     d3d12_desc_create_uav(descriptor.ptr,
@@ -6380,7 +6380,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateRenderTargetView(d3d12_device_i
         ID3D12Resource *resource, const D3D12_RENDER_TARGET_VIEW_DESC *desc,
         D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
 {
-    TRACE("iface %p, resource %p, desc %p, descriptor %#lx.\n",
+    TRACE("iface %p, resource %p, desc %p, descriptor %#zx.\n",
             iface, resource, desc, descriptor.ptr);
 
     d3d12_rtv_desc_create_rtv(d3d12_rtv_desc_from_cpu_handle(descriptor),
@@ -6391,7 +6391,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateDepthStencilView(d3d12_device_i
         ID3D12Resource *resource, const D3D12_DEPTH_STENCIL_VIEW_DESC *desc,
         D3D12_CPU_DESCRIPTOR_HANDLE descriptor)
 {
-    TRACE("iface %p, resource %p, desc %p, descriptor %#lx.\n",
+    TRACE("iface %p, resource %p, desc %p, descriptor %#zx.\n",
             iface, resource, desc, descriptor.ptr);
 
     d3d12_rtv_desc_create_dsv(d3d12_rtv_desc_from_cpu_handle(descriptor),
@@ -6404,7 +6404,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSampler_heap(d3d12_device_iface
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     D3D12_SAMPLER_DESC2 desc2;
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     memcpy(&desc2, desc, sizeof(*desc));
     desc2.Flags = D3D12_SAMPLER_FLAG_NONE;
@@ -6417,7 +6417,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSampler_embedded(d3d12_device_i
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     D3D12_SAMPLER_DESC2 desc2;
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     memcpy(&desc2, desc, sizeof(*desc));
     desc2.Flags = D3D12_SAMPLER_FLAG_NONE;
@@ -6430,7 +6430,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSampler_default(d3d12_device_if
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     D3D12_SAMPLER_DESC2 desc2;
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     memcpy(&desc2, desc, sizeof(*desc));
     desc2.Flags = D3D12_SAMPLER_FLAG_NONE;
@@ -6442,7 +6442,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSampler2_heap(d3d12_device_ifac
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     d3d12_desc_create_sampler_heap(descriptor.ptr, device, desc);
 }
@@ -6452,7 +6452,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSampler2_embedded(d3d12_device_
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     d3d12_desc_create_sampler_embedded(descriptor.ptr, device, desc);
 }
@@ -6462,7 +6462,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSampler2_default(d3d12_device_i
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    TRACE("iface %p, desc %p, descriptor %#lx.\n", iface, desc, descriptor.ptr);
+    TRACE("iface %p, desc %p, descriptor %#zx.\n", iface, desc, descriptor.ptr);
 
     d3d12_desc_create_sampler(descriptor.ptr, device, desc);
 }
@@ -6590,8 +6590,8 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_descriptor_buff
     struct d3d12_desc_split src;
     size_t i, n;
 
-    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
-          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#zx, "
+          "src_descriptor_range_offset %#zx, descriptor_heap_type %#x.\n",
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
@@ -6694,8 +6694,8 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_descriptor_buff
     struct d3d12_desc_split src;
     size_t i, n;
 
-    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
-          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#zx, "
+          "src_descriptor_range_offset %#zx, descriptor_heap_type %#x.\n",
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
@@ -6792,8 +6792,8 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_embedded_64_16_
         D3D12_DESCRIPTOR_HEAP_TYPE descriptor_heap_type)
 {
     struct d3d12_device *device;
-    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
-          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#zx, "
+          "src_descriptor_range_offset %#zx, descriptor_heap_type %#x.\n",
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
@@ -6885,8 +6885,8 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_embedded_32_16_
         D3D12_DESCRIPTOR_HEAP_TYPE descriptor_heap_type)
 {
     struct d3d12_device *device;
-    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
-          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#zx, "
+          "src_descriptor_range_offset %#zx, descriptor_heap_type %#x.\n",
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
@@ -6942,8 +6942,8 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_embedded_32_32_
         D3D12_DESCRIPTOR_HEAP_TYPE descriptor_heap_type)
 {
     struct d3d12_device *device;
-    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
-          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#zx, "
+          "src_descriptor_range_offset %#zx, descriptor_heap_type %#x.\n",
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
@@ -6982,8 +6982,8 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_embedded_128_32
         D3D12_DESCRIPTOR_HEAP_TYPE descriptor_heap_type)
 {
     struct d3d12_device *device;
-    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
-          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#zx, "
+          "src_descriptor_range_offset %#zx, descriptor_heap_type %#x.\n",
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
@@ -7028,8 +7028,8 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_embedded_generi
         D3D12_DESCRIPTOR_HEAP_TYPE descriptor_heap_type)
 {
     struct d3d12_device *device;
-    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
-          "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#zx, "
+          "src_descriptor_range_offset %#zx, descriptor_heap_type %#x.\n",
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
@@ -7064,8 +7064,8 @@ static void STDMETHODCALLTYPE d3d12_device_CopyDescriptorsSimple_default(d3d12_d
         D3D12_DESCRIPTOR_HEAP_TYPE descriptor_heap_type)
 {
     struct d3d12_device *device;
-    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#lx, "
-            "src_descriptor_range_offset %#lx, descriptor_heap_type %#x.\n",
+    TRACE("iface %p, descriptor_count %u, dst_descriptor_range_offset %#zx, "
+            "src_descriptor_range_offset %#zx, descriptor_heap_type %#x.\n",
             iface, descriptor_count, dst_descriptor_range_offset.ptr, src_descriptor_range_offset.ptr,
             descriptor_heap_type);
 
@@ -7242,7 +7242,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateSharedHandle(d3d12_device_if
     vk_procs = &device->vk_procs;
 
     TRACE("iface %p, object %p, attributes %p, access %#x, name %s, handle %p\n",
-            iface, object, attributes, access, debugstr_w(name), handle);
+            iface, object, attributes, (int)access, debugstr_w(name), handle);
 
     attr.Length = sizeof(attr);
     attr.SecurityDescriptor = (void *)attributes;
@@ -7282,7 +7282,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateSharedHandle(d3d12_device_if
         if (attributes)
             FIXME("attributes %p not handled.\n", attributes);
         if (access)
-            FIXME("access %#x not handled.\n", access);
+            FIXME("access %#x not handled.\n", (int)access);
         if (name)
             FIXME("name %s not handled.\n", debugstr_w(name));
 
@@ -7353,7 +7353,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateSharedHandle(d3d12_device_if
         if (attributes)
             FIXME("attributes %p not handled\n", attributes);
         if (access)
-            FIXME("access %#x not handled\n", access);
+            FIXME("access %#x not handled\n", (int)access);
         if (name)
             FIXME("name %s not handled\n", debugstr_w(name));
 
@@ -7415,7 +7415,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_OpenSharedHandle(d3d12_device_ifac
             if (FAILED(hr = d3d12_resource_create_committed(device, &desc, &heap_props,
                     D3D12_HEAP_FLAG_SHARED, D3D12_RESOURCE_STATE_COMMON, NULL, 0, NULL, handle, &resource)))
             {
-                WARN("Failed to open shared ID3D12Resource, hr %#x.\n", hr);
+                WARN("Failed to open shared ID3D12Resource, hr %#x.\n", (int)hr);
                 *object = NULL;
                 return hr;
             }
@@ -7490,7 +7490,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_OpenSharedHandle(d3d12_device_ifac
 
         if (FAILED(hr))
         {
-            WARN("Failed to open shared ID3D12Resource, hr %#x.\n", hr);
+            WARN("Failed to open shared ID3D12Resource, hr %#x.\n", (int)hr);
             *object = NULL;
             return hr;
         }
@@ -7508,7 +7508,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_OpenSharedHandle(d3d12_device_ifac
 
         if (FAILED(hr))
         {
-            WARN("Failed to create object for imported ID3D12Fence, hr %#x.\n", hr);
+            WARN("Failed to create object for imported ID3D12Fence, hr %#x.\n", (int)hr);
             *object = NULL;
             return hr;
         }
@@ -7546,7 +7546,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_OpenSharedHandleByName(d3d12_devic
         const WCHAR *name, DWORD access, HANDLE *handle)
 {
     FIXME("iface %p, name %s, access %#x, handle %p stub!\n",
-            iface, debugstr_w(name), access, handle);
+            iface, debugstr_w(name), (int)access, handle);
 
     return E_NOTIMPL;
 }
@@ -7842,7 +7842,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreatePipelineLibrary(d3d12_device
     uint32_t flags;
     HRESULT hr;
 
-    TRACE("iface %p, blob %p, blob_size %lu, iid %s, lib %p.\n",
+    TRACE("iface %p, blob %p, blob_size %zu, iid %s, lib %p.\n",
             iface, blob, blob_size, debugstr_guid(iid), lib);
 
     flags = 0;
@@ -7907,7 +7907,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_SetEventOnMultipleFenceCompletion(
 
         if (FAILED(hr))
         {
-            ERR("Failed to create temporary event, hr %#x.\n", hr);
+            ERR("Failed to create temporary event, hr %#x.\n", (int)hr);
             return hr;
         }
     }
@@ -8339,7 +8339,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateMetaCommand(d3d12_device_ifa
     struct d3d12_meta_command *object;
     HRESULT hr;
 
-    TRACE("iface %p, command_id %s, node_mask %#x, param_data %p, param_size %lu, iid %s, meta_command %p.\n",
+    TRACE("iface %p, command_id %s, node_mask %#x, param_data %p, param_size %zu, iid %s, meta_command %p.\n",
             iface, debugstr_guid(command_id), node_mask, param_data, param_size, debugstr_guid(iid), meta_command);
 
     if (FAILED(hr = d3d12_meta_command_create(device, command_id, param_data, param_size, &object)))
@@ -8710,7 +8710,7 @@ static D3D12_RESOURCE_ALLOCATION_INFO* STDMETHODCALLTYPE d3d12_device_GetResourc
         }
 
         TRACE("Offset = %"PRIu64", size = %"PRIu64", alignment = %"PRIu64
-                ", desc: %u x %u x %u, levels %u, samples %u, dim %u, fmt #%x, align %"PRIu64", flags #%x.\n",
+                ", desc: %"PRIu64" x %u x %u, levels %u, samples %u, dim %u, fmt #%x, align %"PRIu64", flags #%x.\n",
                 resource_offset, resource_info.SizeInBytes, resource_info.Alignment,
                 desc->Width, desc->Height, desc->DepthOrArraySize, desc->MipLevels, desc->SampleDesc.Count,
                 desc->Dimension, desc->Format, desc->Alignment, desc->Flags);
@@ -8818,7 +8818,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSamplerFeedbackUnorderedAccessV
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     D3D12_UNORDERED_ACCESS_VIEW_DESC uav_desc;
 
-    TRACE("iface %p, target_resource %p, feedback_resource %p, descriptor %#lx\n",
+    TRACE("iface %p, target_resource %p, feedback_resource %p, descriptor %#zx\n",
             iface, target_resource, feedback_resource, descriptor.ptr);
 
     /* NULL paired resource means NULL descriptor.
@@ -8837,7 +8837,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSamplerFeedbackUnorderedAccessV
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     D3D12_UNORDERED_ACCESS_VIEW_DESC uav_desc;
 
-    TRACE("iface %p, target_resource %p, feedback_resource %p, descriptor %#lx\n",
+    TRACE("iface %p, target_resource %p, feedback_resource %p, descriptor %#zx\n",
             iface, target_resource, feedback_resource, descriptor.ptr);
 
     /* NULL paired resource means NULL descriptor.
@@ -8856,7 +8856,7 @@ static void STDMETHODCALLTYPE d3d12_device_CreateSamplerFeedbackUnorderedAccessV
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
     D3D12_UNORDERED_ACCESS_VIEW_DESC uav_desc;
 
-    TRACE("iface %p, target_resource %p, feedback_resource %p, descriptor %#lx\n",
+    TRACE("iface %p, target_resource %p, feedback_resource %p, descriptor %#zx\n",
             iface, target_resource, feedback_resource, descriptor.ptr);
 
     /* NULL paired resource means NULL descriptor.
@@ -11498,7 +11498,7 @@ void d3d12_device_mark_as_removed(struct d3d12_device *device, HRESULT reason,
 
     va_start(args, message);
     WARN("Device %p is lost (reason %#x, \"%s\").\n",
-            device, reason, vkd3d_dbg_vsprintf(message, args));
+            device, (int)reason, vkd3d_dbg_vsprintf(message, args));
     va_end(args);
 
     vkd3d_atomic_uint32_store_explicit(&device->removed_reason, reason, vkd3d_memory_order_release);

--- a/libs/vkd3d/heap.c
+++ b/libs/vkd3d/heap.c
@@ -61,7 +61,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_QueryInterface(d3d12_heap_iface *ifa
 static ULONG STDMETHODCALLTYPE d3d12_heap_AddRef(d3d12_heap_iface *iface)
 {
     struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
-    ULONG refcount = InterlockedIncrement(&heap->refcount);
+    unsigned int refcount = InterlockedIncrement(&heap->refcount);
 
     if (refcount == 1)
     {
@@ -101,7 +101,7 @@ static void d3d12_heap_set_name(struct d3d12_heap *heap, const char *name)
 static ULONG STDMETHODCALLTYPE d3d12_heap_Release(d3d12_heap_iface *iface)
 {
     struct d3d12_heap *heap = impl_from_ID3D12Heap1(iface);
-    ULONG refcount = InterlockedDecrement(&heap->refcount);
+    unsigned int refcount = InterlockedDecrement(&heap->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", heap, refcount);
 
@@ -179,7 +179,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_heap_GetProtectedResourceSession(d3d12_he
 
 ULONG d3d12_heap_incref(struct d3d12_heap *heap)
 {
-    ULONG refcount = InterlockedIncrement(&heap->internal_refcount);
+    unsigned int refcount = InterlockedIncrement(&heap->internal_refcount);
 
     TRACE("%p increasing refcount to %u.\n", heap, refcount);
 
@@ -188,7 +188,7 @@ ULONG d3d12_heap_incref(struct d3d12_heap *heap)
 
 ULONG d3d12_heap_decref(struct d3d12_heap *heap)
 {
-    ULONG refcount = InterlockedDecrement(&heap->internal_refcount);
+    unsigned int refcount = InterlockedDecrement(&heap->internal_refcount);
 
     TRACE("%p decreasing refcount to %u.\n", heap, refcount);
 

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -1130,7 +1130,7 @@ static HRESULT vkd3d_import_host_memory(struct d3d12_device *device, void *host_
             type_flags, type_mask, &import_info, true, allocation)))
     {
         if (FAILED(hr))
-            WARN("Failed to import host memory, hr %#x.\n", hr);
+            WARN("Failed to import host memory, hr %#x.\n", (int)hr);
         /* If we failed, fall back to a host-visible allocation. Generally
          * the app will access the memory thorugh the main host pointer,
          * so it's fine. */
@@ -1204,7 +1204,7 @@ static void *vkd3d_allocate_write_watch_pointer(const D3D12_HEAP_PROPERTIES *pro
 
     if (!(ptr = VirtualAlloc(NULL, (SIZE_T)size, MEM_COMMIT | MEM_RESERVE | MEM_WRITE_WATCH, protect)))
     {
-        ERR("Failed to allocate write watch pointer %#x.\n", GetLastError());
+        ERR("Failed to allocate write watch pointer %#x.\n", (int)GetLastError());
         return NULL;
     }
 
@@ -1222,7 +1222,7 @@ static void vkd3d_free_write_watch_pointer(void *pointer)
 {
 #ifdef _WIN32
     if (!VirtualFree(pointer, 0, MEM_RELEASE))
-        ERR("Failed to free write watch pointer %#x.\n", GetLastError());
+        ERR("Failed to free write watch pointer %#x.\n", (int)GetLastError());
 #else
     /* Not supported on other platforms. */
     (void)pointer;

--- a/libs/vkd3d/meta_commands.c
+++ b/libs/vkd3d/meta_commands.c
@@ -284,7 +284,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_meta_command_QueryInterface(d3d12_meta_co
 static ULONG STDMETHODCALLTYPE d3d12_meta_command_AddRef(d3d12_meta_command_iface *iface)
 {
     struct d3d12_meta_command *meta_command = impl_from_ID3D12MetaCommand(iface);
-    ULONG refcount = InterlockedIncrement(&meta_command->refcount);
+    unsigned int refcount = InterlockedIncrement(&meta_command->refcount);
 
     TRACE("%p increasing refcount to %u.\n", meta_command, refcount);
 
@@ -302,7 +302,7 @@ static ULONG STDMETHODCALLTYPE d3d12_meta_command_Release(d3d12_meta_command_ifa
 {
     struct d3d12_meta_command *meta_command = impl_from_ID3D12MetaCommand(iface);
     struct d3d12_device *device = meta_command->device;
-    ULONG refcount;
+    unsigned int refcount;
 
     refcount = InterlockedDecrement(&meta_command->refcount);
 

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -79,7 +79,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_state_object_properties_QueryInterface(d3
 static ULONG STDMETHODCALLTYPE d3d12_state_object_AddRef(ID3D12StateObject *iface)
 {
     struct d3d12_rt_state_object *state_object = rt_impl_from_ID3D12StateObject(iface);
-    ULONG refcount = InterlockedIncrement(&state_object->refcount);
+    unsigned int refcount = InterlockedIncrement(&state_object->refcount);
 
     TRACE("%p increasing refcount to %u.\n", state_object, refcount);
 
@@ -89,7 +89,7 @@ static ULONG STDMETHODCALLTYPE d3d12_state_object_AddRef(ID3D12StateObject *ifac
 static ULONG STDMETHODCALLTYPE d3d12_state_object_properties_AddRef(d3d12_state_object_properties_iface *iface)
 {
     struct d3d12_rt_state_object *state_object = impl_from_ID3D12StateObjectProperties(iface);
-    ULONG refcount = InterlockedIncrement(&state_object->refcount);
+    unsigned int refcount = InterlockedIncrement(&state_object->refcount);
 
     TRACE("%p increasing refcount to %u.\n", state_object, refcount);
 
@@ -105,7 +105,7 @@ static void d3d12_state_object_inc_ref(struct d3d12_rt_state_object *state_objec
 
 static void d3d12_state_object_dec_ref(struct d3d12_rt_state_object *state_object)
 {
-    ULONG refcount = InterlockedDecrement(&state_object->internal_refcount);
+    unsigned int refcount = InterlockedDecrement(&state_object->internal_refcount);
 
     TRACE("%p decreasing internal refcount to %u.\n", state_object, refcount);
 
@@ -194,7 +194,7 @@ static void d3d12_state_object_cleanup(struct d3d12_rt_state_object *object)
 
 static ULONG d3d12_state_object_release(struct d3d12_rt_state_object *state_object)
 {
-    ULONG refcount = InterlockedDecrement(&state_object->refcount);
+    unsigned int refcount = InterlockedDecrement(&state_object->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", state_object, refcount);
 
@@ -2833,7 +2833,7 @@ HRESULT d3d12_rt_state_object_create(struct d3d12_device *device, const D3D12_ST
     RT_TRACE("==== Create %s ====\n",
             desc->Type == D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE ? "RTPSO" : "Collection");
     hr = d3d12_state_object_init(object, device, desc, parent);
-    RT_TRACE("==== Done %p (hr = #%x) ====\n", (void *)object, hr);
+    RT_TRACE("==== Done %p (hr = #%x) ====\n", (void *)object, (int)hr);
 
     if (FAILED(hr))
     {

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2136,7 +2136,7 @@ static void d3d12_resource_destroy(struct d3d12_resource *resource, struct d3d12
 
 ULONG d3d12_resource_incref(struct d3d12_resource *resource)
 {
-    ULONG refcount = InterlockedIncrement(&resource->internal_refcount);
+    unsigned int refcount = InterlockedIncrement(&resource->internal_refcount);
 
     TRACE("%p increasing refcount to %u.\n", resource, refcount);
 
@@ -2145,7 +2145,7 @@ ULONG d3d12_resource_incref(struct d3d12_resource *resource)
 
 ULONG d3d12_resource_decref(struct d3d12_resource *resource)
 {
-    ULONG refcount = InterlockedDecrement(&resource->internal_refcount);
+    unsigned int refcount = InterlockedDecrement(&resource->internal_refcount);
 
     TRACE("%p decreasing refcount to %u.\n", resource, refcount);
 
@@ -2246,7 +2246,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_resource_QueryInterface(d3d12_resource_if
 static ULONG STDMETHODCALLTYPE d3d12_resource_AddRef(d3d12_resource_iface *iface)
 {
     struct d3d12_resource *resource = impl_from_ID3D12Resource2(iface);
-    ULONG refcount = InterlockedIncrement(&resource->refcount);
+    unsigned int refcount = InterlockedIncrement(&resource->refcount);
 
     TRACE("%p increasing refcount to %u.\n", resource, refcount);
 
@@ -2295,7 +2295,7 @@ static ULONG STDMETHODCALLTYPE d3d12_resource_Release(d3d12_resource_iface *ifac
 {
     struct d3d12_resource *resource = impl_from_ID3D12Resource2(iface);
     struct d3d12_device *device = resource->device;
-    ULONG refcount;
+    unsigned int refcount;
 
     refcount = InterlockedDecrement(&resource->refcount);
 
@@ -4066,7 +4066,7 @@ static UINT64 d3d12_resource_determine_alignment(struct d3d12_device *device, co
         if (SUCCEEDED(hr = vkd3d_get_image_allocation_info(device, desc, num_castable_formats, castable_formats, &allocation_info)))
             return allocation_info.Alignment;
         else
-            ERR("Failed to query image alignment, hr %#x.\n", hr);
+            ERR("Failed to query image alignment, hr %#x.\n", (int)hr);
     }
 
     if (desc->Layout == D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE ||
@@ -8859,7 +8859,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_descriptor_heap_QueryInterface(ID3D12Desc
 static ULONG STDMETHODCALLTYPE d3d12_descriptor_heap_AddRef(ID3D12DescriptorHeap *iface)
 {
     struct d3d12_descriptor_heap *heap = impl_from_ID3D12DescriptorHeap(iface);
-    ULONG refcount = InterlockedIncrement(&heap->refcount);
+    unsigned int refcount = InterlockedIncrement(&heap->refcount);
 
     TRACE("%p increasing refcount to %u.\n", heap, refcount);
 
@@ -8873,7 +8873,7 @@ void d3d12_descriptor_heap_inc_ref(struct d3d12_descriptor_heap *heap)
 
 void d3d12_descriptor_heap_dec_ref(struct d3d12_descriptor_heap *heap)
 {
-    ULONG refcount = InterlockedDecrement(&heap->internal_refcount);
+    unsigned int refcount = InterlockedDecrement(&heap->internal_refcount);
 
     if (!refcount)
     {
@@ -8913,7 +8913,7 @@ void d3d12_descriptor_heap_free_meta_index(struct d3d12_descriptor_heap *heap, u
 static ULONG STDMETHODCALLTYPE d3d12_descriptor_heap_Release(ID3D12DescriptorHeap *iface)
 {
     struct d3d12_descriptor_heap *heap = impl_from_ID3D12DescriptorHeap(iface);
-    ULONG refcount = InterlockedDecrement(&heap->refcount);
+    unsigned int refcount = InterlockedDecrement(&heap->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", heap, refcount);
 
@@ -10384,7 +10384,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_query_heap_QueryInterface(ID3D12QueryHeap
 static ULONG STDMETHODCALLTYPE d3d12_query_heap_AddRef(ID3D12QueryHeap *iface)
 {
     struct d3d12_query_heap *heap = impl_from_ID3D12QueryHeap(iface);
-    ULONG refcount = InterlockedIncrement(&heap->refcount);
+    unsigned int refcount = InterlockedIncrement(&heap->refcount);
 
     TRACE("%p increasing refcount to %u.\n", heap, refcount);
 
@@ -10394,7 +10394,7 @@ static ULONG STDMETHODCALLTYPE d3d12_query_heap_AddRef(ID3D12QueryHeap *iface)
 static ULONG STDMETHODCALLTYPE d3d12_query_heap_Release(ID3D12QueryHeap *iface)
 {
     struct d3d12_query_heap *heap = impl_from_ID3D12QueryHeap(iface);
-    ULONG refcount = InterlockedDecrement(&heap->refcount);
+    unsigned int refcount = InterlockedDecrement(&heap->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", heap, refcount);
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -59,7 +59,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_root_signature_QueryInterface(ID3D12RootS
 static ULONG STDMETHODCALLTYPE d3d12_root_signature_AddRef(ID3D12RootSignature *iface)
 {
     struct d3d12_root_signature *root_signature = impl_from_ID3D12RootSignature(iface);
-    ULONG refcount = InterlockedIncrement(&root_signature->refcount);
+    unsigned int refcount = InterlockedIncrement(&root_signature->refcount);
 
     TRACE("%p increasing refcount to %u.\n", root_signature, refcount);
 
@@ -106,7 +106,7 @@ void d3d12_root_signature_inc_ref(struct d3d12_root_signature *root_signature)
 void d3d12_root_signature_dec_ref(struct d3d12_root_signature *root_signature)
 {
     struct d3d12_device *device = root_signature->device;
-    ULONG refcount = InterlockedDecrement(&root_signature->internal_refcount);
+    unsigned int refcount = InterlockedDecrement(&root_signature->internal_refcount);
 
     if (refcount == 0)
     {
@@ -121,7 +121,7 @@ static ULONG STDMETHODCALLTYPE d3d12_root_signature_Release(ID3D12RootSignature 
 {
     struct d3d12_root_signature *root_signature = impl_from_ID3D12RootSignature(iface);
     struct d3d12_device *device = root_signature->device;
-    ULONG refcount = InterlockedDecrement(&root_signature->refcount);
+    unsigned int refcount = InterlockedDecrement(&root_signature->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", root_signature, refcount);
 
@@ -2636,7 +2636,7 @@ void d3d12_pipeline_state_inc_ref(struct d3d12_pipeline_state *state)
 
 ULONG d3d12_pipeline_state_inc_public_ref(struct d3d12_pipeline_state *state)
 {
-    ULONG refcount = InterlockedIncrement(&state->refcount);
+    unsigned int refcount = InterlockedIncrement(&state->refcount);
     if (refcount == 1)
     {
         d3d12_pipeline_state_inc_ref(state);
@@ -2834,7 +2834,7 @@ void d3d12_pipeline_state_dec_ref(struct d3d12_pipeline_state *state)
 {
     struct d3d12_device *device = state->device;
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    ULONG refcount = InterlockedDecrement(&state->internal_refcount);
+    unsigned int refcount = InterlockedDecrement(&state->internal_refcount);
 
     if (!refcount)
     {
@@ -2864,7 +2864,7 @@ static ULONG STDMETHODCALLTYPE d3d12_pipeline_state_Release(ID3D12PipelineState 
 {
     struct d3d12_pipeline_state *state = impl_from_ID3D12PipelineState(iface);
     struct d3d12_device *device = state->device;
-    ULONG refcount = InterlockedDecrement(&state->refcount);
+    unsigned int refcount = InterlockedDecrement(&state->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", state, refcount);
 
@@ -2951,7 +2951,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_pipeline_state_GetCachedBlob(ID3D12Pipeli
 
     if (FAILED(hr = d3d_blob_create(cache_data, cache_size, &blob_object)))
     {
-        ERR("Failed to create blob, hr %#x.\n", hr);
+        ERR("Failed to create blob, hr %#x.\n", (int)hr);
         vkd3d_free(cache_data);
         return hr;
     }
@@ -3013,7 +3013,7 @@ static HRESULT vkd3d_load_spirv_from_cached_state(struct d3d12_device *device,
         else if (hr == E_INVALIDARG)
             INFO("Pipeline could not be created to mismatch in either root signature or DXBC blobs.\n");
         else
-            INFO("Unexpected error when unserializing SPIR-V (hr %x).\n", hr);
+            INFO("Unexpected error when unserializing SPIR-V (hr %x).\n", (int)hr);
     }
 
     return hr;
@@ -3610,7 +3610,7 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     VK_CALL(vkDestroyShaderModule(device->vk_device, pipeline_info.stage.module, NULL));
     if (vr < 0)
     {
-        ERR("Failed to create Vulkan compute pipeline, hr %#x.\n", hr);
+        ERR("Failed to create Vulkan compute pipeline, hr %#x.\n", (int)hr);
         ERR("  Root signature: %"PRIx64"\n", state->root_signature->pso_compatibility_hash);
         ERR("  Shader: %"PRIx64".\n", state->compute.code.meta.hash);
         return hresult_from_vk_result(vr);
@@ -3644,7 +3644,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
 
     if (FAILED(hr))
     {
-        WARN("Failed to create Vulkan compute pipeline, hr %#x.\n", hr);
+        WARN("Failed to create Vulkan compute pipeline, hr %#x.\n", (int)hr);
         return hr;
     }
 
@@ -6418,7 +6418,7 @@ HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindP
 
     if (!VKD3D_CONFIG_FLAG_IS_SET(GLOBAL_PIPELINE_CACHE))
         if (FAILED(hr = vkd3d_create_pipeline_cache_from_d3d12_desc(device, desc_cached_pso, &object->vk_pso_cache)))
-            ERR("Failed to create pipeline cache, hr %d.\n", hr);
+            ERR("Failed to create pipeline cache, hr %d.\n", (int)hr);
 
     /* By using our own VkPipelineCache, drivers will generally not cache pipelines internally in memory.
      * For games that spam an extreme number of pipelines only to serialize them to pipeline libraries and then
@@ -6911,7 +6911,7 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
                         &stages[i].module, &graphics->code[i])))
                 {
                     /* This is kind of fatal and should only happen for out-of-memory. */
-                    ERR("Unexpected failure (hr %x) in creating fallback SPIR-V module.\n", hr);
+                    ERR("Unexpected failure (hr %x) in creating fallback SPIR-V module.\n", (int)hr);
                     rwlock_unlock_read(&state->lock);
                     vk_pipeline = VK_NULL_HANDLE;
                     goto err;

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -1580,7 +1580,7 @@ static HRESULT dxgi_vk_swap_chain_init_sync_objects(struct dxgi_vk_swap_chain *c
         if (FAILED(hr = vkd3d_native_sync_handle_create(chain->frame_latency,
                 VKD3D_NATIVE_SYNC_HANDLE_TYPE_SEMAPHORE, &chain->frame_latency_event)))
         {
-            WARN("Failed to create frame latency semaphore, hr %#x.\n", hr);
+            WARN("Failed to create frame latency semaphore, hr %#x.\n", (int)hr);
             return hr;
         }
     }
@@ -1623,7 +1623,7 @@ static HRESULT dxgi_vk_swap_chain_init_sync_objects(struct dxgi_vk_swap_chain *c
     if (FAILED(hr = vkd3d_native_sync_handle_create(chain->frame_latency_internal - 1,
             VKD3D_NATIVE_SYNC_HANDLE_TYPE_SEMAPHORE, &chain->frame_latency_event_internal)))
     {
-        WARN("Failed to create internal frame latency semaphore, hr %#x.\n", hr);
+        WARN("Failed to create internal frame latency semaphore, hr %#x.\n", (int)hr);
         return hr;
     }
 
@@ -4199,7 +4199,7 @@ void dxgi_vk_swap_chain_get_latency_info(struct dxgi_vk_swap_chain *chain, D3D12
 
 ULONG dxgi_vk_swap_chain_incref(struct dxgi_vk_swap_chain *chain)
 {
-    ULONG refcount = InterlockedIncrement(&chain->internal_refcount);
+    unsigned int refcount = InterlockedIncrement(&chain->internal_refcount);
 
     TRACE("%p increasing refcount to %u.\n", chain, refcount);
 
@@ -4208,7 +4208,7 @@ ULONG dxgi_vk_swap_chain_incref(struct dxgi_vk_swap_chain *chain)
 
 ULONG dxgi_vk_swap_chain_decref(struct dxgi_vk_swap_chain *chain)
 {
-    ULONG refcount = InterlockedDecrement(&chain->internal_refcount);
+    unsigned int refcount = InterlockedDecrement(&chain->internal_refcount);
 
     TRACE("%p decreasing refcount to %u.\n", chain, refcount);
 

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -1738,7 +1738,7 @@ static HRESULT STDMETHODCALLTYPE d3d_blob_QueryInterface(ID3DBlob *iface, REFIID
 static ULONG STDMETHODCALLTYPE d3d_blob_AddRef(ID3DBlob *iface)
 {
     struct d3d_blob *blob = impl_from_ID3DBlob(iface);
-    ULONG refcount = InterlockedIncrement(&blob->refcount);
+    unsigned int refcount = InterlockedIncrement(&blob->refcount);
 
     TRACE("%p increasing refcount to %u.\n", blob, refcount);
 
@@ -1748,7 +1748,7 @@ static ULONG STDMETHODCALLTYPE d3d_blob_AddRef(ID3DBlob *iface)
 static ULONG STDMETHODCALLTYPE d3d_blob_Release(ID3DBlob *iface)
 {
     struct d3d_blob *blob = impl_from_ID3DBlob(iface);
-    ULONG refcount = InterlockedDecrement(&blob->refcount);
+    unsigned int refcount = InterlockedDecrement(&blob->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", blob, refcount);
 
@@ -1834,7 +1834,7 @@ static HRESULT STDMETHODCALLTYPE d3d_destruction_notifier_QueryInterface(ID3DDes
 static ULONG STDMETHODCALLTYPE d3d_destruction_notifier_AddRef(ID3DDestructionNotifier *iface)
 {
     struct d3d_destruction_notifier *notifier = impl_from_ID3DDestructionNotifier(iface);
-    ULONG refcount = IUnknown_AddRef(notifier->parent);
+    unsigned int refcount = IUnknown_AddRef(notifier->parent);
 
     TRACE("%p increasing refcount to %u.\n", notifier, refcount);
 
@@ -1844,7 +1844,7 @@ static ULONG STDMETHODCALLTYPE d3d_destruction_notifier_AddRef(ID3DDestructionNo
 static ULONG STDMETHODCALLTYPE d3d_destruction_notifier_Release(ID3DDestructionNotifier *iface)
 {
     struct d3d_destruction_notifier *notifier = impl_from_ID3DDestructionNotifier(iface);
-    ULONG refcount = IUnknown_Release(notifier->parent);
+    unsigned int refcount = IUnknown_Release(notifier->parent);
 
     TRACE("%p decreasing refcount to %u.\n", notifier, refcount);
 

--- a/libs/vkd3d/vkd3d_main.c
+++ b/libs/vkd3d/vkd3d_main.c
@@ -56,7 +56,7 @@ HRESULT vkd3d_create_device(const struct vkd3d_device_create_info *create_info,
     }
     else if (FAILED(hr = vkd3d_create_instance(create_info->instance_create_info, &instance)))
     {
-        WARN("Failed to create instance, hr %#x.\n", hr);
+        WARN("Failed to create instance, hr %#x.\n", (int)hr);
         return E_FAIL;
     }
 
@@ -113,7 +113,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_root_signature_deserializer_QueryInterfac
 static ULONG STDMETHODCALLTYPE d3d12_root_signature_deserializer_AddRef(ID3D12RootSignatureDeserializer *iface)
 {
     struct d3d12_root_signature_deserializer *deserializer = impl_from_ID3D12RootSignatureDeserializer(iface);
-    ULONG refcount = InterlockedIncrement(&deserializer->refcount);
+    unsigned int refcount = InterlockedIncrement(&deserializer->refcount);
 
     TRACE("%p increasing refcount to %u.\n", deserializer, refcount);
 
@@ -123,7 +123,7 @@ static ULONG STDMETHODCALLTYPE d3d12_root_signature_deserializer_AddRef(ID3D12Ro
 static ULONG STDMETHODCALLTYPE d3d12_root_signature_deserializer_Release(ID3D12RootSignatureDeserializer *iface)
 {
     struct d3d12_root_signature_deserializer *deserializer = impl_from_ID3D12RootSignatureDeserializer(iface);
-    ULONG refcount = InterlockedDecrement(&deserializer->refcount);
+    unsigned int refcount = InterlockedDecrement(&deserializer->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", deserializer, refcount);
 
@@ -178,7 +178,7 @@ HRESULT vkd3d_create_root_signature_deserializer(const void *data, SIZE_T data_s
     struct d3d12_root_signature_deserializer *object;
     HRESULT hr;
 
-    TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
+    TRACE("data %p, data_size %zu, iid %s, deserializer %p.\n",
             data, data_size, debugstr_guid(iid), deserializer);
 
     if (!(object = vkd3d_malloc(sizeof(*object))))
@@ -240,7 +240,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_versioned_root_signature_deserializer_Que
 static ULONG STDMETHODCALLTYPE d3d12_versioned_root_signature_deserializer_AddRef(ID3D12VersionedRootSignatureDeserializer *iface)
 {
     struct d3d12_versioned_root_signature_deserializer *deserializer = impl_from_ID3D12VersionedRootSignatureDeserializer(iface);
-    ULONG refcount = InterlockedIncrement(&deserializer->refcount);
+    unsigned int refcount = InterlockedIncrement(&deserializer->refcount);
 
     TRACE("%p increasing refcount to %u.\n", deserializer, refcount);
 
@@ -250,7 +250,7 @@ static ULONG STDMETHODCALLTYPE d3d12_versioned_root_signature_deserializer_AddRe
 static ULONG STDMETHODCALLTYPE d3d12_versioned_root_signature_deserializer_Release(ID3D12VersionedRootSignatureDeserializer *iface)
 {
     struct d3d12_versioned_root_signature_deserializer *deserializer = impl_from_ID3D12VersionedRootSignatureDeserializer(iface);
-    ULONG refcount = InterlockedDecrement(&deserializer->refcount);
+    unsigned int refcount = InterlockedDecrement(&deserializer->refcount);
     unsigned int i;
 
     TRACE("%p decreasing refcount to %u.\n", deserializer, refcount);
@@ -370,7 +370,7 @@ HRESULT vkd3d_create_versioned_root_signature_deserializer(const void *data, SIZ
     struct vkd3d_shader_code dxbc = {data, data_size};
     HRESULT hr;
 
-    TRACE("data %p, data_size %lu, iid %s, deserializer %p.\n",
+    TRACE("data %p, data_size %zu, iid %s, deserializer %p.\n",
             data, data_size, debugstr_guid(iid), deserializer);
 
     if (!(object = vkd3d_malloc(sizeof(*object))))
@@ -488,7 +488,7 @@ HRESULT vkd3d_serialize_root_signature(const D3D12_ROOT_SIGNATURE_DESC *desc,
 
     if (FAILED(hr = d3d_blob_create((void *)dxbc.code, dxbc.size, &blob_object)))
     {
-        WARN("Failed to create blob object, hr %#x.\n", hr);
+        WARN("Failed to create blob object, hr %#x.\n", (int)hr);
         vkd3d_shader_free_shader_code(&dxbc);
         return hr;
     }
@@ -529,7 +529,7 @@ HRESULT vkd3d_serialize_versioned_root_signature(const D3D12_VERSIONED_ROOT_SIGN
 
     if (FAILED(hr = d3d_blob_create((void *)dxbc.code, dxbc.size, &blob_object)))
     {
-        WARN("Failed to create blob object, hr %#x.\n", hr);
+        WARN("Failed to create blob object, hr %#x.\n", (int)hr);
         vkd3d_shader_free_shader_code(&dxbc);
         return hr;
     }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5979,14 +5979,14 @@ ULONG d3d12_device_release_common(struct d3d12_device *device);
 
 static inline ULONG d3d12_device_add_ref(struct d3d12_device *device)
 {
-    ULONG refcount = d3d12_device_add_ref_common(device);
+    unsigned int refcount = d3d12_device_add_ref_common(device);
     TRACE("Increasing refcount to %u.\n", refcount);
     return refcount;
 }
 
 static inline ULONG d3d12_device_release(struct d3d12_device *device)
 {
-    ULONG refcount = d3d12_device_release_common(device);
+    unsigned int refcount = d3d12_device_release_common(device);
     TRACE("Decreasing refcount to %u.\n", refcount);
     return refcount;
 }

--- a/libs/vkd3d/workgraphs.c
+++ b/libs/vkd3d/workgraphs.c
@@ -1143,7 +1143,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_work_graph_properties_QueryInterface(d3d1
 static ULONG STDMETHODCALLTYPE d3d12_wg_state_object_AddRef(ID3D12StateObject *iface)
 {
     struct d3d12_wg_state_object *state_object = wg_impl_from_ID3D12StateObject(iface);
-    ULONG refcount = InterlockedIncrement(&state_object->refcount);
+    unsigned int refcount = InterlockedIncrement(&state_object->refcount);
 
     TRACE("%p increasing refcount to %u.\n", state_object, refcount);
 
@@ -1153,7 +1153,7 @@ static ULONG STDMETHODCALLTYPE d3d12_wg_state_object_AddRef(ID3D12StateObject *i
 static ULONG STDMETHODCALLTYPE d3d12_wg_state_object_properties_AddRef(d3d12_state_object_properties_iface *iface)
 {
     struct d3d12_wg_state_object *state_object = impl_from_ID3D12StateObjectProperties(iface);
-    ULONG refcount = InterlockedIncrement(&state_object->refcount);
+    unsigned int refcount = InterlockedIncrement(&state_object->refcount);
 
     TRACE("%p increasing refcount to %u.\n", state_object, refcount);
 
@@ -1163,7 +1163,7 @@ static ULONG STDMETHODCALLTYPE d3d12_wg_state_object_properties_AddRef(d3d12_sta
 static ULONG STDMETHODCALLTYPE d3d12_work_graph_properties_AddRef(d3d12_work_graph_properties_iface *iface)
 {
     struct d3d12_wg_state_object *state_object = impl_from_ID3D12WorkGraphProperties(iface);
-    ULONG refcount = InterlockedIncrement(&state_object->refcount);
+    unsigned int refcount = InterlockedIncrement(&state_object->refcount);
 
     TRACE("%p increasing refcount to %u.\n", state_object, refcount);
 
@@ -1224,7 +1224,7 @@ static void d3d12_wg_state_object_cleanup(struct d3d12_wg_state_object *state_ob
 
 static void d3d12_wg_state_object_dec_ref(struct d3d12_wg_state_object *state_object)
 {
-    ULONG refcount = InterlockedDecrement(&state_object->internal_refcount);
+    unsigned int refcount = InterlockedDecrement(&state_object->internal_refcount);
 
     TRACE("%p decreasing internal refcount to %u.\n", state_object, refcount);
 
@@ -1240,7 +1240,7 @@ static void d3d12_wg_state_object_dec_ref(struct d3d12_wg_state_object *state_ob
 
 static ULONG d3d12_wg_state_object_release(struct d3d12_wg_state_object *state_object)
 {
-    ULONG refcount = InterlockedDecrement(&state_object->refcount);
+    unsigned int refcount = InterlockedDecrement(&state_object->refcount);
 
     TRACE("%p decreasing refcount to %u.\n", state_object, refcount);
 
@@ -1530,7 +1530,7 @@ static UINT STDMETHODCALLTYPE d3d12_work_graph_properties_GetNodeIndex(
     struct d3d12_wg_state_object *object = impl_from_ID3D12WorkGraphProperties(iface);
     const struct d3d12_wg_state_object_program *program;
     unsigned int count, i;
-    TRACE("iface %p, WorkGraphIndex %u, NodeID.Name, NodeID.ArrayIndex %u, stub!\n",
+    TRACE("iface %p, WorkGraphIndex %u, NodeID.Name %s, NodeID.ArrayIndex %u, stub!\n",
             iface, WorkGraphIndex, debugstr_w(NodeID.Name), NodeID.ArrayIndex);
 
     if (WorkGraphIndex >= object->programs_count)
@@ -1639,7 +1639,7 @@ static UINT STDMETHODCALLTYPE d3d12_work_graph_properties_GetEntrypointIndex(
     const struct d3d12_wg_state_object_program *program;
     unsigned int i;
 
-    TRACE("iface %p, WorkGraphIndex %u, NodeID.Name, NodeID.ArrayIndex %u!\n",
+    TRACE("iface %p, WorkGraphIndex %u, NodeID.Name %s, NodeID.ArrayIndex %u!\n",
             iface, WorkGraphIndex, debugstr_w(NodeID.Name), NodeID.ArrayIndex);
 
     if (WorkGraphIndex >= object->programs_count)

--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,8 @@ add_project_arguments(vkd3d_compiler.get_supported_arguments([
     # For some reason, the use of VLAs isn't in all+extra+pedantic
     # We don't want to use these accidentally from consts...
     '-Wvla',
-    '-Wno-format',
+    '-Wformat',
+    '-Wno-format-truncation',
     '-Wno-missing-field-initializers',
     '-Wno-unused-parameter',
     '-Wdeclaration-after-statement',

--- a/programs/vkd3d-compiler/main.c
+++ b/programs/vkd3d-compiler/main.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
     vkd3d_shader_free_shader_code(&dxbc);
     if (FAILED(hr))
     {
-        fprintf(stderr, "Failed to compile DXBC shader, hr %#x.\n", hr);
+        fprintf(stderr, "Failed to compile DXBC shader, hr %#x.\n", (int)hr);
         return 1;
     }
 

--- a/tests/d3d12_bindless.c
+++ b/tests/d3d12_bindless.c
@@ -173,7 +173,7 @@ void test_bindless_heap_sm66(void)
     root_parameters[0].Constants.Num32BitValues = 4;
 
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
     pso = create_compute_pipeline_state(device, root_signature, bindless_heap_sm66_dxil);
     cpu_resource_heap = create_cpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
@@ -454,7 +454,7 @@ static void test_bindless_srv(bool use_dxil)
     }
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 256; i++)
     {
@@ -629,7 +629,7 @@ static void test_bindless_samplers(bool use_dxil)
     descriptor_ranges[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     {
         const float tex_data[] = { 10, 100, 100, 100 };
@@ -767,7 +767,7 @@ void test_bindless_full_root_parameters_sm51(void)
     root_parameters[62].Descriptor.ShaderRegister = 0;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 1024; i++)
     {
@@ -892,7 +892,7 @@ static void test_bindless_cbv(bool use_dxil)
     descriptor_ranges.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_CBV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 512; i++)
     {
@@ -1015,7 +1015,7 @@ static void test_bindless_uav(bool use_dxil)
     descriptor_ranges[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 256; i++)
         output_buffers[i] = create_default_buffer(context.device, 256, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -1164,7 +1164,7 @@ static void test_bindless_uav_counter(bool use_dxil)
     descriptor_ranges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 256; i++)
         output_buffers[i] = create_default_buffer(context.device, 256, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -1333,7 +1333,7 @@ static void test_bindless_bufinfo(bool use_dxil)
     descriptor_ranges[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 256; i++)
         output_buffers[i] = create_default_buffer(context.device, 4096, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -1521,7 +1521,7 @@ void test_divergent_buffer_index_varying(void)
     pso_desc.DepthStencilState.DepthEnable = FALSE;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr %x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr %x\n", (int)hr);
 
     ibv.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(ibo);
     ibv.Format = DXGI_FORMAT_R32_UINT;

--- a/tests/d3d12_clear.c
+++ b/tests/d3d12_clear.c
@@ -249,7 +249,7 @@ void test_clear_render_target_view(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     memset(&rtv_desc, 0, sizeof(rtv_desc));
     rtv_desc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
@@ -275,7 +275,7 @@ void test_clear_render_target_view(void)
 
     /* R16G16B16A16 */
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
     reset_command_list(command_list, context.allocator);
     ID3D12Resource_Release(resource);
     resource_desc.Format = DXGI_FORMAT_R16G16B16A16_TYPELESS;
@@ -283,7 +283,7 @@ void test_clear_render_target_view(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(r16g16b16a16); ++i)
     {
@@ -305,7 +305,7 @@ void test_clear_render_target_view(void)
 
     /* 2D array texture */
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
     reset_command_list(command_list, context.allocator);
     ID3D12Resource_Release(resource);
     resource_desc.Format = DXGI_FORMAT_R8G8B8A8_TYPELESS;
@@ -314,7 +314,7 @@ void test_clear_render_target_view(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(array_colors); ++i)
     {
@@ -344,7 +344,7 @@ void test_clear_render_target_view(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(array_colors); ++i)
     {
@@ -376,7 +376,7 @@ void test_clear_render_target_view(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     ID3D12Device_CreateRenderTargetView(device, resource, NULL, rtv_handle);
 
@@ -706,7 +706,7 @@ void test_clear_unordered_access_view_buffer(void)
     heap_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -938,7 +938,7 @@ void test_clear_unordered_access_view_image(void)
                     D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                     NULL, &IID_ID3D12Resource, (void **)&texture)))
             {
-                skip("Failed to create texture, hr %#x.\n", hr);
+                skip("Failed to create texture, hr %#x.\n", (int)hr);
                 continue;
             }
 
@@ -1520,7 +1520,7 @@ void test_deferred_clears(void)
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     memset(&descriptor_heap_desc, 0u, sizeof(descriptor_heap_desc));
     descriptor_heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
@@ -1528,14 +1528,14 @@ void test_deferred_clears(void)
 
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &descriptor_heap_desc,
             &IID_ID3D12DescriptorHeap, (void**)&dsv_heap);
-    ok(hr == S_OK, "Failed to create DSV heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create DSV heap, hr %#x.\n", (int)hr);
 
     descriptor_heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
     descriptor_heap_desc.NumDescriptors = ARRAY_SIZE(rt) + 2u;
 
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &descriptor_heap_desc,
             &IID_ID3D12DescriptorHeap, (void**)&rtv_heap);
-    ok(hr == S_OK, "Failed to create RTV heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create RTV heap, hr %#x.\n", (int)hr);
 
     memset(&heap_properties, 0, sizeof(heap_properties));
     heap_properties.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -1556,7 +1556,7 @@ void test_deferred_clears(void)
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
                 D3D12_HEAP_FLAG_NONE, &resource_desc[0], D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,
                 &IID_ID3D12Resource, (void**)&rt[i]);
-        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
     }
 
     /* Image with mismatched size */
@@ -1566,7 +1566,7 @@ void test_deferred_clears(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc[0], D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,
             &IID_ID3D12Resource, (void**)&rt[4]);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     /* Image with multiple layers */
     resource_desc[0].Width = 16;
@@ -1576,7 +1576,7 @@ void test_deferred_clears(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc[0], D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,
             &IID_ID3D12Resource, (void**)&rt[5]);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     for (i = 0u; i < ARRAY_SIZE(rt); i++)
     {
@@ -1616,7 +1616,7 @@ void test_deferred_clears(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc[0], D3D12_RESOURCE_STATE_DEPTH_WRITE, NULL,
             &IID_ID3D12Resource, (void**)&ds);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     dsv = get_cpu_dsv_handle(&context, dsv_heap, 0u);
 
@@ -1948,13 +1948,13 @@ void test_deferred_clears(void)
     heap_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
 
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void**)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     for (i = 0u; i < 2u; i++)
     {
         hr = ID3D12Device_CreatePlacedResource(context.device, heap, 0, &resource_desc[i],
             D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&rt[i]);
-        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
         memset(&rtv_desc, 0, sizeof(rtv_desc));
         rtv_desc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
@@ -2030,7 +2030,7 @@ void test_deferred_clears(void)
         hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc1, D3D12_BARRIER_LAYOUT_RENDER_TARGET, NULL, NULL, 0, NULL,
                 &IID_ID3D12Resource, (void**)&rt[0]);
-        ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
         rtv_base = get_cpu_rtv_handle(&context, rtv_heap, 0);
 
@@ -2080,7 +2080,7 @@ void test_deferred_clears(void)
         hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc1, D3D12_BARRIER_LAYOUT_DEPTH_STENCIL_WRITE, NULL, NULL, 0, NULL,
                 &IID_ID3D12Resource, (void**)&ds);
-        ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", (int)hr);
 
         memset(&dsv_desc, 0, sizeof(dsv_desc));
         dsv_desc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;

--- a/tests/d3d12_clip_cull_distance.c
+++ b/tests/d3d12_clip_cull_distance.c
@@ -677,7 +677,7 @@ static void test_clip_distance(bool use_dxil)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     input_layout.pInputElementDescs = layout_desc;
     input_layout.NumElements = ARRAY_SIZE(layout_desc);
@@ -694,7 +694,7 @@ static void test_clip_distance(bool use_dxil)
     }
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso);
-    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", (int)hr);
 
     vb[0] = create_upload_buffer(device, sizeof(quad), quad);
     vbv[0].BufferLocation = ID3D12Resource_GetGPUVirtualAddress(vb[0]);
@@ -744,7 +744,7 @@ static void test_clip_distance(bool use_dxil)
     pso_desc.GS = gs;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso);
-    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", (int)hr);
 
     check_clip_distance(&context, pso, vbv, vb[1], vs_cb, gs_cb);
 
@@ -778,7 +778,7 @@ static void test_clip_distance(bool use_dxil)
     memset(&pso_desc.GS, 0, sizeof(pso_desc.GS));
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso);
-    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", (int)hr);
 
     cb_data.use_constant = false;
     update_buffer_data(vs_cb, 0, sizeof(cb_data), &cb_data);

--- a/tests/d3d12_command.c
+++ b/tests/d3d12_command.c
@@ -51,7 +51,7 @@ void test_set_render_targets(void)
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 0, NULL, false, &dsv);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
 
     ID3D12DescriptorHeap_Release(rtv_heap);
     ID3D12DescriptorHeap_Release(dsv_heap);
@@ -187,7 +187,7 @@ void test_draw_no_descriptor_bindings(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_pipeline_state(context.device,
             context.root_signature, context.render_target_desc.Format, NULL, NULL, NULL);
@@ -241,7 +241,7 @@ void test_multiple_render_targets(void)
         pso_desc.RTVFormats[i] = desc.rt_format;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     rtvs[0] = get_cpu_rtv_handle(&context, context.rtv_heap, 2);
     rtvs[1] = get_cpu_rtv_handle(&context, context.rtv_heap, 0);
@@ -689,7 +689,7 @@ void test_draw_depth_no_ps(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearDepthStencilView(command_list, ds.dsv_handle,
             D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, NULL);
@@ -766,7 +766,7 @@ void test_draw_depth_only(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -880,7 +880,7 @@ void test_draw_uav_only(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_pipeline_state(context.device, context.root_signature, 0, NULL, &draw_uav_only_dxbc, NULL);
 
@@ -934,8 +934,8 @@ void test_texture_resource_barriers(void)
     D3D12_RESOURCE_BARRIER barriers[8];
     ID3D12CommandQueue *queue;
     ID3D12Resource *resource;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -948,11 +948,11 @@ void test_texture_resource_barriers(void)
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
 
     resource = create_default_texture(device, 32, 32, DXGI_FORMAT_R8G8B8A8_UNORM,
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COMMON);
@@ -1021,7 +1021,7 @@ void test_texture_resource_barriers(void)
     ID3D12GraphicsCommandList_ResourceBarrier(command_list, 8, barriers);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
 
@@ -1030,7 +1030,7 @@ void test_texture_resource_barriers(void)
     ID3D12Resource_Release(resource);
     ID3D12CommandQueue_Release(queue);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_bundle_state_inheritance(void)
@@ -1059,10 +1059,10 @@ void test_bundle_state_inheritance(void)
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_BUNDLE,
             &IID_ID3D12CommandAllocator, (void **)&bundle_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_BUNDLE,
             bundle_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&bundle);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
 
     /* A bundle does not inherit the current pipeline state. */
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
@@ -1076,7 +1076,7 @@ void test_bundle_state_inheritance(void)
 
     ID3D12GraphicsCommandList_DrawInstanced(bundle, 3, 1, 0, 0);
     hr = ID3D12GraphicsCommandList_Close(bundle);
-    ok(SUCCEEDED(hr), "Failed to close bundle, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close bundle, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ExecuteBundle(command_list, bundle);
 
@@ -1113,7 +1113,7 @@ void test_bundle_state_inheritance(void)
     ID3D12GraphicsCommandList_SetPipelineState(bundle, context.pipeline_state);
     ID3D12GraphicsCommandList_DrawInstanced(bundle, 3, 1, 0, 0);
     hr = ID3D12GraphicsCommandList_Close(bundle);
-    ok(SUCCEEDED(hr), "Failed to close bundle, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close bundle, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ExecuteBundle(command_list, bundle);
 
@@ -1149,7 +1149,7 @@ void test_bundle_state_inheritance(void)
     ID3D12GraphicsCommandList_IASetPrimitiveTopology(bundle, D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
     ID3D12GraphicsCommandList_DrawInstanced(bundle, 3, 1, 0, 0);
     hr = ID3D12GraphicsCommandList_Close(bundle);
-    ok(SUCCEEDED(hr), "Failed to close bundle, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close bundle, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ExecuteBundle(command_list, bundle);
 
@@ -1172,7 +1172,7 @@ void test_bundle_state_inheritance(void)
     ID3D12GraphicsCommandList_SetPipelineState(bundle, context.pipeline_state);
     ID3D12GraphicsCommandList_IASetPrimitiveTopology(bundle, D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
     hr = ID3D12GraphicsCommandList_Close(bundle);
-    ok(SUCCEEDED(hr), "Failed to close bundle, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close bundle, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ExecuteBundle(command_list, bundle);
 
@@ -1499,7 +1499,7 @@ void test_execute_indirect_multi_dispatch_root_descriptors(void)
     hr = ID3D12Device_CreateCommandSignature(context.device, &desc, context.root_signature, &IID_ID3D12CommandSignature, (void **)&signature);
     if (FAILED(hr))
         signature = NULL;
-    todo ok(SUCCEEDED(hr), "Failed to create command signature, hr #%x.\n", hr);
+    todo ok(SUCCEEDED(hr), "Failed to create command signature, hr #%x.\n", (int)hr);
 
     output = create_default_buffer(context.device, ARRAY_SIZE(indirect_data.dispatches) * 4, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
     for (i = 0; i < ARRAY_SIZE(indirect_data.dispatches); i++)
@@ -1653,7 +1653,7 @@ void test_execute_indirect_multi_dispatch_root_constants(void)
     hr = ID3D12Device_CreateCommandSignature(context.device, &desc, context.root_signature, &IID_ID3D12CommandSignature, (void **)&signature);
     if (FAILED(hr))
         signature = NULL;
-    todo ok(SUCCEEDED(hr), "Failed to create command signature, hr #%x.\n", hr);
+    todo ok(SUCCEEDED(hr), "Failed to create command signature, hr #%x.\n", (int)hr);
 
     output = create_default_buffer(context.device, 8 * 4, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
     indirect = create_upload_buffer(context.device, sizeof(indirect_data), indirect_data);
@@ -1797,7 +1797,7 @@ void test_execute_indirect_multi_dispatch(void)
     memset(arguments, 0, sizeof(arguments));
     arguments[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
     hr = ID3D12Device_CreateCommandSignature(context.device, &desc, NULL, &IID_ID3D12CommandSignature, (void **)&signature);
-    ok(SUCCEEDED(hr), "Failed to create command signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command signature, hr #%x.\n", (int)hr);
 
     output = create_default_buffer(context.device, 8 * 4, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
     indirect = create_upload_buffer(context.device, sizeof(indirect_data), indirect_data);
@@ -2741,10 +2741,10 @@ void test_execute_indirect_state(void)
     root_parameters[3].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
     root_parameters[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signatures[0]);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
     root_parameters[0].Constants.Num32BitValues = 48;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signatures[1]);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
     memset(so_entries, 0, sizeof(so_entries));
     so_entries[0].ComponentCount = 4;
@@ -2765,11 +2765,11 @@ void test_execute_indirect_state(void)
     pso_desc.InputLayout.NumElements = ARRAY_SIZE(layout_desc);
     pso_desc.InputLayout.pInputElementDescs = layout_desc;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&psos[0]);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
     pso_desc.VS = execute_indirect_state_vs_code_large_cbv_dxbc;
     pso_desc.pRootSignature = root_signatures[1];
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&psos[1]);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     /* Verify sanity checks.
      * As per validation layers, there must be exactly one command in the signature.
@@ -2781,7 +2781,7 @@ void test_execute_indirect_state(void)
     indirect_argument_descs[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW;
     hr = ID3D12Device_CreateCommandSignature(context.device, &command_signature_desc, NULL,
             &IID_ID3D12CommandSignature, (void**)&command_signature);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
 
     command_signature_desc.NumArgumentDescs = 2;
     command_signature_desc.pArgumentDescs = indirect_argument_descs;
@@ -2790,14 +2790,14 @@ void test_execute_indirect_state(void)
     indirect_argument_descs[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW;
     hr = ID3D12Device_CreateCommandSignature(context.device, &command_signature_desc, NULL,
             &IID_ID3D12CommandSignature, (void**)&command_signature);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
 
     command_signature_desc.ByteStride = sizeof(D3D12_DRAW_INDEXED_ARGUMENTS) + sizeof(D3D12_DRAW_INDEXED_ARGUMENTS);
     indirect_argument_descs[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
     indirect_argument_descs[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
     hr = ID3D12Device_CreateCommandSignature(context.device, &command_signature_desc, NULL,
             &IID_ID3D12CommandSignature, (void**)&command_signature);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++)
     {
@@ -3158,18 +3158,18 @@ void test_execute_indirect_state_tier_11(void)
     cs_desc.ByteStride = sizeof(D3D12_DRAW_ARGUMENTS);
     hr = ID3D12Device_CreateCommandSignature(context.device, &cs_desc, context.root_signature,
         &IID_ID3D12CommandSignature, (void **)&command_signature[DRAW]);
-    ok(SUCCEEDED(hr), "Failed to create command signature, hr %x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command signature, hr %x.\n", (int)hr);
     init_pipeline_state_desc(&pso_desc, context.root_signature, DXGI_FORMAT_UNKNOWN, &execute_indirect_tier11_draw_dxbc, NULL, NULL);
     pso_desc.PS.BytecodeLength = 0;
     pso_desc.PS.pShaderBytecode = NULL;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&psos[DRAW]);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     arguments[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
     cs_desc.ByteStride = sizeof(D3D12_DRAW_INDEXED_ARGUMENTS);
     hr = ID3D12Device_CreateCommandSignature(context.device, &cs_desc, context.root_signature,
         &IID_ID3D12CommandSignature, (void **)&command_signature[DRAW_INDEXED]);
-    ok(SUCCEEDED(hr), "Failed to create command signature, hr %x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command signature, hr %x.\n", (int)hr);
     psos[DRAW_INDEXED] = psos[DRAW];
     ID3D12PipelineState_AddRef(psos[DRAW_INDEXED]);
 
@@ -3177,7 +3177,7 @@ void test_execute_indirect_state_tier_11(void)
     cs_desc.ByteStride = sizeof(D3D12_DISPATCH_ARGUMENTS);
     hr = ID3D12Device_CreateCommandSignature(context.device, &cs_desc, context.root_signature,
         &IID_ID3D12CommandSignature, (void **)&command_signature[DISPATCH]);
-    ok(SUCCEEDED(hr), "Failed to create command signature, hr %x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command signature, hr %x.\n", (int)hr);
     psos[DISPATCH] = create_compute_pipeline_state(context.device, context.root_signature, execute_indirect_tier11_dispatch_dxbc);
 
     if (options7.MeshShaderTier >= D3D12_MESH_SHADER_TIER_1)
@@ -3190,9 +3190,9 @@ void test_execute_indirect_state_tier_11(void)
         cs_desc.ByteStride = sizeof(D3D12_DISPATCH_MESH_ARGUMENTS);
         hr = ID3D12Device_CreateCommandSignature(context.device, &cs_desc, context.root_signature,
             &IID_ID3D12CommandSignature, (void **)&command_signature[MESH]);
-        ok(SUCCEEDED(hr), "Failed to create command signature, hr %x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create command signature, hr %x.\n", (int)hr);
         hr = create_pipeline_state_from_stream(device2, &ms_only_pipeline_desc, &psos[MESH]);
-        ok(SUCCEEDED(hr), "Failed to create mesh PSO, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create mesh PSO, hr #%x.\n", (int)hr);
         ID3D12Device2_Release(device2);
     }
 
@@ -3546,7 +3546,7 @@ void test_execute_indirect(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_SetComputeRootSignature(command_list, root_signature);
     pipeline_state = create_compute_pipeline_state(context.device, root_signature, execute_indirect_cs_dxbc);
@@ -3685,7 +3685,7 @@ void test_dispatch_huge_groups(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(context.device, context.root_signature, dispatch_zero_thread_groups_dxbc);
 
@@ -3784,7 +3784,7 @@ void test_dispatch_zero_thread_groups(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(context.device, context.root_signature, dispatch_zero_thread_groups_dxbc);
 
@@ -4110,10 +4110,10 @@ static void draw_thread_main(void *thread_data)
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 100; ++i)
     {
@@ -4207,10 +4207,10 @@ void test_command_list_initial_pipeline_state(void)
 
     hr = ID3D12Device_CreateCommandAllocator(context.device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&allocator);
-    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(context.device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             allocator, pipeline_state, &IID_ID3D12GraphicsCommandList, (void **)&command_list);
-    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -4224,9 +4224,9 @@ void test_command_list_initial_pipeline_state(void)
     check_sub_resource_uint(context.render_target, 0, queue, command_list, 0xff804000, 1);
 
     hr = ID3D12CommandAllocator_Reset(allocator);
-    ok(hr == S_OK, "Failed to reset command allocator, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to reset command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_Reset(command_list, allocator, context.pipeline_state);
-    ok(hr == S_OK, "Failed to reset command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to reset command list, hr %#x.\n", (int)hr);
     transition_resource_state(command_list, context.render_target,
             D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -4569,7 +4569,7 @@ void test_conditional_rendering(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&texture);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     memset(&rtv_desc, 0, sizeof(rtv_desc));
     rtv_desc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DMS;
@@ -4643,7 +4643,7 @@ void test_conditional_rendering(void)
     root_signature_desc.NumParameters = 2;
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pipeline_state = create_compute_pipeline_state(context.device, root_signature, conditional_rendering_dxbc);
 
@@ -4727,7 +4727,7 @@ void test_write_buffer_immediate(void)
     parameters[2].Value = 0x5060708;
     ID3D12GraphicsCommandList2_WriteBufferImmediate(command_list2, ARRAY_SIZE(parameters), parameters, NULL);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
     reset_command_list(command_list, context.allocator);
@@ -4752,7 +4752,7 @@ void test_write_buffer_immediate(void)
     modes[2] = D3D12_WRITEBUFFERIMMEDIATE_MODE_MARKER_OUT;
     ID3D12GraphicsCommandList2_WriteBufferImmediate(command_list2, ARRAY_SIZE(parameters), parameters, modes);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
     reset_command_list(command_list, context.allocator);
@@ -4770,7 +4770,7 @@ void test_write_buffer_immediate(void)
     modes[0] = 0x7fffffff;
     ID3D12GraphicsCommandList2_WriteBufferImmediate(command_list2, ARRAY_SIZE(parameters), parameters, modes);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     ID3D12Resource_Release(buffer);
     ID3D12GraphicsCommandList2_Release(command_list2);
@@ -4822,16 +4822,16 @@ void test_aliasing_barrier(void)
 
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void**)&buffer_heap);
-    ok(hr == S_OK, "Failed to create buffer heap hr #%u.\n", hr);
+    ok(hr == S_OK, "Failed to create buffer heap hr #%u.\n", (int)hr);
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&texture_heap);
-    ok(hr == S_OK, "Failed to create buffer heap hr #%u.\n", hr);
+    ok(hr == S_OK, "Failed to create buffer heap hr #%u.\n", (int)hr);
 
     if (supports_heap_tier_2)
     {
         heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES;
         hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&common_heap);
-        ok(hr == S_OK, "Failed to create buffer heap hr #%u.\n", hr);
+        ok(hr == S_OK, "Failed to create buffer heap hr #%u.\n", (int)hr);
     }
     else
         common_heap = NULL;
@@ -4852,12 +4852,12 @@ void test_aliasing_barrier(void)
     {
         placed_buffers[i] = create_placed_buffer(device, buffer_heap, 0, 1, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COMMON);
         hr = ID3D12Device_CreatePlacedResource(device, texture_heap, 0, &texture_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&placed_textures[i]);
-        ok(hr == S_OK, "Failed to create placed resource. hr = #%u.\n", hr);
+        ok(hr == S_OK, "Failed to create placed resource. hr = #%u.\n", (int)hr);
     }
 
     placed_buffers[2] = create_placed_buffer(device, supports_heap_tier_2 ? common_heap : buffer_heap, 0, 1, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COMMON);
     hr = ID3D12Device_CreatePlacedResource(device, supports_heap_tier_2 ? common_heap : texture_heap, 0, &texture_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&placed_textures[2]);
-    ok(hr == S_OK, "Failed to create placed resource. hr = #%u.\n", hr);
+    ok(hr == S_OK, "Failed to create placed resource. hr = #%u.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(barriers); i++)
     {
@@ -5033,20 +5033,20 @@ void test_discard_resource(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&rt);
-    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
 
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
     resource_desc.Format = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
         &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE, NULL, &IID_ID3D12Resource, (void **)&depth_rt);
-    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
 
     resource_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
     resource_desc.Format = DXGI_FORMAT_R32_FLOAT;
     resource_desc.DepthOrArraySize = 1;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
         &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&tmp_depth);
-    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
 
     region.NumRects = 0;
     region.pRects = NULL;
@@ -5073,9 +5073,9 @@ void test_discard_resource(void)
 
     /* Just make sure we don't have validation errors */
     hr = ID3D12GraphicsCommandList_Close(context.list);
-    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_Reset(context.list, context.allocator, NULL);
-    ok(hr == S_OK, "Failed to reset command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to reset command list, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &rtv, false, &dsv);
     ID3D12GraphicsCommandList_DiscardResource(context.list, rt, &region);
@@ -5172,11 +5172,11 @@ void test_root_parameter_preservation(void)
     root_parameter.Descriptor.ShaderRegister = 1;
 
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr = #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr = #%x.\n", (int)hr);
 
     init_pipeline_state_desc(&pso_desc, root_signature, desc.rt_format, NULL, &root_parameter_preservation_ps_dxbc, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&graphics_pso);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr = #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr = #%x.\n", (int)hr);
     compute_pso = create_compute_pipeline_state(context.device, root_signature, root_parameter_preservation_cs_dxbc);
 
     buffer = create_default_buffer(context.device, 4096, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -5272,7 +5272,7 @@ static void test_cbv_hoisting(bool use_dxil)
     }
 
     hr = create_versioned_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr = #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr = #%x.\n", (int)hr);
 
     pso = create_compute_pipeline_state(context.device, root_signature, use_dxil ? cbv_hoisting_dxil : cbv_hoisting_dxbc);
 
@@ -5391,7 +5391,7 @@ static void test_conservative_rasterization(bool use_dxil)
         return;
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (!options.ConservativeRasterizationTier)
     {
@@ -5404,7 +5404,7 @@ static void test_conservative_rasterization(bool use_dxil)
     heap_desc.Count = ARRAY_SIZE(tests);
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateQueryHeap(context.device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
-    ok(SUCCEEDED(hr), "Failed to create query heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create query heap, hr %#x.\n", (int)hr);
 
     readback = create_readback_buffer(context.device, ARRAY_SIZE(tests) * sizeof(uint64_t));
 
@@ -5414,7 +5414,7 @@ static void test_conservative_rasterization(bool use_dxil)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     command_list = context.list;
     queue = context.queue;
@@ -5443,12 +5443,12 @@ static void test_conservative_rasterization(bool use_dxil)
     pso_desc.DepthStencilState.BackFace = pso_desc.DepthStencilState.FrontFace;
     pso_desc.RasterizerState.ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_ON;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pipeline_conservative_overestimate);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     pso_desc.DepthStencilState.StencilWriteMask = 0x02;
     pso_desc.RasterizerState.ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pipeline_conservative_off);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     if (options.ConservativeRasterizationTier >= D3D12_CONSERVATIVE_RASTERIZATION_TIER_3)
     {
@@ -5456,7 +5456,7 @@ static void test_conservative_rasterization(bool use_dxil)
         pso_desc.DepthStencilState.StencilWriteMask = 0x04;
         pso_desc.RasterizerState.ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_ON;
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pipeline_conservative_underestimate);
-        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
     }
     else
         pipeline_conservative_underestimate = NULL;
@@ -5475,7 +5475,7 @@ static void test_conservative_rasterization(bool use_dxil)
     pso_desc.DepthStencilState.BackFace = pso_desc.DepthStencilState.FrontFace;
     pso_desc.RasterizerState.ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pipeline_stencil_test);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 0, NULL, false, &ds.dsv_handle);
     ID3D12GraphicsCommandList_ClearDepthStencilView(command_list, ds.dsv_handle,

--- a/tests/d3d12_copy.c
+++ b/tests/d3d12_copy.c
@@ -691,7 +691,7 @@ void test_copy_texture_bc_rgba(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&rgba_texture);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     resource_desc.Format = DXGI_FORMAT_BC3_UNORM;
     resource_desc.Width = 8;
@@ -699,7 +699,7 @@ void test_copy_texture_bc_rgba(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&bc_texture);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     /* CopyResource from RGBA32 to BC3 */
     subresource_data.pData = bc_data;
@@ -736,7 +736,7 @@ void test_copy_texture_bc_rgba(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&rgba_texture);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_CopyResource(context.list, rgba_texture, bc_texture);
 
@@ -845,7 +845,7 @@ void test_copy_texture_bc_rgba(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&rgba_texture);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     resource_desc.Format = DXGI_FORMAT_BC3_UNORM;
     resource_desc.Width = 4;
@@ -854,7 +854,7 @@ void test_copy_texture_bc_rgba(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&bc_texture);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     upload_texture_data(rgba_texture, &subresource_data, 1, context.queue, context.list);
     reset_command_list(context.list, context.allocator);
@@ -911,7 +911,7 @@ void test_copy_texture_bc_rgba(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&rgba_texture);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     memset(&rgba_region, 0, sizeof(rgba_region));
     rgba_region.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
@@ -1207,7 +1207,7 @@ void test_copy_buffer_texture(void)
 
     zero_buffer = create_upload_buffer(device, buffer_size * sizeof(*ptr) + D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT, NULL);
     hr = ID3D12Resource_Map(zero_buffer, 0, NULL, (void **)&ptr);
-    ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", (int)hr);
     memset(ptr, 0, buffer_size * sizeof(*ptr) + D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT);
     for (i = 0; i < D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT / sizeof(*ptr); ++i)
         ptr[i] = 0xdeadbeef;
@@ -1215,7 +1215,7 @@ void test_copy_buffer_texture(void)
 
     src_buffer = create_upload_buffer(device, buffer_size * sizeof(*ptr), NULL);
     hr = ID3D12Resource_Map(src_buffer, 0, NULL, (void **)&ptr);
-    ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", (int)hr);
     for (z = 0; z < 64; ++z)
     {
         for (y = 0; y < 100; ++y)
@@ -1377,7 +1377,7 @@ void test_copy_block_compressed_texture(void)
     dst_buffer = create_default_buffer(device, 4096, 0, D3D12_RESOURCE_STATE_COPY_DEST);
     src_buffer = create_upload_buffer(device, 4096, NULL);
     hr = ID3D12Resource_Map(src_buffer, 0, NULL, (void **)&ptr);
-    ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", (int)hr);
     for (x = 0; x < 4096 / format_size(DXGI_FORMAT_BC2_UNORM); ++x)
     {
         block_id = x << 8;
@@ -1613,16 +1613,16 @@ void test_multisample_resolve(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
         &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&ms_render_target);
-    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
     resource_desc.Width = 4;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
         &resource_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, NULL, &IID_ID3D12Resource, (void **)&ms_render_target_copy);
-    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
     resource_desc.SampleDesc.Count = 1;
     resource_desc.Height = 8;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
         &resource_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, NULL, &IID_ID3D12Resource, (void **)&render_target);
-    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
 
     ms_rtv = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(heap);
     ID3D12Device_CreateRenderTargetView(context.device, ms_render_target, NULL, ms_rtv);
@@ -1723,7 +1723,7 @@ void test_multisample_resolve_formats(void)
     unsigned int i, j;
     UINT dst_x, dst_y;
     HRESULT hr;
-    LONG x, y;
+    int x, y;
 
     static const float black[] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
@@ -1761,12 +1761,12 @@ void test_multisample_resolve_formats(void)
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     hr = create_root_signature(context.device, &rs_desc, &rs_setup_render_targets);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     rs_desc.NumParameters = 1;
     rs_desc.pParameters = &rs_param;
     hr = create_root_signature(context.device, &rs_desc, &rs_setup_stencil);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pipeline_desc, rs_setup_render_targets,
             DXGI_FORMAT_UNKNOWN, NULL, &ps_resolve_setup_rt_dxbc, NULL);
@@ -1782,7 +1782,7 @@ void test_multisample_resolve_formats(void)
     pipeline_desc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
     pipeline_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pipeline_desc, &IID_ID3D12PipelineState, (void**)&pso_setup_render_targets);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pipeline_desc, rs_setup_stencil,
             DXGI_FORMAT_UNKNOWN, NULL, &ps_resolve_setup_stencil_dxbc, NULL);
@@ -1796,7 +1796,7 @@ void test_multisample_resolve_formats(void)
     pipeline_desc.DepthStencilState.FrontFace.StencilPassOp = D3D12_STENCIL_OP_REPLACE;
     pipeline_desc.DepthStencilState.BackFace = pipeline_desc.DepthStencilState.FrontFace;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pipeline_desc, &IID_ID3D12PipelineState, (void**)&pso_setup_stencil);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     memset(&heap_properties, 0, sizeof(heap_properties));
     heap_properties.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -1815,15 +1815,15 @@ void test_multisample_resolve_formats(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
             NULL, &IID_ID3D12Resource, (void**)&rt_f32_ms);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
             NULL, &IID_ID3D12Resource, (void**)&rt_u32_ms);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
             NULL, &IID_ID3D12Resource, (void**)&rt_s32_ms);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
     resource_desc.SampleDesc.Count = 1;
@@ -1831,26 +1831,26 @@ void test_multisample_resolve_formats(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
             NULL, &IID_ID3D12Resource, (void**)&rt_f32);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
             NULL, &IID_ID3D12Resource, (void**)&rt_u32);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
             NULL, &IID_ID3D12Resource, (void**)&rt_s32);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     /* FIXME we should not require UAV usage */
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST,
             NULL, &IID_ID3D12Resource, (void**)&image_u32);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST,
             NULL, &IID_ID3D12Resource, (void**)&image_s32);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.Alignment = D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT;
     resource_desc.Format = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
@@ -1860,7 +1860,7 @@ void test_multisample_resolve_formats(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE,
             NULL, &IID_ID3D12Resource, (void**)&ds_ms);
-    ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", (int)hr);
 
     resource_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
     resource_desc.Format = DXGI_FORMAT_R32G8X24_TYPELESS;
@@ -1870,7 +1870,7 @@ void test_multisample_resolve_formats(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE,
             NULL, &IID_ID3D12Resource, (void**)&ds);
-    ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", (int)hr);
 
     memset(&resource_desc, 0, sizeof(resource_desc));
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
@@ -1885,7 +1885,7 @@ void test_multisample_resolve_formats(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST,
             NULL, &IID_ID3D12Resource, (void**)&combined_image);
-    ok(hr == S_OK, "Failed to create combined image, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create combined image, hr %#x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 6);
     dsv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, 2);
@@ -2290,7 +2290,7 @@ void test_multisample_resolve_strongly_typed(void)
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pso_desc, context.root_signature,
             DXGI_FORMAT_UNKNOWN, NULL, &ps_resolve_setup_simple_dxbc, NULL);
@@ -2357,7 +2357,7 @@ void test_multisample_resolve_strongly_typed(void)
         pso_desc.RTVFormats[0] = tests[i].src_format;
 
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&pso);
-        ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(context.list, src_rtv, green, 0, NULL);
         ID3D12GraphicsCommandList_ClearRenderTargetView(context.list, dst_rtv, red, 0, NULL);
@@ -2416,22 +2416,22 @@ void test_multisample_resolve_strongly_typed(void)
 
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, NULL, &IID_ID3D12Resource, (void**)&resolve_dst);
-        ok(hr == S_OK, "Failed to create resolve destination, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create resolve destination, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ResolveSubresource(context.list, resolve_dst, 0,
                 resolve_src, 0, invalid_tests[i].resolve_format);
 
         hr = ID3D12GraphicsCommandList_Close(context.list);
         todo_if(invalid_tests[i].is_todo)
-        ok(hr == invalid_tests[i].expected, "Got hr %#x, expected E_INVALIDARG.\n", hr);
+        ok(hr == invalid_tests[i].expected, "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
         ID3D12GraphicsCommandList_Release(context.list);
 
         hr = ID3D12CommandAllocator_Reset(context.allocator);
-        ok(hr == S_OK, "Failed to reset command allocator, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to reset command allocator, hr %#x.\n", (int)hr);
 
         hr = ID3D12Device_CreateCommandList(context.device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
                 context.allocator, NULL, &IID_ID3D12GraphicsCommandList, (void**)&context.list);
-        ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
         ID3D12Resource_Release(resolve_dst);
         ID3D12Resource_Release(resolve_src);
@@ -3241,7 +3241,7 @@ void test_resolve_subresource_depth(void)
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     hr = create_root_signature(context.device, &rs_desc, &rs_setup_ds);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pipeline_desc, rs_setup_ds,
         DXGI_FORMAT_UNKNOWN, NULL, &ps_resolve_setup_rt_dxbc, NULL);
@@ -3251,7 +3251,7 @@ void test_resolve_subresource_depth(void)
     pipeline_desc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
     pipeline_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pipeline_desc, &IID_ID3D12PipelineState, (void **)&pso_setup_ds);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     memset(&heap_properties, 0, sizeof(heap_properties));
     heap_properties.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -3271,7 +3271,7 @@ void test_resolve_subresource_depth(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
         D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE,
         NULL, &IID_ID3D12Resource, (void **)&ds_ms);
-    ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", (int)hr);
 
     resource_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
     resource_desc.Format = DXGI_FORMAT_R32_FLOAT;
@@ -3283,7 +3283,7 @@ void test_resolve_subresource_depth(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
         D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST,
         NULL, &IID_ID3D12Resource, (void **)&ds);
-    ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create depth-stencil resource, hr %#x.\n", (int)hr);
 
     dsv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, 1);
 
@@ -3587,13 +3587,13 @@ static bool init_copy_test_context(struct test_context_copy *context, D3D12_COMM
 
     hr = ID3D12Device_CreateCommandAllocator(context->context.device, type,
         &IID_ID3D12CommandAllocator, (void **)&context->copy_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr #%x\n", (int)hr);
 
     memset(&copy_queue_desc, 0, sizeof(copy_queue_desc));
     copy_queue_desc.Type = type;
     hr = ID3D12Device_CreateCommandQueue(context->context.device, &copy_queue_desc,
         &IID_ID3D12CommandQueue, (void **)&context->copy_queue);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", (int)hr);
 
     ID3D12Device_CreateCommandList(context->context.device, 0, type,
         context->copy_allocator, NULL,
@@ -3626,7 +3626,7 @@ static void test_queue_buffer(D3D12_COMMAND_LIST_TYPE type)
         return;
 
     hr = ID3D12Device_CreateFence(context.context.device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
     a = create_upload_buffer(context.context.device, 4 * 1024 * 1024, NULL);
     ID3D12Resource_Map(a, 0, NULL, (void **)&ptr);
@@ -3712,10 +3712,10 @@ static void test_queue_buffer_image(D3D12_COMMAND_LIST_TYPE type)
 
     hr = ID3D12Device_CreateFence(context.context.device, 0, D3D12_FENCE_FLAG_NONE,
         &IID_ID3D12Fence, (void **)&direct_fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
     hr = ID3D12Device_CreateFence(context.context.device, 0, D3D12_FENCE_FLAG_NONE,
         &IID_ID3D12Fence, (void **)&copy_fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
     a = create_upload_buffer(context.context.device, 4 * 1024 * 1024, NULL);
     ID3D12Resource_Map(a, 0, NULL, (void **)&ptr);
@@ -3833,7 +3833,7 @@ static void test_queue_render_target_inner(D3D12_COMMAND_LIST_TYPE type, bool ms
 
     hr = ID3D12Device_CreateFence(context.context.device, 0, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
     upload_buf = create_default_buffer(context.context.device, 64 * 64 * sizeof(uint32_t),
             D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COMMON);
@@ -3856,11 +3856,11 @@ static void test_queue_render_target_inner(D3D12_COMMAND_LIST_TYPE type, bool ms
 
     hr = ID3D12Device_CreateCommittedResource(context.context.device, &heap_props, D3D12_HEAP_FLAG_NONE, &desc,
         D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&tex);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommittedResource(context.context.device, &heap_props, D3D12_HEAP_FLAG_NONE, &desc,
         D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&copy_tex);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     rtv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(rtv);
     ID3D12Device_CreateRenderTargetView(context.context.device, tex, NULL, rtv_handle);
@@ -4068,18 +4068,18 @@ static void test_queue_depth_stencil_inner(D3D12_COMMAND_LIST_TYPE type, bool ms
 
     hr = ID3D12Device_CreateFence(context.context.device, 0, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
     upload_buf = create_default_buffer(context.context.device, 64 * 64 * sizeof(float),
             D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COMMON);
 
     hr = ID3D12Device_CreateCommittedResource(context.context.device, &heap_props, D3D12_HEAP_FLAG_NONE, &desc,
         D3D12_RESOURCE_STATE_DEPTH_WRITE, NULL, &IID_ID3D12Resource, (void **)&tex);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommittedResource(context.context.device, &heap_props, D3D12_HEAP_FLAG_NONE, &desc,
         D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&copy_tex);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     dsv = create_cpu_descriptor_heap(context.context.device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, 1);
     dsv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(dsv);

--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -345,12 +345,12 @@ static void wait_queue_idle_(unsigned int line, ID3D12Device *device, ID3D12Comm
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&fence);
-    assert_that_(line)(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    assert_that_(line)(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     hr = ID3D12CommandQueue_Signal(queue, fence, 1);
-    assert_that_(line)(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    assert_that_(line)(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
     hr = wait_for_fence(fence, 1);
-    assert_that_(line)(hr == S_OK, "Failed to wait for fence, hr %#x.\n", hr);
+    assert_that_(line)(hr == S_OK, "Failed to wait for fence, hr %#x.\n", (int)hr);
 
     ID3D12Fence_Release(fence);
 }
@@ -362,12 +362,12 @@ static inline void wait_queue_idle_no_event_(unsigned int line, ID3D12Device *de
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
         &IID_ID3D12Fence, (void **)&fence);
-    assert_that_(line)(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    assert_that_(line)(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     hr = ID3D12CommandQueue_Signal(queue, fence, 1);
-    assert_that_(line)(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    assert_that_(line)(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
     hr = wait_for_fence_no_event(fence, 1);
-    assert_that_(line)(hr == S_OK, "Failed to wait for fence, hr %#x.\n", hr);
+    assert_that_(line)(hr == S_OK, "Failed to wait for fence, hr %#x.\n", (int)hr);
 
     ID3D12Fence_Release(fence);
 }
@@ -416,7 +416,7 @@ static IUnknown *create_warp_adapter(IDXGIFactory4 *factory)
     adapter = NULL;
     hr = IDXGIFactory4_EnumWarpAdapter(factory, &IID_IUnknown, (void **)&adapter);
     if (FAILED(hr))
-        trace("Failed to get WARP adapter, hr %#x.\n", hr);
+        trace("Failed to get WARP adapter, hr %#x.\n", (int)hr);
     return adapter;
 }
 
@@ -427,7 +427,7 @@ static IUnknown *create_adapter(void)
     HRESULT hr;
 
     hr = CreateDXGIFactory1(&IID_IDXGIFactory4, (void **)&factory);
-    ok(hr == S_OK, "Failed to create IDXGIFactory4, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create IDXGIFactory4, hr %#x.\n", (int)hr);
 
     if (use_warp_device && (adapter = create_warp_adapter(factory)))
     {
@@ -438,7 +438,7 @@ static IUnknown *create_adapter(void)
     hr = IDXGIFactory4_EnumAdapters(factory, use_adapter_idx, (IDXGIAdapter **)&adapter);
     IDXGIFactory4_Release(factory);
     if (FAILED(hr))
-        trace("Failed to get adapter, hr %#x.\n", hr);
+        trace("Failed to get adapter, hr %#x.\n", (int)hr);
     return adapter;
 }
 
@@ -478,11 +478,11 @@ static inline void init_adapter_info(void)
         return;
 
     hr = IUnknown_QueryInterface(adapter, &IID_IDXGIAdapter, (void **)&dxgi_adapter);
-    ok(hr == S_OK, "Failed to query IDXGIAdapter, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to query IDXGIAdapter, hr %#x.\n", (int)hr);
     IUnknown_Release(adapter);
 
     hr = IDXGIAdapter_GetDesc(dxgi_adapter, &desc);
-    ok(hr == S_OK, "Failed to get adapter desc, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get adapter desc, hr %#x.\n", (int)hr);
 
     /* FIXME: Use debugstr_w(). */
     for (i = 0; i < ARRAY_SIZE(desc.Description) && isprint(desc.Description[i]); ++i)
@@ -515,13 +515,13 @@ static inline bool get_adapter_desc(ID3D12Device *device, DXGI_ADAPTER_DESC *des
     luid = ID3D12Device_GetAdapterLuid(device);
 
     hr = CreateDXGIFactory1(&IID_IDXGIFactory4, (void **)&factory);
-    ok(hr == S_OK, "Failed to create IDXGIFactory4, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create IDXGIFactory4, hr %#x.\n", (int)hr);
 
     hr = IDXGIFactory4_EnumAdapterByLuid(factory, luid, &IID_IDXGIAdapter, (void **)&adapter);
     if (SUCCEEDED(hr))
     {
         hr = IDXGIAdapter_GetDesc(adapter, desc);
-        ok(hr == S_OK, "Failed to get adapter desc, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to get adapter desc, hr %#x.\n", (int)hr);
         IDXGIAdapter_Release(adapter);
     }
 

--- a/tests/d3d12_depth_stencil.c
+++ b/tests/d3d12_depth_stencil.c
@@ -119,7 +119,7 @@ void test_depth_clip(void)
     pso_desc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -158,7 +158,7 @@ void test_depth_clip(void)
     pso_desc.RasterizerState.DepthClipEnable = false;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -198,7 +198,7 @@ void test_depth_clip(void)
     pso_desc.RasterizerState.DepthClipEnable = true;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList_ClearDepthStencilView(command_list,
@@ -273,7 +273,7 @@ static void check_depth_stencil_sampling_(unsigned int line, struct test_context
     transition_sub_resource_state(command_list, texture, 0,
             D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok_(line)(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
     exec_command_list(queue, command_list);
     wait_queue_idle(context->device, queue);
 }
@@ -373,7 +373,7 @@ void test_depth_stencil_sampling(void)
     root_signature_desc.NumStaticSamplers = 2;
     root_signature_desc.pStaticSamplers = sampler_desc;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pso_compare = create_pipeline_state(device,
             context.root_signature, context.render_target_desc.Format, NULL, &ps_depth_compare_dxbc, NULL);
@@ -392,7 +392,7 @@ void test_depth_stencil_sampling(void)
     cb = create_upload_buffer(device, sizeof(ps_constant), &ps_constant);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -571,7 +571,7 @@ void test_depth_load(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pipeline_state = create_compute_pipeline_state(device, context.root_signature, cs_load_depth_dxbc);
     context.pipeline_state = create_pipeline_state(context.device,
@@ -690,7 +690,7 @@ void test_depth_read_only_view(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     heap = create_cpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, 1);
 
@@ -800,7 +800,7 @@ void test_stencil_load(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pipeline_state = create_compute_pipeline_state(device, context.root_signature, cs_load_stencil_dxbc);
     context.pipeline_state = create_pipeline_state(context.device,
@@ -926,7 +926,7 @@ void test_early_depth_stencil_tests(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pso_desc, context.root_signature, 0, NULL, &ps_early_depth_stencil_dxbc, NULL);
     pso_desc.NumRenderTargets = 0;
@@ -936,7 +936,7 @@ void test_early_depth_stencil_tests(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     init_depth_stencil(&ds, context.device, 1, 1, 1, 1, DXGI_FORMAT_D32_FLOAT, 0, NULL);
     set_rect(&context.scissor_rect, 0, 0, 1, 1);
@@ -1056,7 +1056,7 @@ static void test_stencil_export(bool use_dxil)
     }
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (!options.PSSpecifiedStencilRefSupported)
     {
@@ -1093,14 +1093,14 @@ static void test_stencil_export(bool use_dxil)
     pso_desc.DepthStencilState.BackFace = pso_desc.DepthStencilState.FrontFace;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     rs_sample = create_texture_root_signature(context.device,
             D3D12_SHADER_VISIBILITY_PIXEL, 0, 0);
     init_pipeline_state_desc(&pso_desc, rs_sample, DXGI_FORMAT_R8_UINT, NULL, &ps_stencil_export_load_dxbc, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso_sample);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
     heap_desc.NumDescriptors = 1;
@@ -1108,7 +1108,7 @@ static void test_stencil_export(bool use_dxil)
     heap_desc.NodeMask = 0;
 
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&srv_heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearDepthStencilView(command_list, ds.dsv_handle,
             D3D12_CLEAR_FLAG_STENCIL, 0.0f, 0x80, 0, NULL);
@@ -1460,7 +1460,7 @@ void test_depth_stencil_layout_tracking(void)
 
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&psos[i]);
-        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
     }
 
     /* In the tests, begin command lists from a clean slate.
@@ -2071,9 +2071,9 @@ void test_depth_stencil_front_and_back(void)
     pso_desc_write_stencil.root_signature.root_signature = context.root_signature;
 
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream_write_stencil, &IID_ID3D12PipelineState, (void **)&pso_stencil_write);
-    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", (int)hr);
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream_read_stencil, &IID_ID3D12PipelineState, (void **)&pso_stencil_read);
-    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 3; i++)
     {
@@ -2281,7 +2281,7 @@ void test_depth_bias_behaviour(void)
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     hr = create_root_signature(context.device, &rs_desc, &rs);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     viewport.TopLeftX = 0.0f;
     viewport.TopLeftY = 0.0f;
@@ -2298,7 +2298,7 @@ void test_depth_bias_behaviour(void)
     /* Render reference image with no depth bias and no depth test enabled */
     init_pipeline_state_desc(&pso_desc, rs, DXGI_FORMAT_R32_FLOAT, &vs_depth_bias_behaviour_dxbc, &ps_depth_bias_behaviour_dxbc, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearDepthStencilView(context.list, dsv, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, NULL);
     ID3D12GraphicsCommandList_OMSetRenderTargets(context.list, 1, &rtv_no_bias, FALSE, NULL);
@@ -2346,7 +2346,7 @@ void test_depth_bias_behaviour(void)
             }
 
             hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-            ok(SUCCEEDED(hr), "Failed to create graphics pipeline, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
             ID3D12GraphicsCommandList_OMSetRenderTargets(context.list, 1, &rtv, FALSE, tests[i].dsv_handle);
             ID3D12GraphicsCommandList_ClearRenderTargetView(context.list, rtv, black, 0, NULL);
@@ -2518,7 +2518,7 @@ void test_depth_bias_formats(void)
 
             hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
                     D3D12_HEAP_FLAG_NONE, &ds_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE, NULL, &IID_ID3D12Resource, (void**)&ds_resource);
-            ok(hr == S_OK, "Failed to create depth image, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create depth image, hr %#x.\n", (int)hr);
 
             memset(&dsv_desc, 0, sizeof(dsv_desc));
             dsv_desc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
@@ -2541,7 +2541,7 @@ void test_depth_bias_formats(void)
             }
 
             hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&pso);
-            ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
             memcpy(&clear_depth, &tests[i].depth_clear, sizeof(clear_depth));
 

--- a/tests/d3d12_descriptors.c
+++ b/tests/d3d12_descriptors.c
@@ -27,7 +27,7 @@ void test_create_descriptor_heap(void)
     D3D12_DESCRIPTOR_HEAP_DESC heap_desc;
     ID3D12Device *device, *tmp_device;
     ID3D12DescriptorHeap *heap;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -41,16 +41,16 @@ void test_create_descriptor_heap(void)
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12DescriptorHeap_GetDevice(heap, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(hr == S_OK, "Failed to get device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(heap, &IID_ID3D12Object, true);
     check_interface(heap, &IID_ID3D12DeviceChild, true);
@@ -58,46 +58,46 @@ void test_create_descriptor_heap(void)
     check_interface(heap, &IID_ID3D12DescriptorHeap, true);
 
     refcount = ID3D12DescriptorHeap_Release(heap);
-    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", refcount);
 
     heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
     refcount = ID3D12DescriptorHeap_Release(heap);
-    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", refcount);
 
     heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
     refcount = ID3D12DescriptorHeap_Release(heap);
-    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", refcount);
 
     heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
     refcount = ID3D12DescriptorHeap_Release(heap);
-    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", refcount);
 
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
     refcount = ID3D12DescriptorHeap_Release(heap);
-    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", refcount);
 
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_descriptor_tables(void)
@@ -216,7 +216,7 @@ void test_descriptor_tables(void)
     root_signature_desc.NumParameters = 3;
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_pipeline_state(context.device,
             context.root_signature, context.render_target_desc.Format, NULL, &ps, NULL);
@@ -357,7 +357,7 @@ void test_descriptor_tables_overlapping_bindings(void)
     root_signature_desc.NumParameters = 3;
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(device, context.root_signature, overlapping_bindings_dxbc);
 
@@ -508,7 +508,7 @@ void test_update_root_descriptors(void)
     root_signature_desc.NumParameters = 2;
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pipeline_state = create_compute_pipeline_state(device, root_signature, update_root_descriptors_dxil);
 
@@ -600,7 +600,7 @@ void test_update_descriptor_tables(void)
     root_signature_desc.NumStaticSamplers = 1;
     root_signature_desc.pStaticSamplers = &sampler_desc;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_pipeline_state(context.device,
             context.root_signature, context.render_target_desc.Format, NULL, &update_descriptor_tables_dxbc, NULL);
@@ -611,12 +611,12 @@ void test_update_descriptor_tables(void)
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &heap_desc,
             &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &heap_desc,
             &IID_ID3D12DescriptorHeap, (void **)&cpu_heap);
-    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(textures); ++i)
     {
@@ -763,7 +763,7 @@ void test_update_descriptor_heap_after_closing_command_list(void)
     ID3D12GraphicsCommandList_DrawInstanced(command_list, 3, 1, 0, 0);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
     /* Update the descriptor heap used by the closed command list. */
     ID3D12Device_CreateShaderResourceView(context.device, green_texture, NULL, cpu_handle);
@@ -902,7 +902,7 @@ void test_update_compute_descriptor_tables(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     buffer_pso = create_compute_pipeline_state(device, context.root_signature,
         update_compute_descriptor_tables_buffer_dxbc);
@@ -1214,10 +1214,10 @@ void test_update_descriptor_tables_after_root_signature_change(void)
     root_signature_desc.NumParameters = ARRAY_SIZE(root_parameters);
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
     root_signature_desc.NumParameters = ARRAY_SIZE(root_parameters) - 1;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature2);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pipeline_state = create_pipeline_state(context.device,
             root_signature, context.render_target_desc.Format, NULL,
@@ -1619,7 +1619,7 @@ void test_copy_descriptors(void)
     root_signature_desc.NumParameters = 4;
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(device, context.root_signature,
             copy_descriptors_dxbc);
@@ -1995,7 +1995,7 @@ void test_copy_rtv_descriptors(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &rt_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,
             &IID_ID3D12Resource, (void **)&rt_texture);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 9);
 
@@ -2143,7 +2143,7 @@ void test_descriptors_visibility(void)
     root_signature_desc.NumStaticSamplers = 2;
     root_signature_desc.pStaticSamplers = sampler_desc;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_pipeline_state(device,
             context.root_signature, context.render_target_desc.Format,
@@ -2396,7 +2396,7 @@ void test_create_null_descriptors(void)
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc,
             &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     cbv_desc.BufferLocation = 0;
     cbv_desc.SizeInBytes = 0;
@@ -2488,7 +2488,7 @@ void test_null_cbv(void)
     root_signature_desc.NumParameters = ARRAY_SIZE(root_parameters);
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_pipeline_state(context.device,
             context.root_signature, context.render_target_desc.Format, NULL,
@@ -2763,7 +2763,7 @@ void test_null_uav(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     uav_heap = create_gpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
 
@@ -2906,7 +2906,7 @@ void test_cpu_descriptors_lifetime(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&red_resource);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
     clear_value.Color[0] = 0.0f;
     clear_value.Color[1] = 0.0f;
     clear_value.Color[2] = 1.0f;
@@ -2915,7 +2915,7 @@ void test_cpu_descriptors_lifetime(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&blue_resource);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     ID3D12Device_CreateRenderTargetView(device, red_resource, NULL, rtv_handle);
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, rtv_handle, red, 0, NULL);
@@ -2993,9 +2993,9 @@ void test_create_sampler(void)
     unsigned int sampler_increment_size;
     D3D12_SAMPLER_DESC sampler_desc;
     ID3D12DescriptorHeap *heap;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -3014,7 +3014,7 @@ void test_create_sampler(void)
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     cpu_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(heap);
     memset(&sampler_desc, 0, sizeof(sampler_desc));
@@ -3051,9 +3051,9 @@ void test_create_sampler(void)
     ID3D12Device_CreateSampler(device, &sampler_desc, cpu_handle);
 
     refcount = ID3D12DescriptorHeap_Release(heap);
-    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", refcount);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_sampler2(void)
@@ -3065,8 +3065,8 @@ void test_create_sampler2(void)
     D3D12_SAMPLER_DESC2 sampler_desc;
     ID3D12DescriptorHeap *heap;
     ID3D12Device11 *device11;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -3087,7 +3087,7 @@ void test_create_sampler2(void)
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     cpu_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(heap);
     memset(&sampler_desc, 0, sizeof(sampler_desc));
@@ -3101,9 +3101,9 @@ void test_create_sampler2(void)
     ID3D12Device11_Release(device11);
 
     refcount = ID3D12DescriptorHeap_Release(heap);
-    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", refcount);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_unordered_access_view(void)
@@ -3113,8 +3113,8 @@ void test_create_unordered_access_view(void)
     ID3D12Resource *buffer, *texture;
     unsigned int descriptor_size;
     ID3D12DescriptorHeap *heap;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
 
     if (!(device = create_device()))
     {
@@ -3157,9 +3157,9 @@ void test_create_unordered_access_view(void)
     ID3D12Resource_Release(buffer);
     ID3D12Resource_Release(texture);
     refcount = ID3D12DescriptorHeap_Release(heap);
-    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12DescriptorHeap has %u references left.\n", refcount);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_sampler_border_color(void)
@@ -3293,7 +3293,7 @@ void test_sampler_border_color(void)
         }
 
         hr = create_root_signature(device, &root_signature_desc, &root_signature);
-        ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
         pipeline_state = create_pipeline_state(device, root_signature,
                 context.render_target_desc.Format, NULL, &sampler_border_color_dxbc, NULL);
@@ -3406,7 +3406,7 @@ static void test_typed_buffers_many_objects(bool use_dxil)
     descriptor_ranges[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     output_buffer = create_default_buffer(context.device, 64 * 1024 * 1024, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
     input_buffer = create_default_buffer(context.device, 64 * 1024 * 1024, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COPY_DEST);
@@ -3710,7 +3710,7 @@ void test_view_min_lod(void)
             pso_desc.PS = *tests[i].ps;
             hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                     &IID_ID3D12PipelineState, (void **)&pso);
-            ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
         }
 
         view_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -3934,7 +3934,7 @@ void test_typed_srv_uav_cast(void)
                     hr = E_FAIL;
                 }
 
-                ok(FAILED(hr), "Unexpected hr %#x\n", hr);
+                ok(FAILED(hr), "Unexpected hr %#x\n", (int)hr);
                 PURGE_CONTEXT();
                 BEGIN();
             }
@@ -3954,7 +3954,7 @@ void test_typed_srv_uav_cast(void)
                     hr = E_FAIL;
                 }
 
-                ok(FAILED(hr), "Unexpected hr %#x\n", hr);
+                ok(FAILED(hr), "Unexpected hr %#x\n", (int)hr);
                 PURGE_CONTEXT();
                 BEGIN();
             }
@@ -3977,14 +3977,14 @@ void test_typed_srv_uav_cast(void)
                     hr = E_FAIL;
                 }
 
-                ok(FAILED(hr), "Unexpected hr %#x\n", hr);
+                ok(FAILED(hr), "Unexpected hr %#x\n", (int)hr);
                 PURGE_CONTEXT();
                 BEGIN();
             }
         }
 
         hr = ID3D12Device_GetDeviceRemovedReason(context.device);
-        ok(SUCCEEDED(hr), "Unexpected hr %#x\n", hr);
+        ok(SUCCEEDED(hr), "Unexpected hr %#x\n", (int)hr);
 
         if (SUCCEEDED(hr))
         {
@@ -5288,7 +5288,7 @@ void test_sampler_non_normalized_coordinates(void)
     rs_desc.Desc_1_2.pStaticSamplers = &static_sampler_desc;
 
     hr = create_versioned_root_signature(context.device, &rs_desc, &rs_static_sampler);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     rs_desc.Version = D3D_ROOT_SIGNATURE_VERSION_1_2;
@@ -5296,17 +5296,17 @@ void test_sampler_non_normalized_coordinates(void)
     rs_desc.Desc_1_2.pParameters = rs_params;
 
     hr = create_versioned_root_signature(context.device, &rs_desc, &rs_sampler_descriptor);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pso_desc, rs_static_sampler, DXGI_FORMAT_R8_UNORM, NULL,
             &sampler_non_normalized_coordinates_dxbc, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso_static_sampler);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pso_desc, rs_sampler_descriptor, DXGI_FORMAT_R8_UNORM, NULL,
             &sampler_non_normalized_coordinates_dxbc, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso_sampler_descriptor);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);
     srv_heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
@@ -6507,7 +6507,7 @@ void test_large_buffer_descriptors(void)
     hr = ID3D12Device_CreateReservedResource(context.device, &res_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&sparse);
     if (is_radv_device(context.device))
         vkd3d_unmute_validation_message("06409");
-    ok(SUCCEEDED(hr), "Failed to create reserved resource, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create reserved resource, hr #%x\n", (int)hr);
 
     memset(&heap_desc, 0, sizeof(heap_desc));
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_UPLOAD;
@@ -6515,11 +6515,11 @@ void test_large_buffer_descriptors(void)
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
 
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x\n", (int)hr);
 
     res_desc.Width = 128 * 1024;
     hr = ID3D12Device_CreatePlacedResource(context.device, heap, 0, &res_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&input);
-    ok(SUCCEEDED(hr), "Failed to create placed resource, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create placed resource, hr #%x\n", (int)hr);
 
     hr = ID3D12Resource_Map(input, 0, NULL, (void **)&ptr);
     ok(SUCCEEDED(hr), "Failed to map buffer.\n");

--- a/tests/d3d12_device.c
+++ b/tests/d3d12_device.c
@@ -24,8 +24,8 @@
 
 void test_create_device(void)
 {
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -40,41 +40,41 @@ void test_create_device(void)
     check_interface(device, &IID_ID3D12Device, true);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_11_0, &IID_ID3D12Device, (void **)&device);
-    ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
     ID3D12Device_Release(device);
 
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_11_0, &IID_ID3D12Device, NULL);
-    ok(hr == S_FALSE, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_FALSE, "Got unexpected hr %#x.\n", (int)hr);
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_11_0, NULL, NULL);
-    ok(hr == S_FALSE, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_FALSE, "Got unexpected hr %#x.\n", (int)hr);
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_11_0, &IID_ID3D12DeviceChild, NULL);
-    ok(hr == S_FALSE, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_FALSE, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_9_1, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_9_2, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_9_3, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_10_0, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_10_1, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = D3D12CreateDevice(NULL, 0, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = D3D12CreateDevice(NULL, ~0u, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 }
 
 void test_node_count(void)
 {
+    unsigned int refcount;
     ID3D12Device *device;
     UINT node_count;
-    ULONG refcount;
 
     if (!(device = create_device()))
     {
@@ -87,7 +87,7 @@ void test_node_count(void)
     ok(1 <= node_count && node_count <= 32, "Got unexpected node count %u.\n", node_count);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_check_feature_support(void)
@@ -99,9 +99,9 @@ void test_check_feature_support(void)
     D3D12_FEATURE_DATA_ARCHITECTURE architecture;
     D3D12_FEATURE_DATA_FORMAT_INFO format_info;
     unsigned int expected_plane_count;
+    unsigned int refcount;
     ID3D12Device *device;
     DXGI_FORMAT format;
-    ULONG refcount;
     bool is_todo;
     HRESULT hr;
 
@@ -148,7 +148,7 @@ void test_check_feature_support(void)
     memset(&architecture, 0, sizeof(architecture));
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ARCHITECTURE,
             &architecture, sizeof(architecture));
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ok(!architecture.NodeIndex, "Got unexpected node %u.\n", architecture.NodeIndex);
     ok(!architecture.CacheCoherentUMA || architecture.UMA,
             "Got unexpected cache coherent UMA %#x (UMA %#x).\n",
@@ -162,21 +162,21 @@ void test_check_feature_support(void)
         architecture.NodeIndex = 1;
         hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ARCHITECTURE,
                 &architecture, sizeof(architecture));
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     }
 
     /* Feature levels */
     memset(&feature_levels, 0, sizeof(feature_levels));
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FEATURE_LEVELS,
             &feature_levels, sizeof(feature_levels));
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     feature_levels.NumFeatureLevels = ARRAY_SIZE(all_feature_levels);
     feature_levels.pFeatureLevelsRequested = all_feature_levels;
     feature_levels.MaxSupportedFeatureLevel = 0;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FEATURE_LEVELS,
             &feature_levels, sizeof(feature_levels));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
     trace("Max supported feature level %#x.\n", feature_levels.MaxSupportedFeatureLevel);
     max_supported_feature_level = feature_levels.MaxSupportedFeatureLevel;
 
@@ -185,7 +185,7 @@ void test_check_feature_support(void)
     feature_levels.MaxSupportedFeatureLevel = 0;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FEATURE_LEVELS,
             &feature_levels, sizeof(feature_levels));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
     ok(feature_levels.MaxSupportedFeatureLevel == max_supported_feature_level,
             "Got unexpected feature level %#x, expected %#x.\n",
             feature_levels.MaxSupportedFeatureLevel, max_supported_feature_level);
@@ -193,17 +193,17 @@ void test_check_feature_support(void)
     /* Check invalid size. */
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FEATURE_LEVELS,
             &feature_levels, sizeof(feature_levels) + 1);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FEATURE_LEVELS,
             &feature_levels, sizeof(feature_levels) - 1);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     feature_levels.NumFeatureLevels = ARRAY_SIZE(d3d_9_x_feature_levels);
     feature_levels.pFeatureLevelsRequested = d3d_9_x_feature_levels;
     feature_levels.MaxSupportedFeatureLevel = 0;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FEATURE_LEVELS,
             &feature_levels, sizeof(feature_levels));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
     ok(feature_levels.MaxSupportedFeatureLevel == D3D_FEATURE_LEVEL_9_3,
             "Got unexpected max feature level %#x.\n", feature_levels.MaxSupportedFeatureLevel);
 
@@ -212,7 +212,7 @@ void test_check_feature_support(void)
     feature_levels.MaxSupportedFeatureLevel = 0;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FEATURE_LEVELS,
             &feature_levels, sizeof(feature_levels));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
     ok(feature_levels.MaxSupportedFeatureLevel == 0x3000,
             "Got unexpected max feature level %#x.\n", feature_levels.MaxSupportedFeatureLevel);
 
@@ -220,7 +220,7 @@ void test_check_feature_support(void)
     memset(&format_info, 0, sizeof(format_info));
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FORMAT_INFO,
             &format_info, sizeof(format_info));
-    ok(hr == S_OK, "Failed to get format info, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get format info, hr %#x.\n", (int)hr);
     ok(format_info.Format == DXGI_FORMAT_UNKNOWN, "Got unexpected format %#x.\n", format_info.Format);
     ok(format_info.PlaneCount == 1, "Got unexpected plane count %u.\n", format_info.PlaneCount);
 
@@ -263,12 +263,12 @@ void test_check_feature_support(void)
 
         if (format == DXGI_FORMAT_R1_UNORM)
         {
-            ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+            ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
             continue;
         }
 
         todo_if(is_todo)
-        ok(hr == S_OK, "Failed to get format info, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to get format info, hr %#x.\n", (int)hr);
         ok(format_info.Format == format, "Got unexpected format %#x.\n", format_info.Format);
         todo_if(is_todo)
         ok(format_info.PlaneCount == expected_plane_count,
@@ -280,7 +280,7 @@ void test_check_feature_support(void)
     memset(&gpu_virtual_address, 0, sizeof(gpu_virtual_address));
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT,
             &gpu_virtual_address, sizeof(gpu_virtual_address));
-    ok(hr == S_OK, "Failed to check GPU virtual address support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check GPU virtual address support, hr %#x.\n", (int)hr);
     trace("GPU virtual address bits per resource: %u.\n",
             gpu_virtual_address.MaxGPUVirtualAddressBitsPerResource);
     trace("GPU virtual address bits per process: %u.\n",
@@ -289,14 +289,14 @@ void test_check_feature_support(void)
     root_signature.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ROOT_SIGNATURE,
             &root_signature, sizeof(root_signature));
-    ok(hr == S_OK, "Failed to get root signature feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get root signature feature support, hr %#x.\n", (int)hr);
     ok(root_signature.HighestVersion == D3D_ROOT_SIGNATURE_VERSION_1_0,
             "Got unexpected root signature feature version %#x.\n", root_signature.HighestVersion);
 
     root_signature.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ROOT_SIGNATURE,
             &root_signature, sizeof(root_signature));
-    ok(hr == S_OK, "Failed to get root signature feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get root signature feature support, hr %#x.\n", (int)hr);
     ok(root_signature.HighestVersion == D3D_ROOT_SIGNATURE_VERSION_1_0
             || root_signature.HighestVersion == D3D_ROOT_SIGNATURE_VERSION_1_1,
             "Got unexpected root signature feature version %#x.\n", root_signature.HighestVersion);
@@ -304,19 +304,19 @@ void test_check_feature_support(void)
     root_signature.HighestVersion = 0;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ROOT_SIGNATURE,
             &root_signature, sizeof(root_signature));
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(root_signature.HighestVersion == 0, "Got unexpected root signature feature version %#x.\n",
             root_signature.HighestVersion);
 
     root_signature.HighestVersion = 0xdeadbeef;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ROOT_SIGNATURE,
             &root_signature, sizeof(root_signature));
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(root_signature.HighestVersion == 0xdeadbeef, "Got unexpected root signature feature version %#x.\n",
             root_signature.HighestVersion);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 static const DXGI_FORMAT depth_stencil_formats[] =
@@ -341,10 +341,10 @@ void test_format_support(void)
     D3D12_FEATURE_DATA_FEATURE_LEVELS feature_levels;
     bool required_but_fails;
     bool unspecified_format;
+    unsigned int refcount;
     bool optional_format;
     ID3D12Device *device;
     DXGI_FORMAT format;
-    ULONG refcount;
     unsigned int i;
     HRESULT hr;
 
@@ -436,7 +436,7 @@ void test_format_support(void)
     memset(&format_support, 0, sizeof(format_support));
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FORMAT_SUPPORT,
             &format_support, sizeof(format_support));
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ok(format_support.Support1 == D3D12_FORMAT_SUPPORT1_BUFFER,
             "Got unexpected support1 %#x.\n", format_support.Support1);
     ok(!format_support.Support2 || format_support.Support2 == D3D12_FORMAT_SUPPORT2_TILED,
@@ -447,7 +447,7 @@ void test_format_support(void)
     feature_levels.pFeatureLevelsRequested = all_feature_levels;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FEATURE_LEVELS, 
         &feature_levels, sizeof(feature_levels));
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     dxgi_format = NULL;
     for (i = 0; i < ARRAY_SIZE(dxgi_format_list); ++i)
@@ -527,26 +527,26 @@ void test_format_support(void)
                 &format_support, sizeof(format_support));
 
         if (unspecified_format)
-            ok(hr == S_OK || hr == E_FAIL, "Unspecified format %d got unexpected hr %#x.\n", format, hr);
+            ok(hr == S_OK || hr == E_FAIL, "Unspecified format %d got unexpected hr %#x.\n", format, (int)hr);
         else if (optional_format)
-            ok(hr == S_OK || hr == E_FAIL, "Optional format %d got unexpected hr %#x.\n", format, hr);
+            ok(hr == S_OK || hr == E_FAIL, "Optional format %d got unexpected hr %#x.\n", format, (int)hr);
         else 
-            todo_if(required_but_fails) ok(hr == S_OK, "Format %d got unexpected hr %#x.\n", format, hr);
+            todo_if(required_but_fails) ok(hr == S_OK, "Format %d got unexpected hr %#x.\n", format, (int)hr);
     }
     vkd3d_test_set_context(NULL);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_multisample_quality_levels(void)
 {
     static const unsigned int sample_counts[] = {1, 2, 4, 8, 16, 32};
     D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS format_support;
+    unsigned int refcount;
     ID3D12Device *device;
     DXGI_FORMAT format;
     unsigned int i, j;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -559,7 +559,7 @@ void test_multisample_quality_levels(void)
     format_support.NumQualityLevels = 0xdeadbeef;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
             &format_support, sizeof(format_support));
-    ok(hr == E_FAIL, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_FAIL, "Got unexpected hr %#x.\n", (int)hr);
     ok(!format_support.Flags, "Got unexpected flags %#x.\n", format_support.Flags);
     ok(!format_support.NumQualityLevels, "Got unexpected quality levels %u.\n", format_support.NumQualityLevels);
 
@@ -567,7 +567,7 @@ void test_multisample_quality_levels(void)
     format_support.NumQualityLevels = 0xdeadbeef;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
             &format_support, sizeof(format_support));
-    ok(hr == E_FAIL, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_FAIL, "Got unexpected hr %#x.\n", (int)hr);
     ok(!format_support.Flags, "Got unexpected flags %#x.\n", format_support.Flags);
     ok(!format_support.NumQualityLevels, "Got unexpected quality levels %u.\n", format_support.NumQualityLevels);
 
@@ -585,7 +585,7 @@ void test_multisample_quality_levels(void)
         format_support.NumQualityLevels = 0xdeadbeef;
         hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
                 &format_support, sizeof(format_support));
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(format_support.NumQualityLevels == 1, "Got unexpected quality levels %u.\n", format_support.NumQualityLevels);
     }
     vkd3d_test_set_context(NULL);
@@ -600,7 +600,7 @@ void test_multisample_quality_levels(void)
         format_support.NumQualityLevels = 0xdeadbeef;
         hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
                 &format_support, sizeof(format_support));
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(!format_support.Flags, "Got unexpected flags %#x.\n", format_support.Flags);
         ok(!format_support.NumQualityLevels, "Got unexpected quality levels %u.\n", format_support.NumQualityLevels);
 
@@ -608,7 +608,7 @@ void test_multisample_quality_levels(void)
         format_support.NumQualityLevels = 0xdeadbeef;
         hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
                 &format_support, sizeof(format_support));
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(format_support.Flags == D3D12_MULTISAMPLE_QUALITY_LEVELS_FLAG_TILED_RESOURCE,
                 "Got unexpected flags %#x.\n", format_support.Flags);
         ok(!format_support.NumQualityLevels, "Got unexpected quality levels %u.\n", format_support.NumQualityLevels);
@@ -638,7 +638,7 @@ void test_multisample_quality_levels(void)
         format_support.NumQualityLevels = 0xdeadbeef;
         hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
                 &format_support, sizeof(format_support));
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(!format_support.Flags, "Got unexpected flags %#x.\n", format_support.Flags);
         ok(!format_support.NumQualityLevels, "Got unexpected quality levels %u.\n", format_support.NumQualityLevels);
     }
@@ -651,7 +651,7 @@ void test_multisample_quality_levels(void)
     format_support.NumQualityLevels = 0xdeadbeef;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
             &format_support, sizeof(format_support));
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ok(!format_support.Flags, "Got unexpected flags %#x.\n", format_support.Flags);
     ok(format_support.NumQualityLevels >= 1, "Got unexpected quality levels %u.\n", format_support.NumQualityLevels);
 
@@ -661,7 +661,7 @@ void test_multisample_quality_levels(void)
     format_support.NumQualityLevels = 0xdeadbeef;
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
             &format_support, sizeof(format_support));
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ok(format_support.NumQualityLevels >= 1, "Got unexpected quality levels %u.\n", format_support.NumQualityLevels);
 
     for (i = 0; i < ARRAY_SIZE(depth_stencil_formats); ++i)
@@ -672,18 +672,18 @@ void test_multisample_quality_levels(void)
         format_support.NumQualityLevels = 0xdeadbeef;
         hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
                 &format_support, sizeof(format_support));
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     }
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_command_allocator(void)
 {
     ID3D12CommandAllocator *command_allocator;
     ID3D12Device *device, *tmp_device;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -694,16 +694,16 @@ void test_create_command_allocator(void)
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12CommandAllocator_GetDevice(command_allocator, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(command_allocator, &IID_ID3D12Object, true);
     check_interface(command_allocator, &IID_ID3D12DeviceChild, true);
@@ -711,32 +711,32 @@ void test_create_command_allocator(void)
     check_interface(command_allocator, &IID_ID3D12CommandAllocator, true);
 
     refcount = ID3D12CommandAllocator_Release(command_allocator);
-    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", refcount);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_BUNDLE,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     refcount = ID3D12CommandAllocator_Release(command_allocator);
-    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", refcount);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_COMPUTE,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     refcount = ID3D12CommandAllocator_Release(command_allocator);
-    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", refcount);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_COPY,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     refcount = ID3D12CommandAllocator_Release(command_allocator);
-    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", refcount);
 
     hr = ID3D12Device_CreateCommandAllocator(device, ~0u,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_command_list(void)
@@ -744,7 +744,7 @@ void test_create_command_list(void)
     ID3D12CommandAllocator *command_allocator;
     ID3D12Device *device, *tmp_device;
     ID3D12CommandList *command_list;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -755,30 +755,30 @@ void test_create_command_list(void)
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             NULL, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(command_allocator);
-    ok(refcount == 1, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 1, "Got unexpected refcount %u.\n", refcount);
 
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12CommandList_GetDevice(command_list, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 4, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 4, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(command_list, &IID_ID3D12Object, true);
     check_interface(command_list, &IID_ID3D12DeviceChild, true);
@@ -788,60 +788,60 @@ void test_create_command_list(void)
     check_interface(command_list, &IID_ID3D12CommandAllocator, false);
 
     refcount = ID3D12CommandList_Release(command_list);
-    ok(!refcount, "ID3D12CommandList has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandList has %u references left.\n", refcount);
     refcount = ID3D12CommandAllocator_Release(command_allocator);
-    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", refcount);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_BUNDLE,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_BUNDLE,
             command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
     check_interface(command_list, &IID_ID3D12GraphicsCommandList, true);
     refcount = ID3D12CommandList_Release(command_list);
-    ok(!refcount, "ID3D12CommandList has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandList has %u references left.\n", refcount);
     refcount = ID3D12CommandAllocator_Release(command_allocator);
-    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", refcount);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_COMPUTE,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_BUNDLE,
             command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_COMPUTE,
             command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
     check_interface(command_list, &IID_ID3D12GraphicsCommandList, true);
     refcount = ID3D12CommandList_Release(command_list);
-    ok(!refcount, "ID3D12CommandList has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandList has %u references left.\n", refcount);
     refcount = ID3D12CommandAllocator_Release(command_allocator);
-    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", refcount);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_COPY,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_COMPUTE,
             command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_COPY,
             command_allocator, NULL, &IID_ID3D12CommandList, (void **)&command_list);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
     check_interface(command_list, &IID_ID3D12GraphicsCommandList, true);
     refcount = ID3D12CommandList_Release(command_list);
-    ok(!refcount, "ID3D12CommandList has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandList has %u references left.\n", refcount);
     refcount = ID3D12CommandAllocator_Release(command_allocator);
-    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandAllocator has %u references left.\n", refcount);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_command_queue(void)
@@ -850,8 +850,8 @@ void test_create_command_queue(void)
     D3D12_COMMAND_QUEUE_DESC desc, result_desc;
     ID3D12Device *device, *tmp_device;
     ID3D12CommandQueue *queue;
+    unsigned int refcount;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -865,16 +865,16 @@ void test_create_command_queue(void)
     desc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
     desc.NodeMask = 0;
     hr = ID3D12Device_CreateCommandQueue(device, &desc, &IID_ID3D12CommandQueue, (void **)&queue);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12CommandQueue_GetDevice(queue, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(queue, &IID_ID3D12Object, true);
     check_interface(queue, &IID_ID3D12DeviceChild, true);
@@ -888,11 +888,11 @@ void test_create_command_queue(void)
     ok(result_desc.NodeMask == 0x1, "Got unexpected node mask 0x%08x.\n", result_desc.NodeMask);
 
     refcount = ID3D12CommandQueue_Release(queue);
-    ok(!refcount, "ID3D12CommandQueue has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandQueue has %u references left.\n", refcount);
 
     desc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
     hr = ID3D12Device_CreateCommandQueue(device, &desc, &IID_ID3D12CommandQueue, (void **)&queue);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr %#x.\n", (int)hr);
 
     result_desc = ID3D12CommandQueue_GetDesc(queue);
     ok(result_desc.Type == desc.Type, "Got unexpected type %#x.\n", result_desc.Type);
@@ -901,19 +901,19 @@ void test_create_command_queue(void)
     ok(result_desc.NodeMask == 0x1, "Got unexpected node mask 0x%08x.\n", result_desc.NodeMask);
 
     refcount = ID3D12CommandQueue_Release(queue);
-    ok(!refcount, "ID3D12CommandQueue has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12CommandQueue has %u references left.\n", refcount);
 
     desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
     for (i = 0; i < ARRAY_SIZE(direct_queues); ++i)
     {
         hr = ID3D12Device_CreateCommandQueue(device, &desc, &IID_ID3D12CommandQueue, (void **)&direct_queues[i]);
-        ok(hr == S_OK, "Failed to create direct command queue %u, hr %#x.\n", hr, i);
+        ok(hr == S_OK, "Failed to create direct command queue %u, hr %#x.\n", (int)hr, i);
     }
     desc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
     for (i = 0; i < ARRAY_SIZE(compute_queues); ++i)
     {
         hr = ID3D12Device_CreateCommandQueue(device, &desc, &IID_ID3D12CommandQueue, (void **)&compute_queues[i]);
-        ok(hr == S_OK, "Failed to create compute command queue %u, hr %#x.\n", hr, i);
+        ok(hr == S_OK, "Failed to create compute command queue %u, hr %#x.\n", (int)hr, i);
     }
 
     for (i = 0; i < ARRAY_SIZE(direct_queues); ++i)
@@ -922,7 +922,7 @@ void test_create_command_queue(void)
         ID3D12CommandQueue_Release(compute_queues[i]);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_command_signature(void)
@@ -930,9 +930,9 @@ void test_create_command_signature(void)
     D3D12_INDIRECT_ARGUMENT_DESC argument_desc[3];
     D3D12_COMMAND_SIGNATURE_DESC signature_desc;
     ID3D12CommandSignature *command_signature;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -950,29 +950,29 @@ void test_create_command_signature(void)
         argument_desc[i].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
     hr = ID3D12Device_CreateCommandSignature(device, &signature_desc,
             NULL, &IID_ID3D12CommandSignature, (void **)&command_signature);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(argument_desc); ++i)
         argument_desc[i].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
     hr = ID3D12Device_CreateCommandSignature(device, &signature_desc,
             NULL, &IID_ID3D12CommandSignature, (void **)&command_signature);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(argument_desc); ++i)
         argument_desc[i].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
     hr = ID3D12Device_CreateCommandSignature(device, &signature_desc,
             NULL, &IID_ID3D12CommandSignature, (void **)&command_signature);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     argument_desc[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
     argument_desc[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
     signature_desc.NumArgumentDescs = 2;
     hr = ID3D12Device_CreateCommandSignature(device, &signature_desc,
             NULL, &IID_ID3D12CommandSignature, (void **)&command_signature);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 struct private_data
@@ -989,14 +989,14 @@ static void private_data_thread_main(void *untyped_data)
     HRESULT hr;
 
     hr = ID3D12Object_SetPrivateData(data->object, &data->guid, sizeof(data->value), &data->value);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     for (i = 0; i < 100000; ++i)
     {
         hr = ID3D12Object_SetPrivateData(data->object, &data->guid, 0, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateData(data->object, &data->guid, sizeof(data->value), &data->value);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     }
 }
 
@@ -1016,11 +1016,11 @@ static void private_data_interface_thread_main(void *untyped_data)
     for (i = 0; i < 100000; ++i)
     {
         hr = ID3D12Object_SetPrivateDataInterface(data->object, &data->guid, data->iface);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateDataInterface(data->object, &data->guid, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateDataInterface(data->object, &data->guid, data->iface);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     }
 }
 
@@ -1033,13 +1033,13 @@ void test_multithread_private_data(void)
     ID3D12RootSignature *root_signature;
     HANDLE private_data_thread[4];
     IUnknown *test_object, *unk;
+    unsigned int refcount;
     ID3D12Device *device;
     ID3D12Object *object;
     unsigned int value;
     unsigned int size;
     unsigned int id;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -1051,12 +1051,12 @@ void test_multithread_private_data(void)
     root_signature = create_empty_root_signature(device,
             D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
     hr = ID3D12RootSignature_QueryInterface(root_signature, &IID_ID3D12Object, (void **)&object);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ID3D12RootSignature_Release(root_signature);
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&test_object);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     for (i = 0, id = 1; i < ARRAY_SIZE(private_data_interface); ++i, ++id)
     {
@@ -1066,7 +1066,7 @@ void test_multithread_private_data(void)
 
         hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
                 &IID_ID3D12Fence, (void **)&private_data_interface[i].iface);
-        ok(hr == S_OK, "Failed to create fence %u, hr %#x.\n", i, hr);
+        ok(hr == S_OK, "Failed to create fence %u, hr %#x.\n", i, (int)hr);
     }
     for (i = 0; i < ARRAY_SIZE(private_data); ++i, ++id)
     {
@@ -1085,11 +1085,11 @@ void test_multithread_private_data(void)
     for (i = 0; i < 100000; ++i)
     {
         hr = ID3D12Object_SetPrivateDataInterface(object, &guid, test_object);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateDataInterface(object, &guid, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateDataInterface(object, &guid, test_object);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     }
 
     for (i = 0; i < 4; ++i)
@@ -1102,30 +1102,30 @@ void test_multithread_private_data(void)
     {
         size = sizeof(unk);
         hr = ID3D12Object_GetPrivateData(object, &private_data_interface[i].guid, &size, &unk);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         ok(unk == private_data_interface[i].iface, "Got %p, expected %p.\n", unk, private_data_interface[i].iface);
         IUnknown_Release(unk);
         refcount = IUnknown_Release(private_data_interface[i].iface);
-        ok(refcount == 1, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+        ok(refcount == 1, "Got unexpected refcount %u.\n", refcount);
     }
     for (i = 0; i < ARRAY_SIZE(private_data); ++i)
     {
         size = sizeof(value);
         hr = ID3D12Object_GetPrivateData(object, &private_data[i].guid, &size, &value);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         ok(value == private_data[i].value, "Got %u, expected %u.\n", value, private_data[i].value);
     }
 
     hr = ID3D12Object_SetPrivateDataInterface(object, &guid, NULL);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     refcount = IUnknown_Release(test_object);
-    ok(!refcount, "Test object has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "Test object has %u references left.\n", refcount);
     refcount = ID3D12Object_Release(object);
-    ok(!refcount, "Object has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "Object has %u references left.\n", refcount);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_reset_command_allocator(void)
@@ -1134,9 +1134,9 @@ void test_reset_command_allocator(void)
     ID3D12GraphicsCommandList *command_list, *command_list2;
     D3D12_COMMAND_QUEUE_DESC command_queue_desc;
     ID3D12CommandQueue *queue;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     static const D3D12_COMMAND_LIST_TYPE tests[] =
@@ -1157,44 +1157,44 @@ void test_reset_command_allocator(void)
 
         hr = ID3D12Device_CreateCommandAllocator(device, type,
                 &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-        ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
 
         hr = ID3D12CommandAllocator_Reset(command_allocator);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12CommandAllocator_Reset(command_allocator);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Device_CreateCommandList(device, 0, type,
                 command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list);
-        ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
 
         hr = ID3D12CommandAllocator_Reset(command_allocator);
-        ok(hr == E_FAIL, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_FAIL, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12CommandAllocator_Reset(command_allocator);
-        ok(hr == E_FAIL, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_FAIL, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12GraphicsCommandList_Close(command_list);
-        ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
         hr = ID3D12CommandAllocator_Reset(command_allocator);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12CommandAllocator_Reset(command_allocator);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12GraphicsCommandList_Reset(command_list, command_allocator, NULL);
-        ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", (int)hr);
 
         hr = ID3D12CommandAllocator_Reset(command_allocator);
-        ok(hr == E_FAIL, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_FAIL, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12GraphicsCommandList_Close(command_list);
-        ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
         hr = ID3D12GraphicsCommandList_Reset(command_list, command_allocator, NULL);
-        ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", (int)hr);
 
         hr = ID3D12Device_CreateCommandAllocator(device, type,
                 &IID_ID3D12CommandAllocator, (void **)&command_allocator2);
-        ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
 
         if (type != D3D12_COMMAND_LIST_TYPE_BUNDLE)
         {
@@ -1204,68 +1204,68 @@ void test_reset_command_allocator(void)
             command_queue_desc.NodeMask = 0;
             hr = ID3D12Device_CreateCommandQueue(device, &command_queue_desc,
                     &IID_ID3D12CommandQueue, (void **)&queue);
-            ok(SUCCEEDED(hr), "Failed to create command queue, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to create command queue, hr %#x.\n", (int)hr);
 
             uav_barrier(command_list, NULL);
             hr = ID3D12GraphicsCommandList_Close(command_list);
-            ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
             exec_command_list(queue, command_list);
 
             /* A command list can be reset when it is in use. */
             hr = ID3D12GraphicsCommandList_Reset(command_list, command_allocator2, NULL);
-            ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", (int)hr);
             hr = ID3D12GraphicsCommandList_Close(command_list);
-            ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
             wait_queue_idle(device, queue);
             hr = ID3D12CommandAllocator_Reset(command_allocator);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
             hr = ID3D12GraphicsCommandList_Reset(command_list, command_allocator, NULL);
-            ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", (int)hr);
 
             uav_barrier(command_list, NULL);
             hr = ID3D12GraphicsCommandList_Close(command_list);
-            ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
             exec_command_list(queue, command_list);
 
             hr = ID3D12GraphicsCommandList_Reset(command_list, command_allocator, NULL);
-            ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", (int)hr);
             hr = ID3D12GraphicsCommandList_Close(command_list);
-            ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
             wait_queue_idle(device, queue);
 
             hr = ID3D12CommandAllocator_Reset(command_allocator);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
             hr = ID3D12GraphicsCommandList_Reset(command_list, command_allocator, NULL);
-            ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to reset command list, hr %#x.\n", (int)hr);
             ID3D12CommandQueue_Release(queue);
         }
 
         /* A command allocator can be used with one command list at a time. */
         hr = ID3D12Device_CreateCommandList(device, 0, type,
                 command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list2);
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Device_CreateCommandList(device, 0, type,
                 command_allocator2, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list2);
-        ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
         hr = ID3D12GraphicsCommandList_Close(command_list2);
-        ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
         hr = ID3D12GraphicsCommandList_Reset(command_list2, command_allocator, NULL);
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
         ID3D12GraphicsCommandList_Release(command_list2);
 
         /* A command allocator can be re-used after closing the command list. */
         hr = ID3D12Device_CreateCommandList(device, 0, type,
                 command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list2);
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12GraphicsCommandList_Close(command_list);
-        ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
         hr = ID3D12Device_CreateCommandList(device, 0, type,
                 command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list2);
-        ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_Release(command_list);
         ID3D12GraphicsCommandList_Release(command_list2);
@@ -1274,7 +1274,7 @@ void test_reset_command_allocator(void)
     }
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_object_interface_null_cases(void)
@@ -1291,24 +1291,24 @@ void test_object_interface_null_cases(void)
     }
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, NULL);
-    ok(hr == S_FALSE, "Unexpected hr #%x.\n", hr);
+    ok(hr == S_FALSE, "Unexpected hr #%x.\n", (int)hr);
 
     /* S_FALSE is returned even for bogus requested interfaces. */
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Heap, NULL);
-    ok(hr == S_FALSE, "Unexpected hr #%x.\n", hr);
+    ok(hr == S_FALSE, "Unexpected hr #%x.\n", (int)hr);
 
     /* E_POINTER is always returned if QueryInterface ppOutput is NULL. */
     hr = ID3D12Fence_QueryInterface(fence, &IID_IUnknown, NULL);
-    ok(hr == E_POINTER, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_POINTER, "Unexpected hr #%x.\n", (int)hr);
 
     hr = ID3D12Fence_QueryInterface(fence, &IID_ID3D12Fence, NULL);
-    ok(hr == E_POINTER, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_POINTER, "Unexpected hr #%x.\n", (int)hr);
 
     hr = ID3D12Fence_QueryInterface(fence, &IID_ID3D12Heap, NULL);
-    ok(hr == E_POINTER, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_POINTER, "Unexpected hr #%x.\n", (int)hr);
 
     ID3D12Fence_Release(fence);
     ref = ID3D12Device_Release(device);
@@ -1318,9 +1318,9 @@ void test_object_interface_null_cases(void)
 void test_object_interface(void)
 {
     D3D12_DESCRIPTOR_HEAP_DESC descriptor_heap_desc;
+    unsigned int refcount, expected_refcount;
     D3D12_QUERY_HEAP_DESC query_heap_desc;
     ID3D12RootSignature *root_signature;
-    ULONG refcount, expected_refcount;
     ID3D12CommandAllocator *allocator;
     D3D12_HEAP_DESC heap_desc;
     IUnknown *test_object;
@@ -1370,17 +1370,17 @@ void test_object_interface(void)
             vkd3d_test_set_context("command allocator");
             hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
                     &IID_IUnknown, (void **)&unknown);
-            ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
         }
         else if (IsEqualGUID(tests[i], &IID_ID3D12CommandList))
         {
             vkd3d_test_set_context("command list");
             hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
                     &IID_ID3D12CommandAllocator, (void **)&allocator);
-            ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
             hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
                     allocator, NULL, &IID_IUnknown, (void **)&unknown);
-            ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
             ID3D12CommandAllocator_Release(allocator);
         }
         else if (IsEqualGUID(tests[i], &IID_ID3D12CommandQueue))
@@ -1403,7 +1403,7 @@ void test_object_interface(void)
             descriptor_heap_desc.NodeMask = 0;
             hr = ID3D12Device_CreateDescriptorHeap(device, &descriptor_heap_desc,
                     &IID_ID3D12DescriptorHeap, (void **)&unknown);
-            ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
         }
         else if (IsEqualGUID(tests[i], &IID_ID3D12Device))
         {
@@ -1415,7 +1415,7 @@ void test_object_interface(void)
             vkd3d_test_set_context("fence");
             hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
                     &IID_IUnknown, (void **)&unknown);
-            ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
         }
         else if (IsEqualGUID(tests[i], &IID_ID3D12Heap))
         {
@@ -1426,7 +1426,7 @@ void test_object_interface(void)
             heap_desc.Alignment = 0;
             heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES;
             hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&unknown);
-            ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
         }
         else if (IsEqualGUID(tests[i], &IID_ID3D12PipelineState))
         {
@@ -1444,7 +1444,7 @@ void test_object_interface(void)
             query_heap_desc.NodeMask = 0;
             hr = ID3D12Device_CreateQueryHeap(device, &query_heap_desc,
                     &IID_ID3D12QueryHeap, (void **)&unknown);
-            ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", (int)hr);
         }
         else if (IsEqualGUID(tests[i], &IID_ID3D12Resource))
         {
@@ -1464,161 +1464,161 @@ void test_object_interface(void)
         ok(unknown, "Unhandled object type %u.\n", i);
         object = NULL;
         hr = IUnknown_QueryInterface(unknown, &IID_ID3D12Object, (void **)&object);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         IUnknown_Release(unknown);
 
         hr = ID3D12Object_SetPrivateData(object, &test_guid, 0, NULL);
-        ok(hr == S_FALSE, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_FALSE, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateDataInterface(object, &test_guid, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateData(object, &test_guid, ~0u, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateData(object, &test_guid, ~0u, NULL);
-        ok(hr == S_FALSE, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_FALSE, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Object_SetPrivateDataInterface(object, &test_guid, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         size = sizeof(ptr) * 2;
         ptr = (IUnknown *)(uintptr_t)0xdeadbeef;
         hr = ID3D12Object_GetPrivateData(object, &test_guid, &size, &ptr);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(!ptr, "Got unexpected pointer %p.\n", ptr);
         ok(size == sizeof(IUnknown *), "Got unexpected size %u.\n", size);
 
         hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
                 &IID_ID3D12Fence, (void **)&test_object);
-        ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
         refcount = get_refcount(test_object);
         hr = ID3D12Object_SetPrivateDataInterface(object, &test_guid, (IUnknown *)test_object);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         expected_refcount = refcount + 1;
         refcount = get_refcount(test_object);
         ok(refcount == expected_refcount, "Got unexpected refcount %u, expected %u.\n",
-                (unsigned int)refcount, (unsigned int)expected_refcount);
+                refcount, expected_refcount);
         hr = ID3D12Object_SetPrivateDataInterface(object, &test_guid, (IUnknown *)test_object);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         refcount = get_refcount(test_object);
         ok(refcount == expected_refcount, "Got unexpected refcount %u, expected %u.\n",
-                (unsigned int)refcount, (unsigned int)expected_refcount);
+                refcount, expected_refcount);
 
         hr = ID3D12Object_SetPrivateDataInterface(object, &test_guid, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         --expected_refcount;
         refcount = get_refcount(test_object);
         ok(refcount == expected_refcount, "Got unexpected refcount %u, expected %u.\n",
-                (unsigned int)refcount, (unsigned int)expected_refcount);
+                refcount, expected_refcount);
 
         hr = ID3D12Object_SetPrivateDataInterface(object, &test_guid, (IUnknown *)test_object);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         size = sizeof(data);
         hr = ID3D12Object_SetPrivateData(object, &test_guid, size, data);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         refcount = get_refcount(test_object);
         ok(refcount == expected_refcount, "Got unexpected refcount %u, expected %u.\n",
-                (unsigned int)refcount, (unsigned int)expected_refcount);
+                refcount, expected_refcount);
         hr = ID3D12Object_SetPrivateData(object, &test_guid, 42, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         hr = ID3D12Object_SetPrivateData(object, &test_guid, 42, NULL);
-        ok(hr == S_FALSE, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_FALSE, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Object_SetPrivateDataInterface(object, &test_guid, (IUnknown *)test_object);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ++expected_refcount;
         size = 2 * sizeof(ptr);
         ptr = NULL;
         hr = ID3D12Object_GetPrivateData(object, &test_guid, &size, &ptr);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(size == sizeof(test_object), "Got unexpected size %u.\n", size);
         ++expected_refcount;
         refcount = get_refcount(test_object);
         ok(refcount == expected_refcount, "Got unexpected refcount %u, expected %u.\n",
-                (unsigned int)refcount, (unsigned int)expected_refcount);
+                refcount, expected_refcount);
         IUnknown_Release(ptr);
         --expected_refcount;
 
         ptr = (IUnknown *)(uintptr_t)0xdeadbeef;
         size = 1;
         hr = ID3D12Object_GetPrivateData(object, &test_guid, &size, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(size == sizeof(ptr), "Got unexpected size %u.\n", size);
         size = 2 * sizeof(ptr);
         hr = ID3D12Object_GetPrivateData(object, &test_guid, &size, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(size == sizeof(ptr), "Got unexpected size %u.\n", size);
         refcount = get_refcount(test_object);
         ok(refcount == expected_refcount, "Got unexpected refcount %u, expected %u.\n",
-                (unsigned int)refcount, (unsigned int)expected_refcount);
+                refcount, expected_refcount);
 
         size = 1;
         hr = ID3D12Object_GetPrivateData(object, &test_guid, &size, &ptr);
-        ok(hr == DXGI_ERROR_MORE_DATA, "Got unexpected hr %#x.\n", hr);
+        ok(hr == DXGI_ERROR_MORE_DATA, "Got unexpected hr %#x.\n", (int)hr);
         ok(size == sizeof(object), "Got unexpected size %u.\n", size);
         ok(ptr == (IUnknown *)(uintptr_t)0xdeadbeef, "Got unexpected pointer %p.\n", ptr);
         size = 1;
         hr = ID3D12Object_GetPrivateData(object, &test_guid2, &size, &ptr);
-        ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", hr);
+        ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", (int)hr);
         ok(!size, "Got unexpected size %u.\n", size);
         ok(ptr == (IUnknown *)(uintptr_t)0xdeadbeef, "Got unexpected pointer %p.\n", ptr);
 
         if (IsEqualGUID(tests[i], &IID_ID3D12Device))
         {
             hr = ID3D12Object_SetPrivateDataInterface(object, &test_guid, NULL);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         }
 
         hr = ID3D12Object_SetName(object, u"");
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Object_SetName(object, u"deadbeef");
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         size = 1;
         hr = ID3D12Object_GetPrivateData(object, &WKPDID_D3DDebugObjectNameW, &size, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(size == 18, "Got unexpected size %u.\n", size);
         hr = ID3D12Object_GetPrivateData(object, &WKPDID_D3DDebugObjectNameW, &size, temp_name_buffer);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(size == 18, "Got unexpected size %u.\n", size);
         ok(temp_name_buffer[1] == L'e', "Got unexpected name");
         size = 1;
         hr = ID3D12Object_GetPrivateData(object, &WKPDID_D3DDebugObjectName, &size, NULL);
-        ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", hr);
+        ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", (int)hr);
 
 #if 0
         /* NULL name crashes on Windows 11 22621. */
         hr = ID3D12Object_SetName(object, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Object_GetPrivateData(object, &WKPDID_D3DDebugObjectNameW, &size, NULL);
-        ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", hr);
+        ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected hr %#x.\n", (int)hr);
 #endif
 
         hr = ID3D12Object_SetPrivateData(object, &WKPDID_D3DDebugObjectName, sizeof(terminated_name_a), terminated_name_a);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Object_SetPrivateData(object, &WKPDID_D3DDebugObjectName, sizeof(non_terminated_name_a), non_terminated_name_a);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Object_SetPrivateData(object, &WKPDID_D3DDebugObjectNameW, sizeof(non_terminated_name_w), non_terminated_name_w);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Object_SetPrivateData(object, &WKPDID_D3DDebugObjectNameW, 0, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         hr = ID3D12Object_SetPrivateData(object, &WKPDID_D3DDebugObjectName, 0, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         ID3D12Object_Release(object);
 
         refcount = IUnknown_Release(test_object);
-        ok(!refcount, "Test object has %u references left.\n", (unsigned int)refcount);
+        ok(!refcount, "Test object has %u references left.\n", refcount);
 
         vkd3d_test_set_context(NULL);
     }
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_device_removed_reason(void)
@@ -1627,8 +1627,8 @@ void test_device_removed_reason(void)
     ID3D12CommandAllocator *command_allocator;
     ID3D12GraphicsCommandList *command_list;
     ID3D12CommandQueue *queue, *tmp_queue;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -1638,7 +1638,7 @@ void test_device_removed_reason(void)
     }
 
     hr = ID3D12Device_GetDeviceRemovedReason(device);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     command_queue_desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
     command_queue_desc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
@@ -1646,36 +1646,36 @@ void test_device_removed_reason(void)
     command_queue_desc.NodeMask = 0;
     hr = ID3D12Device_CreateCommandQueue(device, &command_queue_desc,
             &IID_ID3D12CommandQueue, (void **)&queue);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
 
     /* Execute a command list in the recording state. */
     exec_command_list(queue, command_list);
 
     hr = ID3D12Device_GetDeviceRemovedReason(device);
-    ok(hr == DXGI_ERROR_INVALID_CALL, "Got unexpected hr %#x.\n", hr);
+    ok(hr == DXGI_ERROR_INVALID_CALL, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandQueue(device, &command_queue_desc,
             &IID_ID3D12CommandQueue, (void **)&tmp_queue);
-    ok(hr == DXGI_ERROR_DEVICE_REMOVED, "Got unexpected hr %#x.\n", hr);
+    ok(hr == DXGI_ERROR_DEVICE_REMOVED, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12CommandQueue_Release(tmp_queue);
 
     hr = ID3D12Device_GetDeviceRemovedReason(device);
-    ok(hr == DXGI_ERROR_INVALID_CALL, "Got unexpected hr %#x.\n", hr);
+    ok(hr == DXGI_ERROR_INVALID_CALL, "Got unexpected hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_Release(command_list);
     ID3D12CommandAllocator_Release(command_allocator);
     ID3D12CommandQueue_Release(queue);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_enumerate_meta_commands(void)
@@ -1683,8 +1683,8 @@ void test_enumerate_meta_commands(void)
     D3D12_META_COMMAND_DESC dummy_desc, *descs;
     UINT desc_count, supported_count;
     ID3D12Device5 *device5;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -1703,13 +1703,13 @@ void test_enumerate_meta_commands(void)
     }
 
     hr = ID3D12Device5_EnumerateMetaCommands(device5, NULL, NULL);
-    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", (int)hr);
     hr = ID3D12Device5_EnumerateMetaCommands(device5, NULL, &dummy_desc);
-    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", (int)hr);
 
     desc_count = 0xdeadbeef;
     hr = ID3D12Device5_EnumerateMetaCommands(device5, &desc_count, NULL);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     supported_count = desc_count;
 
@@ -1717,7 +1717,7 @@ void test_enumerate_meta_commands(void)
     memset(&dummy_desc, 0, sizeof(dummy_desc));
 
     hr = ID3D12Device5_EnumerateMetaCommands(device5, &desc_count, descs);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
     ok(desc_count == supported_count, "Unexpected desc count %u.\n", desc_count);
 
     if (desc_count)
@@ -1725,7 +1725,7 @@ void test_enumerate_meta_commands(void)
         desc_count -= 1;
 
         hr = ID3D12Device5_EnumerateMetaCommands(device5, &desc_count, descs);
-        ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
         ok(desc_count == supported_count, "Unexpected desc count %u.\n", desc_count);
     }
 
@@ -1735,7 +1735,7 @@ void test_enumerate_meta_commands(void)
     free(descs);
 
     refcount = ID3D12Device5_Release(device5);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_vtable_origins(void)
@@ -1829,10 +1829,10 @@ void test_destruction_notifier_callback(void)
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&resource);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_QueryInterface(resource, &IID_ID3DDestructionNotifier, (void**)&notifier);
-    ok(hr == S_OK, "Failed to query destruction notifier from resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to query destruction notifier from resource, hr %#x.\n", (int)hr);
 
     if (FAILED(hr))
     {
@@ -1844,32 +1844,32 @@ void test_destruction_notifier_callback(void)
     callback_id = 0xdeadbeef;
 
     hr = ID3DDestructionNotifier_RegisterDestructionCallback(notifier, NULL, NULL, &callback_id);
-    ok(hr == DXGI_ERROR_INVALID_CALL, "Got hr %#x, expected DXGI_ERROR_INVALID_CALL.\n", hr);
+    ok(hr == DXGI_ERROR_INVALID_CALL, "Got hr %#x, expected DXGI_ERROR_INVALID_CALL.\n", (int)hr);
     ok(callback_id == 0xdeadbeef, "Got callback ID %d\n", callback_id);
 
     hr = ID3DDestructionNotifier_RegisterDestructionCallback(notifier, &destruction_notifier_callback, &tests[0].invoked, &callback_id);
-    ok(hr == S_OK, "Failed to register callback, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to register callback, hr %#x.\n", (int)hr);
     ok(callback_id == 1, "Expected callback ID 0, got %d.\n", callback_id);
 
     /* Not capturing the callback ID is fine */
     hr = ID3DDestructionNotifier_RegisterDestructionCallback(notifier, &destruction_notifier_callback, &tests[1].invoked, NULL);
-    ok(hr == S_OK, "Failed to register callback, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to register callback, hr %#x.\n", (int)hr);
 
     hr = ID3DDestructionNotifier_UnregisterDestructionCallback(notifier, callback_id);
-    ok(hr == S_OK, "Failed to unregister callback, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to unregister callback, hr %#x.\n", (int)hr);
 
     hr = ID3DDestructionNotifier_RegisterDestructionCallback(notifier, &destruction_notifier_callback, &tests[2].invoked, &callback_id);
-    ok(hr == S_OK, "Failed to register callback, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to register callback, hr %#x.\n", (int)hr);
     ok(callback_id == 2, "Expected callback ID 0, got %d.\n", callback_id);
 
     hr = ID3DDestructionNotifier_RegisterDestructionCallback(notifier, &destruction_notifier_callback, &tests[3].invoked, &callback_id);
-    ok(hr == S_OK, "Failed to register callback, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to register callback, hr %#x.\n", (int)hr);
     ok(callback_id == 3, "Expected callback ID 2, got %d.\n", callback_id);
 
     hr = ID3DDestructionNotifier_UnregisterDestructionCallback(notifier, 0);
-    ok(hr == DXGI_ERROR_NOT_FOUND, "Got hr %#x, expected DXGI_ERROR_NOT_FOUND.\n", hr);
+    ok(hr == DXGI_ERROR_NOT_FOUND, "Got hr %#x, expected DXGI_ERROR_NOT_FOUND.\n", (int)hr);
     hr = ID3DDestructionNotifier_UnregisterDestructionCallback(notifier, 0xdeadbeef);
-    ok(hr == DXGI_ERROR_NOT_FOUND, "Got hr %#x, expected DXGI_ERROR_NOT_FOUND.\n", hr);
+    ok(hr == DXGI_ERROR_NOT_FOUND, "Got hr %#x, expected DXGI_ERROR_NOT_FOUND.\n", (int)hr);
 
     ID3DDestructionNotifier_Release(notifier);
     ID3D12Resource_Release(resource);
@@ -1894,6 +1894,7 @@ void test_destruction_notifier_interfaces(void)
     D3D12_ROOT_SIGNATURE_DESC root_signature_desc;
     ID3D12CommandAllocator *command_allocator;
     ID3D12CommandSignature *command_signature;
+    unsigned int refcount, expected_refcount;
     ID3D12PipelineLibrary *pipeline_library;
     D3D12_QUERY_HEAP_DESC query_heap_desc;
     ID3D12DescriptorHeap *descriptor_heap;
@@ -1902,7 +1903,6 @@ void test_destruction_notifier_interfaces(void)
     ID3DDestructionNotifier *notifier;
     D3D12_RESOURCE_DESC resource_desc;
     ID3D12CommandQueue *command_queue;
-    ULONG refcount, expected_refcount;
     ID3D12CommandList *command_list;
     ID3D12PipelineState *pipeline;
     ID3D12QueryHeap *query_heap;
@@ -1948,7 +1948,7 @@ void test_destruction_notifier_interfaces(void)
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
 
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void**)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     memset(&resource_desc, 0, sizeof(resource_desc));
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
@@ -1962,17 +1962,17 @@ void test_destruction_notifier_interfaces(void)
 
     hr = ID3D12Device_CreatePlacedResource(device, heap, 0, &resource_desc,
             D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&resource);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void**)&fence);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     memset(&root_signature_desc, 0, sizeof(root_signature_desc));
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
 
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&query_heap_desc, 0, sizeof(query_heap_desc));
     query_heap_desc.Type = D3D12_QUERY_HEAP_TYPE_OCCLUSION;
@@ -1980,22 +1980,22 @@ void test_destruction_notifier_interfaces(void)
 
     hr = ID3D12Device_CreateQueryHeap(device, &query_heap_desc,
             &IID_ID3D12QueryHeap, (void**)&query_heap);
-    ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void**)&command_allocator);
-    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12CommandList, (void**)&command_list);
-    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
     memset(&queue_desc, 0, sizeof(queue_desc));
     queue_desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
     queue_desc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
 
     hr = ID3D12Device_CreateCommandQueue(device, &queue_desc, &IID_ID3D12CommandQueue, (void**)&command_queue);
-    ok(hr == S_OK, "Failed to create command queue, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command queue, hr %#x.\n", (int)hr);
 
     memset(&descriptor_heap_desc, 0, sizeof(descriptor_heap_desc));
     descriptor_heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
@@ -2003,14 +2003,14 @@ void test_destruction_notifier_interfaces(void)
     descriptor_heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
 
     hr = ID3D12Device_CreateDescriptorHeap(device, &descriptor_heap_desc, &IID_ID3D12DescriptorHeap, (void**)&descriptor_heap);
-    ok(hr == S_OK, "Failed to create command queue, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command queue, hr %#x.\n", (int)hr);
 
     pipeline_library = NULL;
 
     if (device1)
     {
         hr = ID3D12Device1_CreatePipelineLibrary(device1, NULL, 0, &IID_ID3D12PipelineLibrary, (void**)&pipeline_library);
-        ok(hr == S_OK, "Failed to create pipeline library, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create pipeline library, hr %#x.\n", (int)hr);
     }
 
     memset(&command_signature_arg, 0, sizeof(command_signature_arg));
@@ -2023,12 +2023,12 @@ void test_destruction_notifier_interfaces(void)
 
     hr = ID3D12Device_CreateCommandSignature(device, &command_signature_desc,
             NULL, &IID_ID3D12CommandSignature, (void**)&command_signature);
-    ok(hr == S_OK, "Failed to create command signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pipeline_desc, root_signature,
             DXGI_FORMAT_R8G8B8A8_UNORM, NULL, NULL, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pipeline_desc, &IID_ID3D12PipelineState, (void**)&pipeline);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++)
     {
@@ -2046,7 +2046,7 @@ void test_destruction_notifier_interfaces(void)
 
         notifier = NULL;
         hr = IUnknown_QueryInterface(iface, &IID_ID3DDestructionNotifier, (void**)&notifier);
-        ok(hr == S_OK, "Failed to query ID3DDestructionNotifier, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to query ID3DDestructionNotifier, hr %#x.\n", (int)hr);
 
         if (!notifier)
             continue;
@@ -2154,7 +2154,7 @@ void test_sdk_configuration_set_sdk_path(void)
     /* Docs say that this is only allowed in developer mode, but that's not true.
      * It seems to just return S_OK always, even for bogus values, so *shrug* */
     hr = ID3D12SDKConfiguration_SetSDKVersion(config, 1234213432, "OMGIDONTCARE");
-    ok(hr == S_OK, "Unexpected hr #%x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr #%x.\n", (int)hr);
 
     ok(ID3D12SDKConfiguration_Release(config) == 0, "Unexpected refcount.\n");
 }
@@ -2266,7 +2266,7 @@ void test_device_factory(void)
     ok(flags == D3D12_DEVICE_FACTORY_FLAG_NONE, "Unexpected flags #%x.\n", flags);
     /* This doesn't actually seem to work. Flags is not updated. */
     hr = ID3D12DeviceFactory_InitializeFromGlobalState(factory);
-    ok(SUCCEEDED(hr), "Unexpected hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Unexpected hr #%x.\n", (int)hr);
     flags = ID3D12DeviceFactory_GetFlags(factory);
     ok(flags == D3D12_DEVICE_FACTORY_FLAG_NONE, "Unexpected flags #%x.\n", flags);
 
@@ -2274,13 +2274,13 @@ void test_device_factory(void)
         ID3D12Debug *debug;
         hr = ID3D12DeviceFactory_GetConfigurationInterface(factory,
             &CLSID_D3D12Debug, &IID_ID3D12Debug, (void **)&debug);
-        todo ok(SUCCEEDED(hr), "Failed to get debug interface, hr #%x\n", hr);
+        todo ok(SUCCEEDED(hr), "Failed to get debug interface, hr #%x\n", (int)hr);
         if (SUCCEEDED(hr))
         {
             ID3D12Debug_Release(debug);
             hr = ID3D12DeviceFactory_GetConfigurationInterface(factory,
                 &CLSID_D3D12Debug, &IID_ID3D12Debug, NULL);
-            ok(hr == S_FALSE, "Unexpected hr #%x.\n", hr);
+            ok(hr == S_FALSE, "Unexpected hr #%x.\n", (int)hr);
         }
     }
 
@@ -2288,13 +2288,13 @@ void test_device_factory(void)
         ID3D12Tools *tools;
         hr = ID3D12DeviceFactory_GetConfigurationInterface(factory,
             &CLSID_D3D12Tools, &IID_ID3D12Tools, (void **)&tools);
-        todo ok(SUCCEEDED(hr), "Failed to get tools interface, hr #%x\n", hr);
+        todo ok(SUCCEEDED(hr), "Failed to get tools interface, hr #%x\n", (int)hr);
         if (SUCCEEDED(hr))
         {
             ID3D12Tools_Release(tools);
             hr = ID3D12DeviceFactory_GetConfigurationInterface(factory,
                 &CLSID_D3D12Tools, &IID_ID3D12Tools, NULL);
-            ok(hr == S_FALSE, "Unexpected hr #%x.\n", hr);
+            ok(hr == S_FALSE, "Unexpected hr #%x.\n", (int)hr);
         }
     }
 
@@ -2303,14 +2303,14 @@ void test_device_factory(void)
         hr = ID3D12DeviceFactory_GetConfigurationInterface(factory,
             &CLSID_D3D12DeviceRemovedExtendedData, &IID_ID3D12DeviceRemovedExtendedDataSettings, (void **)&dred);
         /* We implement this in a stubbed form. */
-        ok(SUCCEEDED(hr), "Failed to get dred interface, hr #%x\n", hr);
+        ok(SUCCEEDED(hr), "Failed to get dred interface, hr #%x\n", (int)hr);
         if (SUCCEEDED(hr))
         {
             ID3D12DeviceRemovedExtendedDataSettings_Release(dred);
             /* S_FALSE is returned even if ExtendedData is not supported, as we expect from return_interface(). */
             hr = ID3D12DeviceFactory_GetConfigurationInterface(factory,
                 &CLSID_D3D12DeviceRemovedExtendedData, &IID_ID3D12DeviceRemovedExtendedData, NULL);
-            ok(hr == S_FALSE, "Unexpected hr #%x.\n", hr);
+            ok(hr == S_FALSE, "Unexpected hr #%x.\n", (int)hr);
         }
     }
 
@@ -2328,11 +2328,11 @@ static void check_create_devices(ID3D12DeviceFactory *factory, ID3D12Device *sin
     HRESULT hr;
 
     hr = ID3D12DeviceFactory_CreateDevice(factory, NULL, D3D_FEATURE_LEVEL_11_0, &IID_ID3D12Device, (void **)&device1);
-    ok(SUCCEEDED(hr), "Failed to create device (hr #%x).\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create device (hr #%x).\n", (int)hr);
     if (FAILED(hr))
         device1 = NULL;
     hr = ID3D12DeviceFactory_CreateDevice(factory, NULL, D3D_FEATURE_LEVEL_11_0, &IID_ID3D12Device, (void **)&device2);
-    ok(SUCCEEDED(hr), "Failed to create device (hr #%x).\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create device (hr #%x).\n", (int)hr);
     if (FAILED(hr))
         device2 = NULL;
 
@@ -2447,7 +2447,7 @@ static void test_root_signature_serialization(ID3D12DeviceConfiguration1 *config
     param.Descriptor.ShaderRegister = 2;
 
     hr = ID3D12DeviceConfiguration1_SerializeVersionedRootSignature(config, &desc, &blob, NULL);
-    ok(SUCCEEDED(hr), "Failed to serialize versioned root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to serialize versioned root signature, hr #%x.\n", (int)hr);
     if (FAILED(hr))
         return;
 

--- a/tests/d3d12_dstorage.c
+++ b/tests/d3d12_dstorage.c
@@ -67,10 +67,10 @@ void test_dstorage_decompression(void)
     ID3D12CommandQueue *queue;
     uint32_t control_data[5];
     ID3D12Device5 *device5;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int i;
     uint32_t count;
-    ULONG refcount;
     size_t offset;
     HRESULT hr;
 
@@ -120,12 +120,12 @@ void test_dstorage_decompression(void)
 
     count = 0;
     hr = ID3D12Device5_EnumerateMetaCommands(device5, &count, NULL);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     meta_command_descs = calloc(count, sizeof(*meta_command_descs));
 
     hr = ID3D12Device5_EnumerateMetaCommands(device5, &count, meta_command_descs);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     for (i = 0; i < count && !supports_meta_command; i++)
         supports_meta_command = !memcmp(&meta_command_descs[i].Id, &IID_META_COMMAND_DSTORAGE, sizeof(meta_command_descs[i].Id));
@@ -189,14 +189,14 @@ void test_dstorage_decompression(void)
 
     hr = ID3D12Device5_CreateMetaCommand(device5, &IID_META_COMMAND_DSTORAGE,
             0, create_args, sizeof(create_args), &IID_ID3D12MetaCommand, (void**)&meta_command);
-    ok(hr == DXGI_ERROR_UNSUPPORTED, "Unexpected hr %#x.\n", hr);
+    ok(hr == DXGI_ERROR_UNSUPPORTED, "Unexpected hr %#x.\n", (int)hr);
 
     create_args[0] = 0u;                /* version */
     create_args[1] = 1u;                /* format */
 
     hr = ID3D12Device5_CreateMetaCommand(device5, &IID_META_COMMAND_DSTORAGE,
             0, create_args, sizeof(create_args), &IID_ID3D12MetaCommand, (void**)&meta_command);
-    ok(hr == DXGI_ERROR_UNSUPPORTED, "Unexpected hr %#x.\n", hr);
+    ok(hr == DXGI_ERROR_UNSUPPORTED, "Unexpected hr %#x.\n", (int)hr);
 
     /* Create the actual meta command */
     create_args[0] = 1u;
@@ -204,7 +204,7 @@ void test_dstorage_decompression(void)
 
     hr = ID3D12Device5_CreateMetaCommand(device5, &IID_META_COMMAND_DSTORAGE,
             0, create_args, sizeof(create_args), &IID_ID3D12MetaCommand, (void**)&meta_command);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     /* Create resources for the actual decompression. */
     memset(&heap_desc, 0, sizeof(heap_desc));
@@ -227,20 +227,20 @@ void test_dstorage_decompression(void)
     hr = ID3D12Device5_CreateCommittedResource(device5, &heap_desc,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             NULL, &IID_ID3D12Resource, (void**)&control_buffer);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_Map(control_buffer, 0, NULL, &control_buffer_ptr);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     /* Input buffer */
     resource_desc.Width = input_buffer_size;
     hr = ID3D12Device5_CreateCommittedResource(device5, &heap_desc,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             NULL, &IID_ID3D12Resource, (void**)&input_buffer);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_Map(input_buffer, 0, NULL, &input_buffer_ptr);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     offset = 0;
 
@@ -264,7 +264,7 @@ void test_dstorage_decompression(void)
         hr = ID3D12Device5_CreateCommittedResource(device5, &heap_desc,
                 D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                 NULL, &IID_ID3D12Resource, (void**)&scratch_buffer);
-        ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
     }
     else
         scratch_buffer = NULL;
@@ -274,25 +274,25 @@ void test_dstorage_decompression(void)
     hr = ID3D12Device5_CreateCommittedResource(device5, &heap_desc,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             NULL, &IID_ID3D12Resource, (void**)&output_buffer);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     /* Set up compute queue and list to do the decompression on */
     memset(&queue_desc, 0u, sizeof(queue_desc));
     queue_desc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
 
     hr = ID3D12Device5_CreateCommandQueue(device5, &queue_desc, &IID_ID3D12CommandQueue, (void**)&queue);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Device5_CreateCommandAllocator(device5, queue_desc.Type,
             &IID_ID3D12CommandAllocator, (void**)&command_allocator);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Device5_CreateCommandList1(device5, 0, queue_desc.Type,
             D3D12_COMMAND_LIST_FLAG_NONE, &IID_ID3D12GraphicsCommandList4, (void**)&command_list4);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12GraphicsCommandList4_QueryInterface(command_list4, &IID_ID3D12GraphicsCommandList, (void**)&command_list);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     /* Initialize meta command. This is expected to be done once after
      * creation, and in case of DirectStorage, does not take any arguments. */
@@ -353,5 +353,5 @@ void test_dstorage_decompression(void)
 
     ID3D12Device5_Release(device5);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }

--- a/tests/d3d12_dxvk_interop_device.c
+++ b/tests/d3d12_dxvk_interop_device.c
@@ -66,7 +66,7 @@ void test_vkd3d_dxvk_cmdbuf_interop(void)
         &vkPhysicalDevice,
         &vkDevice)))
     {
-        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_GetVulkanHandles failed %#x.\n", hr);
+        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_GetVulkanHandles failed %#x.\n", (int)hr);
         destroy_test_context(&context);
         return;
     }
@@ -84,7 +84,7 @@ void test_vkd3d_dxvk_cmdbuf_interop(void)
         VK_QUEUE_FAMILY_IGNORED,
         &allocator)))
     {
-        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_CreateInteropCommandAllocator failed %#x.\n", hr);
+        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_CreateInteropCommandAllocator failed %#x.\n", (int)hr);
         destroy_test_context(&context);
         return;
     }
@@ -92,7 +92,7 @@ void test_vkd3d_dxvk_cmdbuf_interop(void)
     if (FAILED(hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list)))
     {
-        ok(hr == S_OK, "ID3D12Device_CreateCommandList failed %#x.\n", hr);
+        ok(hr == S_OK, "ID3D12Device_CreateCommandList failed %#x.\n", (int)hr);
         destroy_test_context(&context);
         return;
     }
@@ -101,7 +101,7 @@ void test_vkd3d_dxvk_cmdbuf_interop(void)
         (ID3D12CommandList*)command_list,
         &vkCmdBuf)))
     {
-        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_BeginVulkanCmdHandles failed %#x.\n", hr);
+        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_BeginVulkanCmdHandles failed %#x.\n", (int)hr);
         destroy_test_context(&context);
         return;
     }
@@ -131,14 +131,14 @@ void test_vkd3d_dxvk_cmdbuf_interop(void)
     if (FAILED(hr = ID3D12DXVKInteropDevice1_EndVkCommandBufferInterop(interop_device,
         (ID3D12CommandList*)command_list)))
     {
-        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_EndVulkanCmdHandles failed %#x.\n", hr);
+        ok(hr == S_OK, "ID3D12DXVKInteropDevice1_EndVulkanCmdHandles failed %#x.\n", (int)hr);
         destroy_test_context(&context);
         return;
     }
 
     // Back to D3D12 logic, close the command list + execute it
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
     reset_command_list(command_list, allocator);

--- a/tests/d3d12_enhanced_barriers.c
+++ b/tests/d3d12_enhanced_barriers.c
@@ -65,26 +65,26 @@ void test_enhanced_barrier_castable_formats_buffer(void)
             &desc1, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS,
             NULL, NULL,
             0, NULL, &IID_ID3D12Resource, NULL);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
 
     hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_props, D3D12_HEAP_FLAG_NONE,
             &desc1, D3D12_BARRIER_LAYOUT_UNDEFINED,
             NULL, NULL, 0, NULL, &IID_ID3D12Resource, NULL);
-    ok(hr == S_FALSE, "Unexpected hr #%x.\n", hr);
+    ok(hr == S_FALSE, "Unexpected hr #%x.\n", (int)hr);
 
     /* Castable formats are not allowed for buffers. */
     hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_props, D3D12_HEAP_FLAG_NONE,
             &desc1, D3D12_BARRIER_LAYOUT_UNDEFINED,
             NULL, NULL,
             ARRAY_SIZE(formats0), formats0, &IID_ID3D12Resource, NULL);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
 
     /* For some reason, this is allowed for buffers. It seems to compare byte size of UNKNOWN vs UNKNOWN (0 == 0) based on validation error above. */
     hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_props, D3D12_HEAP_FLAG_NONE,
             &desc1, D3D12_BARRIER_LAYOUT_UNDEFINED,
             NULL, NULL,
             ARRAY_SIZE(formats1), formats1, &IID_ID3D12Resource, NULL);
-    ok(hr == S_FALSE, "Unexpected hr #%x.\n", hr);
+    ok(hr == S_FALSE, "Unexpected hr #%x.\n", (int)hr);
 
     ID3D12Device_Release(device);
     ID3D12Device10_Release(device10);
@@ -253,7 +253,7 @@ void test_enhanced_barrier_castable_formats_validation(void)
             resource = NULL;
 
         if (tests[i].valid)
-            ok(hr == S_OK, "Unexpected failure in GetResourceAllocationInfo3, hr #%x.\n", hr);
+            ok(hr == S_OK, "Unexpected failure in GetResourceAllocationInfo3, hr #%x.\n", (int)hr);
         else
             ok(hr == E_INVALIDARG, "Unexpected success in GetResourceAllocationInfo3.\n");
 
@@ -265,7 +265,7 @@ void test_enhanced_barrier_castable_formats_validation(void)
                     &IID_ID3D12Resource, NULL);
 
             if (tests[i].valid)
-                ok(hr == S_FALSE, "Unexpected failure in GetResourceAllocationInfo2, hr #%x.\n", hr);
+                ok(hr == S_FALSE, "Unexpected failure in GetResourceAllocationInfo2, hr #%x.\n", (int)hr);
             else
                 ok(hr == E_INVALIDARG, "Unexpected success in GetResourceAllocationInfo2.\n");
         }
@@ -494,7 +494,7 @@ void test_enhanced_barrier_castable_dsv(void)
     desc_range[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
     psos[PSO_INDEX_FLOAT] = create_compute_pipeline_state(context.device, context.root_signature, cs_read_float_dxbc);
     psos[PSO_INDEX_UINT] = create_compute_pipeline_state(context.device, context.root_signature, cs_read_uint_dxbc);
@@ -529,7 +529,7 @@ void test_enhanced_barrier_castable_dsv(void)
                 &desc1, D3D12_BARRIER_LAYOUT_COMMON, NULL, NULL,
                 castable_format_count, castable_formats,
                 &IID_ID3D12Resource, (void **)&resource);
-        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
         cpu_h = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(dsv_heap);
 
@@ -728,7 +728,7 @@ void test_enhanced_barrier_castable_formats(void)
             &desc1, D3D12_BARRIER_LAYOUT_COMMON, NULL, NULL,
             ARRAY_SIZE(castable_formats), castable_formats,
             &IID_ID3D12Resource, (void **)&resources[0]);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
     /* Transition to legacy model. */
     transition_resource_state(context.list, resources[0], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
@@ -745,12 +745,12 @@ void test_enhanced_barrier_castable_formats(void)
     heap_desc.Properties = heap_props;
     heap_desc.Flags = D3D12_HEAP_FLAG_CREATE_NOT_ZEROED;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&place_heap);
-    ok(SUCCEEDED(hr), "Failed to allocate heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to allocate heap, hr #%x.\n", (int)hr);
 
     hr = ID3D12Device12_CreatePlacedResource2(device12, place_heap, 64 * 1024, &desc1,
             D3D12_BARRIER_LAYOUT_COMMON, NULL,
             ARRAY_SIZE(castable_formats), castable_formats, &IID_ID3D12Resource, (void **)&resources[1]);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
     /* Transition to legacy model. */
     transition_resource_state(context.list, resources[1], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
@@ -764,7 +764,7 @@ void test_enhanced_barrier_castable_formats(void)
                 NULL, NULL,
                 ARRAY_SIZE(castable_formats), castable_formats,
                 &IID_ID3D12Resource, (void **)&resources[2]);
-        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
         /* Transition to legacy model. */
         transition_resource_state(context.list, resources[2], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
@@ -820,7 +820,7 @@ void test_enhanced_barrier_castable_formats(void)
     rs_params[1].Descriptor.ShaderRegister = 2;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
     write_pso = create_compute_pipeline_state(context.device, context.root_signature, cs_write_dxbc);
     read_pso = create_compute_pipeline_state(context.device, context.root_signature, cs_read_dxbc);
@@ -1436,10 +1436,10 @@ void test_enhanced_barrier_discard_behavior(void)
     heap_desc.SizeInBytes = alloc_info.SizeInBytes;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
 
     hr = ID3D12Device10_CreatePlacedResource2(device10, heap, 0, &desc1, D3D12_BARRIER_LAYOUT_RENDER_TARGET, NULL, 0, NULL, &IID_ID3D12Resource, (void **)&rtv);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);
     ID3D12Device_CreateRenderTargetView(context.device, rtv, NULL,
@@ -1815,10 +1815,10 @@ void test_enhanced_barrier_self_copy(void)
     heap_desc.SizeInBytes = alloc_info.SizeInBytes;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
 
     hr = ID3D12Device10_CreatePlacedResource2(device10, heap, 0, &desc1, D3D12_BARRIER_LAYOUT_RENDER_TARGET, NULL, 0, NULL, &IID_ID3D12Resource, (void **)&rtv);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);
     ID3D12Device_CreateRenderTargetView(context.device, rtv, NULL,

--- a/tests/d3d12_geometry_shader.c
+++ b/tests/d3d12_geometry_shader.c
@@ -427,11 +427,11 @@ static void test_geometry_shader(bool use_dxil)
     pso_desc.GS = gs_5_0;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso_5_0);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
     pso_desc.GS = gs;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     vb = create_upload_buffer(context.device, sizeof(vertex), vertex);
     vbv.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(vb);
@@ -1005,7 +1005,7 @@ static void test_layered_rendering(bool use_dxil)
     queue = context.queue;
 
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     input_layout.pInputElementDescs = layout_desc;
     input_layout.NumElements = ARRAY_SIZE(layout_desc);
@@ -1040,7 +1040,7 @@ static void test_layered_rendering(bool use_dxil)
 
         hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&pipeline_state);
-        ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
 
@@ -1389,7 +1389,7 @@ static void test_ps_layer(bool use_dxil)
     pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
 

--- a/tests/d3d12_invalid_usage.c
+++ b/tests/d3d12_invalid_usage.c
@@ -27,11 +27,11 @@ static void recreate_command_list_(unsigned int line, ID3D12Device *device,
     HRESULT hr;
 
     hr = ID3D12CommandAllocator_Reset(allocator);
-    ok_(line)(hr == S_OK, "Failed to reset command allocator, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to reset command allocator, hr %#x.\n", (int)hr);
     ID3D12GraphicsCommandList_Release(*command_list);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)command_list);
-    ok_(line)(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 }
 
 static void test_invalid_resource_barriers(void)
@@ -40,8 +40,8 @@ static void test_invalid_resource_barriers(void)
     ID3D12CommandAllocator *command_allocator;
     ID3D12GraphicsCommandList *command_list;
     ID3D12CommandQueue *queue;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -54,11 +54,11 @@ static void test_invalid_resource_barriers(void)
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list);
-    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
     texture = create_default_texture(device, 32, 32, DXGI_FORMAT_R8G8B8A8_UNORM,
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
@@ -69,7 +69,7 @@ static void test_invalid_resource_barriers(void)
     transition_resource_state(command_list, texture,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
 
     reset_command_list(command_list, command_allocator);
 
@@ -80,7 +80,7 @@ static void test_invalid_resource_barriers(void)
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
     hr = ID3D12GraphicsCommandList_Close(command_list);
     /* The returned error code has changed after a Windows update. */
-    ok(hr == S_OK || hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK || hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (hr == S_OK)
     {
         exec_command_list(queue, command_list);
@@ -97,7 +97,7 @@ static void test_invalid_resource_barriers(void)
             D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
     hr = ID3D12GraphicsCommandList_Close(command_list);
     /* The returned error code has changed after a Windows update. */
-    ok(hr == S_OK || hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK || hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (hr == S_OK)
     {
         exec_command_list(queue, command_list);
@@ -111,7 +111,7 @@ static void test_invalid_resource_barriers(void)
             D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     recreate_command_list(device, command_allocator, &command_list);
 
@@ -119,7 +119,7 @@ static void test_invalid_resource_barriers(void)
     transition_resource_state(command_list, readback_buffer,
             D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COMMON);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     recreate_command_list(device, command_allocator, &command_list);
 
@@ -127,7 +127,7 @@ static void test_invalid_resource_barriers(void)
     transition_resource_state(command_list, upload_buffer,
             D3D12_RESOURCE_STATE_GENERIC_READ, D3D12_RESOURCE_STATE_COMMON);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     recreate_command_list(device, command_allocator, &command_list);
 
@@ -135,7 +135,7 @@ static void test_invalid_resource_barriers(void)
     transition_resource_state(command_list, NULL,
             D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     ID3D12CommandAllocator_Release(command_allocator);
     ID3D12CommandQueue_Release(queue);
@@ -144,7 +144,7 @@ static void test_invalid_resource_barriers(void)
     ID3D12Resource_Release(texture);
     ID3D12Resource_Release(upload_buffer);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 static void test_invalid_copy_texture_region(void)
@@ -153,8 +153,8 @@ static void test_invalid_copy_texture_region(void)
     D3D12_TEXTURE_COPY_LOCATION src_location, dst_location;
     ID3D12CommandAllocator *command_allocator;
     ID3D12GraphicsCommandList *command_list;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     D3D12_BOX box;
     HRESULT hr;
 
@@ -166,11 +166,11 @@ static void test_invalid_copy_texture_region(void)
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_list);
-    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
     src_buffer = create_upload_buffer(device, 0x40000, NULL);
     dst_buffer = create_default_buffer(device, 0x40000, 0, D3D12_RESOURCE_STATE_COPY_DEST);
@@ -198,7 +198,7 @@ static void test_invalid_copy_texture_region(void)
             &dst_location, 0, 0, 0, &src_location, NULL);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     recreate_command_list(device, command_allocator, &command_list);
 
@@ -210,7 +210,7 @@ static void test_invalid_copy_texture_region(void)
             &dst_location, 0, 3, 0, &src_location, NULL);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     recreate_command_list(device, command_allocator, &command_list);
 
@@ -222,7 +222,7 @@ static void test_invalid_copy_texture_region(void)
             &dst_location, 0, 0, 0, &src_location, NULL);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     recreate_command_list(device, command_allocator, &command_list);
 
@@ -246,7 +246,7 @@ static void test_invalid_copy_texture_region(void)
             &dst_location, 0, 0, 0, &src_location, &box);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     recreate_command_list(device, command_allocator, &command_list);
 
@@ -264,7 +264,7 @@ static void test_invalid_copy_texture_region(void)
             &dst_location, 0, 0, 0, &src_location, &box);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     recreate_command_list(device, command_allocator, &command_list);
 
@@ -276,7 +276,7 @@ static void test_invalid_copy_texture_region(void)
             &dst_location, 0, 0, 0, &src_location, &box);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     ID3D12CommandAllocator_Release(command_allocator);
     ID3D12GraphicsCommandList_Release(command_list);
@@ -285,7 +285,7 @@ static void test_invalid_copy_texture_region(void)
     ID3D12Resource_Release(src_texture);
     ID3D12Resource_Release(dst_texture);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 static void test_invalid_unordered_access_views(void)
@@ -294,8 +294,8 @@ static void test_invalid_unordered_access_views(void)
     D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle;
     ID3D12DescriptorHeap *heap;
     ID3D12Resource *buffer;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
 
     if (!(device = create_device()))
     {
@@ -323,7 +323,7 @@ static void test_invalid_unordered_access_views(void)
     ID3D12DescriptorHeap_Release(heap);
     ID3D12Resource_Release(buffer);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 START_TEST(d3d12_invalid_usage)

--- a/tests/d3d12_mesh_shader.c
+++ b/tests/d3d12_mesh_shader.c
@@ -129,14 +129,14 @@ void test_mesh_shader_create_pipeline(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     /* On the most basic level, only a root signature and mesh shader are required */
     ms_only_pipeline_desc.root_signature = root_signature_subobject;
     ms_only_pipeline_desc.root_signature.root_signature = root_signature;
     ms_only_pipeline_desc.ms = ms_subobject;
     hr = create_pipeline_state_from_stream(device2, &ms_only_pipeline_desc, &pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create pipeline, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(pipeline_state);
 
     /* Mixing mesh shaders and any part of the old geometry pipelines is not allowed */
@@ -149,7 +149,7 @@ void test_mesh_shader_create_pipeline(void)
     ms_vs_pipeline_desc.rasterizer = rasterizer_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &ms_vs_pipeline_desc, &pipeline_state);
-    ok(hr == E_INVALIDARG, "Unexpected result for pipeline creation, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected result for pipeline creation, hr %#x.\n", (int)hr);
 
     /* Pixel shaders require a non-trivial mesh shader */
     ms_ps_pipeline_desc.root_signature = root_signature_subobject;
@@ -160,7 +160,7 @@ void test_mesh_shader_create_pipeline(void)
     ms_ps_pipeline_desc.rasterizer = rasterizer_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &ms_ps_pipeline_desc, &pipeline_state);
-    todo ok(hr == E_INVALIDARG, "Unexpected result for pipeline creation, hr %#x.\n", hr);
+    todo ok(hr == E_INVALIDARG, "Unexpected result for pipeline creation, hr %#x.\n", (int)hr);
 
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(pipeline_state);
@@ -168,7 +168,7 @@ void test_mesh_shader_create_pipeline(void)
     ms_ps_pipeline_desc.ms = ms_nontrivial_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &ms_ps_pipeline_desc, &pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create pipeline, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(pipeline_state);
 
     /* Input assembly and primitive topology are ignored */
@@ -179,7 +179,7 @@ void test_mesh_shader_create_pipeline(void)
     ms_ia_pipeline_desc.input_layout = input_layout_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &ms_ia_pipeline_desc, &pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create pipeline, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(pipeline_state);
 
     ID3D12RootSignature_Release(root_signature);
@@ -349,12 +349,12 @@ void test_mesh_shader_rendering(void)
 
     hr = ID3D12Device2_CreateCommittedResource(device2, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&srv_resource);
-    ok(SUCCEEDED(hr), "Failed to create SRV resource, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create SRV resource, hr %#x.\n", (int)hr);
 
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     hr = ID3D12Device2_CreateCommittedResource(device2, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&uav_resource);
-    ok(SUCCEEDED(hr), "Failed to create UAV resource, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create UAV resource, hr %#x.\n", (int)hr);
 
     memset(&root_signature_desc, 0, sizeof(root_signature_desc));
     root_signature_desc.NumParameters = 3;
@@ -372,7 +372,7 @@ void test_mesh_shader_rendering(void)
     root_parameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     /* Test rendering a simple quad using mesh shaders */
     pipeline_desc.root_signature.type = D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE;
@@ -386,7 +386,7 @@ void test_mesh_shader_rendering(void)
     pipeline_desc.blend = blend_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList6_ClearRenderTargetView(command_list6, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList6_OMSetRenderTargets(command_list6, 1, &context.rtv, false, NULL);
@@ -407,7 +407,7 @@ void test_mesh_shader_rendering(void)
     pipeline_desc.ps = ps_interface_matching_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     reset_command_list(context.list, context.allocator);
     upload_buffer_data(uav_resource, 0, sizeof(clear_buffer_data), clear_buffer_data, context.queue, context.list);
@@ -445,7 +445,7 @@ void test_mesh_shader_rendering(void)
     pipeline_desc.ps = ps_culling_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     reset_command_list(context.list, context.allocator);
     upload_buffer_data(srv_resource, 0, sizeof(cull_buffer_data), cull_buffer_data, context.queue, context.list);
@@ -482,7 +482,7 @@ void test_mesh_shader_rendering(void)
     pipeline_desc.ms = ms_cull_primitive_subobject;
     pipeline_desc.ps = ps_culling_subobject;
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     reset_command_list(context.list, context.allocator);
     transition_resource_state(context.list, uav_resource, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COPY_DEST);
@@ -517,7 +517,7 @@ void test_mesh_shader_rendering(void)
     pipeline_desc.ps = ps_simple_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < 2; i++)
     {
@@ -548,7 +548,7 @@ void test_mesh_shader_rendering(void)
     pipeline_desc.ps = ps_system_values_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     reset_command_list(context.list, context.allocator);
     transition_resource_state(context.list, uav_resource, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COPY_DEST);
@@ -592,7 +592,7 @@ void test_mesh_shader_rendering(void)
         pipeline_desc.ps = ps_derivatives_subobject;
 
         hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
         reset_command_list(context.list, context.allocator);
         transition_resource_state(context.list, context.render_target, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
@@ -754,14 +754,14 @@ void test_mesh_shader_execute_indirect(void)
 
     hr = ID3D12Device2_CreateCommittedResource(device2, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&indirect_buffer);
-    ok(SUCCEEDED(hr), "Failed to create SRV resource, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create SRV resource, hr %#x.\n", (int)hr);
 
     memset(&root_signature_desc, 0, sizeof(root_signature_desc));
     root_signature_desc.NumParameters = 0;
     root_signature_desc.pParameters = NULL;
 
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&command_signature_desc, 0, sizeof(command_signature_desc));
     command_signature_desc.ByteStride = 12;
@@ -772,7 +772,7 @@ void test_mesh_shader_execute_indirect(void)
     indirect_argument_desc.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH_MESH;
 
     hr = ID3D12Device2_CreateCommandSignature(device2, &command_signature_desc, NULL, &IID_ID3D12CommandSignature, (void **)&command_signature);
-    ok(SUCCEEDED(hr), "Failed to create command signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command signature, hr %#x.\n", (int)hr);
 
     pipeline_desc.root_signature.type = D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE;
     pipeline_desc.root_signature.root_signature = root_signature;
@@ -785,7 +785,7 @@ void test_mesh_shader_execute_indirect(void)
     pipeline_desc.blend = blend_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++)
     {
@@ -931,7 +931,7 @@ void test_mesh_shader_execute_indirect_state(void)
     root_parameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&command_signature_desc, 0, sizeof(command_signature_desc));
     command_signature_desc.ByteStride = sizeof(struct test_data);
@@ -947,7 +947,7 @@ void test_mesh_shader_execute_indirect_state(void)
     indirect_argument_desc[2].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH_MESH;
 
     hr = ID3D12Device2_CreateCommandSignature(device2, &command_signature_desc, root_signature, &IID_ID3D12CommandSignature, (void **)&command_signature);
-    ok(SUCCEEDED(hr) || hr == E_NOTIMPL, "Failed to create command signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr) || hr == E_NOTIMPL, "Failed to create command signature, hr %#x.\n", (int)hr);
     if (FAILED(hr))
         command_signature = NULL;
     if (hr == E_NOTIMPL)
@@ -960,7 +960,7 @@ void test_mesh_shader_execute_indirect_state(void)
     pipeline_desc.rasterizer = rasterizer_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     output = create_default_buffer(context.device, sizeof(tests) * sizeof(uint32_t), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
@@ -1161,12 +1161,12 @@ void test_amplification_shader(void)
 
     hr = ID3D12Device2_CreateCommittedResource(device2, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&srv_resource);
-    ok(SUCCEEDED(hr), "Failed to create SRV resource, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create SRV resource, hr %#x.\n", (int)hr);
 
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     hr = ID3D12Device2_CreateCommittedResource(device2, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&uav_resource);
-    ok(SUCCEEDED(hr), "Failed to create UAV resource, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create UAV resource, hr %#x.\n", (int)hr);
 
     memset(&root_signature_desc, 0, sizeof(root_signature_desc));
     root_signature_desc.NumParameters = 2;
@@ -1180,7 +1180,7 @@ void test_amplification_shader(void)
     root_parameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     /* Test forwarding a simple payload from an amplification shader */
     pipeline_desc.root_signature.type = D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE;
@@ -1195,7 +1195,7 @@ void test_amplification_shader(void)
     pipeline_desc.blend = blend_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList6_ClearRenderTargetView(command_list6, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList6_OMSetRenderTargets(command_list6, 1, &context.rtv, false, NULL);
@@ -1215,7 +1215,7 @@ void test_amplification_shader(void)
     pipeline_desc.render_targets = render_target_subobject_none;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     reset_command_list(context.list, context.allocator);
     upload_buffer_data(uav_resource, 0, sizeof(clear_buffer_data), clear_buffer_data, context.queue, context.list);
@@ -1384,7 +1384,7 @@ void test_amplification_shader_execute_indirect_state(void)
     root_parameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&command_signature_desc, 0, sizeof(command_signature_desc));
     command_signature_desc.ByteStride = sizeof(tests[0].data);
@@ -1400,7 +1400,7 @@ void test_amplification_shader_execute_indirect_state(void)
     indirect_argument_desc[2].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH_MESH;
 
     hr = ID3D12Device2_CreateCommandSignature(device2, &command_signature_desc, root_signature, &IID_ID3D12CommandSignature, (void **)&command_signature);
-    ok(SUCCEEDED(hr) || hr == E_NOTIMPL, "Failed to create command signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr) || hr == E_NOTIMPL, "Failed to create command signature, hr %#x.\n", (int)hr);
     if (FAILED(hr))
         command_signature = NULL;
     if (hr == E_NOTIMPL)
@@ -1414,7 +1414,7 @@ void test_amplification_shader_execute_indirect_state(void)
     pipeline_desc.rasterizer = rasterizer_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pipeline_desc, &pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     output = create_default_buffer(context.device, sizeof(tests) * sizeof(uint32_t), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 

--- a/tests/d3d12_pso.c
+++ b/tests/d3d12_pso.c
@@ -29,7 +29,7 @@ void test_create_compute_pipeline_state(void)
     ID3D12RootSignature *root_signature;
     ID3D12PipelineState *pipeline_state;
     ID3D12Device *device, *tmp_device;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
 #include "shaders/pso/headers/cs_create_pso.h"
@@ -46,10 +46,10 @@ void test_create_compute_pipeline_state(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     memset(&pipeline_state_desc, 0, sizeof(pipeline_state_desc));
     pipeline_state_desc.pRootSignature = root_signature;
@@ -59,19 +59,19 @@ void test_create_compute_pipeline_state(void)
 
     hr = ID3D12Device_CreateComputePipelineState(device, &pipeline_state_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(root_signature);
-    ok(refcount == 1, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 1, "Got unexpected refcount %u.\n", refcount);
 
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12PipelineState_GetDevice(pipeline_state, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(hr == S_OK, "Failed to get device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 4, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 4, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(pipeline_state, &IID_ID3D12Object, true);
     check_interface(pipeline_state, &IID_ID3D12DeviceChild, true);
@@ -79,12 +79,12 @@ void test_create_compute_pipeline_state(void)
     check_interface(pipeline_state, &IID_ID3D12PipelineState, true);
 
     refcount = ID3D12PipelineState_Release(pipeline_state);
-    ok(!refcount, "ID3D12PipelineState has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12PipelineState has %u references left.\n", refcount);
     refcount = ID3D12RootSignature_Release(root_signature);
-    ok(!refcount, "ID3D12RootSignature has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignature has %u references left.\n", refcount);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_integer_blending_pipeline_state(void)
@@ -126,7 +126,7 @@ void test_integer_blending_pipeline_state(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++)
     {
@@ -144,7 +144,7 @@ void test_integer_blending_pipeline_state(void)
         blend->RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
         hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&pso);
-        ok(hr == tests[i].hr, "Unexpected hr %#x.\n", hr);
+        ok(hr == tests[i].hr, "Unexpected hr %#x.\n", (int)hr);
         if (SUCCEEDED(hr))
             ID3D12PipelineState_Release(pso);
     }
@@ -162,7 +162,7 @@ void test_create_graphics_pipeline_state(void)
     ID3D12PipelineState *pipeline_state;
     ID3D12Device *device, *tmp_device;
     D3D12_BLEND_DESC *blend;
-    ULONG refcount;
+    unsigned int refcount;
     unsigned int i;
     HRESULT hr;
 
@@ -184,27 +184,27 @@ void test_create_graphics_pipeline_state(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     init_pipeline_state_desc(&pso_desc, root_signature, DXGI_FORMAT_R8G8B8A8_UNORM, NULL, NULL, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(root_signature);
-    ok(refcount == 1, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 1, "Got unexpected refcount %u.\n", refcount);
 
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12PipelineState_GetDevice(pipeline_state, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(hr == S_OK, "Failed to get device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 4, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 4, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(pipeline_state, &IID_ID3D12Object, true);
     check_interface(pipeline_state, &IID_ID3D12DeviceChild, true);
@@ -212,7 +212,7 @@ void test_create_graphics_pipeline_state(void)
     check_interface(pipeline_state, &IID_ID3D12PipelineState, true);
 
     refcount = ID3D12PipelineState_Release(pipeline_state);
-    ok(!refcount, "ID3D12PipelineState has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12PipelineState has %u references left.\n", refcount);
 
     blend = &pso_desc.BlendState;
     blend->IndependentBlendEnable = false;
@@ -226,7 +226,7 @@ void test_create_graphics_pipeline_state(void)
     blend->RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(pipeline_state);
 
     /* Only one of BlendEnable or LogicOpEnable can be set to true. */
@@ -235,11 +235,11 @@ void test_create_graphics_pipeline_state(void)
     blend->RenderTarget[0].LogicOpEnable = true;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     pso_desc.RTVFormats[0] = DXGI_FORMAT_R32_UINT;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     blend->IndependentBlendEnable = false;
     blend->RenderTarget[0].BlendEnable = false;
@@ -250,7 +250,7 @@ void test_create_graphics_pipeline_state(void)
     {
         hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **) &pipeline_state);
-        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
         ID3D12PipelineState_Release(pipeline_state);
     }
 
@@ -261,7 +261,7 @@ void test_create_graphics_pipeline_state(void)
         blend->RenderTarget[i] = blend->RenderTarget[0];
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* DSVFormat = DXGI_FORMAT_UNKNOWN */
     memset(blend, 0, sizeof(*blend));
@@ -271,7 +271,7 @@ void test_create_graphics_pipeline_state(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(pipeline_state);
 
     /* Invalid DSVFormat */
@@ -279,7 +279,7 @@ void test_create_graphics_pipeline_state(void)
     pso_desc.DepthStencilState.DepthEnable = true;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(pipeline_state);
 
     /* Inactive render targets formats must be set to DXGI_FORMAT_UNKNOWN. */
@@ -287,7 +287,7 @@ void test_create_graphics_pipeline_state(void)
     pso_desc.RTVFormats[1] = DXGI_FORMAT_R8G8B8A8_UNORM;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* Stream output without D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT. */
     init_pipeline_state_desc(&pso_desc, root_signature, DXGI_FORMAT_R8G8B8A8_UNORM, NULL, NULL, NULL);
@@ -297,12 +297,12 @@ void test_create_graphics_pipeline_state(void)
     pso_desc.StreamOutput.NumStrides = ARRAY_SIZE(strides);
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     refcount = ID3D12RootSignature_Release(root_signature);
-    ok(!refcount, "ID3D12RootSignature has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignature has %u references left.\n", refcount);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_pipeline_state(void)
@@ -311,9 +311,9 @@ void test_create_pipeline_state(void)
     ID3D12RootSignature *root_signature;
     ID3D12PipelineState *pipeline_state;
     ID3D12Device2 *device2;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
 #include "shaders/pso/headers/cs_create_pso.h"
@@ -622,7 +622,7 @@ void test_create_pipeline_state(void)
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT |
             D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++)
     {
@@ -638,21 +638,21 @@ void test_create_pipeline_state(void)
             rs_subobject->root_signature = root_signature;
 
         hr = ID3D12Device2_CreatePipelineState(device2, &tests[i].stream_desc, &IID_ID3D12PipelineState, (void **)&pipeline_state);
-        ok(hr == tests[i].expected_result, "Got unexpected return value %#x.\n", hr);
+        ok(hr == tests[i].expected_result, "Got unexpected return value %#x.\n", (int)hr);
 
         if (hr == S_OK)
         {
             refcount = ID3D12PipelineState_Release(pipeline_state);
-            ok(!refcount, "ID3D12PipelineState has %u references left.\n", (unsigned int)refcount);
+            ok(!refcount, "ID3D12PipelineState has %u references left.\n", refcount);
         }
     }
 
     refcount = ID3D12RootSignature_Release(root_signature);
-    ok(!refcount, "ID3D12RootSignature has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignature has %u references left.\n", refcount);
     refcount = ID3D12Device2_Release(device2);
-    ok(refcount == 1, "ID3D12Device2 has %u references left.\n", (unsigned int)refcount);
+    ok(refcount == 1, "ID3D12Device2 has %u references left.\n", refcount);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_shader_interstage_interface(void)
@@ -837,7 +837,7 @@ void test_shader_input_output_components(void)
         pso_desc.PS = *tests[i].ps;
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-        ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
         if (i)
         {
@@ -1045,7 +1045,7 @@ void test_blend_factor(void)
     pso_desc.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -1147,55 +1147,55 @@ static void test_dual_source_blending(bool use_dxil)
     pso_desc.RTVFormats[1] = pso_desc.RTVFormats[0];
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", (int)hr);
 
     /* Write mask of 0 is not enough. */
     pso_desc.BlendState.IndependentBlendEnable = TRUE;
     pso_desc.BlendState.RenderTarget[1].RenderTargetWriteMask = 0;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
         &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", (int)hr);
 
     /* This appears to be allowed however. */
     pso_desc.RTVFormats[1] = DXGI_FORMAT_UNKNOWN;
     pso_desc.BlendState.IndependentBlendEnable = FALSE;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
         &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(context.pipeline_state);
 
     /* >2 RTs is also allowed as long as we keep using NULL format. */
     pso_desc.NumRenderTargets = 3;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
         &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(context.pipeline_state);
 
     /* This is still allowed. We need to only consider RTs with IOSIG entry apparently ... */
     pso_desc.RTVFormats[2] = pso_desc.RTVFormats[0];
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
         &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(context.pipeline_state);
 
     /* If we try to write to o2 however, this must fail. */
     pso_desc.PS = ps_3rt;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
         &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", (int)hr);
 
     /* Writing to unused RTs is allowed if they aren't bound to the PSO. */
     pso_desc.NumRenderTargets = 1;
     pso_desc.RTVFormats[2] = DXGI_FORMAT_UNKNOWN;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
         &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(context.pipeline_state);
 
     pso_desc.PS = ps;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -1224,7 +1224,7 @@ static void test_dual_source_blending(bool use_dxil)
     pso_desc.BlendState.IndependentBlendEnable = true;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(context.pipeline_state);
     context.pipeline_state = NULL;
@@ -1232,7 +1232,7 @@ static void test_dual_source_blending(bool use_dxil)
     pso_desc.BlendState.RenderTarget[1] = pso_desc.BlendState.RenderTarget[0];
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(context.pipeline_state);
     context.pipeline_state = NULL;
@@ -1241,7 +1241,7 @@ static void test_dual_source_blending(bool use_dxil)
     pso_desc.BlendState.RenderTarget[1].DestBlend = D3D12_BLEND_SRC_COLOR;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(context.pipeline_state);
     context.pipeline_state = NULL;
@@ -1258,7 +1258,7 @@ static void test_dual_source_blending(bool use_dxil)
     pso_desc.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(context.pipeline_state);
     context.pipeline_state = NULL;
@@ -1377,7 +1377,7 @@ void test_primitive_restart(void)
         pso_desc.IBStripCutValue = tests[i].strip_cut_value;
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
         ibv.Format = tests[i].ib_format;
         ib = create_upload_buffer(context.device, tests[i].indices_size, tests[i].indices);
@@ -1386,7 +1386,7 @@ void test_primitive_restart(void)
         index_count = tests[i].indices_size / format_size(ibv.Format);
 
         hr = ID3D12Resource_Map(vb, 0, NULL, &ptr);
-        ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", (int)hr);
         memcpy(ptr, quad, (ARRAY_SIZE(quad) - 1) * sizeof(*quad));
         memcpy((BYTE *)ptr + tests[i].last_index * sizeof(*quad), &quad[ARRAY_SIZE(quad) - 1], sizeof(*quad));
         ID3D12Resource_Unmap(vb, 0, NULL);
@@ -1468,12 +1468,12 @@ void test_create_pipeline_with_null_root_signature(void)
 
     hr = ID3D12Device_CreateRootSignature(context.device, 0, cs_null_root_signature_code_dxbc,
             sizeof(cs_null_root_signature_code_dxbc), &IID_ID3D12RootSignature, (void**)&root_signature);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     memset(&compute_desc, 0, sizeof(compute_desc));
     compute_desc.CS = cs_null_root_signature_dxbc;
     hr = ID3D12Device_CreateComputePipelineState(context.device, &compute_desc, &IID_ID3D12PipelineState, (void**)&pipeline_state);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     if (root_signature && pipeline_state)
     {
@@ -1502,7 +1502,7 @@ void test_create_pipeline_with_null_root_signature(void)
 
     hr = ID3D12Device_CreateRootSignature(context.device, 0, vs_null_root_signature_code_dxbc,
             sizeof(vs_null_root_signature_code_dxbc), &IID_ID3D12RootSignature, (void**)&root_signature);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     memset(&graphics_desc, 0, sizeof(graphics_desc));
     graphics_desc.VS = vs_null_root_signature_dxbc;
@@ -1516,7 +1516,7 @@ void test_create_pipeline_with_null_root_signature(void)
     graphics_desc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
     graphics_desc.SampleDesc.Count = 1;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &graphics_desc, &IID_ID3D12PipelineState, (void**)&pipeline_state);
-    ok(hr == S_OK, "Unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Unexpected hr %#x.\n", (int)hr);
 
     if (root_signature && pipeline_state)
     {
@@ -1591,14 +1591,14 @@ void test_mismatching_pso_stages(void)
     pso_desc.SampleMask = ~0u;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pipeline);
-    ok(SUCCEEDED(hr), "Unexpected hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Unexpected hr #%x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(pipeline);
 
     pso_desc.PS = vs_create_pso_dxbc;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pipeline);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(pipeline);
 
@@ -1783,7 +1783,7 @@ void test_topology_triangle_fan(void)
     pso_desc.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(context.list, context.rtv, black, 0, NULL);
     ID3D12GraphicsCommandList_OMSetRenderTargets(context.list, 1, &context.rtv, false, NULL);
@@ -2027,18 +2027,18 @@ void test_dynamic_depth_bias(void)
     pso_desc.root_signature.root_signature = context.root_signature;
 
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream, &IID_ID3D12PipelineState, (void**)&pso_with_bias);
-    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", (int)hr);
 
     pso_desc.rasterizer = rasterizer_no_bias_subobject;
 
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream, &IID_ID3D12PipelineState, (void**)&pso_no_bias);
-    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", (int)hr);
 
     pso_desc.rasterizer = rasterizer_with_bias_subobject;
     pso_desc.flags_desc = flags_static_bias_subobject;
 
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream, &IID_ID3D12PipelineState, (void**)&pso_static_bias);
-    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline state, hr %#x.\n", (int)hr);
 
     dsv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, 1);
     ds = create_default_texture2d(context.device, 4, 4, 1, 1, DXGI_FORMAT_D32_FLOAT, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL, D3D12_RESOURCE_STATE_DEPTH_WRITE);
@@ -2054,7 +2054,7 @@ void test_dynamic_depth_bias(void)
     query_heap_desc.Count = ARRAY_SIZE(tests);
 
     hr = ID3D12Device_CreateQueryHeap(context.device, &query_heap_desc, &IID_ID3D12QueryHeap, (void**)&query_heap);
-    ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", (int)hr);
 
     query_buffer = create_readback_buffer(context.device, sizeof(uint64_t) * query_heap_desc.Count);
 
@@ -2176,13 +2176,13 @@ void test_dynamic_depth_bias(void)
             D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0, query_heap_desc.Count, query_buffer, 0);
 
     hr = ID3D12GraphicsCommandList9_Close(command_list9);
-    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
 
     exec_command_list(context.queue, context.list);
     wait_queue_idle(context.device, context.queue);
 
     hr = ID3D12Resource_Map(query_buffer, 0, NULL, (void**)&readback_data);
-    ok(hr == S_OK, "Failed to map readback buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to map readback buffer, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++)
     {
@@ -2443,7 +2443,7 @@ void test_dynamic_index_strip_cut(void)
     rs_desc.NumParameters = ARRAY_SIZE(rs_params);
     rs_desc.pParameters = rs_params;
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pso_desc.root_signature.root_signature = context.root_signature;
 
@@ -2453,20 +2453,20 @@ void test_dynamic_index_strip_cut(void)
     pso_desc.strip_cut = ib_strip_cut_disabled_subobject;
     pso_desc.flags_desc = flags_static_strip_cut_subobject;
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream, &IID_ID3D12PipelineState, (void **)&pso_strip_cut_disabled_static);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     pso_desc.flags_desc = flags_dynamic_strip_cut_subobject;
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream, &IID_ID3D12PipelineState, (void **)&pso_strip_cut_disabled_dynamic);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     pso_desc.strip_cut = ib_strip_cut_enabled_subobject;
     pso_desc.flags_desc = flags_static_strip_cut_subobject;
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream, &IID_ID3D12PipelineState, (void **)&pso_strip_cut_enabled_static);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     pso_desc.flags_desc = flags_dynamic_strip_cut_subobject;
     hr = ID3D12Device2_CreatePipelineState(device2, &pso_stream, &IID_ID3D12PipelineState, (void **)&pso_strip_cut_enabled_dynamic);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     index_buffer_16 = create_upload_buffer(context.device, sizeof(index16_data), index16_data);
     index_buffer_32 = create_upload_buffer(context.device, sizeof(index32_data), index32_data);
@@ -2818,7 +2818,7 @@ void test_line_rasterization(void)
         pso_rs_desc2_desc.rasterizer.rasterizer_desc.LineRasterizationMode = tests[i].line_raster_mode;
 
         hr = ID3D12Device2_CreatePipelineState(device2, tests[i].pso_stream, &IID_ID3D12PipelineState, (void**)&pso);
-        ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
         transition_resource_state(context.list, rt, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -2955,7 +2955,7 @@ void test_coverage_export_atoc(bool use_dxil)
     rs_param.Constants.Num32BitValues = 1;
     rs_param.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
     hr = create_root_signature(context.device, &rs_desc, &rs);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&rs_srv_range, 0, sizeof(rs_srv_range));
     rs_srv_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
@@ -2968,7 +2968,7 @@ void test_coverage_export_atoc(bool use_dxil)
     rs_param.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
     hr = create_root_signature(context.device, &rs_desc, &rs_count_samples);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&heap_properties, 0, sizeof(heap_properties));
     heap_properties.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -2988,14 +2988,14 @@ void test_coverage_export_atoc(bool use_dxil)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, NULL, &IID_ID3D12Resource, (void **)&rt);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.SampleDesc.Count = 4;
     resource_desc.Format = DXGI_FORMAT_R8_UNORM;
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE, NULL, &IID_ID3D12Resource, (void **)&rt_ms);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 2);
 
@@ -3026,7 +3026,7 @@ void test_coverage_export_atoc(bool use_dxil)
     init_pipeline_state_desc(&pso_desc, rs_count_samples, DXGI_FORMAT_R8_UINT, NULL, &ps_count_samples_dxbc, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso_count_samples);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     viewport.TopLeftX = 0.0f;
     viewport.TopLeftY = 0.0f;
@@ -3055,7 +3055,7 @@ void test_coverage_export_atoc(bool use_dxil)
         pso_desc.BlendState.AlphaToCoverageEnable = tests[i].atoc;
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&pso);
-        ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_RSSetViewports(context.list, 1, &viewport);
         ID3D12GraphicsCommandList_RSSetScissorRects(context.list, 1, &scissor);
@@ -3112,7 +3112,7 @@ void test_coverage_export_atoc(bool use_dxil)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&rt);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     memset(&rtv_desc, 0, sizeof(rtv_desc));
     rtv_desc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
@@ -3130,7 +3130,7 @@ void test_coverage_export_atoc(bool use_dxil)
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_RSSetViewports(context.list, 1, &viewport);
     ID3D12GraphicsCommandList_RSSetScissorRects(context.list, 1, &scissor);
@@ -3428,7 +3428,7 @@ void test_view_instancing(void)
     rs_desc.pParameters = &rs_arg;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     /* Shaders must accept SV_ViewID even if view instancing is not supported,
      * or disabled for the PSO. */
@@ -3436,7 +3436,7 @@ void test_view_instancing(void)
             &vs_view_id_passthrough_dxil, &ps_view_id_passthrough_dxil, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device,
             &pso_desc_simple, &IID_ID3D12PipelineState, (void **)&pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_OMSetRenderTargets(context.list, 1, &context.rtv, TRUE, NULL);
     ID3D12GraphicsCommandList_ClearRenderTargetView(context.list, context.rtv, clear_value, 0, NULL);
@@ -3491,7 +3491,7 @@ void test_view_instancing(void)
     pso_vs_ps_desc.view_instancing = view_instancing_simple_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pso_vs_ps_desc, &pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     transition_resource_state(context.list, context.render_target, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -3529,7 +3529,7 @@ void test_view_instancing(void)
     command_desc.pArgumentDescs = &command_arg;
 
     hr = ID3D12Device_CreateCommandSignature(context.device, &command_desc, NULL, &IID_ID3D12CommandSignature, (void**)&command_sig);
-    ok(hr == S_OK, "Failed to create command signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command signature, hr %#x.\n", (int)hr);
 
     transition_resource_state(context.list, context.render_target, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -3560,7 +3560,7 @@ void test_view_instancing(void)
     pso_vs_ps_desc.view_instancing = view_instancing_simple_mask_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pso_vs_ps_desc, &pso2);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(view_mask_tests); i++)
     {
@@ -3659,7 +3659,7 @@ void test_view_instancing(void)
     pso_vs_ps_desc.view_instancing = view_instancing_shuffle_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pso_vs_ps_desc, &pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     transition_resource_state(context.list, context.render_target, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -3690,7 +3690,7 @@ void test_view_instancing(void)
 
     hr = create_pipeline_state_from_stream(device2, &pso_vs_ps_desc, &pso);
     /* Normal multiview cannot support this. */
-    todo ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    todo ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
     if (FAILED(hr))
     {
         ok(hr == E_NOTIMPL, "Expected NOTIMPL.\n");
@@ -3761,7 +3761,7 @@ void test_view_instancing(void)
     pso_vs_ps_desc.view_instancing = view_instancing_mixed_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pso_vs_ps_desc, &pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     transition_resource_state(context.list, context.render_target, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -3814,7 +3814,7 @@ void test_view_instancing(void)
         hr = create_pipeline_state_from_stream(device2, &pso_vs_ps_desc, &pso);
 
         /* We don't support layer bias at the moment. */
-        todo ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+        todo ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
         if (FAILED(hr))
         {
             ok(hr == E_NOTIMPL, "Expected E_NOTIMPL.\n");
@@ -3897,7 +3897,7 @@ void test_view_instancing(void)
     pso_vs_gs_ps_desc.view_instancing = view_instancing_export_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pso_vs_gs_ps_desc, &pso);
-    todo ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    todo ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
     if (FAILED(hr))
     {
         ok(hr == E_NOTIMPL, "Expected E_NOTIMPL.\n");
@@ -3971,7 +3971,7 @@ void test_view_instancing(void)
         pso_ms_ps_desc.view_instancing = view_instancing_simple_subobject;
 
         hr = create_pipeline_state_from_stream(device2, &pso_ms_ps_desc, &pso);
-        ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
         transition_resource_state(context.list, context.render_target, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -4192,7 +4192,7 @@ void test_view_instancing_indirect_state(void)
     rs_desc.pParameters = &rs_arg;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_depth_stencil(&ds, context.device, 16, 16, 2, 1, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, NULL);
 
@@ -4219,7 +4219,7 @@ void test_view_instancing_indirect_state(void)
     pso_vs_ps_desc.view_instancing = view_instancing_simple_subobject;
 
     hr = create_pipeline_state_from_stream(device2, &pso_vs_ps_desc, &context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     /* Test ExecuteIndirect */
     arg_buffer = create_upload_buffer(context.device, sizeof(indirect_draw_data), indirect_draw_data);
@@ -4648,7 +4648,7 @@ void test_shader_io_mismatch(void)
         expected = i > 1 ? E_INVALIDARG : S_OK;
 
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-        ok(hr == expected, "Got hr %#x, expected %#x.\n", hr, expected);
+        ok(hr == expected, "Got hr %#x, expected %#x.\n", (int)hr, (int)expected);
 
         if (SUCCEEDED(hr))
             ID3D12PipelineState_Release(pso);
@@ -4701,7 +4701,7 @@ void test_shader_io_mismatch(void)
             pso_desc.PS = *tests[i].ps;
 
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-        ok(hr == expected, "Got hr %#x, expected %#x.\n", hr, expected);
+        ok(hr == expected, "Got hr %#x, expected %#x.\n", (int)hr, (int)expected);
 
         if (SUCCEEDED(hr))
             ID3D12PipelineState_Release(pso);
@@ -4739,7 +4739,7 @@ void test_shader_io_mismatch(void)
         pso_desc.StreamOutput.pBufferStrides = so_strides;
 
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-        ok(hr == expected, "Got hr %#x, expected %#x.\n", hr, expected);
+        ok(hr == expected, "Got hr %#x, expected %#x.\n", (int)hr, (int)expected);
 
         if (SUCCEEDED(hr))
             ID3D12PipelineState_Release(pso);
@@ -4789,7 +4789,7 @@ void test_shader_io_mismatch(void)
                 pso_ms_desc.ps.shader_bytecode = *tests[i].ps;
 
             hr = create_pipeline_state_from_stream(device2, &pso_ms_desc, &pso);
-            ok(hr == expected, "Got hr %#x, expected %#x.\n", hr, expected);
+            ok(hr == expected, "Got hr %#x, expected %#x.\n", (int)hr, (int)expected);
 
             if (SUCCEEDED(hr))
                 ID3D12PipelineState_Release(pso);
@@ -4893,7 +4893,7 @@ void test_gs_topology_mismatch(bool dxil)
             hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&pso);
             expected = geometry_shaders[j].topology == topology_types[i] ? S_OK : E_INVALIDARG;
 
-            ok(hr == expected, "Got hr %#x, expected %#x.\n", hr, expected);
+            ok(hr == expected, "Got hr %#x, expected %#x.\n", (int)hr, (int)expected);
 
             if (hr == S_OK)
                 ID3D12PipelineState_Release(pso);
@@ -4922,7 +4922,7 @@ void test_gs_topology_mismatch(bool dxil)
             expected = (geometry_shaders[j].topology == tess_shaders[i].topology &&
                     !geometry_shaders[j].uses_adjacency) ? S_OK : E_INVALIDARG;
 
-            ok(hr == expected, "Got hr %#x, expected %#x.\n", hr, expected);
+            ok(hr == expected, "Got hr %#x, expected %#x.\n", (int)hr, (int)expected);
 
             if (hr == S_OK)
                 ID3D12PipelineState_Release(pso);
@@ -5252,7 +5252,7 @@ void test_sample_shading_coverage_mask(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_props, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&output);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     vbo = create_upload_buffer(context.device, sizeof(vbo_data), vbo_data);
 
@@ -5262,10 +5262,10 @@ void test_sample_shading_coverage_mask(void)
     pso_desc.SampleDesc.Count = 4;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso60);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
     pso_desc.PS = ps_sample_mask66_dxil;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso66);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     rtv = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);
     rtv_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(rtv);
@@ -5371,14 +5371,14 @@ void test_render_target_support_validation(void)
 
     init_pipeline_state_desc(&pso_desc, NULL, DXGI_FORMAT_R32_FLOAT, &vs_null_root_signature_dxbc, &ps_null_root_signature_dxbc, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(pso);
 
     /* No errors are created. Only logical conclusion is that bogus formats are nulled out. */
     pso_desc.RTVFormats[0] = DXGI_FORMAT_BC6H_UF16;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(pso);
 
@@ -5387,14 +5387,14 @@ void test_render_target_support_validation(void)
     pso_desc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
     pso_desc.DSVFormat = DXGI_FORMAT_BC7_UNORM;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(pso);
 
     /* No errors are created. Only logical conclusion is that bogus formats are nulled out. */
     pso_desc.RTVFormats[0] = DXGI_FORMAT_R32_TYPELESS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(pso);
 

--- a/tests/d3d12_pso_blob.c
+++ b/tests/d3d12_pso_blob.c
@@ -65,11 +65,11 @@ void test_get_cached_blob(void)
 
     memset(&root_signature_desc, 0, sizeof(root_signature_desc));
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
     hr = create_root_signature(device, &root_signature_desc, &root_signature_alt);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&compute_desc, 0, sizeof(compute_desc));
     compute_desc.pRootSignature = root_signature;
@@ -78,10 +78,10 @@ void test_get_cached_blob(void)
 
     hr = ID3D12Device_CreateComputePipelineState(device,
             &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", (int)hr);
 
     hr = ID3D12PipelineState_GetCachedBlob(state, &blob);
-    ok(hr == S_OK, "Failed to get cached blob, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get cached blob, hr %#x.\n", (int)hr);
     ok(ID3D10Blob_GetBufferSize(blob) > 0, "Cached blob is empty.\n");
 
     ID3D12PipelineState_Release(state);
@@ -91,7 +91,7 @@ void test_get_cached_blob(void)
 
     hr = ID3D12Device_CreateComputePipelineState(device,
             &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", (int)hr);
 
     ID3D12PipelineState_Release(state);
 
@@ -100,7 +100,7 @@ void test_get_cached_blob(void)
     compute_desc.CS.BytecodeLength = sizeof(cs_dxbc_2);
     hr = ID3D12Device_CreateComputePipelineState(device,
             &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", (int)hr);
 
     /* Using mismatched root signature must fail. */
     compute_desc.CS.pShaderBytecode = cs_dxbc;
@@ -108,7 +108,7 @@ void test_get_cached_blob(void)
     compute_desc.pRootSignature = root_signature_alt;
     hr = ID3D12Device_CreateComputePipelineState(device,
             &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", (int)hr);
 
     ID3D12RootSignature_Release(root_signature);
     ID3D12RootSignature_Release(root_signature_alt);
@@ -124,11 +124,11 @@ void test_pipeline_library(void)
     D3D12_ROOT_SIGNATURE_DESC root_signature_desc;
     ID3D12PipelineLibrary *pipeline_library;
     ID3D12RootSignature *root_signature;
+    unsigned int reference_refcount;
     struct test_context context;
     ID3D12PipelineState *state3;
     ID3D12PipelineState *state2;
     ID3D12PipelineState *state;
-    ULONG reference_refcount;
     size_t serialized_size;
     ID3D12Device1 *device1;
     void *serialized_data;
@@ -194,15 +194,15 @@ void test_pipeline_library(void)
 
     /* Test adding pipelines to an empty pipeline library */
     hr = ID3D12Device1_CreatePipelineLibrary(device1, NULL, 0, &IID_ID3D12PipelineLibrary, (void**)&pipeline_library);
-    ok(hr == S_OK, "Failed to create pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline library, hr %#x.\n", (int)hr);
 
     /* ppData == NULL means a query */
     hr = ID3D12Device1_CreatePipelineLibrary(device1, NULL, 0, NULL, NULL);
-    ok(hr == S_FALSE, "Failed to query pipeline library, hr %#x.\n", hr);
+    ok(hr == S_FALSE, "Failed to query pipeline library, hr %#x.\n", (int)hr);
 
     memset(&root_signature_desc, 0, sizeof(root_signature_desc));
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&compute_desc, 0, sizeof(compute_desc));
     compute_desc.pRootSignature = root_signature;
@@ -211,14 +211,14 @@ void test_pipeline_library(void)
 
     hr = ID3D12PipelineLibrary_LoadComputePipeline(pipeline_library,
             compute_name, &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateComputePipelineState(device,
             &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", (int)hr);
 
     hr = ID3D12PipelineLibrary_StorePipeline(pipeline_library, compute_name, state);
-    ok(hr == S_OK, "Failed to store compute pipeline, hr %x.\n", hr);
+    ok(hr == S_OK, "Failed to store compute pipeline, hr %x.\n", (int)hr);
 
     ID3D12PipelineState_Release(state);
 
@@ -239,24 +239,24 @@ void test_pipeline_library(void)
 
     hr = ID3D12PipelineLibrary_LoadGraphicsPipeline(pipeline_library,
             graphics_name, &graphics_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateGraphicsPipelineState(device,
             &graphics_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     hr = ID3D12PipelineLibrary_StorePipeline(pipeline_library, graphics_name, state);
-    ok(hr == S_OK, "Failed to store graphics pipeline, hr %x.\n", hr);
+    ok(hr == S_OK, "Failed to store graphics pipeline, hr %x.\n", (int)hr);
 
     /* Try to load PSO after a Store. Verify that we have a ref-count. */
     hr = ID3D12PipelineLibrary_LoadGraphicsPipeline(pipeline_library, graphics_name, &graphics_desc,
             &IID_ID3D12PipelineState, (void**)&state2);
-    ok(hr == S_OK, "Failed to load graphics pipeline, hr %x.\n", hr);
+    ok(hr == S_OK, "Failed to load graphics pipeline, hr %x.\n", (int)hr);
     ok(state == state2, "Resulting PSOs must point to same object.\n");
     ok(get_refcount(state2) == 2, "Refcount %u != 2.\n", get_refcount(state2));
 
     hr = ID3D12PipelineLibrary_StorePipeline(pipeline_library, compute_name, state);
-    ok(hr == E_INVALIDARG, "Storing pipeline with already existing name succeeded, hr %x.\n", hr);
+    ok(hr == E_INVALIDARG, "Storing pipeline with already existing name succeeded, hr %x.\n", (int)hr);
 
     ID3D12PipelineState_Release(state);
     ID3D12PipelineState_Release(state2);
@@ -264,19 +264,19 @@ void test_pipeline_library(void)
     /* Test looking up pipelines in a new pipeline library */
     hr = ID3D12PipelineLibrary_LoadComputePipeline(pipeline_library,
             compute_name, &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(state);
 
     hr = ID3D12PipelineLibrary_LoadGraphicsPipeline(pipeline_library,
             graphics_name, &graphics_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(state);
 
     /* Verify that modifying a PSO description must be invalidated by runtime. */
     graphics_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE;
     hr = ID3D12PipelineLibrary_LoadGraphicsPipeline(pipeline_library,
             graphics_name, &graphics_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected result, hr %#x.\n", (int)hr);
     graphics_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
 
     serialized_size = ID3D12PipelineLibrary_GetSerializedSize(pipeline_library);
@@ -284,28 +284,28 @@ void test_pipeline_library(void)
 
     serialized_data = malloc(serialized_size);
     hr = ID3D12PipelineLibrary_Serialize(pipeline_library, serialized_data, serialized_size - 1);
-    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12PipelineLibrary_Serialize(pipeline_library, serialized_data, serialized_size);
-    ok(hr == S_OK, "Failed to serialize pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to serialize pipeline library, hr %#x.\n", (int)hr);
 
     ID3D12PipelineLibrary_Release(pipeline_library);
 
     /* Test deserializing a pipeline library */
     hr = ID3D12Device1_CreatePipelineLibrary(device1, serialized_data,
             serialized_size, &IID_ID3D12PipelineLibrary, (void**)&pipeline_library);
-    ok(hr == S_OK, "Failed to create pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline library, hr %#x.\n", (int)hr);
 
     /* Verify that PSO library must internally ref-count a unique PSO. */
     hr = ID3D12PipelineLibrary_LoadGraphicsPipeline(pipeline_library,
             graphics_name, &graphics_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", (int)hr);
     hr = ID3D12PipelineLibrary_LoadGraphicsPipeline(pipeline_library,
             graphics_name, &graphics_desc, &IID_ID3D12PipelineState, (void**)&state2);
-    ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", (int)hr);
     hr = ID3D12PipelineLibrary_LoadGraphicsPipeline(pipeline_library,
             graphics_name, &graphics_desc, &IID_ID3D12PipelineState, (void**)&state3);
-    ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to load graphics pipeline from pipeline library, hr %#x.\n", (int)hr);
 
     ok(state == state2 && state == state3, "Resulting PSOs must point to same object.\n");
     ok(get_refcount(state) == 3, "Refcount %u != 3.\n", get_refcount(state));
@@ -320,13 +320,13 @@ void test_pipeline_library(void)
     /* Verify that PSO library must internally ref-count a unique PSO. */
     hr = ID3D12PipelineLibrary_LoadComputePipeline(pipeline_library,
             compute_name, &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", (int)hr);
     hr = ID3D12PipelineLibrary_LoadComputePipeline(pipeline_library,
             compute_name, &compute_desc, &IID_ID3D12PipelineState, (void**)&state2);
-    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", (int)hr);
     hr = ID3D12PipelineLibrary_LoadComputePipeline(pipeline_library,
             compute_name, &compute_desc, &IID_ID3D12PipelineState, (void**)&state3);
-    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", (int)hr);
 
     ok(get_refcount(context.device) == reference_refcount + 1, "Refcount %u != %u\n", get_refcount(context.device), reference_refcount + 1);
     ID3D12Device_CreateFence(context.device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void**)&fence);
@@ -342,24 +342,27 @@ void test_pipeline_library(void)
     ID3D12PipelineState_Release(state);
     ID3D12PipelineState_Release(state2);
     ok(get_refcount(fence) == 2, "Refcount %u != 2.\n", get_refcount(fence));
-    ok(get_refcount(context.device) == reference_refcount + 2, "Refcount %u != %u\n", get_refcount(context.device), reference_refcount + 2);
+    ok(get_refcount(context.device) == reference_refcount + 2, "Refcount %u != %u\n",
+            get_refcount(context.device), reference_refcount + 2);
     ok(ID3D12PipelineState_Release(state3) == 0, "Refcount did not hit 0.\n");
     /* Releasing the last public reference does not release private data. */
     ok(get_refcount(fence) == 2, "Refcount %u != 2.\n", get_refcount(fence));
     /* Device ref count does release however ... */
-    ok(get_refcount(context.device) == reference_refcount + 1, "Refcount %u != %u\n", get_refcount(context.device), reference_refcount + 1);
+    ok(get_refcount(context.device) == reference_refcount + 1, "Refcount %u != %u\n",
+            get_refcount(context.device), reference_refcount + 1);
 
     hr = ID3D12PipelineLibrary_LoadComputePipeline(pipeline_library,
         compute_name, &compute_desc, &IID_ID3D12PipelineState, (void**)&state2);
     /* Device ref count increases here again. */
-    ok(get_refcount(context.device) == reference_refcount + 2, "Refcount %u != %u\n", get_refcount(context.device), reference_refcount + 2);
-    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", hr);
+    ok(get_refcount(context.device) == reference_refcount + 2, "Refcount %u != %u\n",
+            get_refcount(context.device), reference_refcount + 2);
+    ok(hr == S_OK, "Failed to load compute pipeline from pipeline library, hr %#x.\n", (int)hr);
     ok(state == state2, "Reloading dead PSO must point to same object.\n");
     ID3D12PipelineState_Release(state2);
 
     hr = ID3D12PipelineLibrary_LoadComputePipeline(pipeline_library,
             graphics_name, &compute_desc, &IID_ID3D12PipelineState, (void**)&state);
-    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", (int)hr);
 
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(state);

--- a/tests/d3d12_query.c
+++ b/tests/d3d12_query.c
@@ -27,7 +27,7 @@ void test_create_query_heap(void)
     ID3D12Device *device;
     D3D12_QUERY_HEAP_DESC heap_desc;
     ID3D12QueryHeap *query_heap;
-    ULONG refcount;
+    unsigned int refcount;
     unsigned int i;
     HRESULT hr;
 
@@ -51,7 +51,7 @@ void test_create_query_heap(void)
         heap_desc.NodeMask = 0;
 
         hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
-        ok(hr == S_OK, "Failed to create query heap, type %u, hr %#x.\n", types[i], hr);
+        ok(hr == S_OK, "Failed to create query heap, type %u, hr %#x.\n", types[i], (int)hr);
 
         ID3D12QueryHeap_Release(query_heap);
     }
@@ -63,7 +63,7 @@ void test_create_query_heap(void)
     hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
     if (hr != E_NOTIMPL)
     {
-        ok(hr == S_OK, "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, hr);
+        ok(hr == S_OK, "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, (int)hr);
         ID3D12QueryHeap_Release(query_heap);
     }
     else
@@ -72,7 +72,7 @@ void test_create_query_heap(void)
     }
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_query_timestamp_write_after_read(void)
@@ -162,13 +162,13 @@ void test_query_timestamp(void)
     queue = context.queue;
 
     hr = ID3D12CommandQueue_GetTimestampFrequency(queue, &timestamp_frequency);
-    ok(SUCCEEDED(hr), "Failed to get timestamp frequency, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to get timestamp frequency, hr %#x.\n", (int)hr);
 
     heap_desc.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
     heap_desc.Count = ARRAY_SIZE(timestamps);
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
-    ok(SUCCEEDED(hr), "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, hr);
+    ok(SUCCEEDED(hr), "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, (int)hr);
 
     resource = create_readback_buffer(device, sizeof(timestamps));
 
@@ -230,7 +230,7 @@ void test_query_pipeline_statistics(void)
     heap_desc.Count = 2;
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
-    ok(SUCCEEDED(hr), "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, hr);
+    ok(SUCCEEDED(hr), "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, (int)hr);
 
     resource = create_readback_buffer(device, 2 * sizeof(struct D3D12_QUERY_DATA_PIPELINE_STATISTICS));
 
@@ -380,13 +380,13 @@ void test_query_occlusion(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     heap_desc.Type = D3D12_QUERY_HEAP_TYPE_OCCLUSION;
     heap_desc.Count = ARRAY_SIZE(tests);
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
-    ok(SUCCEEDED(hr), "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, hr);
+    ok(SUCCEEDED(hr), "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, (int)hr);
 
     resource = create_readback_buffer(device, ARRAY_SIZE(tests) * sizeof(uint64_t));
 
@@ -467,7 +467,7 @@ void test_resolve_non_issued_query_data(void)
     heap_desc.Count = ARRAY_SIZE(initial_data);
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
-    ok(SUCCEEDED(hr), "Failed to create query heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create query heap, hr %#x.\n", (int)hr);
 
     readback_buffer = create_readback_buffer(device, sizeof(initial_data));
     upload_buffer = create_upload_buffer(context.device, sizeof(initial_data), initial_data);
@@ -520,7 +520,7 @@ void test_resolve_query_data_in_different_command_list(void)
     heap_desc.Count = 1;
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
-    ok(SUCCEEDED(hr), "Failed to create query heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create query heap, hr %#x.\n", (int)hr);
 
     readback_buffer = create_readback_buffer(device, readback_buffer_capacity * sizeof(uint64_t));
 
@@ -548,7 +548,7 @@ void test_resolve_query_data_in_different_command_list(void)
                 query_heap, D3D12_QUERY_TYPE_OCCLUSION, 0, 1, readback_buffer, i * sizeof(uint64_t));
     }
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
     exec_command_list(queue, command_list);
     wait_queue_idle(context.device, queue);
 
@@ -596,16 +596,16 @@ void test_resolve_query_data_in_reordered_command_list(void)
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&command_allocator);
-    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             command_allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&command_lists[1]);
-    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
 
     heap_desc.Type = D3D12_QUERY_HEAP_TYPE_OCCLUSION;
     heap_desc.Count = 1;
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heap);
-    ok(SUCCEEDED(hr), "Failed to create query heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create query heap, hr %#x.\n", (int)hr);
 
     readback_buffer = create_readback_buffer(device, sizeof(uint64_t));
 
@@ -613,7 +613,7 @@ void test_resolve_query_data_in_reordered_command_list(void)
     ID3D12GraphicsCommandList_ResolveQueryData(command_lists[1],
             query_heap, D3D12_QUERY_TYPE_OCCLUSION, 0, 1, readback_buffer, 0);
     hr = ID3D12GraphicsCommandList_Close(command_lists[1]);
-    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
     /* Produce query results in the first command list. */
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_lists[0], 1, &context.rtv, false, NULL);
@@ -626,7 +626,7 @@ void test_resolve_query_data_in_reordered_command_list(void)
     ID3D12GraphicsCommandList_DrawInstanced(command_lists[0], 3, 1, 0, 0);
     ID3D12GraphicsCommandList_EndQuery(command_lists[0], query_heap, D3D12_QUERY_TYPE_OCCLUSION, 0);
     hr = ID3D12GraphicsCommandList_Close(command_lists[0]);
-    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
     ID3D12CommandQueue_ExecuteCommandLists(queue,
             ARRAY_SIZE(command_lists), (ID3D12CommandList **)command_lists);
@@ -707,7 +707,7 @@ void test_virtual_queries(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     heap_desc.Type = D3D12_QUERY_HEAP_TYPE_OCCLUSION;
     heap_desc.Count = ARRAY_SIZE(expected_results) / 2;
@@ -715,7 +715,7 @@ void test_virtual_queries(void)
     for (i = 0; i < ARRAY_SIZE(query_heaps); i++)
     {
         hr = ID3D12Device_CreateQueryHeap(device, &heap_desc, &IID_ID3D12QueryHeap, (void **)&query_heaps[i]);
-        ok(SUCCEEDED(hr), "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, hr);
+        ok(SUCCEEDED(hr), "Failed to create query heap, type %u, hr %#x.\n", heap_desc.Type, (int)hr);
     }
 
     resource = create_readback_buffer(device, ARRAY_SIZE(expected_results) * sizeof(uint64_t));

--- a/tests/d3d12_raytracing.c
+++ b/tests/d3d12_raytracing.c
@@ -1115,7 +1115,7 @@ static ID3D12StateObject *rt_pso_add_to_state_object(ID3D12Device5 *device, ID3D
 
     /* Have to add ALLOW_STATE_OBJECT_ADDITIONS for both parent and addition. */
     hr = ID3D12Device7_AddToStateObject(device7, &desc, parent, &IID_ID3D12StateObject, (void**)&new_state_object);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
 
     config.Flags = D3D12_STATE_OBJECT_FLAG_ALLOW_STATE_OBJECT_ADDITIONS;
     subobj[desc.NumSubobjects].Type = D3D12_STATE_SUBOBJECT_TYPE_STATE_OBJECT_CONFIG;
@@ -1125,11 +1125,11 @@ static ID3D12StateObject *rt_pso_add_to_state_object(ID3D12Device5 *device, ID3D
     /* Type must be RAYTRACING_PIPELINE. */
     desc.Type = D3D12_STATE_OBJECT_TYPE_COLLECTION;
     hr = ID3D12Device7_AddToStateObject(device7, &desc, parent, &IID_ID3D12StateObject, (void**)&new_state_object);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
     desc.Type = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE;
 
     hr = ID3D12Device7_AddToStateObject(device7, &desc, parent, &IID_ID3D12StateObject, (void**)&new_state_object);
-    ok(SUCCEEDED(hr), "Failed to AddToStateObject, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to AddToStateObject, hr #%x.\n", (int)hr);
     if (FAILED(hr))
         new_state_object = NULL;
     ID3D12Device7_Release(device7);
@@ -1307,7 +1307,7 @@ static void test_raytracing_pipeline(enum rt_test_mode mode, D3D12_RAYTRACING_TI
         root_parameters[1].Constants.ShaderRegister = 0;
 
         hr = create_root_signature(device, &root_signature_desc, &global_rs);
-        ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
     }
 
     /* Create local root signature. This defines how the data in the SBT for each individual shader is laid out. */
@@ -1338,7 +1338,7 @@ static void test_raytracing_pipeline(enum rt_test_mode mode, D3D12_RAYTRACING_TI
         root_parameters[1].Constants.ShaderRegister = 1;
 
         hr = create_root_signature(device, &root_signature_desc, &local_rs);
-        ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
         root_parameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
         root_parameters[0].DescriptorTable.pDescriptorRanges = &table_range;
@@ -1354,7 +1354,7 @@ static void test_raytracing_pipeline(enum rt_test_mode mode, D3D12_RAYTRACING_TI
         root_parameters[1].Descriptor.ShaderRegister = 1;
 
         hr = create_root_signature(device, &root_signature_desc, &local_rs_table);
-        ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
     }
 
     /* Create RT collection (triangles). */
@@ -2163,7 +2163,7 @@ static void test_rayquery_pipeline(enum rt_test_mode mode, bool root_table)
     root_parameters[3].Constants.ShaderRegister = 0;
 
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
     pso = create_compute_pipeline_state(device, root_signature, get_rayquery_shader());
 
     init_test_geometry(device, &test_geom);
@@ -3181,7 +3181,7 @@ void test_raytracing_collection_identifiers(void)
     ok(!!object, "Failed to create collection.\n");
 
     hr = ID3D12StateObject_QueryInterface(object, &IID_ID3D12StateObjectProperties, (void **)&props);
-    ok(SUCCEEDED(hr), "Failed to query props interface, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query props interface, hr #%x.\n", (int)hr);
     ident = ID3D12StateObjectProperties_GetShaderIdentifier(props, u"main");
     ok(!!ident, "Failed to query identifier for COLLECTION.\n");
     if (ident)
@@ -3388,7 +3388,7 @@ void test_raytracing_root_signature_from_subobject(void)
     /* Unambiguous case. */
     lib = get_embedded_root_signature_subobject_rt_lib();
     hr = ID3D12Device5_CreateRootSignature(context.device5, 0, lib.pShaderBytecode, lib.BytecodeLength, &IID_ID3D12RootSignature, (void **)&rs);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
     if (SUCCEEDED(hr))
     {
@@ -3397,7 +3397,7 @@ void test_raytracing_root_signature_from_subobject(void)
         cs_desc.CS.BytecodeLength = sizeof(cs_code_dxil);
         cs_desc.pRootSignature = rs;
         hr = ID3D12Device5_CreateComputePipelineState(context.device5, &cs_desc, &IID_ID3D12PipelineState, (void **)&cs);
-        ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x.\n", (int)hr);
         if (SUCCEEDED(hr))
             ID3D12PipelineState_Release(cs);
         ID3D12RootSignature_Release(rs);
@@ -3406,7 +3406,7 @@ void test_raytracing_root_signature_from_subobject(void)
     /* Two global root signatures are declared in the lib. This results in failure. */
     lib = get_embedded_root_signature_subobject_rt_lib_conflict();
     hr = ID3D12Device5_CreateRootSignature(context.device5, 0, lib.pShaderBytecode, lib.BytecodeLength, &IID_ID3D12RootSignature, (void **)&rs);
-    ok(hr == E_INVALIDARG, "Unexpected return value in creating root signature, hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected return value in creating root signature, hr #%x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12RootSignature_Release(rs);
 
@@ -3421,7 +3421,7 @@ void test_raytracing_root_signature_from_subobject(void)
         cs_desc.CS.BytecodeLength = sizeof(cs_code_dxil);
         cs_desc.pRootSignature = rs;
         hr = ID3D12Device5_CreateComputePipelineState(context.device5, &cs_desc, &IID_ID3D12PipelineState, (void **)&cs);
-        ok(hr == E_INVALIDARG, "Unexpected success in creating pipeline state, hr #%x.\n", hr);
+        ok(hr == E_INVALIDARG, "Unexpected success in creating pipeline state, hr #%x.\n", (int)hr);
         if (SUCCEEDED(hr))
             ID3D12PipelineState_Release(cs);
         ID3D12RootSignature_Release(rs);
@@ -4741,7 +4741,7 @@ void test_raytracing_acceleration_structure_validation(void)
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &desc, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE, NULL, &IID_ID3D12Resource, (void**)&rtas);
-    ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", hr);
+    ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
 
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(rtas);
@@ -4750,7 +4750,7 @@ void test_raytracing_acceleration_structure_validation(void)
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &desc, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE, NULL, &IID_ID3D12Resource, (void**)&rtas);
-    ok(hr == S_OK, "Failed to create RTAS, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create RTAS, hr %#x.\n", (int)hr);
 
     desc = ID3D12Resource_GetDesc(rtas);
     ok(!(desc.Flags & D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE),
@@ -4772,7 +4772,7 @@ void test_raytracing_acceleration_structure_validation(void)
 
         hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_properties, D3D12_HEAP_FLAG_NONE, &desc1,
                 D3D12_BARRIER_LAYOUT_UNDEFINED, NULL, NULL, 0, NULL, &IID_ID3D12Resource, (void**)&rtas);
-        ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", hr);
+        ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
 
         desc1.Flags = D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE;
 
@@ -4782,7 +4782,7 @@ void test_raytracing_acceleration_structure_validation(void)
         desc1.Flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
         hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_properties, D3D12_HEAP_FLAG_NONE, &desc1,
                 D3D12_BARRIER_LAYOUT_UNDEFINED, NULL, NULL, 0, NULL, &IID_ID3D12Resource, (void**)&rtas);
-        ok(hr == S_OK, "Failed to create RTAS, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create RTAS, hr %#x.\n", (int)hr);
 
         desc = ID3D12Resource_GetDesc(rtas);
         ok(desc.Flags & D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE,

--- a/tests/d3d12_render_target.c
+++ b/tests/d3d12_render_target.c
@@ -59,7 +59,7 @@ void test_srgb_unorm_mismatch_usage_aliasing(void)
             &srgb_unorm_mismatch_vs_dxbc, &srgb_unorm_mismatch_ps_dxbc, NULL);
     pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x\n", (int)hr);
 
     /* Triages an AC: Shadows bug where these resources are aliased on top of a heap and game expects this to "just werk". */
 
@@ -85,12 +85,12 @@ void test_srgb_unorm_mismatch_usage_aliasing(void)
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;
     heap_desc.SizeInBytes = 64 * 1024 + max(unorm_alloc_info.SizeInBytes, srgb_alloc_info.SizeInBytes);
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x\n", (int)hr);
 
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     resource_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     hr = ID3D12Device_CreatePlacedResource(context.device, heap, 64 * 1024, &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE, NULL, &IID_ID3D12Resource, (void **)&unorm);
-    ok(SUCCEEDED(hr), "Failed to create placed resource, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create placed resource, hr #%x\n", (int)hr);
 
     /* AC: Shadows does not add this UAV flag, but D3D12 has requirements about aliasing if all things match,
      * and we should be using VK_IMAGE_CREATE_ALIAS_BIT for all placed resoures, which makes this test pass on RDNA4.
@@ -98,7 +98,7 @@ void test_srgb_unorm_mismatch_usage_aliasing(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     resource_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
     hr = ID3D12Device_CreatePlacedResource(context.device, heap, 64 * 1024, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&srgb);
-    ok(SUCCEEDED(hr), "Failed to create placed resource, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create placed resource, hr #%x\n", (int)hr);
 
     context.rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);
     context.rtv = get_cpu_rtv_handle(&context, context.rtv_heap, 0);
@@ -189,7 +189,7 @@ void test_unbound_rtv_rendering(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, rt_handle, white, 0, NULL);
@@ -259,7 +259,7 @@ void test_unknown_rtv_format(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     rtvs[0] = get_cpu_rtv_handle(&context, context.rtv_heap, 0);
     rtvs[1] = get_cpu_rtv_handle(&context, context.rtv_heap, 1);
@@ -355,7 +355,7 @@ void test_unknown_dsv_format(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_EQUAL;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList_ClearDepthStencilView(command_list, ds.dsv_handle,
@@ -426,7 +426,7 @@ void test_unknown_dsv_format(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     reset_command_list(command_list, context.allocator);
     transition_resource_state(command_list, context.render_target,
@@ -460,7 +460,7 @@ void test_unknown_dsv_format(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     reset_command_list(command_list, context.allocator);
     transition_resource_state(command_list, context.render_target,
@@ -538,7 +538,7 @@ void test_depth_stencil_test_no_dsv(void)
     pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList_ClearDepthStencilView(command_list, ds.dsv_handle, D3D12_CLEAR_FLAG_DEPTH,
@@ -654,7 +654,7 @@ void test_render_a8_dxil(void)
 
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, black, 0, NULL);
 
@@ -717,13 +717,13 @@ void test_multisample_rendering(void)
             context.render_target_desc.Format, NULL, &ps_multisample_resolve_dxbc, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     pso_desc.PS = ps_multisample_color_dxbc;
     pso_desc.SampleDesc.Count = 4;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&ms_pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ms_rtv = get_cpu_rtv_handle(&context, context.rtv_heap, 1);
     desc.sample_desc.Count = 4;
@@ -815,7 +815,7 @@ void test_multisample_rendering(void)
     vkd3d_set_out_of_spec_test_behavior(VKD3D_DEBUG_CONTROL_OUT_OF_SPEC_BEHAVIOR_SAMPLE_COUNT_MISMATCH, TRUE);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&ms_pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
     vkd3d_set_out_of_spec_test_behavior(VKD3D_DEBUG_CONTROL_OUT_OF_SPEC_BEHAVIOR_SAMPLE_COUNT_MISMATCH, FALSE);
 
     reset_command_list(command_list, context.allocator);
@@ -859,7 +859,7 @@ void test_multisample_rendering(void)
                 D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE);
 
         hr = ID3D12GraphicsCommandList_Close(command_list);
-        ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
 
         exec_command_list(queue, command_list);
         wait_queue_idle(context.device, queue);
@@ -925,7 +925,7 @@ void test_rendering_no_attachments_layers(void)
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_OMSetRenderTargets(context.list, 0, NULL, FALSE, NULL);
 
@@ -992,7 +992,7 @@ void test_renderpass_validation(void)
     }
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT, &IID_ID3D12CommandAllocator, (void**)&allocator);
-    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
         allocator, NULL, &IID_ID3D12GraphicsCommandList4, (void**)&command_list4);
@@ -1024,33 +1024,33 @@ void test_renderpass_validation(void)
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, 0, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&rt[0]);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, 0, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&rt[1]);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.Width = 16;
     resource_desc.Height = 16;
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, 0, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&rt[2]);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.SampleDesc.Count = 4;
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, 0, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&rt[3]);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.Format = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
     resource_desc.SampleDesc.Count = 1;
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, 0, &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE, NULL, &IID_ID3D12Resource, (void**)&ds);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(rt); i++)
         ID3D12Device_CreateRenderTargetView(device, rt[i], NULL, get_cpu_handle(device, rtv_heap, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, i));
@@ -1059,7 +1059,7 @@ void test_renderpass_validation(void)
     ID3D12GraphicsCommandList4_BeginRenderPass(command_list4, 0, NULL, NULL, 0);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    ok(SUCCEEDED(hr), "Got hr %#x, expected S_OK.\n", hr);
+    ok(SUCCEEDED(hr), "Got hr %#x, expected S_OK.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     /* Test that binding a simple RTV works */
@@ -1079,7 +1079,7 @@ void test_renderpass_validation(void)
     ID3D12GraphicsCommandList4_BeginRenderPass(command_list4, 1, rtv_infos, NULL, 0);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    ok(SUCCEEDED(hr), "Got hr %#x, expected S_OK.\n", hr);
+    ok(SUCCEEDED(hr), "Got hr %#x, expected S_OK.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     /* Test that not matching BeginRenderPass and EndRenderPass fails */
@@ -1088,7 +1088,7 @@ void test_renderpass_validation(void)
         allocator, NULL, &IID_ID3D12GraphicsCommandList4, (void**)&command_list4);
     ID3D12GraphicsCommandList4_BeginRenderPass(command_list4, 1, rtv_infos, NULL, 0);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    ok(FAILED(hr), "Got hr %#x, expected E_FAIL.\n", hr);
+    ok(FAILED(hr), "Got hr %#x, expected E_FAIL.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     ID3D12CommandAllocator_Reset(allocator);
@@ -1096,7 +1096,7 @@ void test_renderpass_validation(void)
         allocator, NULL, &IID_ID3D12GraphicsCommandList4, (void**)&command_list4);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", hr);
+    ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     ID3D12CommandAllocator_Reset(allocator);
@@ -1106,7 +1106,7 @@ void test_renderpass_validation(void)
     ID3D12GraphicsCommandList4_BeginRenderPass(command_list4, 1, rtv_infos, NULL, 0);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", hr);
+    ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     ID3D12CommandAllocator_Reset(allocator);
@@ -1116,7 +1116,7 @@ void test_renderpass_validation(void)
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", hr);
+    ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     /* Test consecutive render pass validation with suspend/resume flags */
@@ -1136,7 +1136,7 @@ void test_renderpass_validation(void)
     ID3D12GraphicsCommandList4_BeginRenderPass(command_list4, 2, rtv_infos, NULL, D3D12_RENDER_PASS_FLAG_RESUMING_PASS);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    ok(SUCCEEDED(hr), "Got hr %#x, expected S_OK.\n", hr);
+    ok(SUCCEEDED(hr), "Got hr %#x, expected S_OK.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     ID3D12CommandAllocator_Reset(allocator);
@@ -1148,7 +1148,7 @@ void test_renderpass_validation(void)
     ID3D12GraphicsCommandList4_BeginRenderPass(command_list4, 2, rtv_infos, NULL, D3D12_RENDER_PASS_FLAG_RESUMING_PASS);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    todo ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", hr);
+    todo ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     ID3D12CommandAllocator_Reset(allocator);
@@ -1160,7 +1160,7 @@ void test_renderpass_validation(void)
     ID3D12GraphicsCommandList4_BeginRenderPass(command_list4, 2, rtv_infos, NULL, D3D12_RENDER_PASS_FLAG_SUSPENDING_PASS);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    todo ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", hr);
+    todo ok(FAILED(hr), "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     /* Test that executing certain commands during a render pass fails */
@@ -1171,7 +1171,7 @@ void test_renderpass_validation(void)
     ID3D12GraphicsCommandList4_ClearRenderTargetView(command_list4, get_cpu_handle(device, rtv_heap, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 0), black, 0, NULL);
     ID3D12GraphicsCommandList4_EndRenderPass(command_list4);
     hr = ID3D12GraphicsCommandList4_Close(command_list4);
-    ok(FAILED(hr), "Got hr %#x, expected E_FAIL.\n", hr);
+    ok(FAILED(hr), "Got hr %#x, expected E_FAIL.\n", (int)hr);
     ID3D12GraphicsCommandList4_Release(command_list4);
 
     /* Barriers inside render passes, GPU work occuring between render passes with
@@ -1276,7 +1276,7 @@ void test_renderpass_rendering(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
             NULL, &IID_ID3D12Resource, (void**)&rt);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.Alignment = D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT;
     resource_desc.SampleDesc.Count = 4;
@@ -1284,7 +1284,7 @@ void test_renderpass_rendering(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
             NULL, &IID_ID3D12Resource, (void**)&rt_ms);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     resource_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
     resource_desc.DepthOrArraySize = 1;
@@ -1295,7 +1295,7 @@ void test_renderpass_rendering(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE,
             NULL, &IID_ID3D12Resource, (void**)&ds);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 8);
     dsv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, 1);
@@ -1345,13 +1345,13 @@ void test_renderpass_rendering(void)
     pso_desc.DepthStencilState.BackFace = pso_desc.DepthStencilState.FrontFace;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     pso_desc.SampleDesc.Count = 4;
     pso_desc.SampleMask = 0xf;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pso_ms);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     memset(&rtv_desc, 0, sizeof(rtv_desc));
     rtv_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -1900,7 +1900,7 @@ void test_renderpass_resolve_suspend_resume(void)
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     memset(&resource_desc, 0, sizeof(resource_desc));
     resource_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -2073,7 +2073,7 @@ void test_renderpass_resolve_suspend_resume(void)
         if (test->inter_suspend_resume)
         {
             hr = ID3D12GraphicsCommandList4_Close(list4);
-            ok(SUCCEEDED(hr), "Failed to close command list, hr #%x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to close command list, hr #%x.\n", (int)hr);
             ID3D12GraphicsCommandList4_Reset(altlist, context.allocator, NULL);
 
             ID3D12GraphicsCommandList4_BeginRenderPass(altlist, 2, rt_descs, &dsv_desc,
@@ -2092,7 +2092,7 @@ void test_renderpass_resolve_suspend_resume(void)
             }
 
             hr = ID3D12GraphicsCommandList4_Close(altlist);
-            ok(SUCCEEDED(hr), "Failed to close command list, hr #%x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to close command list, hr #%x.\n", (int)hr);
             {
                 ID3D12CommandList *lists[] = {(ID3D12CommandList *) list4, (ID3D12CommandList *) altlist};
                 ID3D12CommandQueue_ExecuteCommandLists(context.queue, 2, lists);
@@ -2170,7 +2170,7 @@ void test_scissor_clamping(void)
     init_pipeline_state_desc(&pso_desc, context.root_signature, DXGI_FORMAT_R8G8B8A8_UNORM, &vs_flat_color_dxbc, &ps_flat_color_dxbc, NULL);
     pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 3);
     highres[0] = create_default_texture2d(context.device, 1920, 1080, 1, 1, DXGI_FORMAT_R8G8B8A8_UNORM,
@@ -2317,7 +2317,7 @@ void test_mismatching_rtv_dsv_size(void)
     memset(&rs_desc, 0, sizeof(rs_desc));
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc(&pso_desc, context.root_signature, 0, NULL, &ps_rt_mismatch_dxbc, NULL);
     pso_desc.DepthStencilState.DepthEnable = TRUE;
@@ -2329,7 +2329,7 @@ void test_mismatching_rtv_dsv_size(void)
     pso_desc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, ARRAY_SIZE(rt_ds_size));
     dsv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, ARRAY_SIZE(rt_ds_size));
@@ -2354,7 +2354,7 @@ void test_mismatching_rtv_dsv_size(void)
 
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&rt[i]);
-        ok(hr == S_OK, "Failed to create color image, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create color image, hr %#x.\n", (int)hr);
 
         memset(&rtv_desc, 0, sizeof(rtv_desc));
         rtv_desc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
@@ -2366,7 +2366,7 @@ void test_mismatching_rtv_dsv_size(void)
 
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE, NULL, &IID_ID3D12Resource, (void**)&ds[i]);
-        ok(hr == S_OK, "Failed to create depth image, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create depth image, hr %#x.\n", (int)hr);
 
         memset(&dsv_desc, 0, sizeof(dsv_desc));
         dsv_desc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
@@ -2560,7 +2560,7 @@ void test_rgb9e5_rendering(void)
     rtv_heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
 
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &rtv_heap_desc, &IID_ID3D12DescriptorHeap, (void**)&rtv_heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     rtv_descriptor = get_cpu_rtv_handle(&context, rtv_heap, 0);
 
@@ -2580,7 +2580,7 @@ void test_rgb9e5_rendering(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &rt_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&rt);
-    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create render target, hr %#x.\n", (int)hr);
 
     memset(&rtv_desc, 0, sizeof(rtv_desc));
     rtv_desc.Format = DXGI_FORMAT_R9G9B9E5_SHAREDEXP;
@@ -2596,7 +2596,7 @@ void test_rgb9e5_rendering(void)
     pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     memset(&vp, 0, sizeof(vp));
     vp.Width = 16.0f;
@@ -2648,7 +2648,7 @@ void test_rgb9e5_rendering(void)
     pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0x7u; /* no alpha */
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     transition_resource_state(context.list, rt, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -2683,7 +2683,7 @@ void test_rgb9e5_rendering(void)
     pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0x8u; /* only alpha */
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&pso);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     transition_resource_state(context.list, rt, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -2796,7 +2796,7 @@ void test_unused_attachments_mix_and_match(void)
         }
 
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&psos[i]);
-        ok(SUCCEEDED(hr), "Failed to create PSO %u, hr #%x.\n", i, hr);
+        ok(SUCCEEDED(hr), "Failed to create PSO %u, hr #%x.\n", i, (int)hr);
     }
 
     rtv = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 9);

--- a/tests/d3d12_resource.c
+++ b/tests/d3d12_resource.c
@@ -33,8 +33,8 @@ void test_create_committed_resource(void)
     D3D12_CLEAR_VALUE clear_value;
     D3D12_RESOURCE_STATES state;
     ID3D12Resource *resource;
+    unsigned int refcount;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     static const struct
@@ -87,16 +87,16 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12Resource_GetDevice(resource, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(hr == S_OK, "Failed to get device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(resource, &IID_ID3D12Object, true);
     check_interface(resource, &IID_ID3D12DeviceChild, true);
@@ -107,13 +107,13 @@ void test_create_committed_resource(void)
     ok(!gpu_address, "Got unexpected GPU virtual address %#"PRIx64".\n", gpu_address);
 
     refcount = ID3D12Resource_Release(resource);
-    ok(!refcount, "ID3D12Resource has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Resource has %u references left.\n", refcount);
 
     resource_desc.MipLevels = 0;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
     resource_desc = ID3D12Resource_GetDesc(resource);
     ok(resource_desc.MipLevels == 6, "Got unexpected miplevels %u.\n", resource_desc.MipLevels);
     ok(resource_desc.Alignment == D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,
@@ -125,7 +125,7 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
     resource_desc = ID3D12Resource_GetDesc(resource);
     ok(resource_desc.MipLevels == 10, "Got unexpected miplevels %u.\n", resource_desc.MipLevels);
     ok(resource_desc.Alignment == D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,
@@ -138,20 +138,20 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     resource_desc.SampleDesc.Count = 1;
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
             &clear_value, &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* For D3D12_RESOURCE_STATE_RENDER_TARGET the D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET flag is required. */
     resource_desc.Flags = 0;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -161,14 +161,14 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(!resource, "Got unexpected pointer %p.\n", resource);
 
     resource = (void *)(uintptr_t)0xdeadbeef;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ, NULL,
             &IID_ID3D12Device, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(!resource, "Got unexpected pointer %p.\n", resource);
 
     /* A texture *can* be created on a GPU UPLOAD heap. */
@@ -179,9 +179,9 @@ void test_create_committed_resource(void)
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,
             &IID_ID3D12Resource, (void **)&resource);
     if (is_gpu_upload_heap_supported)
-        ok(hr == S_OK, "Failed to create committed resource (rendertarget) on GPU upload heap, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create committed resource (rendertarget) on GPU upload heap, hr %#x.\n", (int)hr);
     else
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -192,9 +192,9 @@ void test_create_committed_resource(void)
         &resource_desc, D3D12_RESOURCE_STATE_DEPTH_READ, NULL,
         &IID_ID3D12Resource, (void**)&resource);
     if (is_gpu_upload_heap_supported)
-        todo ok(hr == S_OK, "Failed to create committed resource (depth texture) on GPU upload heap, hr %#x.\n", hr);
+        todo ok(hr == S_OK, "Failed to create committed resource (depth texture) on GPU upload heap, hr %#x.\n", (int)hr);
     else
-        todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        todo ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
     resource_desc.Flags = 0;
@@ -205,7 +205,7 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     heap_properties.Type = D3D12_HEAP_TYPE_DEFAULT;
     resource_desc.Format = DXGI_FORMAT_BC1_UNORM;
@@ -215,7 +215,7 @@ void test_create_committed_resource(void)
     resource_desc = ID3D12Resource_GetDesc(resource);
     ok(resource_desc.Alignment == D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,
             "Got aligment %"PRIu64", expected D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT.\n", resource_desc.Alignment);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
     ID3D12Resource_Release(resource);
 
     resource_desc.Alignment = 0;
@@ -224,7 +224,7 @@ void test_create_committed_resource(void)
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
     /* Unaligned mip 0 textures are allowed now on AgilitySDK 606. */
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -234,7 +234,7 @@ void test_create_committed_resource(void)
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
     /* Unaligned mip 0 textures are allowed now on AgilitySDK 606. */
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -244,7 +244,7 @@ void test_create_committed_resource(void)
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
     /* Unaligned mip 0 textures are allowed now on AgilitySDK 606. */
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -254,7 +254,7 @@ void test_create_committed_resource(void)
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
     /* Unaligned mip 0 textures are allowed now on AgilitySDK 606. */
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -264,7 +264,7 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* Texture that meets small alignment requirements */
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
@@ -282,7 +282,7 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     resource_desc = ID3D12Resource_GetDesc(resource);
     ok(resource_desc.Alignment == D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT,
             "Got aligment %"PRIu64", expected D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT.\n", resource_desc.Alignment);
@@ -294,7 +294,7 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* MSAA with large alignment */
     resource_desc.Alignment = 0;
@@ -306,7 +306,7 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     resource_desc = ID3D12Resource_GetDesc(resource);
     ok(resource_desc.Alignment == D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT,
             "Got aligment %"PRIu64", expected D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT.\n", resource_desc.Alignment);
@@ -332,7 +332,7 @@ void test_create_committed_resource(void)
     resource_desc = ID3D12Resource_GetDesc(resource);
     ok(resource_desc.Alignment == D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,
             "Got aligment %"PRIu64", expected D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT.\n", resource_desc.Alignment);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     check_interface(resource, &IID_ID3D12Object, true);
     check_interface(resource, &IID_ID3D12DeviceChild, true);
@@ -343,7 +343,7 @@ void test_create_committed_resource(void)
     ok(gpu_address, "Got unexpected GPU virtual address %#"PRIx64".\n", gpu_address);
 
     refcount = ID3D12Resource_Release(resource);
-    ok(!refcount, "ID3D12Resource has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Resource has %u references left.\n", refcount);
     resource_desc.Alignment = 0;
 
     heap_properties.Type = D3D12_HEAP_TYPE_GPU_UPLOAD;
@@ -352,7 +352,7 @@ void test_create_committed_resource(void)
             &IID_ID3D12Resource, (void **)&resource);
     if (is_gpu_upload_heap_supported)
     {
-        ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
         check_interface(resource, &IID_ID3D12Object, true);
         check_interface(resource, &IID_ID3D12DeviceChild, true);
@@ -363,30 +363,30 @@ void test_create_committed_resource(void)
         ok(gpu_address, "Got unexpected GPU virtual address %#"PRIx64".\n", gpu_address);
 
         refcount = ID3D12Resource_Release(resource);
-        ok(!refcount, "ID3D12Resource has %u references left.\n", (unsigned int)refcount);
+        ok(!refcount, "ID3D12Resource has %u references left.\n", refcount);
     }
     else
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     heap_properties.Type = D3D12_HEAP_TYPE_UPLOAD;
     resource_desc.MipLevels = 0;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Failed to create committed resource, hr %#x.\n", (int)hr);
     resource_desc.MipLevels = 1;
 
     /* The clear value must be NULL for buffers. */
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* For D3D12_HEAP_TYPE_UPLOAD the state must be D3D12_RESOURCE_STATE_GENERIC_READ. */
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     /* AgilitySDK 606 allows COMMON for UPLOAD heap now. */
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
@@ -394,7 +394,7 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     /* AgilitySDK 606 allows partial GENERIC_READ for UPLOAD heap now. */
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
@@ -404,21 +404,21 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == (is_gpu_upload_heap_supported ? S_OK : E_INVALIDARG), "Got unexpected hr %#x.\n", hr);
+    ok(hr == (is_gpu_upload_heap_supported ? S_OK : E_INVALIDARG), "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == (is_gpu_upload_heap_supported ? S_OK : E_INVALIDARG), "Got unexpected hr %#x.\n", hr);
+    ok(hr == (is_gpu_upload_heap_supported ? S_OK : E_INVALIDARG), "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
         &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL,
         &IID_ID3D12Resource, (void**)&resource);
-    ok(hr == (is_gpu_upload_heap_supported ? S_OK : E_INVALIDARG), "Got unexpected hr %#x.\n", hr);
+    ok(hr == (is_gpu_upload_heap_supported ? S_OK : E_INVALIDARG), "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -427,30 +427,30 @@ void test_create_committed_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     gpu_address = ID3D12Resource_GetGPUVirtualAddress(resource);
     ok(gpu_address, "Got unexpected GPU virtual address %#"PRIx64".\n", gpu_address);
 
     refcount = ID3D12Resource_Release(resource);
-    ok(!refcount, "ID3D12Resource has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Resource has %u references left.\n", refcount);
 
     /* For D3D12_HEAP_TYPE_READBACK the state must be D3D12_RESOURCE_STATE_COPY_DEST. */
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     /* AgilitySDK 606 allows COMMON for READBACK heap now. */
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(invalid_buffer_desc_tests); ++i)
     {
@@ -476,11 +476,11 @@ void test_create_committed_resource(void)
 
         hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, state, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == E_INVALIDARG, "Test %u: Got unexpected hr %#x.\n", i, hr);
+        ok(hr == E_INVALIDARG, "Test %u: Got unexpected hr %#x.\n", i, (int)hr);
     }
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_heap(void)
@@ -492,9 +492,9 @@ void test_create_heap(void)
     bool is_gpu_upload_heap_supported;
     bool is_pool_L1_supported;
     HRESULT hr, expected_hr;
+    unsigned int refcount;
     unsigned int i, j;
     ID3D12Heap *heap;
-    ULONG refcount;
 
     static const struct
     {
@@ -556,16 +556,16 @@ void test_create_heap(void)
     desc.Alignment = 0;
     desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(device, &desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12Heap_GetDevice(heap, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(hr == S_OK, "Failed to get device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(heap, &IID_ID3D12Object, true);
     check_interface(heap, &IID_ID3D12DeviceChild, true);
@@ -576,21 +576,21 @@ void test_create_heap(void)
     check_heap_desc(&result_desc, &desc);
 
     refcount = ID3D12Heap_Release(heap);
-    ok(!refcount, "ID3D12Heap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Heap has %u references left.\n", refcount);
 
     desc.SizeInBytes = 0;
     hr = ID3D12Device_CreateHeap(device, &desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     desc.SizeInBytes = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
     desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_ALLOW_DISPLAY;
     hr = ID3D12Device_CreateHeap(device, &desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     heap = (void *)(uintptr_t)0xdeadbeef;
     desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES | D3D12_HEAP_FLAG_ALLOW_DISPLAY;
     hr = ID3D12Device_CreateHeap(device, &desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(!heap, "Got unexpected pointer %p.\n", heap);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
@@ -604,7 +604,7 @@ void test_create_heap(void)
             desc.Flags = heap_flags[j].flags;
             hr = ID3D12Device_CreateHeap(device, &desc, &IID_ID3D12Heap, (void **)&heap);
             ok(hr == tests[i].expected_hr, "Test %u, %s: Got hr %#x, expected %#x.\n",
-                    i, heap_flags[j].name, hr, tests[i].expected_hr);
+                    i, heap_flags[j].name, (int)hr, (int)tests[i].expected_hr);
             if (FAILED(hr))
                 continue;
 
@@ -612,13 +612,13 @@ void test_create_heap(void)
             check_heap_desc(&result_desc, &desc);
 
             refcount = ID3D12Heap_Release(heap);
-            ok(!refcount, "ID3D12Heap has %u references left.\n", (unsigned int)refcount);
+            ok(!refcount, "ID3D12Heap has %u references left.\n", refcount);
         }
     }
     vkd3d_test_set_context(NULL);
 
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
     if (options.ResourceHeapTier < D3D12_RESOURCE_HEAP_TIER_2)
     {
         skip("Resource heap tier %u.\n", options.ResourceHeapTier);
@@ -629,15 +629,15 @@ void test_create_heap(void)
     desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
     desc.Flags = D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES;
     hr = ID3D12Device_CreateHeap(device, &desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     result_desc = ID3D12Heap_GetDesc(heap);
     check_heap_desc(&result_desc, &desc);
     refcount = ID3D12Heap_Release(heap);
-    ok(!refcount, "ID3D12Heap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Heap has %u references left.\n", refcount);
 
     memset(&architecture, 0, sizeof(architecture));
     hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ARCHITECTURE, &architecture, sizeof(architecture));
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     for (i = D3D12_HEAP_TYPE_DEFAULT; i <= D3D12_HEAP_TYPE_GPU_UPLOAD; ++i)
     {
         if (i == D3D12_HEAP_TYPE_CUSTOM || (i == D3D12_HEAP_TYPE_GPU_UPLOAD && !is_gpu_upload_heap_supported))
@@ -687,7 +687,7 @@ void test_create_heap(void)
         }
 
         hr = ID3D12Device_CreateHeap(device, &desc, &IID_ID3D12Heap, (void **)&heap);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         result_desc = ID3D12Heap_GetDesc(heap);
         check_heap_desc(&result_desc, &desc);
         ID3D12Heap_Release(heap);
@@ -712,7 +712,7 @@ void test_create_heap(void)
             expected_hr = E_INVALIDARG;
 
         ok(hr == expected_hr, "Test %u, page_property %u, pool_preference %u: Got hr %#x, expected %#x.\n",
-                i, custom_tests[i].page_property, custom_tests[i].pool_preference, hr, expected_hr);
+                i, custom_tests[i].page_property, custom_tests[i].pool_preference, (int)hr, (int)expected_hr);
         if (FAILED(hr))
             continue;
 
@@ -720,13 +720,13 @@ void test_create_heap(void)
         check_heap_desc(&result_desc, &desc);
 
         refcount = ID3D12Heap_Release(heap);
-        ok(!refcount, "ID3D12Heap has %u references left.\n", (unsigned int)refcount);
+        ok(!refcount, "ID3D12Heap has %u references left.\n", refcount);
     }
     vkd3d_test_set_context(NULL);
 
 done:
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_placed_resource_size(void)
@@ -775,21 +775,21 @@ void test_create_placed_resource_size(void)
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;
     heap_desc.SizeInBytes = mip_sizes[ARRAY_SIZE(mip_sizes) - 1];
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
 
     hr = ID3D12Device_CreatePlacedResource(device, heap, 0, &desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&resource);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     ID3D12Resource_Release(resource);
     ID3D12Heap_Release(heap);
 
     heap_desc.SizeInBytes = 64 * 1024;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
 
     /* Runtime validates range, this must fail. */
     hr = ID3D12Device_CreatePlacedResource(device, heap, 0, &desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Unexpected result, hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected result, hr #%x.\n", (int)hr);
 
     ID3D12Heap_Release(heap);
     ID3D12Device_Release(device);
@@ -805,9 +805,9 @@ void test_create_placed_resource(void)
     D3D12_RESOURCE_STATES state;
     D3D12_HEAP_DESC heap_desc;
     ID3D12Resource *resource;
+    unsigned int refcount;
     ID3D12Heap *heap;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     static const struct
@@ -840,7 +840,7 @@ void test_create_placed_resource(void)
     heap_desc.Alignment = 0;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
     resource_desc.Alignment = 0;
@@ -861,24 +861,24 @@ void test_create_placed_resource(void)
     clear_value.Color[3] = 1.0f;
 
     refcount = get_refcount(heap);
-    ok(refcount == 1, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 1, "Got unexpected refcount %u.\n", refcount);
 
     hr = ID3D12Device_CreatePlacedResource(device, heap, 0,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(heap);
-    ok(refcount == 1, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 1, "Got unexpected refcount %u.\n", refcount);
 
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12Resource_GetDevice(resource, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(hr == S_OK, "Failed to get device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 4, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 4, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(resource, &IID_ID3D12Object, true);
     check_interface(resource, &IID_ID3D12DeviceChild, true);
@@ -889,13 +889,13 @@ void test_create_placed_resource(void)
     ok(gpu_address, "Got unexpected GPU virtual address %#"PRIx64".\n", gpu_address);
 
     refcount = ID3D12Resource_Release(resource);
-    ok(!refcount, "ID3D12Resource has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Resource has %u references left.\n", refcount);
 
     /* The clear value must be NULL for buffers. */
     hr = ID3D12Device_CreatePlacedResource(device, heap, 0,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* Textures are disallowed on ALLOW_ONLY_HEAPS */
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
@@ -905,7 +905,7 @@ void test_create_placed_resource(void)
     hr = ID3D12Device_CreatePlacedResource(device, heap, 0,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     ID3D12Heap_Release(heap);
 
@@ -918,10 +918,10 @@ void test_create_placed_resource(void)
         heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
         hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
         if (heap_desc.Properties.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported)
-            ok(hr == S_OK, "Test %u: Failed to create heap, hr %#x.\n", i, hr);
+            ok(hr == S_OK, "Test %u: Failed to create heap, hr %#x.\n", i, (int)hr);
         else
         {
-            ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+            ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
             continue;
         }
 
@@ -944,13 +944,13 @@ void test_create_placed_resource(void)
 
         hr = ID3D12Device_CreatePlacedResource(device, heap, 0,
                 &resource_desc, state, &clear_value, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == E_INVALIDARG, "Test %u: Got unexpected hr %#x.\n", i, hr);
+        ok(hr == E_INVALIDARG, "Test %u: Got unexpected hr %#x.\n", i, (int)hr);
 
         ID3D12Heap_Release(heap);
     }
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_reserved_resource(void)
@@ -963,8 +963,8 @@ void test_create_reserved_resource(void)
     ID3D12Resource *resource;
     ID3D12Device10 *device10;
     bool standard_swizzle;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
     void *ptr;
 
@@ -998,7 +998,7 @@ void test_create_reserved_resource(void)
     hr = ID3D12Device_CreateReservedResource(device,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", (int)hr);
 
     check_interface(resource, &IID_ID3D12Object, true);
     check_interface(resource, &IID_ID3D12DeviceChild, true);
@@ -1010,15 +1010,15 @@ void test_create_reserved_resource(void)
 
     heap_flags = 0xdeadbeef;
     hr = ID3D12Resource_GetHeapProperties(resource, &heap_properties, &heap_flags);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(heap_flags == 0xdeadbeef, "Got unexpected heap flags %#x.\n", heap_flags);
 
     /* Map() is not allowed on reserved resources */
     hr = ID3D12Resource_Map(resource, 0, NULL, &ptr);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     refcount = ID3D12Resource_Release(resource);
-    ok(!refcount, "ID3D12Resource has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Resource has %u references left.\n", refcount);
 
     /* The clear value must be NULL for buffers. */
     clear_value.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -1030,20 +1030,20 @@ void test_create_reserved_resource(void)
     hr = ID3D12Device_CreateReservedResource(device,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, &clear_value,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* D3D12_TEXTURE_LAYOUT_ROW_MAJOR must be used for buffers. */
     resource_desc.Layout = D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE;
     hr = ID3D12Device_CreateReservedResource(device,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     resource_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
     hr = ID3D12Device_CreateReservedResource(device,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE must be used for textures. */
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
@@ -1061,28 +1061,28 @@ void test_create_reserved_resource(void)
     hr = ID3D12Device_CreateReservedResource(device,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", (int)hr);
     refcount = ID3D12Resource_Release(resource);
-    ok(!refcount, "ID3D12Resource has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Resource has %u references left.\n", refcount);
 
     resource_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
     hr = ID3D12Device_CreateReservedResource(device,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     resource_desc.MipLevels = 1;
     resource_desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
     hr = ID3D12Device_CreateReservedResource(device,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     resource_desc.Layout = D3D12_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE;
     hr = ID3D12Device_CreateReservedResource(device,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == (standard_swizzle ? S_OK : E_INVALIDARG) || broken(use_warp_device), "Got unexpected hr %#x.\n", hr);
+    ok(hr == (standard_swizzle ? S_OK : E_INVALIDARG) || broken(use_warp_device), "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -1092,7 +1092,7 @@ void test_create_reserved_resource(void)
     hr = ID3D12Device_CreateReservedResource(device,
         &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
         &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -1104,7 +1104,7 @@ void test_create_reserved_resource(void)
         &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
         &IID_ID3D12Resource, (void **)&resource);
     ok(hr == ((get_tiled_resources_tier(device) < D3D12_TILED_RESOURCES_TIER_4)
-            ? E_INVALIDARG : S_OK), "Got unexpected hr %#x.\n", hr);
+            ? E_INVALIDARG : S_OK), "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -1117,7 +1117,7 @@ void test_create_reserved_resource(void)
     hr = ID3D12Device_CreateReservedResource(device,
         &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
         &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
 
@@ -1140,7 +1140,7 @@ void test_create_reserved_resource(void)
         hr = ID3D12Device10_CreateReservedResource2(device10,
             &resource_desc, D3D12_BARRIER_LAYOUT_GENERIC_READ, NULL, NULL,
             1, &castable_format, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", (int)hr);
 
         if (SUCCEEDED(hr))
             ID3D12Resource_Release(resource);
@@ -1154,7 +1154,7 @@ void test_create_reserved_resource(void)
 
 done:
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_map_resource(void)
@@ -1163,8 +1163,8 @@ void test_map_resource(void)
     D3D12_RESOURCE_DESC resource_desc;
     bool is_gpu_upload_heap_supported;
     ID3D12Resource *resource;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     void *data;
     HRESULT hr;
 
@@ -1193,12 +1193,12 @@ void test_map_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     /* Resources on a DEFAULT heap cannot be mapped. */
     data = (void *)(uintptr_t)0xdeadbeef;
     hr = ID3D12Resource_Map(resource, 0, NULL, &data);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(data == (void *)(uintptr_t)0xdeadbeef, "Pointer was modified %p.\n", data);
 
     ID3D12Resource_Release(resource);
@@ -1218,12 +1218,12 @@ void test_map_resource(void)
         /* The data pointer must be NULL for the UNKNOWN layout. */
         data = (void *)(uintptr_t)0xdeadbeef;
         hr = ID3D12Resource_Map(resource, 0, NULL, &data);
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
         ok(data == (void *)(uintptr_t)0xdeadbeef, "Pointer was modified %p.\n", data);
 
         /* Texture on custom heaps can be mapped, but the address doesn't get disclosed to applications */
         hr = ID3D12Resource_Map(resource, 0, NULL, NULL);
-        todo ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        todo ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ID3D12Resource_Unmap(resource, 0, NULL);
 
         ID3D12Resource_Release(resource);
@@ -1239,12 +1239,12 @@ void test_map_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     /* Resources on a DEFAULT heap cannot be mapped. */
     data = (void *)(uintptr_t)0xdeadbeef;
     hr = ID3D12Resource_Map(resource, 0, NULL, &data);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(data == (void *)(uintptr_t)0xdeadbeef, "Pointer was modified %p.\n", data);
 
     ID3D12Resource_Release(resource);
@@ -1253,29 +1253,29 @@ void test_map_resource(void)
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ, NULL,
             &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     data = NULL;
     hr = ID3D12Resource_Map(resource, 0, NULL, &data);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ok(data, "Got NULL pointer.\n");
     ID3D12Resource_Unmap(resource, 0, NULL);
 
     data = (void *)(uintptr_t)0xdeadbeef;
     hr = ID3D12Resource_Map(resource, 1, NULL, &data);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     ok(data == (void *)(uintptr_t)0xdeadbeef, "Pointer was modified %p.\n", data);
 
     data = NULL;
     hr = ID3D12Resource_Map(resource, 0, NULL, &data);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ok(data, "Got NULL pointer.\n");
     ID3D12Resource_Unmap(resource, 1, NULL);
     ID3D12Resource_Unmap(resource, 0, NULL);
 
     /* Passing NULL to Map should map, but not disclose the CPU VA to caller. */
     hr = ID3D12Resource_Map(resource, 0, NULL, NULL);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ID3D12Resource_Unmap(resource, 0, NULL);
 
     ID3D12Resource_Release(resource);
@@ -1286,39 +1286,39 @@ void test_map_resource(void)
             &IID_ID3D12Resource, (void **)&resource);
     if (is_gpu_upload_heap_supported)
     {
-        ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
         data = NULL;
         hr = ID3D12Resource_Map(resource, 0, NULL, &data);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(data, "Got NULL pointer.\n");
         ID3D12Resource_Unmap(resource, 0, NULL);
 
         data = (void *)(uintptr_t)0xdeadbeef;
         hr = ID3D12Resource_Map(resource, 1, NULL, &data);
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
         ok(data == (void *)(uintptr_t)0xdeadbeef, "Pointer was modified %p.\n", data);
 
         data = NULL;
         hr = ID3D12Resource_Map(resource, 0, NULL, &data);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(data, "Got NULL pointer.\n");
         ID3D12Resource_Unmap(resource, 1, NULL);
         ID3D12Resource_Unmap(resource, 0, NULL);
 
         /* Passing NULL to Map should map, but not disclose the CPU VA to caller. */
         hr = ID3D12Resource_Map(resource, 0, NULL, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ID3D12Resource_Unmap(resource, 0, NULL);
 
         ID3D12Resource_Release(resource);
     }
     else
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_map_placed_resources(void)
@@ -1374,7 +1374,7 @@ void test_map_placed_resources(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_pipeline_state(device, context.root_signature, 0, NULL, &ps_store_buffer_dxbc, NULL);
 
@@ -1384,12 +1384,12 @@ void test_map_placed_resources(void)
     heap_desc.Alignment = 0;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&upload_heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     heap_desc.SizeInBytes = 1024;
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_READBACK;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&readback_heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
     resource_desc.Alignment = 0;
@@ -1409,14 +1409,14 @@ void test_map_placed_resources(void)
                 i * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,
                 &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ, NULL,
                 &IID_ID3D12Resource, (void **)&cb[i]);
-        ok(hr == S_OK, "Failed to create placed resource %u, hr %#x.\n", i, hr);
+        ok(hr == S_OK, "Failed to create placed resource %u, hr %#x.\n", i, (int)hr);
     }
 
     resource_desc.Width = 1024;
     hr = ID3D12Device_CreatePlacedResource(device, readback_heap, 0,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL,
             &IID_ID3D12Resource, (void **)&readback_buffer);
-    ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", (int)hr);
 
     uav_buffer = create_default_buffer(device, resource_desc.Width,
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -1424,11 +1424,11 @@ void test_map_placed_resources(void)
     for (i = 0; i < ARRAY_SIZE(cb); ++i)
     {
         hr = ID3D12Resource_Map(cb[i], 0, NULL, (void **)&cb_data[i]);
-        ok(hr == S_OK, "Failed to map buffer %u, hr %#x.\n", i, hr);
+        ok(hr == S_OK, "Failed to map buffer %u, hr %#x.\n", i, (int)hr);
     }
 
     hr = ID3D12Resource_Map(cb[0], 0, NULL, (void **)&ptr);
-    ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to map buffer, hr %#x.\n", (int)hr);
     ok(ptr == cb_data[0], "Got map ptr %p, expected %p.\n", ptr, cb_data[0]);
     cb_data[0][0] = 0;
     cb_data[0][1] = expected_values[0];
@@ -1492,9 +1492,9 @@ void test_map_placed_resources(void)
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_GPU_UPLOAD;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&gpu_upload_heap);
     if (is_gpu_upload_heap_supported)
-        ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
     else
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     if (is_gpu_upload_heap_supported)
     {
@@ -1502,36 +1502,36 @@ void test_map_placed_resources(void)
         hr = ID3D12Device_CreatePlacedResource(device, gpu_upload_heap, 0,
             &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ, NULL,
             &IID_ID3D12Resource, (void**)&cb[0]);
-        ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", (int)hr);
 
         cb_data[0] = NULL;
         hr = ID3D12Resource_Map(cb[0], 0, NULL, (void **)&cb_data[0]);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(cb_data[0], "Got NULL pointer.\n");
         ID3D12Resource_Unmap(cb[0], 0, NULL);
 
         cb_data[0] = (void *)(uintptr_t)0xdeadbeef;
         hr = ID3D12Resource_Map(cb[0], 1, NULL, (void **)&cb_data[0]);
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
         ok(cb_data[0] == (void *)(uintptr_t)0xdeadbeef, "Pointer was modified %p.\n", cb_data[0]);
 
         cb_data[0] = NULL;
         hr = ID3D12Resource_Map(cb[0], 0, NULL, (void **)&cb_data[0]);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ok(cb_data[0], "Got NULL pointer.\n");
         ID3D12Resource_Unmap(cb[0], 1, NULL);
         ID3D12Resource_Unmap(cb[0], 0, NULL);
 
         /* Passing NULL to Map should map, but not disclose the CPU VA to caller. */
         hr = ID3D12Resource_Map(cb[0], 0, NULL, NULL);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         ID3D12Resource_Unmap(cb[0], 0, NULL);
 
         ID3D12Resource_Release(cb[0]);
         ID3D12Heap_Release(gpu_upload_heap);
     }
     else
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     destroy_test_context(&context);
 }
@@ -1661,9 +1661,9 @@ void test_get_copyable_footprints(void)
     UINT64 row_sizes[10], total_size;
     unsigned int sub_resource_count;
     unsigned int i, j, k, l;
+    unsigned int refcount;
     ID3D12Device *device;
     UINT row_counts[10];
-    ULONG refcount;
 
     static const struct
     {
@@ -1883,7 +1883,7 @@ void test_get_copyable_footprints(void)
     }
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_resource_allocation_info(void)
@@ -1892,9 +1892,9 @@ void test_resource_allocation_info(void)
     D3D12_RESOURCE_ALLOCATION_INFO info, info1;
     D3D12_RESOURCE_DESC desc[2];
     ID3D12Device4 *device4;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int i, j;
-    ULONG refcount;
 
     static const unsigned int alignments[] =
     {
@@ -2065,7 +2065,7 @@ void test_resource_allocation_info(void)
         ID3D12Device4_Release(device4);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_suballocate_small_textures_size(void)
@@ -2325,10 +2325,10 @@ void test_suballocate_small_textures(void)
     D3D12_RESOURCE_DESC resource_desc;
     ID3D12Resource *textures[10];
     D3D12_HEAP_DESC heap_desc;
+    unsigned int refcount;
     ID3D12Device *device;
     ID3D12Heap *heap;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -2370,14 +2370,14 @@ void test_suballocate_small_textures(void)
     heap_desc.Alignment = 0;
     heap_desc.Flags = D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(textures); ++i)
     {
         hr = ID3D12Device_CreatePlacedResource(device, heap, i * info.SizeInBytes,
                 &resource_desc, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
                 NULL, &IID_ID3D12Resource, (void **)&textures[i]);
-        ok(hr == S_OK, "Failed to create placed resource %u, hr %#x.\n", i, hr);
+        ok(hr == S_OK, "Failed to create placed resource %u, hr %#x.\n", i, (int)hr);
 
         check_interface(textures[i], &IID_ID3D12Object, true);
         check_interface(textures[i], &IID_ID3D12DeviceChild, true);
@@ -2389,18 +2389,18 @@ void test_suballocate_small_textures(void)
     }
 
     refcount = get_refcount(heap);
-    ok(refcount == 1, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 1, "Got unexpected refcount %u.\n", refcount);
 
     for (i = 0; i < ARRAY_SIZE(textures); ++i)
     {
         refcount = ID3D12Resource_Release(textures[i]);
-        ok(!refcount, "ID3D12Resource has %u references left.\n", (unsigned int)refcount);
+        ok(!refcount, "ID3D12Resource has %u references left.\n", refcount);
     }
 
     refcount = ID3D12Heap_Release(heap);
-    ok(!refcount, "ID3D12Heap has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Heap has %u references left.\n", refcount);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_read_subresource_rt(void)
@@ -2556,10 +2556,10 @@ void test_read_write_subresource_2d(void)
 
     set_box(&box, 0, 0, 0, 1, 1, 1);
     hr = ID3D12Resource_WriteToSubresource(rb_buffer, 0, &box, dst_buffer, row_pitch, slice_pitch);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_ReadFromSubresource(rb_buffer, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     ID3D12Resource_Release(rb_buffer);
 
@@ -2591,34 +2591,34 @@ void test_read_write_subresource_2d(void)
     /* Invalid box */
     set_box(&box, 0, 0, 0, 128, 100, 2);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 0, 0, 2, 128, 100, 2);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 128, 0, 0, 129, 100, 1);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* NULL box */
     hr = ID3D12Resource_WriteToSubresource(src_texture, 0, NULL, dst_buffer, row_pitch, slice_pitch);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, NULL);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     /* Empty box */
     set_box(&box, 128, 100, 1, 128, 100, 1);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 0, 0, 0, 0, 0, 0);
     hr = ID3D12Resource_WriteToSubresource(src_texture, 0, &box, dst_buffer, row_pitch, slice_pitch);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     for (i = 0; i < 2; ++i)
     {
@@ -2641,18 +2641,18 @@ void test_read_write_subresource_2d(void)
         if (i)
         {
             hr = ID3D12Resource_WriteToSubresource(src_texture, 0, NULL, zero_buffer, row_pitch, slice_pitch);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
             /* Write region 1 */
             set_box(&box, 0, 0, 0, 2, 2, 1);
             hr = ID3D12Resource_WriteToSubresource(src_texture, 0, &box, dst_buffer, row_pitch, slice_pitch);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
             /* Write region 2 */
             set_box(&box, 2, 2, 0, 11, 13, 1);
             hr = ID3D12Resource_WriteToSubresource(src_texture, 0, &box, &dst_buffer[2 * 128 + 2],
                     row_pitch, slice_pitch);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         }
         else
         {
@@ -2673,13 +2673,13 @@ void test_read_write_subresource_2d(void)
         /* Read region 1 */
         set_box(&box, 0, 0, 0, 2, 2, 1);
         hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         /* Read region 2 */
         set_box(&box, 2, 2, 0, 11, 13, 1);
         hr = ID3D12Resource_ReadFromSubresource(src_texture, &dst_buffer[2 * 128 + 2], row_pitch,
                 slice_pitch, 0, &box);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         for (y = 0; y < 100; ++y)
         {
@@ -2801,10 +2801,10 @@ void test_read_write_subresource(void)
 
     set_box(&box, 0, 0, 0, 1, 1, 1);
     hr = ID3D12Resource_WriteToSubresource(rb_buffer, 0, &box, dst_buffer, row_pitch, slice_pitch);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_ReadFromSubresource(rb_buffer, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     ID3D12Resource_Release(rb_buffer);
 
@@ -2836,34 +2836,34 @@ void test_read_write_subresource(void)
     /* Invalid box */
     set_box(&box, 0, 0, 0, 128, 100, 65);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 0, 0, 65, 128, 100, 65);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 128, 0, 0, 128, 100, 65);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* NULL box */
     hr = ID3D12Resource_WriteToSubresource(src_texture, 0, NULL, dst_buffer, row_pitch, slice_pitch);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, NULL);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     /* Empty box */
     set_box(&box, 128, 100, 64, 128, 100, 64);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 0, 0, 0, 0, 0, 0);
     hr = ID3D12Resource_WriteToSubresource(src_texture, 0, &box, dst_buffer, row_pitch, slice_pitch);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
     for (i = 0; i < 2; ++i)
     {
@@ -2889,18 +2889,18 @@ void test_read_write_subresource(void)
         if (i)
         {
             hr = ID3D12Resource_WriteToSubresource(src_texture, 0, NULL, zero_buffer, row_pitch, slice_pitch);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
             /* Write region 1 */
             set_box(&box, 0, 0, 0, 2, 2, 2);
             hr = ID3D12Resource_WriteToSubresource(src_texture, 0, &box, dst_buffer, row_pitch, slice_pitch);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
             /* Write region 2 */
             set_box(&box, 2, 2, 2, 11, 13, 17);
             hr = ID3D12Resource_WriteToSubresource(src_texture, 0, &box, &dst_buffer[2 * 128 * 100 + 2 * 128 + 2],
                     row_pitch, slice_pitch);
-            ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+            ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
         }
         else
         {
@@ -2921,13 +2921,13 @@ void test_read_write_subresource(void)
         /* Read region 1 */
         set_box(&box, 0, 0, 0, 2, 2, 2);
         hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         /* Read region 2 */
         set_box(&box, 2, 2, 2, 11, 13, 17);
         hr = ID3D12Resource_ReadFromSubresource(src_texture, &dst_buffer[2 * 128 * 100 + 2 * 128 + 2], row_pitch,
                 slice_pitch, 0, &box);
-        ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+        ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
 
         for (z = 0; z < 64; ++z)
         {
@@ -3026,29 +3026,29 @@ void test_read_write_subresource(void)
     heap_properties.MemoryPoolPreference = D3D12_MEMORY_POOL_L0;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&src_texture);
-    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
     /* Unaligned coordinates for BC format */
     set_box(&box, 0, 0, 0, 2, 2, 1);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 2, 2, 0, 4, 4, 1);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 2, 2, 0, 6, 6, 1);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     /* Invalid coordinates for resource dimensions */
     set_box(&box, 0, 0, 0, 64, 32, 2);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     set_box(&box, 0, 0, 0, 68, 32, 1);
     hr = ID3D12Resource_ReadFromSubresource(src_texture, dst_buffer, row_pitch, slice_pitch, 0, &box);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     ID3D12Resource_Release(src_texture);
 
@@ -3346,13 +3346,13 @@ void test_stress_fallback_render_target_allocation_device(void)
     for (i = 0; i < ARRAY_SIZE(heaps); i++)
     {
         hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void**)&heaps[i]);
-        ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
 
         if (SUCCEEDED(hr))
         {
             hr = ID3D12Device_CreatePlacedResource(context.device, heaps[i], 0, &desc,
                     D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&resource);
-            ok(SUCCEEDED(hr), "Failed to place resource, hr #%x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to place resource, hr #%x.\n", (int)hr);
             if (SUCCEEDED(hr))
                 ID3D12Resource_Release(resource);
         }
@@ -3823,13 +3823,13 @@ void test_map_texture_validation(void)
 
             /* We cannot successfully create host visible linear RT on all implementations. */
             todo_if(tests[i].is_todo)
-            ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].heap_creation_hr : E_INVALIDARG), "Unexpected hr %#x.\n", hr);
+            ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].heap_creation_hr : E_INVALIDARG), "Unexpected hr %#x.\n", (int)hr);
 
             if (SUCCEEDED(hr))
             {
                 hr = ID3D12Device_CreatePlacedResource(device, heap, 0, &desc, D3D12_RESOURCE_STATE_GENERIC_READ,
                         NULL, &IID_ID3D12Resource, (void**)&resource);
-                todo_if(tests[i].is_todo) ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].creation_hr : E_INVALIDARG), "Unexpected hr %#x.\n", hr);
+                todo_if(tests[i].is_todo) ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].creation_hr : E_INVALIDARG), "Unexpected hr %#x.\n", (int)hr);
                 if (SUCCEEDED(hr))
                     ID3D12Resource_Release(resource);
                 ID3D12Heap_Release(heap);
@@ -3839,17 +3839,17 @@ void test_map_texture_validation(void)
         hr = ID3D12Device_CreateCommittedResource(device, &heap_props, tests[i].heap_flags,
                 &desc, D3D12_RESOURCE_STATE_GENERIC_READ, NULL, &IID_ID3D12Resource,
                 (void**)&resource);
-        todo_if(tests[i].is_todo) ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].creation_hr : E_INVALIDARG), "Unexpected hr %#x.\n", hr);
+        todo_if(tests[i].is_todo) ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].creation_hr : E_INVALIDARG), "Unexpected hr %#x.\n", (int)hr);
 
         if (SUCCEEDED(hr))
         {
             hr = ID3D12Resource_Map(resource, 0, NULL, &mapped_ptr);
-            ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].map_hr_with_ppdata : E_INVALIDARG), "Unexpected hr %#x.\n", hr);
+            ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].map_hr_with_ppdata : E_INVALIDARG), "Unexpected hr %#x.\n", (int)hr);
             if (SUCCEEDED(hr))
                 ID3D12Resource_Unmap(resource, 0, NULL);
 
             hr = ID3D12Resource_Map(resource, 0, NULL, NULL);
-            ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].map_hr_without_ppdata : E_INVALIDARG), "Unexpected hr %#x.\n", hr);
+            ok(hr == (heap_props.Type != D3D12_HEAP_TYPE_GPU_UPLOAD || is_gpu_upload_heap_supported ? tests[i].map_hr_without_ppdata : E_INVALIDARG), "Unexpected hr %#x.\n", (int)hr);
             if (SUCCEEDED(hr))
                 ID3D12Resource_Unmap(resource, 0, NULL);
             ID3D12Resource_Release(resource);
@@ -3900,7 +3900,7 @@ void test_aliasing_barrier_edge_cases(void)
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void**)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
 
     rtvs = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, ARRAY_SIZE(resources));
     for (i = 0; i < ARRAY_SIZE(resources); i++)
@@ -3909,7 +3909,7 @@ void test_aliasing_barrier_edge_cases(void)
         h.ptr += i * ID3D12Device_GetDescriptorHandleIncrementSize(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
         hr = ID3D12Device_CreatePlacedResource(context.device, heap, 0, &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
                 NULL, &IID_ID3D12Resource, (void**)&resources[i]);
-        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
         ID3D12Device_CreateRenderTargetView(context.device, resources[i], NULL, h);
         rtv[i] = h;
     }
@@ -4129,14 +4129,14 @@ void test_planar_video_formats(void)
     rs_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&compute_pso_desc, 0, sizeof(compute_pso_desc));
     compute_pso_desc.CS = cs_copy_simple_dxbc;
     compute_pso_desc.pRootSignature = context.root_signature;
 
     hr = ID3D12Device_CreateComputePipelineState(context.device, &compute_pso_desc, &IID_ID3D12PipelineState, (void**)&compute_pso);
-    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);
     rtv = get_cpu_descriptor_handle(&context, rtv_heap, 0);
@@ -4156,7 +4156,7 @@ void test_planar_video_formats(void)
         format_support.Format = test_formats[i].format;
 
         hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_FORMAT_SUPPORT, &format_support, sizeof(format_support));
-        ok(hr == S_OK || hr == E_FAIL, "Got invalid hr %#x.\n", hr);
+        ok(hr == S_OK || hr == E_FAIL, "Got invalid hr %#x.\n", (int)hr);
 
         if (FAILED(hr))
         {
@@ -4173,7 +4173,7 @@ void test_planar_video_formats(void)
         format_info.Format = test_formats[i].format;
 
         hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_FORMAT_INFO, &format_info, sizeof(format_info));
-        ok(hr == S_OK, "Checking format info failed, hr %#x.\n", hr);
+        ok(hr == S_OK, "Checking format info failed, hr %#x.\n", (int)hr);
         ok(format_info.PlaneCount == test_formats[i].plane_count, "Got plane count %u, expected %u.\n", format_info.PlaneCount, test_formats[i].plane_count);
 
         /* Validate copyable footprints */
@@ -4202,7 +4202,7 @@ void test_planar_video_formats(void)
 
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void**)&resources[0]);
-        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
         for (j = 0; j < test_formats[i].plane_count; j++)
         {
@@ -4214,10 +4214,10 @@ void test_planar_video_formats(void)
             row_pitch = resource_desc.Width * element_size;
 
             hr = ID3D12Resource_Map(resources[0], j, NULL, NULL);
-            ok(hr == S_OK, "Failed to map subresource %u, hr %#x.\n", j, hr);
+            ok(hr == S_OK, "Failed to map subresource %u, hr %#x.\n", j, (int)hr);
 
             hr = ID3D12Resource_WriteToSubresource(resources[0], j, NULL, plane->data, row_pitch, 0);
-            ok(hr == S_OK, "Failed to write subresource %u, hr %#x.\n", j, hr);
+            ok(hr == S_OK, "Failed to write subresource %u, hr %#x.\n", j, (int)hr);
 
             ID3D12Resource_Unmap(resources[0], j, NULL);
 
@@ -4231,13 +4231,13 @@ void test_planar_video_formats(void)
             reset_command_list(context.list, context.allocator);
 
             hr = ID3D12Resource_Map(resources[0], j, NULL, NULL);
-            ok(hr == S_OK, "Failed to map subresource %u, hr %#x.\n", j, hr);
+            ok(hr == S_OK, "Failed to map subresource %u, hr %#x.\n", j, (int)hr);
 
             memset(dst_data, 0xff, sizeof(dst_data));
 
             hr = ID3D12Resource_ReadFromSubresource(resources[0], dst_data,
                     row_pitch, 0, j, NULL);
-            ok(hr == S_OK, "Failed to read subresource %u, hr %#x.\n", j, hr);
+            ok(hr == S_OK, "Failed to read subresource %u, hr %#x.\n", j, (int)hr);
 
             for (k = 0; k < resource_desc.Height; k++)
             {
@@ -4268,7 +4268,7 @@ void test_planar_video_formats(void)
 
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&resources[0]);
-        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
         memset(&heap_properties, 0, sizeof(heap_properties));
         heap_properties.Type = D3D12_HEAP_TYPE_CUSTOM;
@@ -4285,14 +4285,14 @@ void test_planar_video_formats(void)
 
             hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                     &resource_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void**)&resources[1]);
-            ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
             hr = ID3D12Resource_Map(resources[1], 0, NULL, NULL);
-            ok(hr == S_OK, "Failed to map resource, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to map resource, hr %#x.\n", (int)hr);
 
             hr = ID3D12Resource_WriteToSubresource(resources[1], 0, NULL, plane->data,
                     resource_desc.Width * format_size_planar(test_formats[i].format, j), 0);
-            ok(hr == S_OK, "Failed to write resource, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to write resource, hr %#x.\n", (int)hr);
 
             memset(&dst_location, 0, sizeof(dst_location));
             dst_location.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
@@ -4336,7 +4336,7 @@ void test_planar_video_formats(void)
 
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&resources[0]);
-        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
         for (j = 0; j < test_formats[i].plane_count; j++)
         {
@@ -4363,7 +4363,7 @@ void test_planar_video_formats(void)
         /* Test full copy via CopyResource */
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&resources[1]);
-        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_CopyResource(context.list, resources[1], resources[0]);
         transition_resource_state(context.list, resources[1], D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COPY_SOURCE);
@@ -4388,7 +4388,7 @@ void test_planar_video_formats(void)
         /* Test copy via CopyTextureRegion */
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&resources[1]);
-        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
         for (j = 0; j < test_formats[i].plane_count; j++)
         {
@@ -4428,7 +4428,7 @@ void test_planar_video_formats(void)
 
             hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                     &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&resources[1]);
-            ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
             memset(&dst_location, 0, sizeof(dst_location));
             dst_location.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
@@ -4469,7 +4469,7 @@ void test_planar_video_formats(void)
 
                 init_pipeline_state_desc(&graphics_pso_desc, context.root_signature, plane->view_format, NULL, &ps_copy_simple_dxbc, NULL);
                 hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &graphics_pso_desc, &IID_ID3D12PipelineState, (void**)&graphics_psos[j]);
-                ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+                ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
             }
 
             /* Test reading image data via SRV */
@@ -4497,7 +4497,7 @@ void test_planar_video_formats(void)
 
                 hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                         &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&resources[1]);
-                ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+                ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
                 memset(&rtv_desc, 0, sizeof(rtv_desc));
                 rtv_desc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
@@ -4544,7 +4544,7 @@ void test_planar_video_formats(void)
 
                 hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                         &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void**)&resources[1]);
-                ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+                ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
                 for (j = 0; j < test_formats[i].plane_count; j++)
                 {
@@ -4619,7 +4619,7 @@ void test_planar_video_formats(void)
 
                 hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                         &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void**)&resources[1]);
-                ok(hr == S_OK, "Failed to create resource, hr %#x.\n", hr);
+                ok(hr == S_OK, "Failed to create resource, hr %#x.\n", (int)hr);
 
                 for (j = 0; j < test_formats[i].plane_count; j++)
                 {
@@ -4728,7 +4728,8 @@ void test_planar_video_formats(void)
 
         hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&resources[0]);
-        ok(hr == test_resource_descs[i].expected_hr, "Got hr %#x, expected %#x.\n", hr, test_resource_descs[i].expected_hr);
+        ok(hr == test_resource_descs[i].expected_hr, "Got hr %#x, expected %#x.\n",
+                (int)hr, (int)test_resource_descs[i].expected_hr);
 
         if (resources[0])
             ID3D12Resource_Release(resources[0]);
@@ -4839,7 +4840,7 @@ void test_large_texel_buffer_view(void)
     if (FAILED(hr))
     {
         /* Be robust if the implementation does not support huge allocations */
-        skip("Failed to create data buffer, hr %#x.\n", hr);
+        skip("Failed to create data buffer, hr %#x.\n", (int)hr);
         ID3D12GraphicsCommandList2_Release(command_list2);
         destroy_test_context(&context);
         return;
@@ -4849,7 +4850,7 @@ void test_large_texel_buffer_view(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void**)&feedback_buffer);
-    ok(hr == S_OK, "Failed to create feedback buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create feedback buffer, hr %#x.\n", (int)hr);
 
     descriptor_heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 4);
     descriptor_cpu_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
@@ -4886,7 +4887,7 @@ void test_large_texel_buffer_view(void)
     rs_desc_ranges[1].NumDescriptors = 2;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     srv_pso = create_compute_pipeline_state(context.device, context.root_signature, cs_large_tbo_load_dxbc);
     uav_pso = create_compute_pipeline_state(context.device, context.root_signature, cs_large_tbo_store_dxbc);
@@ -5079,7 +5080,7 @@ void test_large_heap(void)
 
     if (FAILED(hr))
     {
-        skip("Failed to create large heap, hr %#x.\n", hr);
+        skip("Failed to create large heap, hr %#x.\n", (int)hr);
         destroy_test_context(&context);
         return;
     }
@@ -5094,7 +5095,7 @@ void test_large_heap(void)
     resource_desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_desc.Properties, D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void**)&readback_buffer);
-    ok(hr == S_OK, "Failed to create committed buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed buffer, hr %#x.\n", (int)hr);
 
     /* Create tiled buffer to test for aliasing issues */
     memset(&resource_desc, 0, sizeof(resource_desc));
@@ -5108,7 +5109,7 @@ void test_large_heap(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
 
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void**)&tiled_buffer);
-    ok(hr == S_OK, "Failed to create tiled buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create tiled buffer, hr %#x.\n", (int)hr);
 
     memset(&tile_coord, 0, sizeof(tile_coord));
     memset(&tile_size, 0, sizeof(tile_size));
@@ -5137,7 +5138,7 @@ void test_large_heap(void)
     for (i = 0; i < SECTION_COUNT; i++)
     {
         hr = ID3D12Device_CreatePlacedResource(context.device, heap, SECTION_SIZE * i, &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE, NULL, &IID_ID3D12Resource, (void**)&placed_buffers[i]);
-        ok(hr == S_OK, "Failed to create placed buffer, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create placed buffer, hr %#x.\n", (int)hr);
     }
 
     /* Create large placed buffer covering the entire heap */
@@ -5147,7 +5148,7 @@ void test_large_heap(void)
 
     if (FAILED(hr))
     {
-        skip("Failed to create large buffer, hr %#x.\n", hr);
+        skip("Failed to create large buffer, hr %#x.\n", (int)hr);
         large_buffer = NULL;
     }
 
@@ -5156,12 +5157,12 @@ void test_large_heap(void)
     descriptor_heap_desc.NumDescriptors = SECTION_COUNT;
 
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &descriptor_heap_desc, &IID_ID3D12DescriptorHeap, (void**)&cpu_heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     descriptor_heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
 
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &descriptor_heap_desc, &IID_ID3D12DescriptorHeap, (void**)&gpu_heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     /* Test writing data to the sparse buffer. Offsets will all be smmall, so if this
      * goes wrong, this proves an issue with large offsets in UpdateTileMappings. */
@@ -5443,15 +5444,15 @@ static void test_non_zeroed_behavior(bool placed)
             if (placed)
             {
                 hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heaps[i]);
-                ok(SUCCEEDED(hr), "Failed to create heap, hr #%x\n", hr);
+                ok(SUCCEEDED(hr), "Failed to create heap, hr #%x\n", (int)hr);
                 hr = ID3D12Device_CreatePlacedResource(context.device, heaps[i], 0, &res_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resources[i]);
-                ok(SUCCEEDED(hr), "Failed to create placed resource, hr #%x\n", hr);
+                ok(SUCCEEDED(hr), "Failed to create placed resource, hr #%x\n", (int)hr);
             }
             else
             {
                 hr = ID3D12Device_CreateCommittedResource(context.device, &heap_desc.Properties, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
                     &res_desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resources[i]);
-                ok(SUCCEEDED(hr), "Failed to create committed resource, hr #%x\n", hr);
+                ok(SUCCEEDED(hr), "Failed to create committed resource, hr #%x\n", (int)hr);
             }
 
             burned_vram += heap_size;
@@ -5591,7 +5592,7 @@ void test_tight_resource_alignment(void)
 
         hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &res_desc[0], D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", hr);
+        ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
     }
 
     vkd3d_test_set_context(NULL);
@@ -5603,7 +5604,7 @@ void test_tight_resource_alignment(void)
     if (options.TiledResourcesTier)
     {
         hr = ID3D12Device_CreateReservedResource(device, &res_desc[0], D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", (int)hr);
 
         queried_desc = ID3D12Resource_GetDesc(resource);
         ok(queried_desc.Flags & D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT, "Missing D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT in flags %#x.\n", queried_desc.Flags);
@@ -5708,7 +5709,7 @@ void test_tight_resource_alignment(void)
 
             hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                     &res_desc[i], D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resource);
-            ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
             queried_desc = ID3D12Resource_GetDesc(resource);
 
@@ -5773,7 +5774,7 @@ void test_tight_resource_alignment(void)
         heap_desc.Alignment = D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT;
 
         hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void**)&heap);
-        ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
         heap_va = 0u;
 
@@ -5783,7 +5784,7 @@ void test_tight_resource_alignment(void)
 
             hr = ID3D12Device_CreatePlacedResource(device, heap, res_infos[i].Offset, &res_desc[i],
                     D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void**)&resource);
-            ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", (int)hr);
 
             queried_desc = ID3D12Resource_GetDesc(resource);
             ok(queried_desc.Alignment == res_infos[i].Alignment, "Got resource aligment %"PRIu64", expected %"PRIu64".\n",
@@ -5805,7 +5806,7 @@ void test_tight_resource_alignment(void)
             /* Ensure that we can successfully place the resource at the end of the heap too */
             hr = ID3D12Device_CreatePlacedResource(device, heap, heap_desc.SizeInBytes - res_infos[i].SizeInBytes,
                     &res_desc[i], D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void**)&resource);
-            ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create placed resource, hr %#x.\n", (int)hr);
 
             ID3D12Resource_Release(resource);
 
@@ -5816,7 +5817,7 @@ void test_tight_resource_alignment(void)
 
                 hr = ID3D12Device_CreatePlacedResource(device, heap, res_infos[i].Offset, &res_desc[i],
                         D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void**)&resource);
-                ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", hr);
+                ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
 
                 res_desc[i].Alignment = 0u;
             }
@@ -5828,7 +5829,7 @@ void test_tight_resource_alignment(void)
             res_desc[0].Flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
             hr = ID3D12Device_CreatePlacedResource(device, heap, 0u, &res_desc[0],
                     D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void**)&resource);
-            ok(hr == S_OK, "Failed to create RTAS, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create RTAS, hr %#x.\n", (int)hr);
 
             queried_desc = ID3D12Resource_GetDesc(resource);
             ok(queried_desc.Alignment >= 8u && queried_desc.Alignment <= 256u,
@@ -5859,13 +5860,13 @@ void test_tight_resource_alignment(void)
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
 
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void**)&heap);
-    ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", hr);
+    ok(hr == E_INVALIDARG, "Got hr %#x, expected E_INVALIDARG.\n", (int)hr);
 
     vkd3d_test_set_context(NULL);
 
     ID3D12Device4_Release(device4);
     ref_count = ID3D12Device_Release(device);
-    ok(!ref_count, "Device has %u references left.\n", ref_count);
+    ok(!ref_count, "Device has %u references left.\n", (unsigned int)ref_count);
 }
 
 void test_placed_msaa_alignment_workaround(void)
@@ -5913,7 +5914,7 @@ void test_placed_msaa_alignment_workaround(void)
         ID3D12Resource_Release(res);
 
     /* This fails on native. As a workaround, we have to make it work anyway. */
-    ok(hr == (is_vkd3d_proton_device(device) ? S_OK : E_INVALIDARG), "Unexpected hr #%x.\n", hr);
+    ok(hr == (is_vkd3d_proton_device(device) ? S_OK : E_INVALIDARG), "Unexpected hr #%x.\n", (int)hr);
 
     ID3D12Heap_Release(heap);
     refcount = ID3D12Device_Release(device);
@@ -6248,21 +6249,21 @@ void test_buffer_rtv_dsv_usage(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_props, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resource);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x\n", (int)hr);
 
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_props, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resource);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
     /* For some reason, this is allowed. */
-    ok(SUCCEEDED(hr), "Unexpected hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Unexpected hr #%x.\n", (int)hr);
 
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_props, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resource);
     if (SUCCEEDED(hr))
         ID3D12Resource_Release(resource);
     /* But not this ... */
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
 
     destroy_test_context(&context);
 }

--- a/tests/d3d12_robustness.c
+++ b/tests/d3d12_robustness.c
@@ -84,7 +84,7 @@ void test_buffers_oob_behavior_vectorized_structured_16bit(void)
     descriptor_ranges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, ARRAY_SIZE(output_buffers));
 
@@ -243,7 +243,7 @@ void test_buffers_oob_behavior_vectorized_byte_address(void)
     descriptor_ranges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
     output_buffer = create_default_buffer(context.device, 8 * 16 * sizeof(uint32_t),
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -485,7 +485,7 @@ static void test_buffers_oob_behavior(bool use_dxil)
     descriptor_ranges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     output_buffer = create_default_buffer(context.device, chunk_size * 32, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
@@ -1498,7 +1498,7 @@ static void test_undefined_read_typed_buffer_as_untyped_simple(bool use_dxil)
     descriptor_ranges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     output_buffer = create_default_buffer(context.device, 64 * 1024, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
@@ -1628,7 +1628,7 @@ void test_null_descriptor_mismatch_type(void)
     }
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     {
         const UINT buffer_data[] = { 1, 1, 1, 1 };

--- a/tests/d3d12_root_signature.c
+++ b/tests/d3d12_root_signature.c
@@ -29,7 +29,7 @@ void test_create_root_signature(void)
     D3D12_ROOT_PARAMETER root_parameters[3];
     ID3D12RootSignature *root_signature;
     ID3D12Device *device, *tmp_device;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
     if (!(device = create_device()))
@@ -54,16 +54,16 @@ void test_create_root_signature(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12RootSignature_GetDevice(root_signature, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(hr == S_OK, "Failed to get device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(root_signature, &IID_ID3D12Object, true);
     check_interface(root_signature, &IID_ID3D12DeviceChild, true);
@@ -71,7 +71,7 @@ void test_create_root_signature(void)
     check_interface(root_signature, &IID_ID3D12RootSignature, true);
 
     refcount = ID3D12RootSignature_Release(root_signature);
-    ok(!refcount, "ID3D12RootSignature has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignature has %u references left.\n", refcount);
 
     /* sampler and SRV in the same descriptor table */
     descriptor_ranges[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
@@ -89,7 +89,7 @@ void test_create_root_signature(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == E_INVALIDARG, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     /* empty root signature */
     root_signature_desc.NumParameters = 0;
@@ -98,9 +98,9 @@ void test_create_root_signature(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
     refcount = ID3D12RootSignature_Release(root_signature);
-    ok(!refcount, "ID3D12RootSignature has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignature has %u references left.\n", refcount);
 
     /* root constants */
     root_parameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
@@ -119,14 +119,14 @@ void test_create_root_signature(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    todo ok(hr == E_FAIL || hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_FAIL || hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12RootSignature_Release(root_signature);
     root_parameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
     refcount = ID3D12RootSignature_Release(root_signature);
-    ok(!refcount, "ID3D12RootSignature has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignature has %u references left.\n", refcount);
 
     root_parameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
     root_parameters[2].Constants.ShaderRegister = 1;
@@ -135,9 +135,9 @@ void test_create_root_signature(void)
     root_parameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
     root_signature_desc.NumParameters = 3;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
     refcount = ID3D12RootSignature_Release(root_signature);
-    ok(!refcount, "ID3D12RootSignature has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignature has %u references left.\n", refcount);
 
     /* root descriptors */
     root_parameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
@@ -154,17 +154,17 @@ void test_create_root_signature(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    todo ok(hr == E_FAIL || hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    todo ok(hr == E_FAIL || hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12RootSignature_Release(root_signature);
     root_parameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_GEOMETRY;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
     refcount = ID3D12RootSignature_Release(root_signature);
-    ok(!refcount, "ID3D12RootSignature has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignature has %u references left.\n", refcount);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_root_signature_limits(void)
@@ -173,8 +173,8 @@ void test_root_signature_limits(void)
     D3D12_ROOT_PARAMETER root_parameters[D3D12_MAX_ROOT_COST + 1];
     D3D12_ROOT_SIGNATURE_DESC root_signature_desc;
     ID3D12RootSignature *root_signature;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     unsigned int i;
     HRESULT hr;
 
@@ -205,15 +205,15 @@ void test_root_signature_limits(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
     ID3D12RootSignature_Release(root_signature);
 
     root_signature_desc.NumParameters = D3D12_MAX_ROOT_COST + 1;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 static void check_descriptor_range_(unsigned int line, const D3D12_DESCRIPTOR_RANGE *range,
@@ -536,7 +536,7 @@ static void check_root_signature_deserialization_(unsigned int line, const D3D12
     ID3D12VersionedRootSignatureDeserializer *versioned_deserializer;
     ID3D12RootSignatureDeserializer *deserializer;
     const D3D12_ROOT_SIGNATURE_DESC *desc;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
     if (!code->BytecodeLength)
@@ -544,21 +544,21 @@ static void check_root_signature_deserialization_(unsigned int line, const D3D12
 
     hr = D3D12CreateRootSignatureDeserializer(code->pShaderBytecode, code->BytecodeLength,
             &IID_ID3D12RootSignatureDeserializer, (void **)&deserializer);
-    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", (int)hr);
 
     desc = ID3D12RootSignatureDeserializer_GetRootSignatureDesc(deserializer);
     ok(desc, "Got NULL root signature desc.\n");
     check_root_signature_desc_(line, desc, expected_desc);
 
     refcount = ID3D12RootSignatureDeserializer_Release(deserializer);
-    ok_(line)(!refcount, "ID3D12RootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok_(line)(!refcount, "ID3D12RootSignatureDeserializer has %u references left.\n", refcount);
 
     if (!pfn_D3D12CreateVersionedRootSignatureDeserializer)
         return;
 
     hr = pfn_D3D12CreateVersionedRootSignatureDeserializer(code->pShaderBytecode, code->BytecodeLength,
             &IID_ID3D12VersionedRootSignatureDeserializer, (void **)&versioned_deserializer);
-    ok_(line)(hr == S_OK, "Failed to create versioned deserializer, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create versioned deserializer, hr %#x.\n", (int)hr);
 
     versioned_desc = ID3D12VersionedRootSignatureDeserializer_GetUnconvertedRootSignatureDesc(versioned_deserializer);
     ok(versioned_desc, "Got NULL root signature desc.\n");
@@ -567,18 +567,18 @@ static void check_root_signature_deserialization_(unsigned int line, const D3D12
 
     hr = ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion(versioned_deserializer,
             D3D_ROOT_SIGNATURE_VERSION_1_0, &versioned_desc2);
-    ok_(line)(hr == S_OK, "Failed to get root signature 1.0, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to get root signature 1.0, hr %#x.\n", (int)hr);
     ok_(line)(versioned_desc2 == versioned_desc, "Got unexpected pointer %p.\n", versioned_desc2);
 
     hr = ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion(versioned_deserializer,
             D3D_ROOT_SIGNATURE_VERSION_1_1, &versioned_desc);
-    ok_(line)(hr == S_OK, "Failed to get root signature 1.0, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to get root signature 1.0, hr %#x.\n", (int)hr);
     ok(versioned_desc, "Got NULL root signature desc.\n");
     ok(versioned_desc->Version == D3D_ROOT_SIGNATURE_VERSION_1_1, "Got unexpected version %#x.\n", versioned_desc->Version);
     check_root_signature_desc1_(line, &versioned_desc->Desc_1_1, expected_desc1, true);
 
     refcount = ID3D12VersionedRootSignatureDeserializer_Release(versioned_deserializer);
-    ok_(line)(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok_(line)(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", refcount);
 }
 
 #define check_root_signature_serialization(a, b) check_root_signature_serialization_(__LINE__, a, b)
@@ -597,7 +597,7 @@ static void check_root_signature_serialization_(unsigned int line, const D3D12_S
 
     error_blob = (ID3DBlob *)(uintptr_t)0xdeadbeef;
     hr = D3D12SerializeRootSignature(desc, D3D_ROOT_SIGNATURE_VERSION_1_0, &blob, &error_blob);
-    ok_(line)(hr == S_OK, "Failed to serialize root signature, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to serialize root signature, hr %#x.\n", (int)hr);
     ok_(line)(!error_blob, "Got unexpected error blob %p.\n", error_blob);
 
     blob_buffer = ID3D10Blob_GetBufferPointer(blob);
@@ -622,12 +622,12 @@ static void check_root_signature_deserialization1_(unsigned int line, const D3D1
     ID3D12VersionedRootSignatureDeserializer *versioned_deserializer;
     ID3D12RootSignatureDeserializer *deserializer;
     const D3D12_ROOT_SIGNATURE_DESC *desc;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
     hr = pfn_D3D12CreateVersionedRootSignatureDeserializer(code->pShaderBytecode, code->BytecodeLength,
             &IID_ID3D12VersionedRootSignatureDeserializer, (void **)&versioned_deserializer);
-    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", (int)hr);
 
     versioned_desc = ID3D12VersionedRootSignatureDeserializer_GetUnconvertedRootSignatureDesc(versioned_deserializer);
     ok(versioned_desc, "Got NULL root signature desc.\n");
@@ -636,29 +636,29 @@ static void check_root_signature_deserialization1_(unsigned int line, const D3D1
 
     hr = ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion(versioned_deserializer,
             D3D_ROOT_SIGNATURE_VERSION_1_1, &versioned_desc2);
-    ok_(line)(hr == S_OK, "Failed to get root signature 1.1, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to get root signature 1.1, hr %#x.\n", (int)hr);
     ok_(line)(versioned_desc2 == versioned_desc, "Got unexpected pointer %p.\n", versioned_desc2);
 
     hr = ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion(versioned_deserializer,
             D3D_ROOT_SIGNATURE_VERSION_1_0, &versioned_desc);
-    ok_(line)(hr == S_OK, "Failed to get root signature 1.0, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to get root signature 1.0, hr %#x.\n", (int)hr);
     ok(versioned_desc, "Got NULL root signature desc.\n");
     ok(versioned_desc->Version == D3D_ROOT_SIGNATURE_VERSION_1_0, "Got unexpected version %#x.\n", versioned_desc->Version);
     check_root_signature_desc_(line, &versioned_desc->Desc_1_0, expected_desc);
 
     refcount = ID3D12VersionedRootSignatureDeserializer_Release(versioned_deserializer);
-    ok_(line)(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok_(line)(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", refcount);
 
     hr = D3D12CreateRootSignatureDeserializer(code->pShaderBytecode, code->BytecodeLength,
             &IID_ID3D12RootSignatureDeserializer, (void **)&deserializer);
-    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", (int)hr);
 
     desc = ID3D12RootSignatureDeserializer_GetRootSignatureDesc(deserializer);
     ok(desc, "Got NULL root signature desc.\n");
     check_root_signature_desc_(line, desc, expected_desc);
 
     refcount = ID3D12RootSignatureDeserializer_Release(deserializer);
-    ok_(line)(!refcount, "ID3D12RootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok_(line)(!refcount, "ID3D12RootSignatureDeserializer has %u references left.\n", refcount);
 }
 
 #define check_root_signature_deserialization2(a, b, c, d) check_root_signature_deserialization2_(__LINE__, a, b, c, d)
@@ -671,12 +671,12 @@ static void check_root_signature_deserialization2_(unsigned int line, const D3D1
     ID3D12VersionedRootSignatureDeserializer *versioned_deserializer;
     ID3D12RootSignatureDeserializer *deserializer;
     const D3D12_ROOT_SIGNATURE_DESC *desc;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
     hr = pfn_D3D12CreateVersionedRootSignatureDeserializer(code->pShaderBytecode, code->BytecodeLength,
             &IID_ID3D12VersionedRootSignatureDeserializer, (void **)&versioned_deserializer);
-    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", (int)hr);
 
     versioned_desc = ID3D12VersionedRootSignatureDeserializer_GetUnconvertedRootSignatureDesc(versioned_deserializer);
     ok(versioned_desc, "Got NULL root signature desc.\n");
@@ -685,36 +685,36 @@ static void check_root_signature_deserialization2_(unsigned int line, const D3D1
 
     hr = ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion(versioned_deserializer,
             D3D_ROOT_SIGNATURE_VERSION_1_2, &versioned_desc2);
-    ok_(line)(hr == S_OK, "Failed to get root signature 1.2, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to get root signature 1.2, hr %#x.\n", (int)hr);
     ok_(line)(versioned_desc2 == versioned_desc, "Got unexpected pointer %p.\n", versioned_desc2);
 
     hr = ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion(versioned_deserializer,
             D3D_ROOT_SIGNATURE_VERSION_1_1, &versioned_desc2);
-    ok_(line)(hr == S_OK, "Failed to get root signature 1.1, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to get root signature 1.1, hr %#x.\n", (int)hr);
     ok(versioned_desc2, "Got NULL root signature desc.\n");
     ok(versioned_desc2->Version == D3D_ROOT_SIGNATURE_VERSION_1_1, "Got unexpected version %#x.\n", versioned_desc2->Version);
     check_root_signature_desc1_(line, &versioned_desc2->Desc_1_1, expected_desc1, false);
 
     hr = ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion(versioned_deserializer,
             D3D_ROOT_SIGNATURE_VERSION_1_0, &versioned_desc);
-    ok_(line)(hr == S_OK, "Failed to get root signature 1.0, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to get root signature 1.0, hr %#x.\n", (int)hr);
     ok(versioned_desc, "Got NULL root signature desc.\n");
     ok(versioned_desc->Version == D3D_ROOT_SIGNATURE_VERSION_1_0, "Got unexpected version %#x.\n", versioned_desc->Version);
     check_root_signature_desc_(line, &versioned_desc->Desc_1_0, expected_desc);
 
     refcount = ID3D12VersionedRootSignatureDeserializer_Release(versioned_deserializer);
-    ok_(line)(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok_(line)(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", refcount);
 
     hr = D3D12CreateRootSignatureDeserializer(code->pShaderBytecode, code->BytecodeLength,
             &IID_ID3D12RootSignatureDeserializer, (void **)&deserializer);
-    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create deserializer, hr %#x.\n", (int)hr);
 
     desc = ID3D12RootSignatureDeserializer_GetRootSignatureDesc(deserializer);
     ok(desc, "Got NULL root signature desc.\n");
     check_root_signature_desc_(line, desc, expected_desc);
 
     refcount = ID3D12RootSignatureDeserializer_Release(deserializer);
-    ok_(line)(!refcount, "ID3D12RootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok_(line)(!refcount, "ID3D12RootSignatureDeserializer has %u references left.\n", refcount);
 }
 
 #define check_root_signature_serialization1(a, b) check_root_signature_serialization1_(__LINE__, a, b)
@@ -734,7 +734,7 @@ static void check_root_signature_serialization1_(unsigned int line, const D3D12_
 
     error_blob = (ID3DBlob *)(uintptr_t)0xdeadbeef;
     hr = pfn_D3D12SerializeVersionedRootSignature(&versioned_desc, &blob, &error_blob);
-    ok_(line)(hr == S_OK, "Failed to serialize root signature, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to serialize root signature, hr %#x.\n", (int)hr);
     ok_(line)(!error_blob, "Got unexpected error blob %p.\n", error_blob);
 
     blob_buffer = ID3D10Blob_GetBufferPointer(blob);
@@ -768,7 +768,7 @@ static void check_root_signature_serialization2_(unsigned int line, const D3D12_
 
     error_blob = (ID3DBlob *)(uintptr_t)0xdeadbeef;
     hr = pfn_D3D12SerializeVersionedRootSignature(&versioned_desc, &blob, &error_blob);
-    ok_(line)(hr == S_OK, "Failed to serialize root signature, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to serialize root signature, hr %#x.\n", (int)hr);
     ok_(line)(!error_blob, "Got unexpected error blob %p.\n", error_blob);
 
     blob_buffer = ID3D10Blob_GetBufferPointer(blob);
@@ -789,9 +789,9 @@ void test_root_signature_byte_code(void)
 {
     ID3D12VersionedRootSignatureDeserializer *versioned_deserializer;
     ID3D12RootSignatureDeserializer *deserializer;
+    unsigned int refcount;
     ID3DBlob *blob;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
 #if 0
@@ -1350,14 +1350,14 @@ void test_root_signature_byte_code(void)
 
     hr = D3D12CreateRootSignatureDeserializer(empty_rootsig, sizeof(empty_rootsig),
             &IID_IUnknown, (void **)&deserializer);
-    ok(hr == E_NOINTERFACE, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_NOINTERFACE, "Got unexpected hr %#x.\n", (int)hr);
     hr = D3D12CreateRootSignatureDeserializer(empty_rootsig, sizeof(empty_rootsig),
             &IID_ID3D12VersionedRootSignatureDeserializer, (void **)&deserializer);
-    ok(hr == E_NOINTERFACE, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_NOINTERFACE, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = D3D12CreateRootSignatureDeserializer(empty_rootsig, sizeof(empty_rootsig),
             &IID_ID3D12RootSignatureDeserializer, (void **)&deserializer);
-    ok(hr == S_OK, "Failed to create deserializer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create deserializer, hr %#x.\n", (int)hr);
 
     check_interface(deserializer, &IID_IUnknown, false);
     check_interface(deserializer, &IID_ID3D12RootSignatureDeserializer, true);
@@ -1367,7 +1367,7 @@ void test_root_signature_byte_code(void)
     check_interface(deserializer, &IID_ID3D12Pageable, false);
 
     refcount = ID3D12RootSignatureDeserializer_Release(deserializer);
-    ok(!refcount, "ID3D12RootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12RootSignatureDeserializer has %u references left.\n", refcount);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -1380,7 +1380,7 @@ void test_root_signature_byte_code(void)
 
         blob = (ID3DBlob *)(uintptr_t)0xdeadbeef;
         hr = D3D12SerializeRootSignature(t->desc, D3D_ROOT_SIGNATURE_VERSION_1_1, &blob, NULL);
-        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+        ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
         ok(blob == (ID3DBlob *)(uintptr_t)0xdeadbeef, "Got unexpected blob %p.\n", blob);
 
         if (!pfn_D3D12CreateVersionedRootSignatureDeserializer)
@@ -1399,14 +1399,14 @@ void test_root_signature_byte_code(void)
 
     hr = pfn_D3D12CreateVersionedRootSignatureDeserializer(empty_rootsig, sizeof(empty_rootsig),
             &IID_IUnknown, (void **)&versioned_deserializer);
-    ok(hr == E_NOINTERFACE, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_NOINTERFACE, "Got unexpected hr %#x.\n", (int)hr);
     hr = pfn_D3D12CreateVersionedRootSignatureDeserializer(empty_rootsig, sizeof(empty_rootsig),
             &IID_ID3D12RootSignatureDeserializer, (void **)&versioned_deserializer);
-    ok(hr == E_NOINTERFACE, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_NOINTERFACE, "Got unexpected hr %#x.\n", (int)hr);
 
     hr = pfn_D3D12CreateVersionedRootSignatureDeserializer(empty_rootsig, sizeof(empty_rootsig),
             &IID_ID3D12VersionedRootSignatureDeserializer, (void **)&versioned_deserializer);
-    ok(hr == S_OK, "Failed to create deserializer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create deserializer, hr %#x.\n", (int)hr);
 
     check_interface(versioned_deserializer, &IID_IUnknown, false);
     check_interface(versioned_deserializer, &IID_ID3D12RootSignatureDeserializer, false);
@@ -1416,7 +1416,7 @@ void test_root_signature_byte_code(void)
     check_interface(versioned_deserializer, &IID_ID3D12Pageable, false);
 
     refcount = ID3D12VersionedRootSignatureDeserializer_Release(versioned_deserializer);
-    ok(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", refcount);
 }
 
 void test_root_signature_byte_code2(void)
@@ -1619,13 +1619,13 @@ void test_root_signature_byte_code2(void)
 
     hr = pfn_D3D12CreateVersionedRootSignatureDeserializer(rs_blob_dxbc, sizeof(rs_blob_dxbc),
             &IID_ID3D12VersionedRootSignatureDeserializer, (void **)&deserializer);
-    ok(SUCCEEDED(hr), "Got unexpected hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Got unexpected hr %#x.\n", (int)hr);
 
     check_root_signature_deserialization2(&rs_blob, &desc0, &desc1, &desc2);
     check_root_signature_serialization2(&rs_blob, &desc2);
 
     refcount = ID3D12VersionedRootSignatureDeserializer_Release(deserializer);
-    ok(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12VersionedRootSignatureDeserializer has %u references left.\n", refcount);
 }
 
 void test_root_signature_priority(void)
@@ -1693,10 +1693,10 @@ void test_root_signature_priority(void)
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
 
     hr = create_root_signature(device, &root_signature_desc, &api_root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateRootSignature(context.device, 0, cs_code, sizeof(cs_code), &IID_ID3D12RootSignature, (void**)&shader_root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pipeline = create_compute_pipeline_state(device, api_root_signature, cs);
     resource = create_buffer(device, D3D12_HEAP_TYPE_DEFAULT, sizeof(expected),
@@ -1790,17 +1790,17 @@ void test_missing_bindings_root_signature(void)
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
 
     hr = create_root_signature(device, &root_signature_desc, &api_root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateRootSignature(context.device, 0, cs_code, sizeof(cs_code), &IID_ID3D12RootSignature, (void **)&shader_root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&cs_desc, 0, sizeof(cs_desc));
     cs_desc.pRootSignature = api_root_signature;
     cs_desc.CS = cs;
 
     hr = ID3D12Device_CreateComputePipelineState(context.device, &cs_desc, &IID_ID3D12PipelineState, (void **)&pipeline);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
     if (SUCCEEDED(hr))
         ID3D12PipelineState_Release(pipeline);
 
@@ -1839,7 +1839,7 @@ void test_root_signature_empty_blob(void)
 
     hr = ID3D12Device_CreateRootSignature(context.device, 0, cs_code, sizeof(cs_code), &IID_ID3D12RootSignature, (void **)&root_signature);
     /* Has to be E_FAIL, not E_INVALIDARG, oddly enough. */
-    ok(hr == E_FAIL, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_FAIL, "Unexpected hr #%x.\n", (int)hr);
     destroy_test_context(&context);
 }
 
@@ -1900,7 +1900,7 @@ void test_root_signature_embedded(void)
             pso_desc.GS = *tests[i].gs;
         pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-        todo_if(tests[i].is_todo) ok(hr == tests[i].hr, "Expected hr #%x, got hr #%x\n", tests[i].hr, hr);
+        todo_if(tests[i].is_todo) ok(hr == tests[i].hr, "Expected hr #%x, got hr #%x\n", (int)tests[i].hr, (int)hr);
         if (SUCCEEDED(hr))
             ID3D12PipelineState_Release(pso);
     }

--- a/tests/d3d12_rov.c
+++ b/tests/d3d12_rov.c
@@ -755,7 +755,7 @@ static ID3D12PipelineState *create_pso(ID3D12Device *device, ID3D12RootSignature
     pso_desc.DepthStencilState.StencilEnable = FALSE;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create PSO: hr = #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO: hr = #%x\n", (int)hr);
     return pso;
 }
 

--- a/tests/d3d12_sampler_feedback.c
+++ b/tests/d3d12_sampler_feedback.c
@@ -65,7 +65,7 @@ void test_sampler_feedback_resource_creation(void)
     }
 
     hr = ID3D12Device_QueryInterface(device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
 
     memset(&desc, 0, sizeof(desc));
     memset(&heap_props, 0, sizeof(heap_props));
@@ -80,7 +80,7 @@ void test_sampler_feedback_resource_creation(void)
     heap_desc.Properties = heap_props;
     heap_desc.Flags = D3D12_HEAP_FLAG_CREATE_NOT_ZEROED | D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++)
     {
@@ -96,12 +96,12 @@ void test_sampler_feedback_resource_creation(void)
 
         hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
             &desc, D3D12_RESOURCE_STATE_COMMON, NULL, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == tests[i].expected, "Unexpected hr, expected #%x, got #%x.\n", tests[i].expected, hr);
+        ok(hr == tests[i].expected, "Unexpected hr, expected #%x, got #%x.\n", (int)tests[i].expected, (int)hr);
         if (SUCCEEDED(hr))
             ID3D12Resource_Release(resource);
 
         hr = ID3D12Device8_CreatePlacedResource1(device8, heap, 0, &desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == tests[i].expected, "Unexpected hr, expected #%x, got #%x.\n", tests[i].expected, hr);
+        ok(hr == tests[i].expected, "Unexpected hr, expected #%x, got #%x.\n", (int)tests[i].expected, (int)hr);
         if (SUCCEEDED(hr))
             ID3D12Resource_Release(resource);
 
@@ -109,12 +109,12 @@ void test_sampler_feedback_resource_creation(void)
 
         hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
             &desc, D3D12_RESOURCE_STATE_COMMON, NULL, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == tests[i].expected, "Unexpected hr, expected #%x, got #%x.\n", tests[i].expected, hr);
+        ok(hr == tests[i].expected, "Unexpected hr, expected #%x, got #%x.\n", (int)tests[i].expected, (int)hr);
         if (SUCCEEDED(hr))
             ID3D12Resource_Release(resource);
 
         hr = ID3D12Device8_CreatePlacedResource1(device8, heap, 0, &desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == tests[i].expected, "Unexpected hr, expected #%x, got #%x.\n", tests[i].expected, hr);
+        ok(hr == tests[i].expected, "Unexpected hr, expected #%x, got #%x.\n", (int)tests[i].expected, (int)hr);
         if (SUCCEEDED(hr))
             ID3D12Resource_Release(resource);
 
@@ -161,7 +161,7 @@ void test_sampler_feedback_format_features(void)
         format.Support2 = UINT32_MAX;
 
         hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_FORMAT_SUPPORT, &format, sizeof(format));
-        ok(SUCCEEDED(hr), "Failed to query for format features, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to query for format features, hr #%x.\n", (int)hr);
 
         ok(format.Support1 == (D3D12_FORMAT_SUPPORT1_TEXTURE2D | D3D12_FORMAT_SUPPORT1_MIP), "Unexpected feature support #%x.\n", format.Support1);
         ok(format.Support2 == D3D12_FORMAT_SUPPORT2_SAMPLER_FEEDBACK, "Unexpected feature support #%x.\n", format.Support2);
@@ -427,9 +427,9 @@ static void test_sampler_feedback_min_mip_level_inner(bool arrayed)
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(desc_range, 0, sizeof(desc_range));
@@ -485,9 +485,9 @@ static void test_sampler_feedback_min_mip_level_inner(bool arrayed)
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     desc.Format = DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback_copy);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap));
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap_cpu));
@@ -713,9 +713,9 @@ void test_sampler_feedback_npot_min_mip_level(void)
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(desc_range, 0, sizeof(desc_range));
@@ -772,7 +772,7 @@ void test_sampler_feedback_npot_min_mip_level(void)
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     desc.Format = DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap));
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap_cpu));
@@ -905,9 +905,9 @@ void test_sampler_feedback_decode_encode_min_mip(void)
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     desc_heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
 
@@ -930,12 +930,12 @@ void test_sampler_feedback_decode_encode_min_mip(void)
     desc.DepthOrArraySize = LAYERS;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
             &desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback_min_mip_array);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     desc.DepthOrArraySize = 1;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
             &desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback_min_mip_single);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     resolve = create_default_buffer(context.device, MIP_REGIONS_FLAT, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_RESOLVE_DEST);
     resolve_tex = create_default_texture2d(context.device, MIP_REGIONS_X, MIP_REGIONS_Y, LAYERS, 1, DXGI_FORMAT_R8_UINT, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COPY_SOURCE);
@@ -1160,9 +1160,9 @@ void test_sampler_feedback_decode_encode_mip_used(void)
     desc_heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     memset(&desc, 0, sizeof(desc));
     memset(&heap_props, 0, sizeof(heap_props));
@@ -1181,7 +1181,7 @@ void test_sampler_feedback_decode_encode_mip_used(void)
     desc.DepthOrArraySize = LAYERS;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
             &desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     /* Add padding so we can test offsets. */
     resolve_tex = create_default_texture2d(context.device, MIP_REGIONS_X * 4, MIP_REGIONS_Y * 4, LAYERS, LEVELS, DXGI_FORMAT_R8_UINT, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COPY_SOURCE);
@@ -1488,9 +1488,9 @@ void test_sampler_feedback_mip_used_region_level(void)
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(desc_range, 0, sizeof(desc_range));
@@ -1546,7 +1546,7 @@ void test_sampler_feedback_mip_used_region_level(void)
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     desc.Format = DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap));
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap_cpu));
@@ -1665,9 +1665,9 @@ void test_sampler_feedback_npot_used_region(void)
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(desc_range, 0, sizeof(desc_range));
@@ -1811,7 +1811,7 @@ void test_sampler_feedback_npot_used_region(void)
         desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
         desc.Format = DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE;
         hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback);
-        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
         ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap));
         ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap_cpu));
@@ -2305,9 +2305,9 @@ void test_sampler_feedback_grad(void)
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(desc_range, 0, sizeof(desc_range));
@@ -2363,10 +2363,10 @@ void test_sampler_feedback_grad(void)
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     desc.Format = DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_RESOLVE_SOURCE, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback_used);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
     desc.Format = DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_RESOLVE_SOURCE, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback_min);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback_used, get_cpu_descriptor_handle(&context, desc_heaps[0], 0));
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback_used, get_cpu_descriptor_handle(&context, desc_heap_cpu, 0));
@@ -2865,9 +2865,9 @@ static void test_sampler_feedback_implicit_lod_inner(bool biased)
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(desc_range, 0, sizeof(desc_range));
@@ -2905,7 +2905,7 @@ static void test_sampler_feedback_implicit_lod_inner(bool biased)
     pso_desc.DepthStencilState.StencilEnable = FALSE;
     pso_desc.DSVFormat = DXGI_FORMAT_UNKNOWN;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x.\n", (int)hr);
 
     desc_heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 2);
     desc_heap_cpu = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
@@ -2929,7 +2929,7 @@ static void test_sampler_feedback_implicit_lod_inner(bool biased)
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     desc.Format = DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap));
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap_cpu));
@@ -3289,9 +3289,9 @@ void test_sampler_feedback_implicit_lod_aniso(void)
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device8, (void **)&device8);
-    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query Device8, hr #%x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList1, (void **)&list1);
-    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query GraphicsCommandList1, hr #%x.\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(desc_range, 0, sizeof(desc_range));
@@ -3330,7 +3330,7 @@ void test_sampler_feedback_implicit_lod_aniso(void)
     pso_desc.DepthStencilState.StencilEnable = FALSE;
     pso_desc.DSVFormat = DXGI_FORMAT_UNKNOWN;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline state, hr #%x.\n", (int)hr);
 
     desc_heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 2);
     desc_heap_cpu = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
@@ -3354,7 +3354,7 @@ void test_sampler_feedback_implicit_lod_aniso(void)
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     desc.Format = DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE;
     hr = ID3D12Device8_CreateCommittedResource2(device8, &heap_props, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, NULL, &IID_ID3D12Resource, (void **)&feedback);
-    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap));
     ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView(device8, resource, feedback, ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(desc_heap_cpu));

--- a/tests/d3d12_shaders.c
+++ b/tests/d3d12_shaders.c
@@ -3429,7 +3429,7 @@ void test_shader_instructions(void)
     vkd3d_test_set_context(NULL);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
     reset_command_list(command_list, context.allocator);
     ID3D12Resource_Release(context.render_target);
     desc.rt_format = DXGI_FORMAT_R32G32B32A32_UINT;
@@ -3635,7 +3635,7 @@ void test_compute_shader_instructions(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     buffer = create_default_buffer(device, 512,
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_DEST);
@@ -3890,7 +3890,7 @@ void test_cs_constant_buffer(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pipeline_state = create_compute_pipeline_state(device, root_signature,
             shader_bytecode(cs_code, sizeof(cs_code)));
@@ -3901,7 +3901,7 @@ void test_cs_constant_buffer(void)
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc,
             &IID_ID3D12DescriptorHeap, (void **)&descriptor_heap);
-    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     descriptor_size = ID3D12Device_GetDescriptorHandleIncrementSize(device,
             D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
@@ -4041,7 +4041,7 @@ void test_constant_buffer_relative_addressing(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(device, context.root_signature,
             shader_bytecode(cs_code, sizeof(cs_code)));
@@ -4398,7 +4398,7 @@ void test_root_constants(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
     context.pipeline_state = create_pipeline_state(context.device,
             context.root_signature, desc.rt_format, &vs_color, &ps_color, NULL);
 
@@ -4470,7 +4470,7 @@ void test_root_constants(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
     context.pipeline_state = create_pipeline_state(context.device,
             context.root_signature, desc.rt_format, &vs_mix, &ps_mix, NULL);
 
@@ -4884,7 +4884,7 @@ void test_sample_instructions(void)
     root_signature_desc.NumParameters = ARRAY_SIZE(root_parameters);
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     heap = create_gpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
     cpu_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(heap);
@@ -6347,7 +6347,7 @@ void test_cube_maps(void)
             pso_desc.PS = *test->ps;
             hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                     &IID_ID3D12PipelineState, (void **)&pso);
-            ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
         }
 
         texture = create_default_texture2d(context.device, texture_size, texture_size,
@@ -6561,7 +6561,7 @@ void test_multisample_array_texture(void)
     root_signature_desc.pParameters = root_parameters;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_pipeline_state(context.device,
             context.root_signature, context.render_target_desc.Format, NULL, &ps, NULL);
@@ -6582,7 +6582,7 @@ void test_multisample_array_texture(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&texture);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     cpu_handle = get_cpu_rtv_handle(&context, context.rtv_heap, 1);
 
@@ -6967,7 +6967,7 @@ void test_resinfo(void)
                 &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
                 D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, NULL,
                 &IID_ID3D12Resource, (void **)&texture);
-        ok(hr == S_OK, "Test %u: Failed to create texture, hr %#x.\n", i, hr);
+        ok(hr == S_OK, "Test %u: Failed to create texture, hr %#x.\n", i, (int)hr);
 
         current_srv_desc = NULL;
         if (test->texture_desc.cube_count)
@@ -7340,7 +7340,7 @@ void test_typed_buffer_uav(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     pipeline_state = create_compute_pipeline_state(device, root_signature,
             shader_bytecode(cs_code, sizeof(cs_code)));
@@ -7464,7 +7464,7 @@ void test_typed_uav_store(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(device, context.root_signature,
             shader_bytecode(cs_float_code, sizeof(cs_float_code)));
@@ -7613,7 +7613,7 @@ void test_compute_shader_registers(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(device, context.root_signature,
             shader_bytecode(cs_code, sizeof(cs_code)));
@@ -7881,7 +7881,7 @@ void test_tgsm(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     buffer = create_default_buffer(device, 1024,
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -8297,7 +8297,7 @@ void test_uav_load(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     set_viewport(&context.viewport, 0.0f, 0.0f, 640.0f, 480.0f, 0.0f, 1.0f);
     set_rect(&context.scissor_rect, 0, 0, 640, 480);
@@ -8324,7 +8324,7 @@ void test_uav_load(void)
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)&rt_texture);
-    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
 
     rtv_heap = create_cpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 3);
     cpu_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(rtv_heap);
@@ -8383,7 +8383,7 @@ void test_uav_load(void)
                     &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
                     D3D12_RESOURCE_STATE_COPY_DEST, NULL,
                     &IID_ID3D12Resource, (void **)&texture);
-            ok(SUCCEEDED(hr), "Test %u: Failed to create texture, hr %#x.\n", i, hr);
+            ok(SUCCEEDED(hr), "Test %u: Failed to create texture, hr %#x.\n", i, (int)hr);
 
             upload_texture_data(texture, current_texture->data,
                     resource_desc.MipLevels * resource_desc.DepthOrArraySize, queue, command_list);
@@ -8677,7 +8677,7 @@ void test_cs_uav_store(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     descriptor_heap = create_gpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
     cpu_descriptor_heap = create_cpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
@@ -8693,7 +8693,7 @@ void test_cs_uav_store(void)
     ID3D12Device_CreateUnorderedAccessView(device, resource, NULL, &uav_desc, cpu_descriptor_handle);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
     memset(&uav_barrier, 0, sizeof(uav_barrier));
     uav_barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
@@ -8955,7 +8955,7 @@ void test_uav_counters(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(device, context.root_signature,
             shader_bytecode(cs_producer_code, sizeof(cs_producer_code)));
@@ -9163,7 +9163,7 @@ void test_decrement_uav_counter(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(device, context.root_signature,
             shader_bytecode(cs_code, sizeof(cs_code)));
@@ -9531,7 +9531,7 @@ static void test_atomic_instructions(bool use_dxil)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     ps_buffer = create_default_buffer(device, sizeof(tests->input),
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_DEST);
@@ -9866,7 +9866,7 @@ void test_buffer_srv(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     descriptor_heap = create_gpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
     cpu_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(descriptor_heap);
@@ -10345,7 +10345,7 @@ static void test_instance_id(bool use_dxil)
         pso_desc.RTVFormats[1] = DXGI_FORMAT_R32_UINT;
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-        ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, rtvs[0], white, 0, NULL);
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, rtvs[1], white, 0, NULL);
@@ -10657,7 +10657,7 @@ static void test_vertex_id(bool use_dxil)
         destroy_test_context(&context);
         return;
     }
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     vb = create_upload_buffer(context.device, sizeof(vertices), vertices);
     vbv.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(vb);
@@ -11133,7 +11133,7 @@ static void test_face_culling(bool use_dxil)
         pso_desc.RasterizerState.FrontCounterClockwise = tests[i].front_ccw;
         hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&pso);
-        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
         ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -11157,7 +11157,7 @@ static void test_face_culling(bool use_dxil)
         pso_desc.VS = vs_ccw;
         hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&pso);
-        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
         ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -11200,7 +11200,7 @@ static void test_face_culling(bool use_dxil)
         pso_desc.RasterizerState.FrontCounterClockwise = front_tests[i];
         hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&pso);
-        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
         ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -11223,7 +11223,7 @@ static void test_face_culling(bool use_dxil)
         pso_desc.VS = vs_ccw;
         hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&pso);
-        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
         ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -11446,7 +11446,7 @@ void test_separate_bindings(void)
     root_signature_desc.NumParameters = 4;
     root_signature_desc.pParameters = root_parameters;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     compute_pso = create_compute_pipeline_state(device, context.root_signature,
             shader_bytecode(cs_code, sizeof(cs_code)));
@@ -11711,7 +11711,7 @@ static void test_sample_mask(bool use_dxil)
     pso_desc.SampleDesc.Count = 4;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ms_rtv = get_cpu_rtv_handle(&context, context.rtv_heap, 1);
     desc.sample_desc.Count = 4;
@@ -11913,7 +11913,7 @@ static void test_coverage(bool use_dxil)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     texture = create_default_texture(context.device, desc.rt_width, desc.rt_height, DXGI_FORMAT_R32_UINT,
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -11949,7 +11949,7 @@ static void test_coverage(bool use_dxil)
         pso_desc.SampleDesc.Count = desc.sample_desc.Count;
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearUnorderedAccessViewUint(command_list,
                 get_gpu_descriptor_handle(&context, gpu_heap, 0),
@@ -12111,7 +12111,7 @@ static void test_shader_get_render_target_sample_count(bool use_dxil)
     pso_desc.SampleDesc.Count = desc.sample_desc.Count;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, black, 0, NULL);
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -12282,7 +12282,7 @@ static void test_shader_sample_position(bool use_dxil)
     hr = ID3D12Device_CreateCommittedResource(context.device,
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&texture);
-    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 16);
     readback_texture = create_default_texture(context.device, 4, 1, DXGI_FORMAT_R32G32B32A32_FLOAT,
@@ -12764,7 +12764,7 @@ static void test_shader_eval_attribute(bool use_dxil)
     pso_desc.SampleDesc.Count = desc.sample_desc.Count;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -12788,7 +12788,7 @@ static void test_shader_eval_attribute(bool use_dxil)
     pso_desc.PS = ps_eval_centroid;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
     ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
@@ -13576,7 +13576,7 @@ static void test_bufinfo_instruction(bool use_dxil)
             root_signature_desc.pStaticSamplers = NULL;
             root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
             hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-            ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
         }
 
         if (current_shader != test->ps)
@@ -13591,7 +13591,7 @@ static void test_bufinfo_instruction(bool use_dxil)
                     context.render_target_desc.Format, &vs, current_shader, &input_layout);
             hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
                     &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-            ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
         }
 
         if (test->uav)
@@ -13973,7 +13973,7 @@ static void test_register_space(bool use_dxil)
     }
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(context.device,
                                                            context.root_signature,
@@ -14407,7 +14407,7 @@ static void test_constant_buffers(bool use_dxil)
     root_parameters[4].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(context.device,
                                                            context.root_signature,
@@ -14950,7 +14950,7 @@ static void test_derivative_hoisting(bool use_dxil)
     pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     cbv = create_upload_buffer(context.device, sizeof(cbv_data), cbv_data);
     output = create_default_buffer(context.device, 4 * sizeof(struct vec4), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COMMON);
@@ -15056,7 +15056,7 @@ static void test_root_constant_indexing(bool use_dxil)
     rs_desc.pParameters = rs_args;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&pso_desc, 0, sizeof(pso_desc));
     pso_desc.pRootSignature = context.root_signature;
@@ -15069,7 +15069,7 @@ static void test_root_constant_indexing(bool use_dxil)
     expected = use_dxil ? E_INVALIDARG : S_OK;
 
     todo_if(use_dxil)
-    ok(hr == expected, "Got hr %#x, expected %#x.\n", hr, expected);
+    ok(hr == expected, "Got hr %#x, expected %#x.\n", (int)hr, (int)expected);
 
     if (!context.pipeline_state)
     {
@@ -15093,7 +15093,7 @@ static void test_root_constant_indexing(bool use_dxil)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
         D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
         NULL, &IID_ID3D12Resource, (void**)&uav_resource);
-    ok(hr == S_OK, "Failed to create UAV resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create UAV resource, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_SetComputeRootSignature(context.list, context.root_signature);
     ID3D12GraphicsCommandList_SetPipelineState(context.list, context.pipeline_state);

--- a/tests/d3d12_sm_advanced.c
+++ b/tests/d3d12_sm_advanced.c
@@ -569,7 +569,7 @@ void test_shader_sm66_wave_size(void)
 
         expected_hr = supported_wave_size ? S_OK : E_INVALIDARG;
         hr = ID3D12Device_CreateComputePipelineState(context.device, &compute_desc, &IID_ID3D12PipelineState, (void**)&pso);
-        ok(hr == expected_hr, "Got hr #%x, expected %#x.\n", hr, expected_hr);
+        ok(hr == expected_hr, "Got hr #%x, expected %#x.\n", (int)hr, (int)expected_hr);
 
         if (!supported_wave_size)
         {
@@ -907,7 +907,7 @@ void test_sv_barycentric(void)
     memset(&features3, 0, sizeof(features3));
     if (FAILED(hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS3, &features3, sizeof(features3))) || !features3.BarycentricsSupported)
     {
-        skip("Context does not support barycentrics, hr #%x.\n", hr);
+        skip("Context does not support barycentrics, hr #%x.\n", (int)hr);
         destroy_test_context(&context);
         return;
     }
@@ -924,7 +924,7 @@ void test_sv_barycentric(void)
     pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%u.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%u.\n", (int)hr);
 
     ID3D12GraphicsCommandList_OMSetRenderTargets(context.list, 1, &context.rtv, TRUE, NULL);
     ibv.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(ibo);
@@ -1085,14 +1085,14 @@ void test_shader_fp16(void)
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso[i]);
 
         if (tests[i].native_fp16 && features4.Native16BitShaderOpsSupported)
-            ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%u.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%u.\n", (int)hr);
         else if (tests[i].native_fp16 && !features4.Native16BitShaderOpsSupported)
         {
-            ok(hr == E_INVALIDARG, "Unexpected hr: %x.\n", hr);
+            ok(hr == E_INVALIDARG, "Unexpected hr: %x.\n", (int)hr);
             skip("NativeFP16 is not supported. Failing pipeline compilation is expected.\n");
         }
         else
-            ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%u.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%u.\n", (int)hr);
 
         if (FAILED(hr))
             pso[i] = NULL;
@@ -2035,7 +2035,7 @@ void test_shader_sm66_is_helper_lane(void)
             DXGI_FORMAT_R32G32B32A32_FLOAT, NULL, &ps_discard_atomic_loop_dxil, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     input_keys = create_upload_buffer(context.device, sizeof(alpha_keys), alpha_keys);
     atomic_buffer = create_default_buffer(context.device, 4 * sizeof(uint32_t),
@@ -2085,7 +2085,7 @@ void test_shader_sm66_is_helper_lane(void)
     {
         uint32_t *ptr;
         hr = ID3D12Resource_Map(readback_buffer, 0, NULL, (void**)&ptr);
-        ok(SUCCEEDED(hr), "Failed to map buffer, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to map buffer, hr #%x.\n", (int)hr);
         if (SUCCEEDED(hr))
         {
             static const uint32_t expected[] = { 101, 0, 0, 101 };
@@ -2679,7 +2679,7 @@ void test_sm67_helper_lane_wave_ops(void)
     rs_params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_SRV;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
     init_pipeline_state_desc_shaders(&pso_desc, context.root_signature, DXGI_FORMAT_R32_UINT, NULL, NULL, 0, NULL, 0);
     pso_desc.VS = vs_helper_lane_wave_ops_dxil;
@@ -2687,10 +2687,10 @@ void test_sm67_helper_lane_wave_ops(void)
     pso_desc.DepthStencilState.DepthEnable = FALSE;
     pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&psos[0]);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
     pso_desc.PS = ps_helper_lane_wave_ops_enabled_dxil;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&psos[1]);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests) * 2; i++)
     {
@@ -2833,7 +2833,7 @@ void test_quad_vote_sm67_compute(void)
     rs_params[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
     context.pipeline_state = create_compute_pipeline_state(context.device, context.root_signature, cs_quad_vote_dxil);
     ok(!!context.pipeline_state, "Failed to create pipeline state.\n");
@@ -2954,11 +2954,11 @@ void test_sm67_multi_sample_uav(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
             &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void**)&src);
-    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected hr #%x.\n", (int)hr);
     resource_desc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
             &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void **)&src);
-    ok(SUCCEEDED(hr), "Failed to create UAV MSAA texture, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create UAV MSAA texture, hr #%x.\n", (int)hr);
 
     dst = create_default_buffer(context.device,
             resource_desc.Width * resource_desc.Height *
@@ -3942,16 +3942,16 @@ void test_sm67_integer_sampling(void)
     }
 
     hr = create_versioned_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
     if (FAILED(hr))
     {
-        skip("Root signature v1.2 not supported, hr #%x.\n", hr);
+        skip("Root signature v1.2 not supported, hr #%x.\n", (int)hr);
         destroy_test_context(&context);
         return;
     }
 
     hr = ID3D12Device_QueryInterface(context.device, &IID_ID3D12Device11, (void **)&device11);
-    ok(SUCCEEDED(hr), "Failed to query ID3D12Device11, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query ID3D12Device11, hr #%x.\n", (int)hr);
     if (FAILED(hr))
     {
         skip("ID3D12Device11 is not supported.\n");
@@ -4124,7 +4124,7 @@ void test_sm68_draw_parameters(void)
     rs_desc.pParameters = root_params;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc_dxil(&pso_desc, context.root_signature,
             DXGI_FORMAT_UNKNOWN, &vs_draw_args_dxil, NULL, NULL);
@@ -4132,7 +4132,7 @@ void test_sm68_draw_parameters(void)
     memset(&pso_desc.PS, 0, sizeof(pso_desc.PS));
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     memset(sig_args, 0, sizeof(sig_args));
     sig_args[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
@@ -4147,7 +4147,7 @@ void test_sm68_draw_parameters(void)
     sig_desc.pArgumentDescs = &sig_args[1];
 
     hr = ID3D12Device_CreateCommandSignature(context.device, &sig_desc, NULL, &IID_ID3D12CommandSignature, (void**)&simple_sig);
-    ok(hr == S_OK, "Failed to create command signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command signature, hr %#x.\n", (int)hr);
 
     /* Be robust here in case the implementation does not support dgc */
     sig_desc.NumArgumentDescs = ARRAY_SIZE(sig_args);
@@ -4159,7 +4159,7 @@ void test_sm68_draw_parameters(void)
         is_vk_device_extension_supported(context.device, "VK_EXT_device_generated_commands"))
     {
         hr = ID3D12Device_CreateCommandSignature(context.device, &sig_desc, context.root_signature, &IID_ID3D12CommandSignature, (void**)&complex_sig);
-        todo_if(hr == E_NOTIMPL) ok(hr == S_OK, "Failed to create command signature, hr %#x.\n", hr);
+        todo_if(hr == E_NOTIMPL) ok(hr == S_OK, "Failed to create command signature, hr %#x.\n", (int)hr);
     }
 
     memset(&heap_properties, 0, sizeof(heap_properties));
@@ -4177,7 +4177,7 @@ void test_sm68_draw_parameters(void)
     resource_desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void**)&uav);
-    ok(hr == S_OK, "Failed to create UAV buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create UAV buffer, hr %#x.\n", (int)hr);
 
     uav_heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
     uav_cpu_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
@@ -4200,10 +4200,10 @@ void test_sm68_draw_parameters(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void**)&draw_buffer);
-    ok(hr == S_OK, "Failed to create draw buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create draw buffer, hr %#x.\n", (int)hr);
 
     hr = ID3D12Resource_Map(draw_buffer, 0, NULL, (void**)&draw_args);
-    ok(hr == S_OK, "Failed to map draw buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to map draw buffer, hr %#x.\n", (int)hr);
     memcpy(draw_args, tests, sizeof(tests));
 
     viewport.TopLeftX = 0.0f;
@@ -4396,7 +4396,7 @@ void test_sm68_wave_size_range(void)
 
         expected_hr = supported_wave_size ? S_OK : E_INVALIDARG;
         hr = ID3D12Device_CreateComputePipelineState(context.device, &compute_desc, &IID_ID3D12PipelineState, (void**)&pso);
-        ok(hr == expected_hr, "Got hr #%x, expected %#x.\n", hr, expected_hr);
+        ok(hr == expected_hr, "Got hr #%x, expected %#x.\n", (int)hr, (int)expected_hr);
 
         if (!supported_wave_size)
         {
@@ -4589,12 +4589,12 @@ void test_sm68_sample_cmp_bias_grad(void)
     rs_desc.pStaticSamplers = &sampler_desc;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     init_pipeline_state_desc_dxil(&pso_desc, context.root_signature,
             DXGI_FORMAT_R32G32B32A32_FLOAT, &vs_sample_cmp_grad_bias_dxil, &ps_sample_cmp_grad_bias_dxil, NULL);
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline, hr %#x.\n", (int)hr);
 
     memset(&heap_properties, 0, sizeof(heap_properties));
     heap_properties.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -4612,7 +4612,7 @@ void test_sm68_sample_cmp_bias_grad(void)
 
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE, NULL, &IID_ID3D12Resource, (void**)&ds_resource);
-    ok(hr == S_OK, "Failed to create depth image, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create depth image, hr %#x.\n", (int)hr);
 
     dsv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, resource_desc.MipLevels);
     srv_heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
@@ -4757,7 +4757,7 @@ void test_sm67_helper_lane_only_wave_ops(void)
     rs_params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_SRV;
 
     hr = create_root_signature(context.device, &rs_desc, &context.root_signature);
-    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create root signature, hr #%x.\n", (int)hr);
 
     init_pipeline_state_desc_shaders(&pso_desc, context.root_signature, DXGI_FORMAT_R32G32B32A32_FLOAT, NULL, NULL, 0, NULL, 0);
     pso_desc.VS = vs_helper_lane_wave_ops_dxil;
@@ -4765,10 +4765,10 @@ void test_sm67_helper_lane_only_wave_ops(void)
     pso_desc.DepthStencilState.DepthEnable = FALSE;
     pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&psos[0]);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
     pso_desc.PS = helper_lane_only_wave_ops_sm67_dxil;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&psos[1]);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     src = create_upload_buffer(context.device, sizeof(input_data), input_data);
 
@@ -5010,7 +5010,7 @@ static ID3D12PipelineState *create_wmma_pso(ID3D12Device *device, ID3D12RootSign
     pipeline_state_desc.Flags = D3D12_PIPELINE_STATE_FLAG_NONE;
     hr = ID3D12Device_CreateComputePipelineState(device, &pipeline_state_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    todo ok(SUCCEEDED(hr), "Failed to create compute pipeline state, hr %#x.\n", hr);
+    todo ok(SUCCEEDED(hr), "Failed to create compute pipeline state, hr %#x.\n", (int)hr);
     return pipeline_state;
 }
 
@@ -6701,8 +6701,8 @@ void test_ags_float8_conversion(void)
 
         if ((i & 0x7f) == 0x7f)
         {
-            ok(isnan(fp8_to_fp32_value), "value %u: expected nan, got %f\n", fp8_to_fp32_value);
-            ok(isnan(fp8_to_fp32_sat_value), "value %u: expected nan, got %f\n", fp8_to_fp32_sat_value);
+            ok(isnan(fp8_to_fp32_value), "value %u: expected nan, got %f\n", i, fp8_to_fp32_value);
+            ok(isnan(fp8_to_fp32_sat_value), "value %u: expected nan, got %f\n", i, fp8_to_fp32_sat_value);
         }
         else
         {
@@ -6714,8 +6714,8 @@ void test_ags_float8_conversion(void)
 
         if ((i & 0x7f) > 0x7c)
         {
-            ok(isnan(bf8_to_fp32_value), "value %u: expected nan, got %f\n", bf8_to_fp32_value);
-            ok(isnan(bf8_to_fp32_sat_value), "value %u: expected nan, got %f\n", bf8_to_fp32_sat_value);
+            ok(isnan(bf8_to_fp32_value), "value %u: expected nan, got %f\n", i, bf8_to_fp32_value);
+            ok(isnan(bf8_to_fp32_sat_value), "value %u: expected nan, got %f\n", i, bf8_to_fp32_sat_value);
         }
         else
         {
@@ -6857,7 +6857,7 @@ void test_vs_instance_input_nonuniform_workarounds(void)
     }
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x\n", (int)hr);
 
     ID3D12GraphicsCommandList_SetGraphicsRootSignature(context.list, context.root_signature);
     ID3D12GraphicsCommandList_SetDescriptorHeaps(context.list, 1, &heap);

--- a/tests/d3d12_sparse.c
+++ b/tests/d3d12_sparse.c
@@ -151,7 +151,7 @@ void test_get_resource_tiling(void)
         return;
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (!options.TiledResourcesTier)
     {
@@ -175,7 +175,7 @@ void test_get_resource_tiling(void)
 
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
         D3D12_RESOURCE_STATE_GENERIC_READ, NULL, &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", (int)hr);
 
     /* This is nonsense, but it doesn't crash or generate errors. */
     ID3D12Device_GetResourceTiling(context.device, resource, NULL, NULL, NULL, NULL, 0, NULL);
@@ -245,7 +245,7 @@ void test_get_resource_tiling(void)
         hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
             D3D12_RESOURCE_STATE_GENERIC_READ, NULL, &IID_ID3D12Resource, (void **)&resource);
         todo_if(is_radv_device(context.device) && tests[i].todo_radv)
-        ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", (int)hr);
 
         if (hr != S_OK)
             continue;
@@ -356,7 +356,7 @@ static void test_update_tile_mappings_remap_inner(bool smem)
         return;
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (!options.TiledResourcesTier)
     {
@@ -387,7 +387,7 @@ static void test_update_tile_mappings_remap_inner(bool smem)
 
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create reserved buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create reserved buffer, hr %#x.\n", (int)hr);
 
     output_resource = create_default_buffer(context.device, 64 * sizeof(uint32_t),
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
@@ -432,11 +432,11 @@ static void test_update_tile_mappings_remap_inner(bool smem)
         };
 
         hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&new_heap);
-        ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
         hr = ID3D12Device_CreatePlacedResource(context.device, new_heap, 0, &resource_desc,
                 D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&placed_resource);
-        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create resource, hr #%x.\n", (int)hr);
 
         /* Destroy the old heap while it has mappings to the heap, then rebind those pages. Should not explode. */
         if (heap)
@@ -596,7 +596,7 @@ void test_update_tile_mappings(void)
         return;
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (!options.TiledResourcesTier)
     {
@@ -624,7 +624,7 @@ void test_update_tile_mappings(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     descriptor_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
     root_parameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
@@ -633,7 +633,7 @@ void test_update_tile_mappings(void)
     root_parameters[1].Constants.Num32BitValues = 4;
     root_parameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
     hr = create_root_signature(context.device, &root_signature_desc, &clear_root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     clear_texture_pipeline = create_compute_pipeline_state(context.device, clear_root_signature, update_tile_mappings_cs_clear_dxbc);
     check_texture_pipeline = create_compute_pipeline_state(context.device, root_signature, update_tile_mappings_texture_dxbc);
@@ -660,7 +660,7 @@ void test_update_tile_mappings(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void **)&readback_buffer);
-    ok(hr == S_OK, "Failed to create readback buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create readback buffer, hr %#x.\n", (int)hr);
 
     readback_va = ID3D12Resource_GetGPUVirtualAddress(readback_buffer);
 
@@ -670,12 +670,12 @@ void test_update_tile_mappings(void)
     heap_desc.SizeInBytes = 64 * 65536;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     resource_desc.Width = 64 * 65536;
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
         D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create reserved buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create reserved buffer, hr %#x.\n", (int)hr);
 
     srv_desc.Format = DXGI_FORMAT_UNKNOWN;
     srv_desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
@@ -881,7 +881,7 @@ void test_update_tile_mappings(void)
     heap_desc.SizeInBytes = 64 * 65536;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
     resource_desc.Alignment = 0;
@@ -897,7 +897,7 @@ void test_update_tile_mappings(void)
 
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
         D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void **)&resource);
-    ok(hr == S_OK, "Failed to create reserved texture, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create reserved texture, hr %#x.\n", (int)hr);
 
     num_tilings = resource_desc.MipLevels;
     ID3D12Device_GetResourceTiling(context.device, resource, NULL, &packed_mip_info, &tile_shape, &num_tilings, 0, tilings);
@@ -1057,7 +1057,7 @@ void test_update_tile_mappings(void)
 
         hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == S_OK, "Failed to create reserved texture, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create reserved texture, hr %#x.\n", (int)hr);
 
         num_tilings = resource_desc.MipLevels;
         ID3D12Device_GetResourceTiling(context.device, resource, NULL, &packed_mip_info, &tile_shape, &num_tilings, 0, tilings);
@@ -1210,7 +1210,7 @@ void test_update_tile_mappings(void)
 
         hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void **)&resource);
-        ok(hr == S_OK, "Failed to create reserved texture, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create reserved texture, hr %#x.\n", (int)hr);
 
         /* Map entire image */
         tile_offsets[0] = 0;
@@ -1329,7 +1329,7 @@ void test_copy_tiles(void)
         return;
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (!options.TiledResourcesTier)
     {
@@ -1355,10 +1355,10 @@ void test_copy_tiles(void)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_desc.Properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&src_buffer);
-    ok(hr == S_OK, "Failed to create buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create buffer, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_desc.Properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&dst_buffer);
-    ok(hr == S_OK, "Failed to create buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create buffer, hr %#x.\n", (int)hr);
 
     buffer_data = malloc(resource_desc.Width);
     for (i = 0; i < resource_desc.Width / sizeof(*buffer_data); i++)
@@ -1372,11 +1372,11 @@ void test_copy_tiles(void)
     /* Test buffer */
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
             D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&tiled_resource);
-    ok(hr == S_OK, "Failed to create tiled buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create tiled buffer, hr %#x.\n", (int)hr);
 
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     tile_offset = 0;
     ID3D12CommandQueue_UpdateTileMappings(context.queue, tiled_resource,
@@ -1455,11 +1455,11 @@ void test_copy_tiles(void)
 
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
             D3D12_RESOURCE_STATE_COPY_DEST, NULL, &IID_ID3D12Resource, (void **)&tiled_resource);
-    ok(hr == S_OK, "Failed to create tiled buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create tiled buffer, hr %#x.\n", (int)hr);
 
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     tile_offset = 0;
     ID3D12CommandQueue_UpdateTileMappings(context.queue, tiled_resource,
@@ -1617,7 +1617,7 @@ static void test_buffer_feedback_instructions(bool use_dxil)
     }
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (options.TiledResourcesTier < D3D12_TILED_RESOURCES_TIER_2)
     {
@@ -1655,7 +1655,7 @@ static void test_buffer_feedback_instructions(bool use_dxil)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&heap_desc, 0, sizeof(heap_desc));
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -1674,15 +1674,15 @@ static void test_buffer_feedback_instructions(bool use_dxil)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_desc.Properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE, NULL, &IID_ID3D12Resource, (void **)&out_buffer);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     resource_desc.Width = 4 * TILE_SIZE;
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS, NULL, &IID_ID3D12Resource, (void **)&tiled_buffer);
-    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     /* Map the 0k-64k range and the 128k-192k range, leave the rest unmapped */
     set_region_offset(&tile_regions[0], 0, 0, 0, 0);
@@ -1913,7 +1913,7 @@ static void test_texture_feedback_instructions(bool use_dxil)
     }
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (options.TiledResourcesTier < D3D12_TILED_RESOURCES_TIER_2)
     {
@@ -1956,7 +1956,7 @@ static void test_texture_feedback_instructions(bool use_dxil)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(context.device, &root_signature_desc, &root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&heap_desc, 0, sizeof(heap_desc));
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -1975,12 +1975,12 @@ static void test_texture_feedback_instructions(bool use_dxil)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_desc.Properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&color_rt);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     resource_desc.Format = DXGI_FORMAT_R32_UINT;
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_desc.Properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&residency_rt);
-    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create committed resource, hr %#x.\n", (int)hr);
 
     resource_desc.MipLevels = 2;
     resource_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -1988,10 +1988,10 @@ static void test_texture_feedback_instructions(bool use_dxil)
     resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, NULL, &IID_ID3D12Resource, (void **)&tiled_image);
-    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create reserved resource, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void **)&heap);
-    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create heap, hr %#x.\n", (int)hr);
 
     /* Map top-left + bottom-right of mip 0 + entire mip 1 */
     set_region_offset(&tile_regions[0], 0, 0, 0, 0);
@@ -2081,7 +2081,7 @@ static void test_texture_feedback_instructions(bool use_dxil)
         pipeline_desc.PS = use_dxil ? tests[i].ps_dxil : tests[i].ps_dxbc;
 
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pipeline_desc, &IID_ID3D12PipelineState, (void **)&pipeline_state);
-        ok(hr == S_OK, "Failed to compile graphics pipeline, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to compile graphics pipeline, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_OMSetRenderTargets(context.list, 2, &rt_handle, true, NULL);
         ID3D12GraphicsCommandList_ClearRenderTargetView(context.list, get_cpu_rtv_handle(&context, rtv_heap, 1), clear_residency_rt, 0, NULL);
@@ -2188,7 +2188,7 @@ void test_sparse_buffer_memory_lifetime(void)
         return;
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (options.TiledResourcesTier < D3D12_TILED_RESOURCES_TIER_2)
     {
@@ -2219,9 +2219,9 @@ void test_sparse_buffer_memory_lifetime(void)
     heap_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void**)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void**)&heap_live);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x.\n", (int)hr);
 
     memset(&desc, 0, sizeof(desc));
     desc.Width = 64 * 1024 * 1024;
@@ -2236,7 +2236,7 @@ void test_sparse_buffer_memory_lifetime(void)
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     hr = ID3D12Device_CreateReservedResource(context.device, &desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             NULL, &IID_ID3D12Resource, (void**)&sparse);
-    ok(SUCCEEDED(hr), "Failed to create reserved resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create reserved resource, hr #%x.\n", (int)hr);
 
     {
         const D3D12_TILED_RESOURCE_COORDINATE region_start_coordinate = { 0 };
@@ -2367,7 +2367,7 @@ void test_reserved_resource_mapping(void)
         return;
 
     hr = ID3D12Device_CheckFeatureSupport(context.device, D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to check feature support, hr %#x.\n", (int)hr);
 
     if (!options.TiledResourcesTier)
     {
@@ -2386,10 +2386,10 @@ void test_reserved_resource_mapping(void)
     desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
     desc.SampleDesc.Count = 1;
     hr = ID3D12Device_CreateReservedResource(context.device, &desc, D3D12_RESOURCE_STATE_COMMON, NULL, &IID_ID3D12Resource, (void **)&res);
-    ok(SUCCEEDED(hr), "Failed to create reserved resource, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create reserved resource, hr #%x.\n", (int)hr);
 
     hr = ID3D12Resource_Map(res, 0, NULL, &ptr);
-    ok(hr == E_INVALIDARG, "Unexpected return value hr #%x.\n", hr);
+    ok(hr == E_INVALIDARG, "Unexpected return value hr #%x.\n", (int)hr);
 
     ID3D12Resource_Release(res);
 
@@ -2472,7 +2472,7 @@ void test_sparse_depth_stencil_rendering(void)
     pso_desc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
     pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     memset(&resource_desc, 0, sizeof(resource_desc));
     resource_desc.Width = 256;
@@ -2485,7 +2485,7 @@ void test_sparse_depth_stencil_rendering(void)
     resource_desc.MipLevels = 1;
     resource_desc.SampleDesc.Count = 1;
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE, NULL, &IID_ID3D12Resource, (void**)&ds);
-    ok(SUCCEEDED(hr), "Failed to create reserved resource, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create reserved resource, hr #%x\n", (int)hr);
 
     if (FAILED(hr))
     {
@@ -2503,7 +2503,7 @@ void test_sparse_depth_stencil_rendering(void)
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES;
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;
     hr = ID3D12Device_CreateHeap(context.device, &heap_desc, &IID_ID3D12Heap, (void**)&heap);
-    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create heap, hr #%x\n", (int)hr);
 
     dsv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, 1);
     rtv_heap = create_cpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);
@@ -2750,14 +2750,14 @@ void test_sparse_default_mapping(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             NULL, &IID_ID3D12Resource, (void**)&feedback_buffer);
-    ok(hr == S_OK, "Failed to create feedback buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create feedback buffer, hr %#x.\n", (int)hr);
 
     resource_desc.Width = 256u * TILE_SIZE;
     resource_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
 
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ,
             NULL, &IID_ID3D12Resource, (void**)&tiled_buffer);
-    ok(hr == S_OK, "Failed to create tiled buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create tiled buffer, hr %#x.\n", (int)hr);
 
     memset(&resource_desc, 0, sizeof(resource_desc));
     resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
@@ -2771,7 +2771,7 @@ void test_sparse_default_mapping(void)
 
     hr = ID3D12Device_CreateReservedResource(context.device, &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ,
             NULL, &IID_ID3D12Resource, (void**)&tiled_image);
-    ok(hr == S_OK, "Failed to create tiled image, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create tiled image, hr %#x.\n", (int)hr);
 
     memset(rs_descriptors, 0, sizeof(rs_descriptors));
     rs_descriptors[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
@@ -2796,14 +2796,14 @@ void test_sparse_default_mapping(void)
     rs_desc.pParameters = rs_args;
 
     hr = create_root_signature(context.device, &rs_desc, &rs);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     memset(&pso_desc, 0, sizeof(pso_desc));
     pso_desc.pRootSignature = rs;
     pso_desc.CS = sparse_init_access_dxil;
 
     hr = ID3D12Device_CreateComputePipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void**)&pso);
-    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create compute pipeline, hr %#x.\n", (int)hr);
 
     memset(&descriptor_heap_desc, 0, sizeof(descriptor_heap_desc));
     descriptor_heap_desc.NumDescriptors = 3;
@@ -2811,7 +2811,7 @@ void test_sparse_default_mapping(void)
     descriptor_heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
 
     hr = ID3D12Device_CreateDescriptorHeap(context.device, &descriptor_heap_desc, &IID_ID3D12DescriptorHeap, (void**)&descriptor_heap);
-    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     memset(&uav_desc, 0, sizeof(uav_desc));
     uav_desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;

--- a/tests/d3d12_streamout.c
+++ b/tests/d3d12_streamout.c
@@ -114,7 +114,7 @@ void test_primitive_restart_list_topology_stream_output(void)
     pso_desc.IBStripCutValue = D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFFFFFF;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
 
     counter_buffer = create_default_buffer(device, 32,
             D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_STREAM_OUT);
@@ -239,7 +239,7 @@ static void test_vertex_shader_stream_output(bool use_dxil)
         destroy_test_context(&context);
         return;
     }
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     counter = 0;
     upload_buffer = create_upload_buffer(device, sizeof(counter), &counter);
@@ -362,7 +362,7 @@ void test_index_buffer_edge_case_stream_output(void)
         destroy_test_context(&context);
         return;
     }
-    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     counter = 0;
     upload_buffer = create_upload_buffer(device, sizeof(counter), &counter);

--- a/tests/d3d12_sync.c
+++ b/tests/d3d12_sync.c
@@ -78,9 +78,9 @@ void test_queue_wait(void)
     ok(event, "Failed to create event.\n");
 
     hr = ID3D12Device_CreateFence(device, 1, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence2);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     context.root_signature = create_cb_root_signature(context.device,
             0, D3D12_SHADER_VISIBILITY_PIXEL, D3D12_ROOT_SIGNATURE_FLAG_NONE);
@@ -126,7 +126,7 @@ void test_queue_wait(void)
             D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
 
     /* Wait() with signaled fence */
     update_buffer_data(cb, 0, sizeof(green), &green);
@@ -143,7 +143,7 @@ void test_queue_wait(void)
     exec_command_list(queue, command_list);
     queue_signal(queue, fence2, 1);
     hr = ID3D12Fence_SetEventOnCompletion(fence2, 1, event);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     init_readback(&rb, readback_buffer, buffer_size, resource_desc.Width, resource_desc.Height, 1, row_pitch);
@@ -153,7 +153,7 @@ void test_queue_wait(void)
     ok(value == 0, "Got unexpected value %"PRIu64".\n", value);
 
     hr = ID3D12Fence_Signal(fence, 2);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event, INFINITE);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event, 0);
@@ -170,7 +170,7 @@ void test_queue_wait(void)
     exec_command_list(queue, command_list);
     queue_signal(queue, fence2, 2);
     hr = ID3D12Fence_SetEventOnCompletion(fence2, 2, event);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     init_readback(&rb, readback_buffer, buffer_size, resource_desc.Width, resource_desc.Height, 1, row_pitch);
@@ -194,17 +194,17 @@ void test_queue_wait(void)
     queue_wait(queue, fence, 5);
     exec_command_list(queue, command_list);
     hr = ID3D12Fence_Signal(fence, 4);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
     update_buffer_data(cb, 0, sizeof(blue), &blue);
     hr = ID3D12Fence_Signal(fence, 5);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
     wait_queue_idle(device, queue);
     init_readback(&rb, readback_buffer, buffer_size, resource_desc.Width, resource_desc.Height, 1, row_pitch);
     check_readback_data_uint(&rb, NULL, 0xffff0000, 0);
     release_resource_readback(&rb);
 
     hr = ID3D12Fence_Signal(fence, 6);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
     update_buffer_data(cb, 0, sizeof(green), &green);
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
@@ -322,7 +322,7 @@ void test_graphics_compute_queue_synchronization(void)
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
     hr = create_root_signature(device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     compute_pipeline_state = create_compute_pipeline_state(device, context.root_signature,
             shader_bytecode(cs_code, sizeof(cs_code)));
@@ -331,19 +331,19 @@ void test_graphics_compute_queue_synchronization(void)
 
     compute_queue = create_command_queue(device, D3D12_COMMAND_LIST_TYPE_COMPUTE, D3D12_COMMAND_QUEUE_PRIORITY_NORMAL);
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence2);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     buffer = create_default_buffer(device, 1024,
             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&allocators[0]);
-    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             allocators[0], NULL, &IID_ID3D12GraphicsCommandList, (void **)&graphics_lists[0]);
-    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
     graphics_lists[1] = context.list;
     ID3D12GraphicsCommandList_AddRef(graphics_lists[1]);
@@ -352,10 +352,10 @@ void test_graphics_compute_queue_synchronization(void)
     {
         hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_COMPUTE,
                 &IID_ID3D12CommandAllocator, (void **)&allocators[i + 1]);
-        ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
         hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_COMPUTE,
                 allocators[i + 1], NULL, &IID_ID3D12GraphicsCommandList, (void **)&compute_lists[i]);
-        ok(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
     }
 
     cpu_heap = create_cpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
@@ -388,7 +388,7 @@ void test_graphics_compute_queue_synchronization(void)
         ID3D12GraphicsCommandList_SetComputeRoot32BitConstants(command_list, 1, 1, &value, 0);
         ID3D12GraphicsCommandList_Dispatch(command_list, 1, 1, 1);
         hr = ID3D12GraphicsCommandList_Close(command_list);
-        ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
 
         value += 10;
 
@@ -405,7 +405,7 @@ void test_graphics_compute_queue_synchronization(void)
         ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstants(command_list, 1, 1, &value, 0);
         ID3D12GraphicsCommandList_DrawInstanced(command_list, 3, 1, 0, 0);
         hr = ID3D12GraphicsCommandList_Close(command_list);
-        ok(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
 
         value += 2;
     }
@@ -425,7 +425,7 @@ void test_graphics_compute_queue_synchronization(void)
     exec_command_list(queue, graphics_lists[1]);
 
     hr = wait_for_fence(fence2, 1);
-    ok(hr == S_OK, "Failed to wait for fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to wait for fence, hr %#x.\n", (int)hr);
     reset_command_list(graphics_lists[0], allocators[0]);
     command_list = graphics_lists[0];
 
@@ -456,9 +456,9 @@ void test_fence_values(void)
 {
     uint64_t value, next_value;
     ID3D12CommandQueue *queue;
+    unsigned int refcount;
     ID3D12Device *device;
     ID3D12Fence *fence;
-    ULONG refcount;
     unsigned int i;
     HRESULT hr;
 
@@ -472,7 +472,7 @@ void test_fence_values(void)
 
     next_value = (uint64_t)1 << 60;
     hr = ID3D12Device_CreateFence(device, next_value, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == next_value, "Got value %#"PRIx64", expected %#"PRIx64".\n", value, next_value);
@@ -491,7 +491,7 @@ void test_fence_values(void)
     {
         next_value += 10000;
         hr = ID3D12Fence_Signal(fence, next_value);
-        ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
         value = ID3D12Fence_GetCompletedValue(fence);
         ok(value == next_value, "Got value %#"PRIx64", expected %#"PRIx64".\n", value, next_value);
     }
@@ -499,21 +499,21 @@ void test_fence_values(void)
     ID3D12Fence_Release(fence);
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
     next_value = (uint64_t)1 << 60;
     hr = ID3D12Fence_Signal(fence, next_value);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == next_value, "Got value %#"PRIx64", expected %#"PRIx64".\n", value, next_value);
     next_value = 0;
     hr = ID3D12Fence_Signal(fence, next_value);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == next_value, "Got value %#"PRIx64", expected %#"PRIx64".\n", value, next_value);
     ID3D12Fence_Release(fence);
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
     next_value = (uint64_t)1 << 60;
     queue_signal(queue, fence, next_value);
     wait_queue_idle_no_event(device, queue);
@@ -528,16 +528,16 @@ void test_fence_values(void)
 
     ID3D12CommandQueue_Release(queue);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_cpu_signal_fence(void)
 {
     HANDLE event1, event2;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int i, ret;
     ID3D12Fence *fence;
-    ULONG refcount;
     uint64_t value;
     HRESULT hr;
 
@@ -549,25 +549,25 @@ void test_cpu_signal_fence(void)
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr %#x.\n", (int)hr);
 
     hr = ID3D12Fence_Signal(fence, 1);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 1, "Got unexpected value %"PRIu64".\n", value);
 
     hr = ID3D12Fence_Signal(fence, 10);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 10, "Got unexpected value %"PRIu64".\n", value);
 
     hr = ID3D12Fence_Signal(fence, 5);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 5, "Got unexpected value %"PRIu64".\n", value);
 
     hr = ID3D12Fence_Signal(fence, 0);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 0, "Got unexpected value %"PRIu64".\n", value);
 
@@ -578,29 +578,29 @@ void test_cpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_SetEventOnCompletion(fence, 5, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     hr = ID3D12Fence_Signal(fence, 5);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_SetEventOnCompletion(fence, 6, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     hr = ID3D12Fence_Signal(fence, 7);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, 10);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
@@ -610,18 +610,18 @@ void test_cpu_signal_fence(void)
     for (i = 0; i <= ID3D12Fence_GetCompletedValue(fence); ++i)
     {
         hr = ID3D12Fence_SetEventOnCompletion(fence, i, event1);
-        ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
         ret = wait_event(event1, 0);
         ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x for %u.\n", ret, i);
         ret = wait_event(event1, 0);
         ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x for %u.\n", ret, i);
     }
     hr = ID3D12Fence_SetEventOnCompletion(fence, i, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     hr = ID3D12Fence_Signal(fence, i);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
@@ -629,26 +629,26 @@ void test_cpu_signal_fence(void)
 
     /* Attach event to multiple values. */
     hr = ID3D12Fence_Signal(fence, 0);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_SetEventOnCompletion(fence, 3, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 5, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 9, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 12, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 12, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     for (i = 1; i < 13; ++i)
     {
         hr = ID3D12Fence_Signal(fence, i);
-        ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
         if (i == 3 || i == 5 || i == 9 || i == 12)
         {
             ret = wait_event(event1, 0);
@@ -660,7 +660,7 @@ void test_cpu_signal_fence(void)
 
     /* Tests with 2 events. */
     hr = ID3D12Fence_Signal(fence, 0);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 0, "Got unexpected value %"PRIu64".\n", value);
 
@@ -672,26 +672,26 @@ void test_cpu_signal_fence(void)
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 100, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, ~(uint64_t)0, event2);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
 
     hr = ID3D12Fence_Signal(fence, 50);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, 99);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, 100);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
@@ -700,28 +700,28 @@ void test_cpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, 101);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, 0);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, 100);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, ~(uint64_t)0);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
@@ -730,13 +730,13 @@ void test_cpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, ~(uint64_t)0);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     hr = ID3D12Fence_Signal(fence, 0);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
@@ -744,22 +744,22 @@ void test_cpu_signal_fence(void)
 
     /* Attach two events to the same value. */
     hr = ID3D12Fence_Signal(fence, 0);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_SetEventOnCompletion(fence, 1, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 1, event2);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     hr = ID3D12Fence_Signal(fence, 3);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
@@ -771,7 +771,7 @@ void test_cpu_signal_fence(void)
 
     /* Test passing signaled event. */
     hr = ID3D12Fence_Signal(fence, 20);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 20, "Got unexpected value %"PRIu64".\n", value);
     ret = wait_event(event1, 0);
@@ -779,14 +779,14 @@ void test_cpu_signal_fence(void)
 
     signal_event(event1);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 30, event1);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(fence, 30);
-    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
@@ -797,17 +797,17 @@ void test_cpu_signal_fence(void)
 
     ID3D12Fence_Release(fence);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_gpu_signal_fence(void)
 {
     ID3D12CommandQueue *queue;
     HANDLE event1, event2;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int i, ret;
     ID3D12Fence *fence;
-    ULONG refcount;
     uint64_t value;
     HRESULT hr;
 
@@ -821,7 +821,7 @@ void test_gpu_signal_fence(void)
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&fence);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     /* XXX: It seems that when a queue is idle a fence is signalled immediately
      * in D3D12. Vulkan implementations don't signal a fence immediately so
@@ -844,7 +844,7 @@ void test_gpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_SetEventOnCompletion(fence, 5, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     queue_signal(queue, fence, 5);
@@ -855,7 +855,7 @@ void test_gpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_SetEventOnCompletion(fence, 6, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     queue_signal(queue, fence, 7);
@@ -877,15 +877,15 @@ void test_gpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_SetEventOnCompletion(fence, 3, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 5, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 9, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 12, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 12, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     for (i = 1; i < 13; ++i)
@@ -915,9 +915,9 @@ void test_gpu_signal_fence(void)
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 100, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, ~(uint64_t)0, event2);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
 
     queue_signal(queue, fence, 50);
     wait_queue_idle(device, queue);
@@ -994,9 +994,9 @@ void test_gpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     hr = ID3D12Fence_SetEventOnCompletion(fence, 1, event1);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     hr = ID3D12Fence_SetEventOnCompletion(fence, 1, event2);
-    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", (int)hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
@@ -1020,7 +1020,7 @@ void test_gpu_signal_fence(void)
     ID3D12Fence_Release(fence);
     ID3D12CommandQueue_Release(queue);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 struct multithread_fence_wait_data
@@ -1041,7 +1041,7 @@ static void fence_event_wait_main(void *untyped_data)
     ok(event, "Failed to create event.\n");
 
     hr = ID3D12Fence_SetEventOnCompletion(data->fence, data->value, event);
-    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", (int)hr);
 
     signal_event(data->event);
 
@@ -1065,9 +1065,9 @@ void test_multithread_fence_wait(void)
 {
     struct multithread_fence_wait_data thread_data;
     ID3D12CommandQueue *queue;
+    unsigned int refcount;
     ID3D12Device *device;
     unsigned int ret;
-    ULONG refcount;
     HANDLE thread;
     HRESULT hr;
 
@@ -1084,7 +1084,7 @@ void test_multithread_fence_wait(void)
     ok(thread_data.event, "Failed to create event.\n");
     hr = ID3D12Device_CreateFence(device, thread_data.value, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&thread_data.fence);
-    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create fence, hr %#x.\n", (int)hr);
 
     /* Signal fence on host. */
     ++thread_data.value;
@@ -1094,7 +1094,7 @@ void test_multithread_fence_wait(void)
     ok(ret == WAIT_OBJECT_0, "Failed to wait for thread start, return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(thread_data.fence, thread_data.value);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
 
     ok(join_thread(thread), "Failed to join thread.\n");
 
@@ -1105,7 +1105,7 @@ void test_multithread_fence_wait(void)
     ok(ret == WAIT_OBJECT_0, "Failed to wait for thread start, return value %#x.\n", ret);
 
     hr = ID3D12Fence_Signal(thread_data.fence, thread_data.value);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", (int)hr);
 
     ok(join_thread(thread), "Failed to join thread.\n");
 
@@ -1134,14 +1134,14 @@ void test_multithread_fence_wait(void)
     ID3D12Fence_Release(thread_data.fence);
     ID3D12CommandQueue_Release(queue);
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_create_fence(void)
 {
     ID3D12Device *device, *tmp_device;
+    unsigned int refcount;
     ID3D12Fence *fence;
-    ULONG refcount;
     uint64_t value;
     HRESULT hr;
 
@@ -1153,16 +1153,16 @@ void test_create_fence(void)
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
     hr = ID3D12Fence_GetDevice(fence, &IID_ID3D12Device, (void **)&tmp_device);
-    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", (int)hr);
     refcount = get_refcount(device);
-    ok(refcount == 3, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 3, "Got unexpected refcount %u.\n", refcount);
     refcount = ID3D12Device_Release(tmp_device);
-    ok(refcount == 2, "Got unexpected refcount %u.\n", (unsigned int)refcount);
+    ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
 
     check_interface(fence, &IID_ID3D12Object, true);
     check_interface(fence, &IID_ID3D12DeviceChild, true);
@@ -1173,18 +1173,18 @@ void test_create_fence(void)
     ok(value == 0, "Got unexpected value %"PRIu64".\n", value);
 
     refcount = ID3D12Fence_Release(fence);
-    ok(!refcount, "ID3D12Fence has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Fence has %u references left.\n", refcount);
 
     hr = ID3D12Device_CreateFence(device, 99, D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr %#x.\n", (int)hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 99, "Got unexpected value %"PRIu64".\n", value);
     refcount = ID3D12Fence_Release(fence);
-    ok(!refcount, "ID3D12Fence has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Fence has %u references left.\n", refcount);
 
     refcount = ID3D12Device_Release(device);
-    ok(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 void test_fence_wait_robustness_inner(bool shared_handles)
@@ -1217,7 +1217,7 @@ void test_fence_wait_robustness_inner(bool shared_handles)
     hr = ID3D12Device_CreateFence(context.device, 0,
             shared_handles ? D3D12_FENCE_FLAG_SHARED : D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void**)&signal_fence);
-    todo_if(shared_handles) ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    todo_if(shared_handles) ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
     if (FAILED(hr))
     {
@@ -1229,7 +1229,7 @@ void test_fence_wait_robustness_inner(bool shared_handles)
     hr = ID3D12Device_CreateFence(context.device, 0,
             shared_handles ? D3D12_FENCE_FLAG_SHARED : D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void**)&wait_fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
     if (FAILED(hr))
     {
@@ -1242,7 +1242,7 @@ void test_fence_wait_robustness_inner(bool shared_handles)
     hr = ID3D12Device_CreateFence(context.device, 0,
             shared_handles ? D3D12_FENCE_FLAG_SHARED : D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void**)&drain_fence);
-    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
     if (FAILED(hr))
     {
@@ -1258,32 +1258,32 @@ void test_fence_wait_robustness_inner(bool shared_handles)
     {
         hr = ID3D12Device_CreateSharedHandle(context.device, (ID3D12DeviceChild*)signal_fence,
                 NULL, GENERIC_ALL, NULL, &shared_signal);
-        ok(SUCCEEDED(hr), "Failed to create shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create shared handle, hr #%x.\n", (int)hr);
         hr = ID3D12Device_CreateSharedHandle(context.device, (ID3D12DeviceChild*)wait_fence,
                 NULL, GENERIC_ALL, NULL, &shared_wait);
-        ok(SUCCEEDED(hr), "Failed to create shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create shared handle, hr #%x.\n", (int)hr);
         hr = ID3D12Device_CreateSharedHandle(context.device, (ID3D12DeviceChild*)drain_fence,
                 NULL, GENERIC_ALL, NULL, &shared_drain);
-        ok(SUCCEEDED(hr), "Failed to create shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create shared handle, hr #%x.\n", (int)hr);
 
         ID3D12Fence_Release(signal_fence);
         ID3D12Fence_Release(wait_fence);
         ID3D12Fence_Release(drain_fence);
 
         hr = ID3D12Device_OpenSharedHandle(context.device, shared_signal, &IID_ID3D12Fence, (void**)&signal_fence);
-        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", (int)hr);
         hr = ID3D12Device_OpenSharedHandle(context.device, shared_wait, &IID_ID3D12Fence, (void**)&wait_fence);
-        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", (int)hr);
         hr = ID3D12Device_OpenSharedHandle(context.device, shared_drain, &IID_ID3D12Fence, (void**)&drain_fence);
-        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", (int)hr);
 
         /* OpenSharedHandle takes a kernel level reference on the HANDLE. */
         hr = ID3D12Device_OpenSharedHandle(context.device, shared_signal, &IID_ID3D12Fence, (void**)&signal_fence_dup);
-        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", (int)hr);
         hr = ID3D12Device_OpenSharedHandle(context.device, shared_wait, &IID_ID3D12Fence, (void**)&wait_fence_dup);
-        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", (int)hr);
         hr = ID3D12Device_OpenSharedHandle(context.device, shared_drain, &IID_ID3D12Fence, (void**)&drain_fence_dup);
-        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to open shared handle, hr #%x.\n", (int)hr);
 
         /* Observed behavior: Closing the last reference to the kernel HANDLE object unblocks all waiters.
          * This isn't really implementable in Wine as it stands since applications are free to share
@@ -1445,7 +1445,7 @@ void test_fence_wait_multiple_inner(bool shared_handles)
     unsigned int i;
     HANDLE event;
     HRESULT hr;
-    DWORD ret;
+    int ret;
 
     if (!init_compute_test_context(&context))
         return;
@@ -1464,7 +1464,7 @@ void test_fence_wait_multiple_inner(bool shared_handles)
         hr = ID3D12Device1_CreateFence(device1, 0,
                 shared_handles ? D3D12_FENCE_FLAG_SHARED : D3D12_FENCE_FLAG_NONE,
                 &IID_ID3D12Fence, (void**)&fences[i]);
-        todo_if(shared_handles) ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+        todo_if(shared_handles) ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
 
         if (FAILED(hr))
             break;
@@ -1495,18 +1495,18 @@ void test_fence_wait_multiple_inner(bool shared_handles)
     /* Test various invalid parameter combinations that should not crash */
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             NULL, NULL, 0, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ALL, NULL);
-    ok(hr == E_INVALIDARG, "Got unexpected result, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected result, hr %#x.\n", (int)hr);
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, values, 0, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ANY, event);
-    ok(hr == E_INVALIDARG, "Got unexpected result, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected result, hr %#x.\n", (int)hr);
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, values, 4, 0xFFFFFFFF, event);
-    ok(hr == E_INVALIDARG, "Got unexpected result, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected result, hr %#x.\n", (int)hr);
 
     /* The D3D12 runtime will crash here
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, NULL, 1, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ALL, event);
-    ok(hr == E_INVALIDARG, "Got unexpected result, hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected result, hr %#x.\n", (int)hr);
     */
 
     /* Test simple single-wait scenario */
@@ -1514,7 +1514,7 @@ void test_fence_wait_multiple_inner(bool shared_handles)
 
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, values, 1, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ALL, event);
-    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", (int)hr);
     ret = wait_event(event, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %u.\n", ret);
 
@@ -1532,7 +1532,7 @@ void test_fence_wait_multiple_inner(bool shared_handles)
 
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, values, 4, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ALL, event);
-    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", (int)hr);
     ret = wait_event(event, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %u.\n", ret);
 
@@ -1552,7 +1552,7 @@ void test_fence_wait_multiple_inner(bool shared_handles)
 
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, values, 4, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ALL, NULL);
-    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", (int)hr);
 
     /* Test complex multi-wait with WAIT_ANY */
     values[0] = 100;
@@ -1562,7 +1562,7 @@ void test_fence_wait_multiple_inner(bool shared_handles)
 
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, values, 4, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ANY, event);
-    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", (int)hr);
     ret = wait_event(event, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %u.\n", ret);
 
@@ -1578,11 +1578,11 @@ void test_fence_wait_multiple_inner(bool shared_handles)
 
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, values, 4, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ANY, NULL);
-    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
             fences, values, 4, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ANY, event);
-    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to set event on multiple fence completion, hr %#x.\n", (int)hr);
     ret = wait_event(event, INFINITE);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %u.\n", ret);
 
@@ -1636,7 +1636,7 @@ static void test_concurrent_signal_stress_inner(void)
     for (i = 0; i < ARRAY_SIZE(fences); i++)
     {
         hr = ID3D12Device_CreateFence(context.device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void**)&fences[i]);
-        ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create fence, hr #%x.\n", (int)hr);
         fence_values[i] = 0;
     }
 
@@ -1658,7 +1658,7 @@ static void test_concurrent_signal_stress_inner(void)
 
         hr = ID3D12Device1_SetEventOnMultipleFenceCompletion(device1,
                 fences, fence_values, 4, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ALL, event);
-        ok(SUCCEEDED(hr), "Failed to set event hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to set event hr #%x.\n", (int)hr);
 
         wait_success = wait_event(event, 1000) == WAIT_OBJECT_0;
 
@@ -1733,7 +1733,7 @@ static void test_fence_pending_signal_cpu_rewind(bool use_shared)
     memset(&queue_desc, 0, sizeof(queue_desc));
     queue_desc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
     hr = ID3D12Device_CreateCommandQueue(context.device, &queue_desc, &IID_ID3D12CommandQueue, (void **)&queue);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(&rs_param, 0, sizeof(rs_param));
@@ -1834,7 +1834,7 @@ static void test_fence_pending_signal_cpu_rewind(bool use_shared)
             value = ID3D12Fence_GetCompletedValue(fence);
             ok(value == 9, "Expected completed fence value of 9.\n");
             hr = ID3D12Fence_Signal(fence, 0);
-            ok(SUCCEEDED(hr), "Failed to signal fence, hr #%x\n", hr);
+            ok(SUCCEEDED(hr), "Failed to signal fence, hr #%x\n", (int)hr);
             value = ID3D12Fence_GetCompletedValue(fence);
             ok(value == 0, "Expected completed fence value of 0.\n");
 
@@ -1844,7 +1844,7 @@ static void test_fence_pending_signal_cpu_rewind(bool use_shared)
 
             event = create_event();
             hr = ID3D12Fence_SetEventOnCompletion(fence_alt, 1, event);
-            ok(SUCCEEDED(hr), "Failed to queue event signal, hr #%x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to queue event signal, hr #%x.\n", (int)hr);
 
             /* Add a timeout just in case to avoid a deadlock. */
             wait_result = wait_event(event, wait_timeout);
@@ -1907,7 +1907,7 @@ static void test_fence_ping_pong_deadlock_stress(bool use_shared)
     memset(&queue_desc, 0, sizeof(queue_desc));
     queue_desc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
     hr = ID3D12Device_CreateCommandQueue(context.device, &queue_desc, &IID_ID3D12CommandQueue, (void **)&queue);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", (int)hr);
 
     memset(&rs_desc, 0, sizeof(rs_desc));
     memset(&rs_param, 0, sizeof(rs_param));
@@ -2024,7 +2024,7 @@ static void test_fence_ping_pong_deadlock_stress(bool use_shared)
          * before we have the chance to wait for it, but there is some evidence to suggest
          * that there is a bug in winevulkan as well. */
         hr = ID3D12Fence_Signal(fence, 0);
-        ok(SUCCEEDED(hr), "Failed to rewind fence, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to rewind fence, hr #%x.\n", (int)hr);
     }
 
     for (i = 0; i < ARRAY_SIZE(early_resources); i++)
@@ -2063,9 +2063,9 @@ static void test_fence_signal_order_deadlock_stress(bool use_shared)
     memset(&queue_desc, 0, sizeof(queue_desc));
     queue_desc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
     hr = ID3D12Device_CreateCommandQueue(context.device, &queue_desc, &IID_ID3D12CommandQueue, (void **)&queue_a);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", (int)hr);
     hr = ID3D12Device_CreateCommandQueue(context.device, &queue_desc, &IID_ID3D12CommandQueue, (void **)&queue_b);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", (int)hr);
 
     ID3D12Device_CreateFence(context.device, 0, use_shared ? D3D12_FENCE_FLAG_SHARED : D3D12_FENCE_FLAG_NONE,
             &IID_ID3D12Fence, (void **)&fence);
@@ -2150,7 +2150,7 @@ static void test_fence_signal_availability(bool use_shared)
     memset(&queue_desc, 0, sizeof(queue_desc));
     queue_desc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
     hr = ID3D12Device_CreateCommandQueue(context.device, &queue_desc, &IID_ID3D12CommandQueue, (void **)&queue);
-    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create command queue, hr #%x\n", (int)hr);
 
     for (iter = 0; iter < 2; iter++)
     {
@@ -2192,7 +2192,7 @@ static void test_fence_signal_availability(bool use_shared)
             event = create_event();
             ID3D12Fence_SetEventOnCompletion(fence_progress, 2, event);
             wait_result = wait_event(event, 100);
-            ok(wait_result == WAIT_TIMEOUT, "Expected %u, got %u\n", WAIT_TIMEOUT, wait_result);
+            ok(wait_result == WAIT_TIMEOUT, "Expected %u, got %u\n", (int)WAIT_TIMEOUT, (int)wait_result);
         }
 
         ID3D12Fence_Signal(fence_alt, 1);
@@ -2206,7 +2206,7 @@ static void test_fence_signal_availability(bool use_shared)
 
             /* In shared path we have no way to implement the ticketing system,
              * so this is unimplementable as-is. */
-            todo_if(use_shared) ok(wait_result == WAIT_OBJECT_0, "Expected %u, got %u.\n", WAIT_OBJECT_0, wait_result);
+            todo_if(use_shared) ok(wait_result == WAIT_OBJECT_0, "Expected %u, got %u.\n", (int)WAIT_OBJECT_0, (int)wait_result);
 
             ID3D12Fence_Signal(fence, 8);
             ID3D12Fence_SetEventOnCompletion(fence_progress, 2, NULL);

--- a/tests/d3d12_tessellation.c
+++ b/tests/d3d12_tessellation.c
@@ -125,12 +125,12 @@ void test_nop_tessellation_shaders(void)
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
     /* Runtime used to fail this, but it "just works" now :|. */
-    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(context.pipeline_state);
     pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
     ID3D12PipelineState_Release(context.pipeline_state);
 
     for (i = 0; i < ARRAY_SIZE(hull_shaders); ++i)
@@ -141,7 +141,7 @@ void test_nop_tessellation_shaders(void)
         pso_desc.DS = *domain_shaders[i];
         hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
                 &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-        ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+        ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
         ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
 
@@ -272,7 +272,7 @@ static void test_quad_tessellation(bool use_dxil, bool wrong_pso_topology, bool 
         destroy_test_context(&context);
         return;
     }
-    ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", (int)hr);
 
     context.root_signature = create_32bit_constants_root_signature_(__LINE__,
             device, 0, 6, D3D12_SHADER_VISIBILITY_HULL,
@@ -344,7 +344,7 @@ static void test_quad_tessellation(bool use_dxil, bool wrong_pso_topology, bool 
         pso_desc.HS = use_dxil ? quad_tess_hs_ccw_dxil : quad_tess_hs_ccw_dxbc;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
 
@@ -383,7 +383,7 @@ static void test_quad_tessellation(bool use_dxil, bool wrong_pso_topology, bool 
     pso_desc.HS = use_dxil ? quad_tess_hs_cw_dxil : quad_tess_hs_cw_dxbc;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
 
@@ -561,7 +561,7 @@ static void test_tessellation_dcl_index_range(bool use_dxil)
     pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     vb = create_upload_buffer(device, sizeof(quad), quad);
 
@@ -659,7 +659,7 @@ static void test_tessellation_dcl_index_range_complex(bool use_dxil)
     pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     vb = create_upload_buffer(device, sizeof(quad), quad);
 
@@ -741,7 +741,7 @@ static void test_hull_shader_control_point_phase(bool use_dxil)
     pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
 
@@ -802,7 +802,7 @@ void test_hull_shader_vertex_input_patch_constant_phase(void)
     pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
 
@@ -859,7 +859,7 @@ static void test_hull_shader_fork_phase(bool use_dxil)
     pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, white, 0, NULL);
 
@@ -945,7 +945,7 @@ void test_tessellation_read_tesslevel(void)
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
     vkd3d_unmute_validation_message("09658");
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     so_buffer = create_default_buffer(context.device, 4096,
             D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_STREAM_OUT);
@@ -1085,7 +1085,7 @@ static void test_line_tessellation(bool use_dxil)
         destroy_test_context(&context);
         return;
     }
-    ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create query heap, hr %#x.\n", (int)hr);
 
     input_layout.pInputElementDescs = layout_desc;
     input_layout.NumElements = ARRAY_SIZE(layout_desc);
@@ -1112,7 +1112,7 @@ static void test_line_tessellation(bool use_dxil)
     pso_desc.StreamOutput.RasterizedStream = D3D12_SO_NO_RASTERIZED_STREAM;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     vb = create_upload_buffer(context.device, sizeof(vertices), vertices);
     vbv.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(vb);
@@ -1259,7 +1259,7 @@ void test_tessellation_primitive_id(void)
     root_signature_desc.pParameters = root_parameters;
     root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
     hr = create_root_signature(context.device, &root_signature_desc, &context.root_signature);
-    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", (int)hr);
 
     input_layout.pInputElementDescs = layout_desc;
     input_layout.NumElements = ARRAY_SIZE(layout_desc);
@@ -1272,7 +1272,7 @@ void test_tessellation_primitive_id(void)
     pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&context.pipeline_state);
-    ok(hr == S_OK, "Failed to create state, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create state, hr %#x.\n", (int)hr);
 
     vb = create_upload_buffer(context.device, sizeof(vertices), vertices);
     vbv.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(vb);

--- a/tests/d3d12_test_utils.c
+++ b/tests/d3d12_test_utils.c
@@ -88,7 +88,7 @@ bool compare_uint64(uint64_t a, uint64_t b, unsigned int max_diff)
     return delta_uint64(a, b) <= max_diff;
 }
 
-ULONG get_refcount(void *iface)
+unsigned int get_refcount(void *iface)
 {
     IUnknown *unk = iface;
     IUnknown_AddRef(unk);
@@ -103,7 +103,7 @@ void check_interface_(unsigned int line, IUnknown *iface, REFIID riid, bool supp
     expected_hr = supported ? S_OK : E_NOINTERFACE;
 
     hr = IUnknown_QueryInterface(iface, riid, (void **)&unk);
-    ok_(line)(hr == expected_hr, "Got hr %#x, expected %#x.\n", hr, expected_hr);
+    ok_(line)(hr == expected_hr, "Got hr %#x, expected %#x.\n", (int)hr, (int)expected_hr);
     if (SUCCEEDED(hr))
         IUnknown_Release(unk);
 }
@@ -195,7 +195,7 @@ void upload_buffer_data_(unsigned int line, ID3D12Resource *buffer, size_t offse
     HRESULT hr;
 
     hr = ID3D12Resource_GetDevice(buffer, &IID_ID3D12Device, (void **)&device);
-    ok_(line)(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", (int)hr);
 
     upload_buffer = create_upload_buffer_(line, device, size, data);
 
@@ -203,7 +203,7 @@ void upload_buffer_data_(unsigned int line, ID3D12Resource *buffer, size_t offse
             upload_buffer, 0, size);
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok_(line)(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
 
@@ -236,7 +236,7 @@ void upload_texture_data_base_(unsigned int line, ID3D12Resource *texture,
 
     resource_desc = ID3D12Resource_GetDesc(texture);
     hr = ID3D12Resource_GetDevice(texture, &IID_ID3D12Device, (void **)&device);
-    ok_(line)(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", (int)hr);
 
     ID3D12Device_GetCopyableFootprints(device, &resource_desc, first_subresource, sub_resource_count,
             0, layouts, row_counts, row_sizes, &required_size);
@@ -244,7 +244,7 @@ void upload_texture_data_base_(unsigned int line, ID3D12Resource *texture,
     upload_buffer = create_upload_buffer_(line, device, required_size, NULL);
 
     hr = ID3D12Resource_Map(upload_buffer, 0, NULL, (void **)&ptr);
-    ok_(line)(SUCCEEDED(hr), "Failed to map upload buffer, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to map upload buffer, hr %#x.\n", (int)hr);
     for (i = 0; i < sub_resource_count; ++i)
     {
         dst_data.pData = (BYTE *)ptr + layouts[i].Offset;
@@ -270,7 +270,7 @@ void upload_texture_data_base_(unsigned int line, ID3D12Resource *texture,
     }
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok_(line)(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
@@ -308,7 +308,7 @@ void init_readback(struct resource_readback *rb, ID3D12Resource *buffer,
     read_range.Begin = 0;
     read_range.End = buffer_size;
     hr = ID3D12Resource_Map(rb->resource, 0, &read_range, &rb->data);
-    ok(hr == S_OK, "Failed to map readback buffer, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to map readback buffer, hr %#x.\n", (int)hr);
 }
 
 void get_buffer_readback_with_command_list(ID3D12Resource *buffer, DXGI_FORMAT format,
@@ -322,7 +322,7 @@ void get_buffer_readback_with_command_list(ID3D12Resource *buffer, DXGI_FORMAT f
     HRESULT hr;
 
     hr = ID3D12Resource_GetDevice(buffer, &IID_ID3D12Device, (void **)&device);
-    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to get device, hr %#x.\n", (int)hr);
 
     resource_desc = ID3D12Resource_GetDesc(buffer);
     assert(resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER);
@@ -342,7 +342,7 @@ void get_buffer_readback_with_command_list(ID3D12Resource *buffer, DXGI_FORMAT f
     }
 
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to close command list, hr %#x.\n", (int)hr);
 
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
@@ -358,7 +358,7 @@ void get_buffer_readback_with_command_list(ID3D12Resource *buffer, DXGI_FORMAT f
     read_range.Begin = 0;
     read_range.End = resource_desc.Width;
     hr = ID3D12Resource_Map(rb_buffer, 0, &read_range, &rb->data);
-    ok(SUCCEEDED(hr), "Failed to map readback buffer, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to map readback buffer, hr %#x.\n", (int)hr);
 }
 
 uint8_t get_readback_uint8(struct resource_readback *rb, unsigned int x, unsigned int y)
@@ -622,7 +622,7 @@ bool is_min_max_filtering_supported(ID3D12Device *device)
     if (FAILED(hr = ID3D12Device_CheckFeatureSupport(device,
             D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options))))
     {
-        trace("Failed to check feature support, hr %#x.\n", hr);
+        trace("Failed to check feature support, hr %#x.\n", (int)hr);
         return false;
     }
 
@@ -638,7 +638,7 @@ D3D12_TILED_RESOURCES_TIER get_tiled_resources_tier(ID3D12Device *device)
     if (FAILED(hr = ID3D12Device_CheckFeatureSupport(device,
             D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options))))
     {
-        trace("Failed to check feature support, hr %#x.\n", hr);
+        trace("Failed to check feature support, hr %#x.\n", (int)hr);
         return D3D12_TILED_RESOURCES_TIER_NOT_SUPPORTED;
     }
 
@@ -653,7 +653,7 @@ bool is_standard_swizzle_64kb_supported(ID3D12Device *device)
     if (FAILED(hr = ID3D12Device_CheckFeatureSupport(device,
             D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options))))
     {
-        trace("Failed to check feature support, hr %#x.\n", hr);
+        trace("Failed to check feature support, hr %#x.\n", (int)hr);
         return false;
     }
 
@@ -669,7 +669,7 @@ bool is_memory_pool_L1_supported(ID3D12Device *device)
     if (FAILED(hr = ID3D12Device_CheckFeatureSupport(device, D3D12_FEATURE_ARCHITECTURE,
             &architecture, sizeof(architecture))))
     {
-        trace("Failed to check feature support, hr %#x.\n", hr);
+        trace("Failed to check feature support, hr %#x.\n", (int)hr);
         return false;
     }
 
@@ -687,7 +687,7 @@ bool is_vrs_tier1_supported(ID3D12Device *device, bool *additional_shading_rates
     if (FAILED(hr = ID3D12Device_CheckFeatureSupport(device,
             D3D12_FEATURE_D3D12_OPTIONS6, &options, sizeof(options))))
     {
-        trace("Failed to check feature support, hr %#x.\n", hr);
+        trace("Failed to check feature support, hr %#x.\n", (int)hr);
         return false;
     }
 
@@ -705,7 +705,7 @@ bool is_vrs_tier2_supported(ID3D12Device *device)
     if (FAILED(hr = ID3D12Device_CheckFeatureSupport(device,
             D3D12_FEATURE_D3D12_OPTIONS6, &options, sizeof(options))))
     {
-        trace("Failed to check feature support, hr %#x.\n", hr);
+        trace("Failed to check feature support, hr %#x.\n", (int)hr);
         return false;
     }
     return options.VariableShadingRateTier >= D3D12_VARIABLE_SHADING_RATE_TIER_2;
@@ -730,7 +730,7 @@ ID3D12RootSignature *create_cb_root_signature_(unsigned int line,
     root_signature_desc.pParameters = &root_parameter;
     root_signature_desc.Flags = flags;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok_(line)(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     return root_signature;
 }
@@ -755,7 +755,7 @@ ID3D12RootSignature *create_32bit_constants_root_signature_(unsigned int line,
     root_signature_desc.pParameters = &root_parameter;
     root_signature_desc.Flags = flags;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok_(line)(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     return root_signature;
 }
@@ -813,7 +813,7 @@ ID3D12RootSignature *create_texture_root_signature_(unsigned int line,
     root_signature_desc.Flags = flags;
 
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok_(line)(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     return root_signature;
 }
@@ -833,7 +833,7 @@ ID3D12PipelineState *create_compute_pipeline_state_(unsigned int line, ID3D12Dev
     hr = ID3D12Device_CreateComputePipelineState(device, &pipeline_state_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
     if (checked)
-        ok_(line)(SUCCEEDED(hr), "Failed to create compute pipeline state, hr %#x.\n", hr);
+        ok_(line)(SUCCEEDED(hr), "Failed to create compute pipeline state, hr %#x.\n", (int)hr);
     return pipeline_state;
 }
 
@@ -870,7 +870,7 @@ ID3D12CommandSignature *create_command_signature_(unsigned int line,
     signature_desc.NodeMask = 0;
     hr = ID3D12Device_CreateCommandSignature(device, &signature_desc,
             NULL, &IID_ID3D12CommandSignature, (void **)&command_signature);
-    ok_(line)(hr == S_OK, "Failed to create command signature, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create command signature, hr %#x.\n", (int)hr);
 
     return command_signature;
 }
@@ -902,11 +902,11 @@ bool init_compute_test_context_(unsigned int line, struct test_context *context)
 
     hr = ID3D12Device_CreateCommandAllocator(device, command_list_type,
             &IID_ID3D12CommandAllocator, (void **)&context->allocator);
-    ok_(line)(hr == S_OK, "Failed to create command allocator, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandList(device, 0, command_list_type,
             context->allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&context->list);
-    ok_(line)(hr == S_OK, "Failed to create command list, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create command list, hr %#x.\n", (int)hr);
 
     return true;
 }
@@ -917,7 +917,7 @@ bool context_supports_dxil_(unsigned int line, struct test_context *context)
     HRESULT hr;
     model.HighestShaderModel = D3D_SHADER_MODEL_6_0;
     hr = ID3D12Device_CheckFeatureSupport(context->device, D3D12_FEATURE_SHADER_MODEL, &model, sizeof(model));
-    ok_(line)(hr == S_OK, "Failed to query shader model support, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to query shader model support, hr %#x.\n", (int)hr);
 
     if (hr != S_OK)
         return false;
@@ -960,7 +960,7 @@ void init_depth_stencil_(unsigned int line, struct depth_stencil_resource *ds,
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, D3D12_RESOURCE_STATE_DEPTH_WRITE, clear_value,
             &IID_ID3D12Resource, (void **)&ds->texture);
-    ok_(line)(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
 
     view_desc = NULL;
     if (view_format)

--- a/tests/d3d12_test_utils.h
+++ b/tests/d3d12_test_utils.h
@@ -101,9 +101,9 @@ static inline void reset_command_list_(unsigned int line,
     HRESULT hr;
 
     hr = ID3D12CommandAllocator_Reset(allocator);
-    assert_that_(line)(hr == S_OK, "Failed to reset command allocator, hr %#x.\n", hr);
+    assert_that_(line)(hr == S_OK, "Failed to reset command allocator, hr %#x.\n", (int)hr);
     hr = ID3D12GraphicsCommandList_Reset(list, allocator, NULL);
-    assert_that_(line)(hr == S_OK, "Failed to reset command list, hr %#x.\n", hr);
+    assert_that_(line)(hr == S_OK, "Failed to reset command list, hr %#x.\n", (int)hr);
 }
 
 #define queue_signal(a, b, c) queue_signal_(__LINE__, a, b, c)
@@ -112,7 +112,7 @@ static inline void queue_signal_(unsigned int line, ID3D12CommandQueue *queue, I
     HRESULT hr;
 
     hr = ID3D12CommandQueue_Signal(queue, fence, value);
-    ok_(line)(hr == S_OK, "Failed to submit signal operation to queue, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to submit signal operation to queue, hr %#x.\n", (int)hr);
 }
 
 #define queue_wait(a, b, c) queue_wait_(__LINE__, a, b, c)
@@ -121,7 +121,7 @@ static inline void queue_wait_(unsigned int line, ID3D12CommandQueue *queue, ID3
     HRESULT hr;
 
     hr = ID3D12CommandQueue_Wait(queue, fence, value);
-    ok_(line)(hr == S_OK, "Failed to submit wait operation to queue, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to submit wait operation to queue, hr %#x.\n", (int)hr);
 }
 
 #define create_placed_buffer(a, b, c, d, e, f) create_placed_buffer_(__LINE__, a, b, c, d, e, f)
@@ -147,7 +147,7 @@ static inline ID3D12Resource *create_placed_buffer_(unsigned int line, ID3D12Dev
 
     hr = ID3D12Device_CreatePlacedResource(device, heap, offset, &resource_desc,
             initial_resource_state, NULL, &IID_ID3D12Resource, (void **)&buffer);
-    assert_that_(line)(SUCCEEDED(hr), "Failed to create buffer, hr %#x.\n", hr);
+    assert_that_(line)(SUCCEEDED(hr), "Failed to create buffer, hr %#x.\n", (int)hr);
     return buffer;
 }
 
@@ -180,7 +180,7 @@ static inline ID3D12Resource *create_placed_buffer2_(unsigned int line, ID3D12De
 
     hr = ID3D12Device10_CreatePlacedResource2(device10, heap, offset, &resource_desc,
             D3D12_BARRIER_LAYOUT_UNDEFINED, NULL, 0, NULL, &IID_ID3D12Resource, (void **)&buffer);
-    assert_that_(line)(SUCCEEDED(hr), "Failed to create buffer, hr %#x.\n", hr);
+    assert_that_(line)(SUCCEEDED(hr), "Failed to create buffer, hr %#x.\n", (int)hr);
     ID3D12Device10_Release(device10);
     return buffer;
 }
@@ -213,7 +213,7 @@ static inline ID3D12Resource *create_buffer_(unsigned int line, ID3D12Device *de
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, initial_resource_state,
             NULL, &IID_ID3D12Resource, (void **)&buffer);
-    assert_that_(line)(SUCCEEDED(hr), "Failed to create buffer, hr %#x.\n", hr);
+    assert_that_(line)(SUCCEEDED(hr), "Failed to create buffer, hr %#x.\n", (int)hr);
     return buffer;
 }
 
@@ -251,7 +251,7 @@ static inline ID3D12Resource *create_buffer2_(unsigned int line, ID3D12Device *d
     hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_properties,
             D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_BARRIER_LAYOUT_UNDEFINED,
             NULL, NULL, 0, NULL, &IID_ID3D12Resource, (void **)&buffer);
-    assert_that_(line)(SUCCEEDED(hr), "Failed to create buffer, hr %#x.\n", hr);
+    assert_that_(line)(SUCCEEDED(hr), "Failed to create buffer, hr %#x.\n", (int)hr);
     ID3D12Device10_Release(device10);
     return buffer;
 }
@@ -282,7 +282,7 @@ static inline void update_buffer_data_(unsigned int line, ID3D12Resource *buffer
 
     range.Begin = range.End = 0;
     hr = ID3D12Resource_Map(buffer, 0, &range, &ptr);
-    ok_(line)(hr == S_OK, "Failed to map buffer, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to map buffer, hr %#x.\n", (int)hr);
     memcpy((BYTE *)ptr + offset, data, size);
     ID3D12Resource_Unmap(buffer, 0, NULL);
 }
@@ -327,7 +327,7 @@ static inline ID3D12DescriptorHeap *create_cpu_descriptor_heap_(unsigned int lin
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc,
             &IID_ID3D12DescriptorHeap, (void **)&descriptor_heap);
-    ok_(line)(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     return descriptor_heap;
 }
@@ -346,7 +346,7 @@ static inline ID3D12DescriptorHeap *create_gpu_descriptor_heap_(unsigned int lin
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc,
             &IID_ID3D12DescriptorHeap, (void **)&descriptor_heap);
-    ok_(line)(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     return descriptor_heap;
 }
@@ -379,7 +379,7 @@ static inline ID3D12CommandQueue *create_command_queue_(unsigned int line, ID3D1
     queue_desc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
     queue_desc.NodeMask = 0;
     hr = ID3D12Device_CreateCommandQueue(device, &queue_desc, &IID_ID3D12CommandQueue, (void **)&queue);
-    ok_(line)(hr == S_OK, "Failed to create command queue, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create command queue, hr %#x.\n", (int)hr);
 
     return queue;
 }
@@ -649,7 +649,7 @@ static inline void get_texture_readback_with_command_list(ID3D12Resource *textur
     HRESULT hr;
 
     hr = ID3D12Resource_GetDevice(texture, &IID_ID3D12Device, (void **)&device);
-    assert_that(hr == S_OK, "Failed to get device, hr %#x.\n", hr);
+    assert_that(hr == S_OK, "Failed to get device, hr %#x.\n", (int)hr);
 
     resource_desc = ID3D12Resource_GetDesc(texture);
     assert_that(resource_desc.Dimension != D3D12_RESOURCE_DIMENSION_BUFFER,
@@ -682,7 +682,7 @@ static inline void get_texture_readback_with_command_list(ID3D12Resource *textur
         hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
                 &resource_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, NULL,
                 &IID_ID3D12Resource, (void **)&src_resource);
-        assert_that(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+        assert_that(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
         if (format_is_depth_stencil(resource_desc.Format) &&
             SUCCEEDED(ID3D12GraphicsCommandList_QueryInterface(command_list, &IID_ID3D12GraphicsCommandList1, (void **)&list1)))
@@ -725,7 +725,7 @@ static inline void get_texture_readback_with_command_list(ID3D12Resource *textur
 
     ID3D12GraphicsCommandList_CopyTextureRegion(command_list, &dst_location, 0, 0, 0, &src_location, NULL);
     hr = ID3D12GraphicsCommandList_Close(command_list);
-    assert_that(hr == S_OK, "Failed to close command list, hr %#x.\n", hr);
+    assert_that(hr == S_OK, "Failed to close command list, hr %#x.\n", (int)hr);
 
     exec_command_list(queue, command_list);
     wait_queue_idle(device, queue);
@@ -737,7 +737,7 @@ static inline void get_texture_readback_with_command_list(ID3D12Resource *textur
     read_range.Begin = 0;
     read_range.End = buffer_size;
     hr = ID3D12Resource_Map(rb->resource, 0, &read_range, &rb->data);
-    assert_that(hr == S_OK, "Failed to map readback buffer, hr %#x.\n", hr);
+    assert_that(hr == S_OK, "Failed to map readback buffer, hr %#x.\n", (int)hr);
 }
 
 static inline void *get_readback_data(struct resource_readback *rb,
@@ -848,7 +848,7 @@ static inline ID3D12Resource *create_default_texture_(unsigned int line, ID3D12D
     resource_desc.Flags = flags;
     hr = ID3D12Device_CreateCommittedResource(device, &heap_properties, D3D12_HEAP_FLAG_NONE,
             &resource_desc, initial_state, NULL, &IID_ID3D12Resource, (void **)&texture);
-    ok_(line)(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
 
     return texture;
 }
@@ -886,7 +886,7 @@ static inline ID3D12Resource *create_default_texture_enhanced_(unsigned int line
     resource_desc.Flags = flags;
     hr = ID3D12Device10_CreateCommittedResource3(device10, &heap_properties, D3D12_HEAP_FLAG_NONE,
         &resource_desc, initial_layout, NULL, NULL, 0, NULL, &IID_ID3D12Resource, (void **)&texture);
-    ok_(line)(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create texture, hr %#x.\n", (int)hr);
 
     ID3D12Device10_Release(device10);
 
@@ -975,7 +975,7 @@ static inline ID3D12RootSignature *create_empty_root_signature_(unsigned int lin
     root_signature_desc.pStaticSamplers = NULL;
     root_signature_desc.Flags = flags;
     hr = create_root_signature(device, &root_signature_desc, &root_signature);
-    ok_(line)(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create root signature, hr %#x.\n", (int)hr);
 
     return root_signature;
 }
@@ -1193,7 +1193,7 @@ static inline ID3D12PipelineState *create_pipeline_state_(unsigned int line, ID3
     init_pipeline_state_desc(&pipeline_state_desc, root_signature, rt_format, vs, ps, input_layout);
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pipeline_state_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok_(line)(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     return pipeline_state;
 }
@@ -1211,7 +1211,7 @@ static inline ID3D12PipelineState *create_pipeline_state_dxil_(unsigned int line
     init_pipeline_state_desc_dxil(&pipeline_state_desc, root_signature, rt_format, vs, ps, input_layout);
     hr = ID3D12Device_CreateGraphicsPipelineState(device, &pipeline_state_desc,
                                                   &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok_(line)(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create graphics pipeline state, hr %#x.\n", (int)hr);
 
     return pipeline_state;
 }
@@ -1293,7 +1293,7 @@ static inline void create_render_target_(unsigned int line, struct test_context 
             &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc,
             D3D12_RESOURCE_STATE_RENDER_TARGET, &clear_value,
             &IID_ID3D12Resource, (void **)render_target);
-    ok_(line)(hr == S_OK, "Failed to create texture, hr %#x.\n", hr);
+    ok_(line)(hr == S_OK, "Failed to create texture, hr %#x.\n", (int)hr);
 
     context->render_target_desc = resource_desc;
 
@@ -1369,11 +1369,11 @@ static inline bool init_test_context_(unsigned int line, struct test_context *co
 
     hr = ID3D12Device_CreateCommandAllocator(device, D3D12_COMMAND_LIST_TYPE_DIRECT,
             &IID_ID3D12CommandAllocator, (void **)&context->allocator);
-    ok_(line)(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create command allocator, hr %#x.\n", (int)hr);
 
     hr = ID3D12Device_CreateCommandList(device, 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             context->allocator, NULL, &IID_ID3D12GraphicsCommandList, (void **)&context->list);
-    ok_(line)(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create command list, hr %#x.\n", (int)hr);
 
     if (desc && desc->no_render_target)
         return true;
@@ -1384,7 +1384,7 @@ static inline bool init_test_context_(unsigned int line, struct test_context *co
     rtv_heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &rtv_heap_desc,
             &IID_ID3D12DescriptorHeap, (void **)&context->rtv_heap);
-    ok_(line)(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", hr);
+    ok_(line)(SUCCEEDED(hr), "Failed to create descriptor heap, hr %#x.\n", (int)hr);
 
     context->rtv = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(context->rtv_heap);
 
@@ -1414,7 +1414,7 @@ static inline bool init_test_context_(unsigned int line, struct test_context *co
 #define destroy_test_context(context) destroy_test_context_(__LINE__, context)
 static inline void destroy_test_context_(unsigned int line, struct test_context *context)
 {
-    ULONG refcount;
+    unsigned int refcount;
 
 #ifdef _WIN32
     end_renderdoc_capturing(context->device);
@@ -1435,7 +1435,7 @@ static inline void destroy_test_context_(unsigned int line, struct test_context 
     ID3D12GraphicsCommandList_Release(context->list);
 
     refcount = ID3D12Device_Release(context->device);
-    ok_(line)(!refcount, "ID3D12Device has %u references left.\n", (unsigned int)refcount);
+    ok_(line)(!refcount, "ID3D12Device has %u references left.\n", refcount);
 }
 
 static inline D3D12_CPU_DESCRIPTOR_HANDLE get_cpu_handle(ID3D12Device *device,
@@ -1535,7 +1535,7 @@ bool compare_uvec4(const struct uvec4* v1, const struct uvec4 *v2);
 bool compare_uint8(uint8_t a, uint8_t b, unsigned int max_diff);
 bool compare_uint16(uint16_t a, uint16_t b, unsigned int max_diff);
 bool compare_uint64(uint64_t a, uint64_t b, unsigned int max_diff);
-ULONG get_refcount(void *iface);
+unsigned int get_refcount(void *iface);
 
 void check_interface_(unsigned int line, IUnknown *iface, REFIID riid, bool supported);
 void check_heap_properties_(unsigned int line,

--- a/tests/d3d12_va.c
+++ b/tests/d3d12_va.c
@@ -117,7 +117,7 @@ void test_gpu_virtual_address(void)
     buffer = create_upload_buffer(context.device, ib_offset + sizeof(indices), NULL);
 
     hr = ID3D12Resource_Map(buffer, 0, NULL, (void **)&ptr);
-    ok(SUCCEEDED(hr), "Failed to map upload buffer, hr %#x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to map upload buffer, hr %#x.\n", (int)hr);
     memcpy(ptr + vb_offset, quad, sizeof(quad));
     memcpy(ptr + ib_offset, indices, sizeof(indices));
     ID3D12Resource_Unmap(buffer, 0, NULL);

--- a/tests/d3d12_vrs.c
+++ b/tests/d3d12_vrs.c
@@ -66,7 +66,7 @@ void test_vrs(void)
     }
 
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList5, (void **)&command_list);
-    ok(hr == S_OK, "Couldn't get GraphicsCommandList5, hr %#x.\n", hr);
+    ok(hr == S_OK, "Couldn't get GraphicsCommandList5, hr %#x.\n", (int)hr);
     ID3D12GraphicsCommandList5_Release(command_list);
 
     queue = context.queue;
@@ -76,7 +76,7 @@ void test_vrs(void)
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -170,7 +170,7 @@ void test_vrs_dxil(void)
     }
 
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList5, (void **)&command_list);
-    ok(hr == S_OK, "Couldn't get GraphicsCommandList5, hr %#x.\n", hr);
+    ok(hr == S_OK, "Couldn't get GraphicsCommandList5, hr %#x.\n", (int)hr);
     ID3D12GraphicsCommandList5_Release(command_list);
 
     queue = context.queue;
@@ -180,7 +180,7 @@ void test_vrs_dxil(void)
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -254,7 +254,7 @@ void test_vrs_image(void)
     }
 
     hr = ID3D12GraphicsCommandList_QueryInterface(context.list, &IID_ID3D12GraphicsCommandList5, (void **)&command_list);
-    ok(hr == S_OK, "Couldn't get GraphicsCommandList5, hr %#x.\n", hr);
+    ok(hr == S_OK, "Couldn't get GraphicsCommandList5, hr %#x.\n", (int)hr);
     ID3D12GraphicsCommandList5_Release(command_list);
 
     queue = context.queue;
@@ -264,7 +264,7 @@ void test_vrs_image(void)
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
-    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create pipeline, hr %#x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
@@ -378,11 +378,11 @@ void test_vrs_depth_write(bool use_dxil)
     pso_desc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
 
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso[0]);
-    ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%x.\n", (int)hr);
 
     pso_desc.PS = use_dxil ? vrs_depth_ps_fixed_dxil : vrs_depth_ps_fixed_dxbc;
     hr = ID3D12Device_CreateGraphicsPipelineState(context.device, &pso_desc, &IID_ID3D12PipelineState, (void **)&pso[1]);
-    ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create pipeline, hr #%x.\n", (int)hr);
 
     for (i = 0; i < ARRAY_SIZE(pso); i++)
     {

--- a/tests/d3d12_win32_exclusive.c
+++ b/tests/d3d12_win32_exclusive.c
@@ -35,12 +35,12 @@ void test_clock_calibration(void)
         return;
 
     hr = ID3D12CommandQueue_GetClockCalibration(context.queue, &gpu_times[0], &cpu_times[0]);
-    ok(hr == S_OK, "Failed retrieve calibrated timestamps, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed retrieve calibrated timestamps, hr %#x.\n", (int)hr);
 
     vkd3d_sleep(100);
 
     hr = ID3D12CommandQueue_GetClockCalibration(context.queue, &gpu_times[1], &cpu_times[1]);
-    ok(hr == S_OK, "Failed retrieve calibrated timestamps, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed retrieve calibrated timestamps, hr %#x.\n", (int)hr);
 
     ok(gpu_times[1] > gpu_times[0], "Inconsistent GPU timestamps.\n");
     ok(cpu_times[1] > cpu_times[0], "Inconsistent CPU timestamps.\n");
@@ -73,7 +73,7 @@ void test_open_heap_from_address(void)
 
     device = context.device;
     hr = ID3D12Device_QueryInterface(device, &IID_ID3D12Device3, (void **)&device3);
-    ok(hr == S_OK, "Failed to query ID3D12Device3, hr #%x.\n", hr);
+    ok(hr == S_OK, "Failed to query ID3D12Device3, hr #%x.\n", (int)hr);
 
     /* Simple case, import directly from VirtualAlloc. */
     {
@@ -85,7 +85,7 @@ void test_open_heap_from_address(void)
             addr[i] = i;
 
         hr = ID3D12Device3_OpenExistingHeapFromAddress(device3, addr, &IID_ID3D12Heap, (void **)&heap);
-        ok(hr == S_OK, "Failed to open heap from address: hr #%x.\n", hr);
+        ok(hr == S_OK, "Failed to open heap from address: hr #%x.\n", (int)hr);
 
         freed = false;
 
@@ -99,7 +99,7 @@ void test_open_heap_from_address(void)
             resource = create_placed_buffer(device, heap, 0, heap_size, D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER, D3D12_RESOURCE_STATE_COPY_SOURCE);
             ok(!!resource, "Failed to create resource.\n");
             hr = ID3D12Resource_Map(resource, 0u, NULL, &map_ptr);
-            ok(hr == S_OK, "Failed to map resource, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to map resource, hr %#x.\n", (int)hr);
             ID3D12Resource_Unmap(resource, 0u, NULL);
             ok(map_ptr == addr, "Expected mapped pointer %p to match VirtualAlloc address %p.\n", map_ptr, addr);
             readback_resource = create_default_buffer(device, heap_size, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COPY_DEST);
@@ -143,7 +143,7 @@ void test_open_heap_from_address(void)
             addr[i] = i;
 
         hr = ID3D12Device3_OpenExistingHeapFromFileMapping(device3, file_handle, &IID_ID3D12Heap, (void **)&heap);
-        ok(hr == S_OK, "Failed to open heap from file mapping: hr #%x.\n", hr);
+        ok(hr == S_OK, "Failed to open heap from file mapping: hr #%x.\n", (int)hr);
 
         if (SUCCEEDED(hr))
         {
@@ -229,7 +229,7 @@ void test_write_watch(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_ALLOW_WRITE_WATCH, &resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             NULL, &IID_ID3D12Resource, (void **)&buffer);
-    ok(hr == E_INVALIDARG, "Got hr %#x, expected %#x.\n", hr, E_INVALIDARG);
+    ok(hr == E_INVALIDARG, "Got hr %#x, expected %#x.\n", (int)hr, (int)E_INVALIDARG);
     if (buffer)
         ID3D12Resource_Release(buffer);
 
@@ -239,7 +239,7 @@ void test_write_watch(void)
     hr = ID3D12Device_CreateCommittedResource(context.device, &heap_properties,
             D3D12_HEAP_FLAG_ALLOW_WRITE_WATCH, &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ,
             NULL, &IID_ID3D12Resource, (void **)&buffer);
-    ok(hr == S_OK, "Got hr %#x, expected %#x.\n", hr, S_OK);
+    ok(hr == S_OK, "Got hr %#x, expected %#x.\n", (int)hr, (int)S_OK);
 
     if (FAILED(hr))
     {
@@ -249,7 +249,7 @@ void test_write_watch(void)
 
     /* Do some basic write watch testing... */
     hr = ID3D12Resource_Map(buffer, 0, NULL, (void**) &map_ptr);
-    ok(hr == S_OK, "Got hr %#x, expected %#x.\n", hr, S_OK);
+    ok(hr == S_OK, "Got hr %#x, expected %#x.\n", (int)hr, (int)S_OK);
     if (FAILED(hr))
     {
         skip("Failed to map write watch resource.\n");
@@ -257,7 +257,7 @@ void test_write_watch(void)
     }
 
     result = ResetWriteWatch((void*) map_ptr, mapping_size);
-    ok(!result, "Failed to ResetWriteWatch %#x.\n", GetLastError());
+    ok(!result, "Failed to ResetWriteWatch %#x.\n", (int)GetLastError());
     if (result)
     {
         skip("Failed to ResetWriteWatch, skipping the rest of the WRITE_WATCH tests.\n");
@@ -275,15 +275,15 @@ void test_write_watch(void)
     map_ptr[9 * page_size] = 'd';
 
     result = GetWriteWatch(WRITE_WATCH_FLAG_RESET, (void*) map_ptr, mapping_size, dirty_addresses, &address_count, &page_size);
-    ok(!result, "Failed to GetWriteWatch %#x.\n", GetLastError());
+    ok(!result, "Failed to GetWriteWatch %#x.\n", (int)GetLastError());
     if (result)
     {
         skip("Failed to GetWriteWatch, skipping the rest of the WRITE_WATCH tests.\n");
         goto done;
     }
 
-    ok(address_count == 4, "Expected address_count of %p, got %p\n", 4, address_count);
-    ok(page_size == 0x1000, "Expected page_size of %u, got %u\n", 0x1000, page_size);
+    ok(address_count == 4, "Expected address_count of %d, got %zu\n", 4, (size_t)address_count);
+    ok(page_size == 0x1000, "Expected page_size of %u, got %u\n", 0x1000, (unsigned int)page_size);
     ok(dirty_addresses[0] == (void*)&map_ptr[0 * page_size], "Expected dirty address 0 to be %p, got %p\n",
             (void*)&map_ptr[0 * page_size], dirty_addresses[0]);
     ok(dirty_addresses[1] == (void*)&map_ptr[1 * page_size], "Expected dirty address 1 to be %p, got %p\n",

--- a/tests/d3d12_workgraphs.c
+++ b/tests/d3d12_workgraphs.c
@@ -116,7 +116,7 @@ static void check_work_graph_properties(ID3D12StateObject *pso,
     UINT size;
 
     hr = ID3D12StateObject_QueryInterface(pso, &IID_ID3D12WorkGraphProperties, (void **)&props);
-    ok(SUCCEEDED(hr), "Failed to query work graph props, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to query work graph props, hr #%x.\n", (int)hr);
 
     if (SUCCEEDED(hr))
     {
@@ -207,7 +207,7 @@ static ID3D12StateObject *create_workgraph_pso(
     wg_desc.ProgramName = program_name;
 
     hr = ID3D12Device5_CreateStateObject(context->device, &pso_desc, &IID_ID3D12StateObject, (void **)&pso);
-    ok(SUCCEEDED(hr), "Failed to create state object, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create state object, hr #%x.\n", (int)hr);
     if (FAILED(hr))
         return NULL;
 

--- a/tests/descriptor_performance.c
+++ b/tests/descriptor_performance.c
@@ -123,11 +123,11 @@ static void do_benchmark_run(ID3D12Device *device)
     heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
     heap_desc.NodeMask = 0;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void**)&cpu_heap);
-    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr #%x.\n", (int)hr);
 
     heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     hr = ID3D12Device_CreateDescriptorHeap(device, &heap_desc, &IID_ID3D12DescriptorHeap, (void**)&gpu_heap);
-    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr #%x.\n", hr);
+    ok(SUCCEEDED(hr), "Failed to create descriptor heap, hr #%x.\n", (int)hr);
 
     texture = create_default_texture2d(device,
                                        256, 256, 1, 1, DXGI_FORMAT_R8G8B8A8_UNORM,

--- a/tests/pso_library_bloat.c
+++ b/tests/pso_library_bloat.c
@@ -877,7 +877,7 @@ START_TEST(pso_library_bloat)
         void *ptr;
 
         hr = ID3D12Device1_CreatePipelineLibrary(device1, NULL, 0, &IID_ID3D12PipelineLibrary, (void**)&lib);
-        ok(SUCCEEDED(hr), "Failed to create library, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to create library, hr #%x.\n", (int)hr);
 
         for (i = 0; i < 100; i++, overall_iteration++)
         {
@@ -910,7 +910,7 @@ START_TEST(pso_library_bloat)
             desc.CS.pShaderBytecode = cs_code_dxil;
             desc.CS.BytecodeLength = sizeof(cs_code_dxil);
             hr = ID3D12Device1_CreateComputePipelineState(device1, &desc, &IID_ID3D12PipelineState, (void**)&pso);
-            ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", hr);
+            ok(SUCCEEDED(hr), "Failed to create PSO, hr #%x.\n", (int)hr);
             ID3D12RootSignature_Release(desc.pRootSignature);
             ID3D12PipelineLibrary_StorePipeline(lib, wname, pso);
             ID3D12PipelineState_Release(pso);
@@ -920,7 +920,7 @@ START_TEST(pso_library_bloat)
         printf("Iteration %u, serialized size = %zu\n", library_iteration, serialized_size);
         ptr = malloc(serialized_size);
         hr = ID3D12PipelineLibrary_Serialize(lib, ptr, serialized_size);
-        ok(SUCCEEDED(hr), "Failed to serialize library, hr #%x.\n", hr);
+        ok(SUCCEEDED(hr), "Failed to serialize library, hr #%x.\n", (int)hr);
         ID3D12PipelineLibrary_Release(lib);
         free(ptr);
 

--- a/tests/vkd3d_api.c
+++ b/tests/vkd3d_api.c
@@ -82,12 +82,12 @@ static void test_create_instance(void)
 {
     struct vkd3d_instance_create_info create_info;
     struct vkd3d_instance *instance;
-    ULONG refcount;
+    unsigned int refcount;
     HRESULT hr;
 
     create_info = instance_default_create_info;
     hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", (int)hr);
     refcount = vkd3d_instance_incref(instance);
     ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
     vkd3d_instance_decref(instance);
@@ -97,12 +97,12 @@ static void test_create_instance(void)
     create_info = instance_default_create_info;
     create_info.pfn_signal_event = NULL;
     hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     create_info = instance_default_create_info;
     create_info.pfn_vkGetInstanceProcAddr = vkGetInstanceProcAddr;
     hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", (int)hr);
     refcount = vkd3d_instance_decref(instance);
     ok(!refcount, "Instance has %u references left.\n", refcount);
 }
@@ -197,8 +197,8 @@ static void test_additional_instance_extensions(void)
     uint32_t extension_count;
     PFN_vkVoidFunction pfn;
     VkInstance vk_instance;
+    unsigned int refcount;
     unsigned int i;
-    ULONG refcount;
     HRESULT hr;
 
     if (!(extension_count = check_instance_extensions(enabled_extensions,
@@ -212,7 +212,7 @@ static void test_additional_instance_extensions(void)
     create_info.instance_extensions = enabled_extensions;
     create_info.instance_extension_count = extension_count;
     hr = vkd3d_create_instance(&create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", (int)hr);
     vk_instance = vkd3d_instance_get_vk_instance(instance);
     ok(vk_instance != VK_NULL_HANDLE, "Failed to get Vulkan instance.\n");
 
@@ -241,32 +241,32 @@ static void test_create_device(void)
 {
     struct vkd3d_instance *instance, *tmp_instance;
     struct vkd3d_device_create_info create_info;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     hr = vkd3d_create_device(NULL, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     create_info = device_default_create_info;
     create_info.instance = NULL;
     create_info.instance_create_info = NULL;
     hr = vkd3d_create_device(&create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     create_info.instance_create_info = &instance_default_create_info;
     hr = vkd3d_create_device(&create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
     refcount = ID3D12Device_Release(device);
     ok(!refcount, "Device has %u references left.\n", refcount);
 
     hr = vkd3d_create_instance(&instance_default_create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", (int)hr);
 
     create_info.instance = instance;
     create_info.instance_create_info = NULL;
     hr = vkd3d_create_device(&create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
     refcount = vkd3d_instance_incref(instance);
     ok(refcount >= 3, "Got unexpected refcount %u.\n", refcount);
     vkd3d_instance_decref(instance);
@@ -278,7 +278,7 @@ static void test_create_device(void)
     create_info.instance = instance;
     create_info.instance_create_info = &instance_default_create_info;
     hr = vkd3d_create_device(&create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", (int)hr);
 
     refcount = vkd3d_instance_decref(instance);
     ok(!refcount, "Instance has %u references left.\n", refcount);
@@ -361,20 +361,20 @@ static void test_required_device_extensions(void)
     struct vkd3d_instance_create_info instance_create_info;
     struct vkd3d_device_create_info device_create_info;
     struct vkd3d_instance *instance;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     instance_create_info = instance_default_create_info;
     instance_create_info.pfn_vkGetInstanceProcAddr = fake_vkGetInstanceProcAddr;
     hr = vkd3d_create_instance(&instance_create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", (int)hr);
 
     device_create_info = device_default_create_info;
     device_create_info.instance = instance;
     device_create_info.instance_create_info = NULL;
     hr = vkd3d_create_device(&device_create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_FAIL, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == E_FAIL, "Failed to create device, hr %#x.\n", (int)hr);
 
     refcount = vkd3d_instance_decref(instance);
     ok(!refcount, "Instance has %u references left.\n", refcount);
@@ -395,10 +395,10 @@ static void test_additional_device_extensions(void)
     uint32_t extension_count;
     PFN_vkVoidFunction pfn;
     VkInstance vk_instance;
+    unsigned int refcount;
     ID3D12Device *device;
     VkDevice vk_device;
     uint32_t count;
-    ULONG refcount;
     VkResult vr;
     HRESULT hr;
 
@@ -411,10 +411,10 @@ static void test_additional_device_extensions(void)
     instance_create_info.instance_extension_count = extension_count;
     if (FAILED(hr = vkd3d_create_instance(&instance_create_info, &instance)))
     {
-        skip("Failed to create instance, hr %#x.\n", hr);
+        skip("Failed to create instance, hr %#x.\n", (int)hr);
         return;
     }
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", (int)hr);
     vk_instance = vkd3d_instance_get_vk_instance(instance);
     ok(vk_instance != VK_NULL_HANDLE, "Failed to get Vulkan instance.\n");
 
@@ -439,7 +439,7 @@ static void test_additional_device_extensions(void)
     device_create_info.device_extensions = enabled_extensions;
     device_create_info.device_extension_count = extension_count;
     hr = vkd3d_create_device(&device_create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
 
     vk_device = vkd3d_get_vk_device(device);
 
@@ -463,13 +463,13 @@ static void test_optional_device_extensions(void)
     struct vkd3d_instance_create_info instance_create_info;
     struct vkd3d_device_create_info device_create_info;
     struct vkd3d_instance *instance;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
 
     instance_create_info = instance_default_create_info;
     hr = vkd3d_create_instance(&instance_create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", (int)hr);
 
     device_create_info = device_default_create_info;
     device_create_info.instance = instance;
@@ -477,14 +477,14 @@ static void test_optional_device_extensions(void)
     device_create_info.device_extensions = extensions;
     device_create_info.device_extension_count = ARRAY_SIZE(extensions);
     hr = vkd3d_create_device(&device_create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == E_FAIL, "Got unexpected hr %#x.\n", hr);
+    ok(hr == E_FAIL, "Got unexpected hr %#x.\n", (int)hr);
 
     device_create_info.device_extensions = NULL;
     device_create_info.device_extension_count = 0;
     device_create_info.optional_device_extensions = extensions;
     device_create_info.optional_device_extensions = ARRAY_SIZE(extensions);
     hr = vkd3d_create_device(&device_create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
 
     refcount = ID3D12Device_Release(device);
     ok(!refcount, "Device has %u references left.\n", refcount);
@@ -499,14 +499,14 @@ static void test_physical_device(void)
     VkPhysicalDevice vk_physical_device;
     struct vkd3d_instance *instance;
     VkInstance vk_instance;
+    unsigned int refcount;
     ID3D12Device *device;
     uint32_t i, count;
-    ULONG refcount;
     VkResult vr;
     HRESULT hr;
 
     hr = vkd3d_create_instance(&instance_default_create_info, &instance);
-    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create instance, hr %#x.\n", (int)hr);
     vk_instance = vkd3d_instance_get_vk_instance(instance);
     ok(vk_instance != VK_NULL_HANDLE, "Failed to get Vulkan instance.\n");
 
@@ -515,7 +515,7 @@ static void test_physical_device(void)
     create_info.instance_create_info = NULL;
     create_info.vk_physical_device = VK_NULL_HANDLE;
     hr = vkd3d_create_device(&create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
     vk_physical_device = vkd3d_get_vk_physical_device(device);
     trace("Default Vulkan physical device %p.\n", vk_physical_device);
     refcount = ID3D12Device_Release(device);
@@ -536,7 +536,7 @@ static void test_physical_device(void)
 
             create_info.vk_physical_device = vk_physical_devices[i];
             hr = vkd3d_create_device(&create_info, &IID_ID3D12Device, (void **)&device);
-            ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+            ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
             vk_physical_device = vkd3d_get_vk_physical_device(device);
             ok(vk_physical_device == vk_physical_devices[i],
                     "Got unexpected Vulkan physical device %p.\n", vk_physical_device);
@@ -557,8 +557,8 @@ static void test_physical_device(void)
 static void test_adapter_luid(void)
 {
     struct vkd3d_device_create_info create_info;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
     HRESULT hr;
     LUID luid;
 
@@ -566,7 +566,7 @@ static void test_adapter_luid(void)
     create_info.adapter_luid.HighPart = 0xdeadc0de;
     create_info.adapter_luid.LowPart = 0xdeadbeef;
     hr = vkd3d_create_device(&create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
 
     luid = ID3D12Device_GetAdapterLuid(device);
     ok(luid.HighPart == 0xdeadc0de && luid.LowPart == 0xdeadbeef,
@@ -626,10 +626,10 @@ static void test_device_parent(void)
 {
     struct vkd3d_device_create_info create_info;
     struct parent parent_impl;
+    unsigned int refcount;
     ID3D12Device *device;
     IUnknown *unknown;
     IUnknown *parent;
-    ULONG refcount;
     HRESULT hr;
 
     parent_impl.IUnknown_iface.lpVtbl = &parent_vtbl;
@@ -642,7 +642,7 @@ static void test_device_parent(void)
     create_info = device_default_create_info;
     create_info.parent = parent;
     hr = vkd3d_create_device(&create_info, &IID_ID3D12Device, (void **)&device);
-    ok(hr == S_OK, "Failed to create device, hr %#x.\n", hr);
+    ok(hr == S_OK, "Failed to create device, hr %#x.\n", (int)hr);
 
     refcount = get_refcount(parent);
     ok(refcount == 2, "Got unexpected refcount %u.\n", refcount);
@@ -661,9 +661,9 @@ static void test_vkd3d_queue(void)
 {
     ID3D12CommandQueue *direct_queue, *compute_queue, *copy_queue;
     uint32_t vk_queue_family;
+    unsigned int refcount;
     ID3D12Device *device;
     VkQueue vk_queue;
-    ULONG refcount;
 
     device = create_device();
     ok(device, "Failed to create device.\n");
@@ -702,8 +702,8 @@ static void test_vkd3d_queue(void)
 static void test_resource_internal_refcount(void)
 {
     ID3D12Resource *resource;
+    unsigned int refcount;
     ID3D12Device *device;
-    ULONG refcount;
 
     device = create_device();
     ok(device, "Failed to create device.\n");


### PR DESCRIPTION
Extremely annoying and there's a reason why we'd had -Wno-format, but there were tons of (mostly benign) formatting bugs all over the place.

Native and MinGW builds use different types for things mostly due to long. There seems to be no good way to have MinGW assume that %zu works since it still targets msvcrt.dll from prehistoric era (tried various things, but gave up), so needed a hack to get around that too.