### PR TITLE
VK_KHR_opacity_micromap - Phase 2

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6377,7 +6377,7 @@ static void vk_access_and_stage_flags_from_d3d12_resource_state(const struct d3d
                     *access |= VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR |
                             VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
 
-                    if (d3d12_device_supports_ray_tracing_tier_1_2(device))
+                    if (device->device_info.opacity_micromap_features_ext.micromap)
                     {
                         *stages |= VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT;
                         *access |= VK_ACCESS_2_MICROMAP_READ_BIT_EXT |
@@ -6395,7 +6395,7 @@ static void vk_access_and_stage_flags_from_d3d12_resource_state(const struct d3d
                     *access |= VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR |
                             VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR;
 
-                    if (d3d12_device_supports_ray_tracing_tier_1_2(device))
+                    if (device->device_info.opacity_micromap_features_ext.micromap)
                     {
                         *stages |= VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT;
                         *access |= VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT |
@@ -6428,7 +6428,7 @@ static void vk_access_and_stage_flags_from_d3d12_resource_state(const struct d3d
                      * They access SHADER_READ_BIT in Vulkan, so just need to add the stage. */
                     *stages |= VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
 
-                    if (d3d12_device_supports_ray_tracing_tier_1_2(device))
+                    if (device->device_info.opacity_micromap_features_ext.micromap)
                         *stages |= VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT;
                 }
                 break;
@@ -20205,7 +20205,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_BuildRaytracingAccelerationStru
         vk_barrier.dstStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
         vk_barrier.dstAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
 
-        if (list->device->device_info.opacity_micromap_features.micromap)
+        if (list->device->device_info.opacity_micromap_features_ext.micromap)
         {
             vk_barrier.srcAccessMask |= VK_ACCESS_2_MICROMAP_READ_BIT_EXT | VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT;
             vk_barrier.dstAccessMask |= VK_ACCESS_2_MICROMAP_READ_BIT_EXT | VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -19972,19 +19972,10 @@ static void d3d12_command_list_clear_rtas_batch(struct d3d12_command_list *list)
     rtas_batch->omm_usage_info_count = 0;
 }
 
-static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
+static void d3d12_command_list_fixup_rtas_batch(struct d3d12_command_list *list)
 {
-    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
     unsigned int i, geometry_index, usage_index;
-
-    if (!rtas_batch->build_info_count && !rtas_batch->omm_build_info_count)
-        return;
-
-    d3d12_command_list_check_end_of_command_list_cleanup(list);
-
-    TRACE("list %p, build_info_count %zu, omm_build_info_count %zu.\n", list,
-            rtas_batch->build_info_count, rtas_batch->omm_build_info_count);
 
     if (rtas_batch->build_info_count &&
             !vkd3d_array_reserve((void **)&rtas_batch->range_ptrs, &rtas_batch->range_ptr_size,
@@ -20039,7 +20030,22 @@ static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
             }
         }
     }
+}
 
+static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
+
+    if (!rtas_batch->build_info_count && !rtas_batch->omm_build_info_count)
+        return;
+
+    d3d12_command_list_check_end_of_command_list_cleanup(list);
+
+    TRACE("list %p, build_info_count %zu, omm_build_info_count %zu.\n", list,
+            rtas_batch->build_info_count, rtas_batch->omm_build_info_count);
+
+    d3d12_command_list_fixup_rtas_batch(list);
     d3d12_command_list_end_current_render_pass(list, true);
     d3d12_command_list_end_transfer_batch(list);
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2934,6 +2934,11 @@ static void vkd3d_trace_physical_device_features(const struct vkd3d_physical_dev
     TRACE("  VkPhysicalDeviceLineRasterizationFeaturesEXT:\n");
     TRACE("    rectangularLines: %u\n", info->line_rasterization_features.rectangularLines);
     TRACE("    smoothLines: %u\n", info->line_rasterization_features.smoothLines);
+
+    TRACE("  VkPhysicalDeviceOpacityMicromapFeaturesEXT:\n");
+    TRACE("    micromap: %#x\n", info->opacity_micromap_features.micromap);
+    TRACE("    micromapCaptureReplay: %#x\n", info->opacity_micromap_features.micromapCaptureReplay);
+    TRACE("    micromapHostCommands: %#x\n", info->opacity_micromap_features.micromapHostCommands);
 }
 
 static HRESULT vkd3d_init_device_extensions(struct d3d12_device *device,

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -95,6 +95,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_PRESENT_WAIT_2, KHR_present_wait2),
     VK_EXTENSION(EXT_PRESENT_TIMING, EXT_present_timing),
     VK_EXTENSION(KHR_DEVICE_ADDRESS_COMMANDS, KHR_device_address_commands),
+    VK_EXTENSION_COND(KHR_OPACITY_MICROMAP, KHR_opacity_micromap, VKD3D_CONFIG_FLAG_STATIC(DXR_1_2)),
 #ifdef _WIN32
     VK_EXTENSION(KHR_EXTERNAL_MEMORY_WIN32, KHR_external_memory_win32),
     VK_EXTENSION(KHR_EXTERNAL_SEMAPHORE_WIN32, KHR_external_semaphore_win32),
@@ -1629,7 +1630,7 @@ bool d3d12_device_supports_ray_tracing_tier_1_0(const struct d3d12_device *devic
 
 bool d3d12_device_supports_ray_tracing_tier_1_2(const struct d3d12_device *device)
 {
-    return device->device_info.opacity_micromap_features.micromap &&
+    return device->device_info.supports_opacity_micromap &&
             device->d3d12_caps.options5.RaytracingTier >= D3D12_RAYTRACING_TIER_1_2;
 }
 
@@ -2446,10 +2447,16 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->features2, &info->device_address_commands_features);
     }
 
+    if (vulkan_info->KHR_opacity_micromap)
+    {
+        info->opacity_micromap_features_khr.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_KHR;
+        vk_prepend_struct(&info->features2, &info->opacity_micromap_features_khr);
+    }
+
     if (vulkan_info->EXT_opacity_micromap)
     {
-        info->opacity_micromap_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT;
-        vk_prepend_struct(&info->features2, &info->opacity_micromap_features);
+        info->opacity_micromap_features_ext.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT;
+        vk_prepend_struct(&info->features2, &info->opacity_micromap_features_ext);
     }
 
     if (vulkan_info->EXT_shader_float8)
@@ -2521,6 +2528,17 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
 
     VK_CALL(vkGetPhysicalDeviceFeatures2(device->vk_physical_device, &info->features2));
     VK_CALL(vkGetPhysicalDeviceProperties2(device->vk_physical_device, &info->properties2));
+
+    /* TODO: Until KHR is fully plumbed in, we will only support EXT */
+    info->opacity_micromap_features_khr.micromap = VK_FALSE;
+
+    /* Prefer KHR_opacity_micromap over EXT_opacity_micromap, and only load one. */
+    info->using_khr_opacity_micromap = info->opacity_micromap_features_khr.micromap;
+
+    if (info->using_khr_opacity_micromap)
+        info->opacity_micromap_features_ext.micromap = VK_FALSE;
+
+    info->supports_opacity_micromap = info->using_khr_opacity_micromap || info->opacity_micromap_features_ext.micromap;
 
     /* if nonzero, this is a layered implementation */
     if (real_driver_props.driverID)
@@ -2936,9 +2954,13 @@ static void vkd3d_trace_physical_device_features(const struct vkd3d_physical_dev
     TRACE("    smoothLines: %u\n", info->line_rasterization_features.smoothLines);
 
     TRACE("  VkPhysicalDeviceOpacityMicromapFeaturesEXT:\n");
-    TRACE("    micromap: %#x\n", info->opacity_micromap_features.micromap);
-    TRACE("    micromapCaptureReplay: %#x\n", info->opacity_micromap_features.micromapCaptureReplay);
-    TRACE("    micromapHostCommands: %#x\n", info->opacity_micromap_features.micromapHostCommands);
+
+    TRACE("    micromap: %#x\n", info->opacity_micromap_features_ext.micromap);
+    TRACE("    micromapCaptureReplay: %#x\n", info->opacity_micromap_features_ext.micromapCaptureReplay);
+    TRACE("    micromapHostCommands: %#x\n", info->opacity_micromap_features_ext.micromapHostCommands);
+
+    TRACE("  VkPhysicalDeviceOpacityMicromapFeaturesKHR:\n");
+    TRACE("    micromap: %#x\n", info->opacity_micromap_features_khr.micromap);
 }
 
 static HRESULT vkd3d_init_device_extensions(struct d3d12_device *device,
@@ -9371,7 +9393,7 @@ static D3D12_RAYTRACING_TIER d3d12_device_determine_ray_tracing_tier(struct d3d1
         }
     }
 
-    if (tier == D3D12_RAYTRACING_TIER_1_1 && info->opacity_micromap_features.micromap)
+    if (tier == D3D12_RAYTRACING_TIER_1_1 && info->supports_opacity_micromap)
     {
         INFO("DXR 1.2 support enabled.\n");
         tier = D3D12_RAYTRACING_TIER_1_2;
@@ -10497,7 +10519,7 @@ static void vkd3d_init_shader_extensions(struct d3d12_device *device)
                 VKD3D_SHADER_TARGET_EXTENSION_RAW_ACCESS_CHAINS_NV;
     }
 
-    if (device->device_info.opacity_micromap_features.micromap)
+    if (device->device_info.supports_opacity_micromap)
     {
         device->vk_info.shader_extensions[device->vk_info.shader_extension_count++] =
                 VKD3D_SHADER_TARGET_EXTENSION_OPACITY_MICROMAP;

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -206,49 +206,6 @@ void vkd3d_opacity_micromap_write_postbuild_info(
     }
 }
 
-void vkd3d_opacity_micromap_emit_postbuild_info(
-        struct d3d12_command_list *list,
-        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        uint32_t count,
-        const D3D12_GPU_VIRTUAL_ADDRESS *addresses)
-{
-    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
-    VkMicromapEXT vk_opacity_micromap;
-    VkDependencyInfo dep_info;
-    VkMemoryBarrier2 barrier;
-    VkDeviceSize stride;
-    uint32_t i;
-
-    /* We resolve the query in TRANSFER, but DXR expects UNORDERED_ACCESS. */
-    memset(&barrier, 0, sizeof(barrier));
-    barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
-    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
-    barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-
-    memset(&dep_info, 0, sizeof(dep_info));
-    dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
-    dep_info.memoryBarrierCount = 1;
-    dep_info.pMemoryBarriers = &barrier;
-
-    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
-
-    stride = desc->InfoType == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION ?
-            2 * sizeof(uint64_t) : sizeof(uint64_t);
-
-    for (i = 0; i < count; i++)
-    {
-        vk_opacity_micromap = vkd3d_va_map_place_opacity_micromap(
-                &list->device->memory_allocator.va_map, list->device, addresses[i]);
-        if (vk_opacity_micromap)
-            vkd3d_opacity_micromap_write_postbuild_info(list, desc, i * stride, vk_opacity_micromap);
-        else
-            ERR("Failed to query opacity micromap for VA 0x%"PRIx64".\n", addresses[i]);
-    }
-
-    vkd3d_opacity_micromap_end_barrier(list);
-}
-
 void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
         struct d3d12_command_list *list, uint32_t count,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -241,7 +241,7 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
         buffer_info.usage |= VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                 VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR;
 
-        if (d3d12_device_supports_ray_tracing_tier_1_2(device))
+        if (device->device_info.opacity_micromap_features_ext.micromap)
         {
             if (heap_type == D3D12_HEAP_TYPE_DEFAULT || !is_cpu_accessible_heap(heap_properties))
                 buffer_info.usage |= VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT;
@@ -10866,7 +10866,7 @@ HRESULT vkd3d_memory_info_init(struct vkd3d_memory_info *info,
                 VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR |
                 VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR;
 
-        if (device->device_info.opacity_micromap_features.micromap)
+        if (device->device_info.opacity_micromap_features_ext.micromap)
         {
             buffer_info.usage |=
                     VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT |

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -6854,11 +6854,6 @@ void vkd3d_opacity_micromap_write_postbuild_info(
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
         VkDeviceSize desc_offset,
         VkMicromapEXT vk_opacity_micromap);
-void vkd3d_opacity_micromap_emit_postbuild_info(
-        struct d3d12_command_list *list,
-        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        uint32_t count,
-        const D3D12_GPU_VIRTUAL_ADDRESS *addresses);
 void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
         struct d3d12_command_list *list, uint32_t count,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -156,6 +156,7 @@ struct vkd3d_vulkan_info
     bool KHR_unified_image_layouts;
     bool KHR_present_mode_fifo_latest_ready;
     bool KHR_device_address_commands;
+    bool KHR_opacity_micromap;
     /* EXT device extensions */
     bool EXT_conditional_rendering;
     bool EXT_conservative_rasterization;
@@ -5266,7 +5267,8 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceOpticalFlowFeaturesNV optical_flow_nv_features;
     VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features;
     VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT zero_initialize_device_memory_features;
-    VkPhysicalDeviceOpacityMicromapFeaturesEXT opacity_micromap_features;
+    VkPhysicalDeviceOpacityMicromapFeaturesEXT opacity_micromap_features_ext;
+    VkPhysicalDeviceOpacityMicromapFeaturesKHR opacity_micromap_features_khr;
     VkPhysicalDeviceShaderFloat8FeaturesEXT shader_float8_features;
     VkPhysicalDeviceCooperativeMatrix2FeaturesNV cooperative_matrix2_features_nv;
     VkPhysicalDeviceAntiLagFeaturesAMD anti_lag_amd;
@@ -5281,6 +5283,10 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR device_address_commands_features;
 
     VkPhysicalDeviceFeatures2 features2;
+
+    /* Logical OR of the KHR and EXT opacity-micromap support flags. */
+    bool supports_opacity_micromap;
+    bool using_khr_opacity_micromap; /* Discriminator KHR / EXT being used. */
 
     /* others, for extensions that have no feature bits */
     uint32_t time_domains;  /* vkd3d_time_domain_flag */


### PR DESCRIPTION
This phase does some basic code cleanup and plumbs in adding the enabling the VK_KHR_opacity_micromap extension. Since there are many commits to actually using the feature, it will be disabled for now.