### PR TITLE
Descriptor heap - Phase 11

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5394,6 +5394,25 @@ void d3d12_command_list_meta_push_data(struct d3d12_command_list *list,
     }
 }
 
+void d3d12_command_list_meta_push_descriptor_index(struct d3d12_command_list *list,
+        VkCommandBuffer vk_command_buffer, uint32_t binding, uint32_t heap_index)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    VkPushDataInfoEXT push;
+    memset(&push, 0, sizeof(push));
+    push.sType = VK_STRUCTURE_TYPE_PUSH_DATA_INFO_EXT;
+    push.data.address = &heap_index;
+    push.data.size = sizeof(heap_index);
+    push.offset = VKD3D_DESCRIPTOR_HEAP_META_PUSH_DATA_OFFSET + binding * sizeof(uint32_t);
+
+    /* We don't go through meta heap path if the currently bound heap is invalid. */
+    assert(!list->descriptor_heap.buffers.global_heap_dirty);
+
+    /* Don't bother invalidating root parameters, that's done in push_data
+     * and we never do push_descriptor_index in complete isolation. */
+    VK_CALL(vkCmdPushDataEXT(vk_command_buffer, &push));
+}
+
 static bool d3d12_command_list_gather_pending_queries(struct d3d12_command_list *list)
 {
     /* TODO allocate arrays from command allocator in case

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -10118,7 +10118,7 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         pipeline_key.sample_count = vk_samples_from_dxgi_sample_desc(&dst_resource->desc.SampleDesc);
         pipeline_key.dst_aspect_mask = region->dstSubresource.aspectMask;
 
-        if (FAILED(hr = vkd3d_meta_get_copy_image_pipeline(&list->device->meta_ops, &pipeline_key, &pipeline_info)))
+        if (FAILED(hr = vkd3d_meta_get_copy_image_pipeline(&list->device->meta_ops, &pipeline_key, &pipeline_info, false)))
         {
             ERR("Failed to obtain pipeline, format %u, view_type %u, sample_count %u.\n",
                     pipeline_key.format->vk_format, pipeline_key.view_type, pipeline_key.sample_count);
@@ -11933,7 +11933,8 @@ static void d3d12_command_list_execute_resolve(struct d3d12_command_list *list,
         resolve_pipeline_key.compute.mode = mode;
         resolve_pipeline_key.compute.srgb = dst_view_desc.format != vk_format;
 
-        if (FAILED(vkd3d_meta_get_resolve_image_pipeline(&list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info)))
+        if (FAILED(vkd3d_meta_get_resolve_image_pipeline(
+            &list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info, false)))
         {
             ERR("Failed to get resolve pipeline.\n");
             return;
@@ -12134,7 +12135,8 @@ cleanup_compute:
                 resolve_pipeline_key.graphics.dst_aspect = (VkImageAspectFlagBits)region->dstSubresource.aspectMask;
                 resolve_pipeline_key.graphics.mode = mode;
 
-                if (FAILED(vkd3d_meta_get_resolve_image_pipeline(&list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info)))
+                if (FAILED(vkd3d_meta_get_resolve_image_pipeline(
+                    &list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info, false)))
                 {
                     ERR("Failed to get resolve pipeline.\n");
                     return;
@@ -15382,7 +15384,7 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
         pipeline = vkd3d_meta_get_clear_image_uav_pipeline(
                 &list->device->meta_ops, args->u.image.vk_view_type,
-                format->type == VKD3D_FORMAT_TYPE_UINT);
+                format->type == VKD3D_FORMAT_TYPE_UINT, false);
         workgroup_size = vkd3d_meta_get_clear_image_uav_workgroup_size(args->u.image.vk_view_type);
     }
     else
@@ -15412,7 +15414,7 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
         layer_count = 1;
         pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops,
                 !args->view || format->type == VKD3D_FORMAT_TYPE_UINT,
-                !args->view);
+                !args->view, false);
         workgroup_size = vkd3d_meta_get_clear_buffer_uav_workgroup_size();
     }
 
@@ -15549,7 +15551,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
         return;
     }
 
-    pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops, true, false);
+    pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops, true, false, false);
     workgroup_size = vkd3d_meta_get_clear_buffer_uav_workgroup_size();
 
     if (!vkd3d_create_vk_buffer_view(list->device, scratch.buffer, format, scratch.offset, scratch_buffer_size,
@@ -18053,7 +18055,7 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
     if (src->desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {
         vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
-                VKD3D_SAMPLER_FEEDBACK_RESOLVE_BUFFER_TO_MIN_MIP, &pipeline_info);
+                VKD3D_SAMPLER_FEEDBACK_RESOLVE_BUFFER_TO_MIN_MIP, &pipeline_info, false);
 
         dst_view_desc.view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
 
@@ -18117,7 +18119,7 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
         vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
                 dst->desc.Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ?
                         VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIN_MIP :
-                        VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIP_USED, &pipeline_info);
+                        VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIP_USED, &pipeline_info, false);
 
         memset(&src_image_view_desc, 0, sizeof(src_image_view_desc));
         src_image_view_desc.image = src->res.vk_image;
@@ -18411,7 +18413,7 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
         vk_image_barrier[0].subresourceRange.levelCount = src_view_desc.miplevel_count;
 
         vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
-                VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER, &pipeline_info);
+                VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER, &pipeline_info, false);
 
         src_view_desc.view_type = VK_IMAGE_VIEW_TYPE_2D;
 
@@ -18499,7 +18501,7 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
         vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
                 src->desc.Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ?
                         VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE :
-                        VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE, &pipeline_info);
+                        VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE, &pipeline_info, false);
 
         memset(&dst_image_view_desc, 0, sizeof(dst_image_view_desc));
         dst_image_view_desc.image = dst->res.vk_image;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2859,6 +2859,12 @@ static void d3d12_command_allocator_free_resources(struct d3d12_command_allocato
         d3d12_descriptor_heap_dec_ref(allocator->descriptor_heaps[i]);
     }
     allocator->descriptor_heaps_count = 0;
+
+    for (i = 0; i < allocator->meta_allocs_count; i++)
+    {
+        d3d12_descriptor_heap_free_meta_index(allocator->meta_allocs[i].heap, allocator->meta_allocs[i].index);
+    }
+    allocator->meta_allocs_count = 0;
 }
 
 static void d3d12_command_allocator_set_name(struct d3d12_command_allocator *allocator, const char *name)
@@ -2968,6 +2974,7 @@ static ULONG d3d12_command_allocator_dec_ref(struct d3d12_command_allocator *all
         vkd3d_free(allocator->views);
         vkd3d_free(allocator->pipelines);
         vkd3d_free(allocator->descriptor_heaps);
+        vkd3d_free(allocator->meta_allocs);
 
         if (VKD3D_CONFIG_FLAG_IS_SET(RECYCLE_COMMAND_POOLS))
         {
@@ -3587,6 +3594,115 @@ static struct d3d12_command_allocator *d3d12_command_allocator_from_iface(ID3D12
         return NULL;
 
     return impl_from_ID3D12CommandAllocator(iface);
+}
+
+uint32_t d3d12_command_allocator_allocate_meta_index(
+        struct d3d12_command_allocator *allocator, struct d3d12_descriptor_heap *heap)
+{
+    uint32_t index = d3d12_descriptor_heap_allocate_meta_index(heap);
+    if (index == UINT32_MAX)
+    {
+        WARN("Meta descriptor pressure! Falling back to global heap (potentially slow) ...\n");
+        return index;
+    }
+
+    vkd3d_array_reserve((void**)&allocator->meta_allocs, &allocator->meta_allocs_size,
+            allocator->meta_allocs_count + 1, sizeof(*allocator->meta_allocs));
+    allocator->meta_allocs[allocator->meta_allocs_count].heap = heap;
+    allocator->meta_allocs[allocator->meta_allocs_count].index = index;
+    allocator->meta_allocs_count++;
+    return index;
+}
+
+static uint32_t d3d12_command_list_allocate_meta_buffer_view(
+        struct d3d12_command_list *list,
+        VkDeviceAddress va, VkDeviceSize range, VkFormat vk_format,
+        VkDescriptorType vk_descriptor_type)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    VkTexelBufferDescriptorInfoEXT texel_buffer_info;
+    VkResourceDescriptorInfoEXT desc_info;
+    struct d3d12_descriptor_heap *heap;
+    VkHostAddressRangeEXT desc_range;
+    uint32_t heap_index;
+
+    heap = list->descriptor_heap.buffers.resource.heap;
+
+    /* If heap is dirty, we've moved back to global heap, and it's meaningless to attempt to rebind the heap.
+    * Just fallback to legacy descriptor model to avoid further disruptions. */
+    if (!heap || list->descriptor_heap.buffers.global_heap_dirty)
+        return UINT32_MAX;
+
+    heap_index = d3d12_command_allocator_allocate_meta_index(list->allocator, heap);
+    if (heap_index == UINT32_MAX)
+        return heap_index;
+
+    memset(&texel_buffer_info, 0, sizeof(texel_buffer_info));
+    texel_buffer_info.sType = VK_STRUCTURE_TYPE_TEXEL_BUFFER_DESCRIPTOR_INFO_EXT;
+    texel_buffer_info.addressRange.address = va;
+    texel_buffer_info.addressRange.size = range;
+    texel_buffer_info.format = vk_format;
+
+    memset(&desc_info, 0, sizeof(desc_info));
+    desc_info.sType = VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT;
+    desc_info.type = vk_descriptor_type;
+    desc_info.data.pTexelBuffer = &texel_buffer_info;
+
+    desc_range.address = heap->descriptor_buffer.host_allocation +
+                         heap_index * list->device->bindless_state.cbv_srv_uav_size;
+    desc_range.size = list->device->bindless_state.cbv_srv_uav_size;
+    VK_CALL(vkWriteResourceDescriptorsEXT(list->device->vk_device, 1, &desc_info, &desc_range));
+    return heap_index;
+}
+
+static uint32_t d3d12_command_list_allocate_meta_image_view(
+        struct d3d12_command_list *list,
+        const struct vkd3d_texture_view_desc *view_desc, VkImageLayout vk_image_layout)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    struct vkd3d_texture_view_create_info vk_view_info;
+    VkResourceDescriptorInfoEXT desc_info;
+    VkImageDescriptorInfoEXT image_info;
+    struct d3d12_descriptor_heap *heap;
+    VkHostAddressRangeEXT desc_range;
+    uint32_t heap_index;
+
+    heap = list->descriptor_heap.buffers.resource.heap;
+
+    /* If heap is dirty, we've moved back to global heap, and it's meaningless to attempt to rebind the heap.
+    * Just fallback to legacy descriptor model to avoid further disruptions. */
+    if (!heap || list->descriptor_heap.buffers.global_heap_dirty)
+        return UINT32_MAX;
+
+    assert(view_desc->image_usage == VK_IMAGE_USAGE_SAMPLED_BIT ||
+           view_desc->image_usage == VK_IMAGE_USAGE_STORAGE_BIT);
+
+    heap_index = d3d12_command_allocator_allocate_meta_index(list->allocator, heap);
+    if (heap_index == UINT32_MAX)
+        return heap_index;
+
+    vkd3d_setup_texture_view(list->device, view_desc, &vk_view_info);
+
+    memset(&image_info, 0, sizeof(image_info));
+    image_info.sType = VK_STRUCTURE_TYPE_IMAGE_DESCRIPTOR_INFO_EXT;
+    image_info.layout = vk_image_layout;
+    image_info.pView = &vk_view_info.view_desc;
+
+    memset(&desc_info, 0, sizeof(desc_info));
+    desc_info.sType = VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT;
+    desc_info.data.pImage = &image_info;
+
+    desc_range.address = heap->descriptor_buffer.host_allocation +
+                         heap_index * list->device->bindless_state.cbv_srv_uav_size;
+
+    if (view_desc->image_usage == VK_IMAGE_USAGE_SAMPLED_BIT)
+        desc_info.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    else
+        desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+
+    desc_range.size = list->device->bindless_state.cbv_srv_uav_size;
+    VK_CALL(vkWriteResourceDescriptorsEXT(list->device->vk_device, 1, &desc_info, &desc_range));
+    return heap_index;
 }
 
 /* ID3D12CommandList */

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -15357,18 +15357,14 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
     if (d3d12_resource_is_texture(resource))
     {
-        /* TODO: This will change in heap. */
-        assert(args->view);
-
-        image_info.sampler = VK_NULL_HANDLE;
-        image_info.imageView = args->view->vk_image_view;
-        image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-        write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        write_set.pImageInfo = &image_info;
-
-        if (args->view)
+        if (!args->use_heap)
         {
+            assert(args->view);
+            image_info.sampler = VK_NULL_HANDLE;
+            image_info.imageView = args->view->vk_image_view;
+            image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+            write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+            write_set.pImageInfo = &image_info;
             view_extent = d3d12_resource_get_view_subresource_extent(resource, args->view);
         }
         else
@@ -15403,7 +15399,7 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
         pipeline = vkd3d_meta_get_clear_image_uav_pipeline(
                 &list->device->meta_ops, args->u.image.vk_view_type,
-                format->type == VKD3D_FORMAT_TYPE_UINT, false);
+                format->type == VKD3D_FORMAT_TYPE_UINT, args->use_heap);
         workgroup_size = vkd3d_meta_get_clear_image_uav_workgroup_size(args->u.image.vk_view_type);
     }
     else
@@ -15412,28 +15408,40 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
         if (args->view)
         {
+            /* Legacy path. */
             VkDeviceSize byte_count = args->view->format->byte_count;
+            assert(!args->use_heap);
             full_rect.right = args->view->info.buffer.size / byte_count;
 
             write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
             write_set.pTexelBufferView = &args->view->vk_buffer_view;
         }
+        else if (format)
+        {
+            VkDeviceSize byte_count = format->byte_count;
+            assert(args->use_heap);
+            full_rect.right = args->u.buffer.range / byte_count;
+        }
         else
         {
+            /* Plain SSBO clear. StructuredBuffers are not allowed, but RAW is (since it has R32_TYPELESS). */
             full_rect.right = args->u.buffer.range / sizeof(uint32_t);
 
-            write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            write_set.pBufferInfo = &buffer_info;
-            /* resource heap offset is already in descriptor */
-            buffer_info.buffer = resource->res.vk_buffer;
-            buffer_info.offset = resource->mem.offset + (args->u.buffer.va - resource->res.va);
-            buffer_info.range = args->u.buffer.range;
+            if (!args->use_heap)
+            {
+                write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                write_set.pBufferInfo = &buffer_info;
+                /* resource heap offset is already in descriptor */
+                buffer_info.buffer = resource->res.vk_buffer;
+                buffer_info.offset = resource->mem.offset + (args->u.buffer.va - resource->res.va);
+                buffer_info.range = args->u.buffer.range;
+            }
         }
 
         layer_count = 1;
         pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops,
-                !args->view || format->type == VKD3D_FORMAT_TYPE_UINT,
-                !args->view, false);
+                !format || format->type == VKD3D_FORMAT_TYPE_UINT,
+                format == NULL, args->use_heap);
         workgroup_size = vkd3d_meta_get_clear_buffer_uav_workgroup_size();
     }
 
@@ -15442,8 +15450,16 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
 
     VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer,
             VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.vk_pipeline));
-    VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-            pipeline.vk_pipeline_layout, 0, 1, &write_set));
+
+    if (args->use_heap)
+    {
+        d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 0, args->heap_index);
+    }
+    else
+    {
+        VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                pipeline.vk_pipeline_layout, 0, 1, &write_set));
+    }
 
     for (i = 0; i < rect_count || !i; i++)
     {
@@ -15518,6 +15534,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     VkMemoryBarrier2 barrier;
     VkExtent3D view_extent;
     uint32_t element_count;
+    uint32_t heap_index;
 
     d3d12_command_list_track_resource_usage(list, resource, true);
     d3d12_command_list_end_current_render_pass(list, false);
@@ -15570,33 +15587,43 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
         return;
     }
 
-    pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops, true, false, false);
+    heap_index = d3d12_command_list_allocate_meta_buffer_view(
+        list, scratch.va, scratch_buffer_size, format->vk_format,
+        VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+
+    pipeline = vkd3d_meta_get_clear_buffer_uav_pipeline(&list->device->meta_ops, true, false,
+        heap_index != UINT32_MAX);
     workgroup_size = vkd3d_meta_get_clear_buffer_uav_workgroup_size();
 
-    if (!vkd3d_create_vk_buffer_view(list->device, scratch.buffer, format, scratch.offset, scratch_buffer_size,
-            VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, &vk_buffer_view))
+    if (heap_index != UINT32_MAX)
     {
-        ERR("Failed to create buffer view for UAV clear.\n");
-        return;
+        d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 0, heap_index);
     }
-
-    if (!(d3d12_command_allocator_add_buffer_view(list->allocator, vk_buffer_view)))
+    else
     {
-        ERR("Failed to add buffer view.\n");
-        VK_CALL(vkDestroyBufferView(list->device->vk_device, vk_buffer_view, NULL));
-        return;
+        if (!vkd3d_create_vk_buffer_view(list->device, scratch.buffer, format, scratch.offset,
+                scratch_buffer_size, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, &vk_buffer_view))
+        {
+            ERR("Failed to create buffer view for UAV clear.\n");
+            return;
+        }
+
+        if (!(d3d12_command_allocator_add_buffer_view(list->allocator, vk_buffer_view)))
+        {
+            ERR("Failed to add buffer view.\n");
+            VK_CALL(vkDestroyBufferView(list->device->vk_device, vk_buffer_view, NULL));
+            return;
+        }
+
+        memset(&write_set, 0, sizeof(write_set));
+        write_set.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        write_set.descriptorCount = 1;
+        write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+        write_set.pTexelBufferView = &vk_buffer_view;
+
+        VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                pipeline.vk_pipeline_layout, 0, 1, &write_set));
     }
-
-    memset(&write_set, 0, sizeof(write_set));
-    write_set.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write_set.descriptorCount = 1;
-    write_set.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
-    write_set.pTexelBufferView = &vk_buffer_view;
-
-    VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer,
-            VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.vk_pipeline));
-    VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-            pipeline.vk_pipeline_layout, 0, 1, &write_set));
 
     clear_args.clear_color = *clear_value;
     clear_args.offset.x = 0;
@@ -15607,6 +15634,9 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
             pipeline.vk_pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT,
             sizeof(clear_args), &clear_args);
+
+    VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer,
+            VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.vk_pipeline));
 
     VK_CALL(vkCmdDispatch(list->cmd.vk_command_buffer,
             vkd3d_compute_workgroup_count(element_count, workgroup_size.width), 1, 1));
@@ -15934,6 +15964,10 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
     if (!vkd3d_clear_uav_info_from_metadata(&args, metadata.view))
         return;
 
+    /* This is illegal D3D12, but we need to robust against it. */
+    if (!list->descriptor_heap.buffers.resource.heap)
+        WARN("ClearUAVUint called without active heap.\n");
+
     if (d3d12_resource_is_texture(resource_impl) && !(args.u.image.flags & VKD3D_DESCRIPTOR_FLAG_IMAGE_VIEW))
     {
         WARN("Image clear mismatch.\n");
@@ -15975,9 +16009,19 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
         }
 
         args.clear_dxgi_format = uint_format->dxgi_format;
-        if (!vkd3d_clear_uav_synthesize_buffer_view(list, resource_impl, &args, uint_format, &inline_view))
-            return;
-        args.view = inline_view;
+
+        args.heap_index = d3d12_command_list_allocate_meta_buffer_view(list,
+                args.u.buffer.va, args.u.buffer.range, uint_format->vk_format,
+                VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+        args.use_heap = args.heap_index != UINT32_MAX;
+
+        /* We cannot allocate space in the heap, have to fallback to legacy :'( */
+        if (!args.use_heap)
+        {
+            if (!vkd3d_clear_uav_synthesize_buffer_view(list, resource_impl, &args, uint_format, &inline_view))
+                return;
+            args.view = inline_view;
+        }
     }
     else if (d3d12_resource_is_texture(resource_impl) && clear_format->type != VKD3D_FORMAT_TYPE_UINT)
     {
@@ -16026,13 +16070,19 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewUint(d3
             struct vkd3d_texture_view_desc view_desc;
             vkd3d_texture_view_desc_convert_from_metadata(resource_impl, clear_format, &view_desc, &args.u.image);
 
-            if (!vkd3d_create_texture_view(list->device, &view_desc, &inline_view))
-            {
-                ERR("Failed to create image view.\n");
-                return;
-            }
+            args.heap_index = d3d12_command_list_allocate_meta_image_view(list, &view_desc, VK_IMAGE_LAYOUT_GENERAL);
+            args.use_heap = args.heap_index != UINT32_MAX;
 
-            args.view = inline_view;
+            if (!args.use_heap)
+            {
+                if (!vkd3d_create_texture_view(list->device, &view_desc, &inline_view))
+                {
+                    ERR("Failed to create image view.\n");
+                    return;
+                }
+
+                args.view = inline_view;
+            }
         }
     }
 
@@ -16071,6 +16121,10 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewFloat(d
     if (!resource_impl || !metadata.view)
         return;
 
+    /* This is illegal D3D12, but we need to robust against it. */
+    if (!list->descriptor_heap.buffers.resource.heap)
+        WARN("ClearUAVFloat called without active heap.\n");
+
     if (!vkd3d_clear_uav_info_from_metadata(&args, metadata.view))
         return;
 
@@ -16105,20 +16159,38 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearUnorderedAccessViewFloat(d
             struct vkd3d_texture_view_desc view_desc;
             vkd3d_texture_view_desc_convert_from_metadata(resource_impl, clear_format, &view_desc, &args.u.image);
 
-            if (!vkd3d_create_texture_view(list->device, &view_desc, &inline_view))
-            {
-                ERR("Failed to create image view.\n");
-                return;
-            }
+            /* It's not legal D3D12 for apps to hit this, but native drivers always seem to just use the CPU descriptor
+             * and push the descriptor somehow. Since we have to anticipate broken games in the wild, we cannot trust
+             * the bound GPU heap. */
+            args.heap_index = d3d12_command_list_allocate_meta_image_view(list, &view_desc, VK_IMAGE_LAYOUT_GENERAL);
+            args.use_heap = args.heap_index != UINT32_MAX;
 
-            args.view = inline_view;
+            if (!args.use_heap)
+            {
+                if (!vkd3d_create_texture_view(list->device, &view_desc, &inline_view))
+                {
+                    ERR("Failed to create image view.\n");
+                    return;
+                }
+
+                args.view  = inline_view;
+            }
         }
     }
     else
     {
-        if (!vkd3d_clear_uav_synthesize_buffer_view(list, resource_impl, &args, clear_format, &inline_view))
-            return;
-        args.view = inline_view;
+        args.heap_index = d3d12_command_list_allocate_meta_buffer_view(list,
+                args.u.buffer.va, args.u.buffer.range, clear_format->vk_format,
+                VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+        args.use_heap = args.heap_index != UINT32_MAX;
+
+        /* We cannot allocate space in the heap, have to fallback to legacy :'( */
+        if (!args.use_heap)
+        {
+            if (!vkd3d_clear_uav_synthesize_buffer_view(list, resource_impl, &args, clear_format, &inline_view))
+                return;
+            args.view = inline_view;
+        }
     }
 
     d3d12_command_list_clear_uav(list, resource_impl, &args, &color, rect_count, rects);

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -51,8 +51,12 @@ static VkResult vkd3d_meta_create_descriptor_set_layout(struct d3d12_device *dev
     set_layout_info.bindingCount = binding_count;
     set_layout_info.pBindings = bindings;
 
-    if (d3d12_device_uses_descriptor_buffers(device) && descriptor_buffer_compatible)
+    if (!d3d12_device_use_descriptor_heap(device) &&
+        d3d12_device_uses_descriptor_buffers(device) &&
+        descriptor_buffer_compatible)
+    {
         set_layout_info.flags |= VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     return VK_CALL(vkCreateDescriptorSetLayout(device->vk_device, &set_layout_info, NULL, set_layout));
 }
@@ -81,7 +85,7 @@ static VkResult vkd3d_meta_create_sampler(struct d3d12_device *device, VkFilter 
 
 static VkResult vkd3d_meta_create_pipeline_layout(struct d3d12_device *device,
         uint32_t set_layout_count, const VkDescriptorSetLayout *set_layouts,
-        uint32_t push_constant_range_count, const VkPushConstantRange *push_constant_ranges,
+        const VkPushConstantRange *push_constant_range,
         VkPipelineLayout *pipeline_layout)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
@@ -92,8 +96,18 @@ static VkResult vkd3d_meta_create_pipeline_layout(struct d3d12_device *device,
     pipeline_layout_info.flags = 0;
     pipeline_layout_info.setLayoutCount = set_layout_count;
     pipeline_layout_info.pSetLayouts = set_layouts;
-    pipeline_layout_info.pushConstantRangeCount = push_constant_range_count;
-    pipeline_layout_info.pPushConstantRanges = push_constant_ranges;
+    pipeline_layout_info.pushConstantRangeCount = push_constant_range ? 1 : 0;
+    pipeline_layout_info.pPushConstantRanges = push_constant_range;
+
+    assert(!push_constant_range ||
+        (push_constant_range->offset + push_constant_range->size <= VKD3D_DESCRIPTOR_HEAP_META_PUSH_DATA_OFFSET));
+
+    if (set_layout_count == 0 && d3d12_device_use_descriptor_heap(device))
+    {
+        /* Don't need a pipeline layout if we're only using pure push data. */
+        *pipeline_layout = VK_NULL_HANDLE;
+        return VK_SUCCESS;
+    }
 
     return VK_CALL(vkCreatePipelineLayout(device->vk_device, &pipeline_layout_info, NULL, pipeline_layout));
 }
@@ -110,6 +124,52 @@ static void vkd3d_meta_make_shader_stage(VkPipelineShaderStageCreateInfo *info, 
     info->pSpecializationInfo = spec_info;
 }
 
+struct vkd3d_meta_heap_mapping_info
+{
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info;
+    VkDescriptorSetAndBindingMappingEXT mapping[3];
+    VkSamplerCreateInfo nearest_sampler;
+};
+
+static void vkd3d_meta_init_heap_mappings(struct d3d12_device *device, struct vkd3d_meta_heap_mapping_info *info)
+{
+    /* We have up to 3 trivial mappings encoded as three individual push descriptors. */
+    unsigned int i;
+    memset(info, 0, sizeof(*info));
+
+    info->mapping_info.sType = VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT;
+    info->mapping_info.pMappings = info->mapping;
+    info->mapping_info.mappingCount = ARRAY_SIZE(info->mapping);
+
+    for (i = 0; i < ARRAY_SIZE(info->mapping); i++)
+    {
+        info->mapping[i].sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+        info->mapping[i].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
+        info->mapping[i].descriptorSet = 0;
+        info->mapping[i].firstBinding = i;
+        info->mapping[i].bindingCount = 1;
+        info->mapping[i].resourceMask = VK_SPIRV_RESOURCE_TYPE_ALL_EXT;
+        info->mapping[i].sourceData.pushIndex.heapOffset = 0; /* We account for any red-zone ourselves. */
+        info->mapping[i].sourceData.pushIndex.pushOffset = VKD3D_DESCRIPTOR_HEAP_META_PUSH_DATA_OFFSET + i * sizeof(uint32_t);
+        info->mapping[i].sourceData.pushIndex.heapArrayStride = device->bindless_state.cbv_srv_uav_size;
+        info->mapping[i].sourceData.pushIndex.heapIndexStride = device->bindless_state.cbv_srv_uav_size;
+    }
+
+    /* TODO: Evaluate later if we can get rid of this and rely on fetches instead.
+     * It's currently used by sampler feedback decode with some gather4s,
+     * which is not impossible to replace with plain fetches if we must. */
+    info->nearest_sampler.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    info->nearest_sampler.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info->nearest_sampler.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info->nearest_sampler.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info->nearest_sampler.minFilter = VK_FILTER_NEAREST;
+    info->nearest_sampler.magFilter = VK_FILTER_NEAREST;
+    info->nearest_sampler.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+
+    for (i = 0; i < ARRAY_SIZE(info->mapping); i++)
+        info->mapping[i].sourceData.pushIndex.pEmbeddedSampler = &info->nearest_sampler;
+}
+
 static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
         size_t code_size, const uint32_t *code, VkPipelineLayout layout,
         const VkSpecializationInfo *specialization_info,
@@ -118,8 +178,10 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
         VkPipeline *pipeline)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct vkd3d_meta_heap_mapping_info mapping_info;
     struct vkd3d_queue_timeline_trace_cookie cookie;
     VkComputePipelineCreateInfo pipeline_info;
+    VkPipelineCreateFlags2CreateInfo flags2;
     VkShaderModule module;
     VkResult vr;
 
@@ -136,13 +198,29 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
     pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
     pipeline_info.basePipelineIndex = -1;
 
-    if (d3d12_device_uses_descriptor_buffers(device) && descriptor_buffer_compatible)
+    if (!d3d12_device_use_descriptor_heap(device) &&
+        d3d12_device_uses_descriptor_buffers(device) &&
+        descriptor_buffer_compatible)
+    {
         pipeline_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     vkd3d_meta_make_shader_stage(&pipeline_info.stage,
             VK_SHADER_STAGE_COMPUTE_BIT, module, "main", specialization_info);
 
     pipeline_info.stage.pNext = required_size;
+
+    if (layout == VK_NULL_HANDLE)
+    {
+        memset(&flags2, 0, sizeof(flags2));
+        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        flags2.flags = pipeline_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+        pipeline_info.flags = 0;
+        vk_prepend_struct(&pipeline_info, &flags2);
+
+        vkd3d_meta_init_heap_mappings(device, &mapping_info);
+        vk_prepend_struct(&pipeline_info.stage, &mapping_info.mapping_info);
+    }
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&device->queue_timeline_trace);
     vr = VK_CALL(vkCreateComputePipelines(device->vk_device, VK_NULL_HANDLE, 1, &pipeline_info, NULL, pipeline));
@@ -160,6 +238,7 @@ static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_
 {
     const struct vkd3d_vk_device_procs *vk_procs = &meta_ops->device->vk_procs;
     VkPipelineColorBlendAttachmentState blend_attachment;
+    struct vkd3d_meta_heap_mapping_info mapping_info;
     VkPipelineShaderStageCreateInfo shader_stages[3];
     struct vkd3d_queue_timeline_trace_cookie cookie;
     VkPipelineInputAssemblyStateCreateInfo ia_state;
@@ -172,6 +251,7 @@ static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_
     VkPipelineDynamicStateCreateInfo dyn_state;
     VkGraphicsPipelineCreateInfo pipeline_info;
     const uint32_t sample_mask = 0xFFFFFFFF;
+    VkPipelineCreateFlags2CreateInfo flags2;
     VkResult vr;
 
     static const VkDynamicState common_dynamic_states[] =
@@ -281,8 +361,12 @@ static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_
     pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
     pipeline_info.basePipelineIndex = -1;
 
-    if (d3d12_device_uses_descriptor_buffers(meta_ops->device) && descriptor_buffer_compatible)
+    if (!d3d12_device_use_descriptor_heap(meta_ops->device) &&
+        d3d12_device_uses_descriptor_buffers(meta_ops->device) &&
+        descriptor_buffer_compatible)
+    {
         pipeline_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     vkd3d_meta_make_shader_stage(&shader_stages[pipeline_info.stageCount++],
             VK_SHADER_STAGE_VERTEX_BIT,
@@ -299,6 +383,18 @@ static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_
     {
         vkd3d_meta_make_shader_stage(&shader_stages[pipeline_info.stageCount++],
                 VK_SHADER_STAGE_FRAGMENT_BIT, fs_module, "main", spec_info);
+    }
+
+    if (layout == VK_NULL_HANDLE)
+    {
+        memset(&flags2, 0, sizeof(flags2));
+        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        flags2.flags = pipeline_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+        pipeline_info.flags = 0;
+        vk_prepend_struct(&pipeline_info, &flags2);
+
+        vkd3d_meta_init_heap_mappings(meta_ops->device, &mapping_info);
+        vk_prepend_struct(&shader_stages[pipeline_info.stageCount - 1], &mapping_info.mapping_info);
     }
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&meta_ops->device->queue_timeline_trace);
@@ -343,12 +439,12 @@ static void vkd3d_clear_uav_ops_cleanup(struct vkd3d_clear_uav_ops *meta_clear_u
 }
 
 static HRESULT vkd3d_clear_uav_ops_init(struct vkd3d_clear_uav_ops *meta_clear_uav_ops,
-        struct d3d12_device *device)
+        struct d3d12_device *device, bool use_heap)
 {
     VkDescriptorSetLayoutBinding set_binding;
     VkPushConstantRange push_constant_range;
+    VkResult vr = VK_SUCCESS;
     unsigned int i;
-    VkResult vr;
 
     struct {
       VkDescriptorSetLayout *set_layout;
@@ -426,7 +522,8 @@ static HRESULT vkd3d_clear_uav_ops_init(struct vkd3d_clear_uav_ops *meta_clear_u
     {
         set_binding.descriptorType = set_layouts[i].descriptor_type;
 
-        vr = vkd3d_meta_create_descriptor_set_layout(device, 1, &set_binding, true, set_layouts[i].set_layout);
+        if (!use_heap)
+            vr = vkd3d_meta_create_descriptor_set_layout(device, 1, &set_binding, true, set_layouts[i].set_layout);
 
         if (vr < 0)
         {
@@ -434,8 +531,8 @@ static HRESULT vkd3d_clear_uav_ops_init(struct vkd3d_clear_uav_ops *meta_clear_u
             goto fail;
         }
 
-        vr = vkd3d_meta_create_pipeline_layout(device, 1, set_layouts[i].set_layout,
-                1, &push_constant_range, set_layouts[i].pipeline_layout);
+        vr = vkd3d_meta_create_pipeline_layout(device, use_heap ? 0 : 1, set_layouts[i].set_layout,
+                &push_constant_range, set_layouts[i].pipeline_layout);
 
         if (vr < 0)
         {
@@ -461,9 +558,9 @@ fail:
 }
 
 struct vkd3d_clear_uav_pipeline vkd3d_meta_get_clear_buffer_uav_pipeline(struct vkd3d_meta_ops *meta_ops,
-        bool as_uint, bool raw)
+        bool as_uint, bool raw, bool heap)
 {
-    struct vkd3d_clear_uav_ops *meta_clear_uav_ops = &meta_ops->clear_uav;
+    struct vkd3d_clear_uav_ops *meta_clear_uav_ops = heap ? &meta_ops->clear_uav_heap : &meta_ops->clear_uav_legacy;
     struct vkd3d_clear_uav_pipeline info;
 
     const struct vkd3d_clear_uav_pipelines *pipelines = (as_uint || raw)
@@ -477,9 +574,9 @@ struct vkd3d_clear_uav_pipeline vkd3d_meta_get_clear_buffer_uav_pipeline(struct 
 }
 
 struct vkd3d_clear_uav_pipeline vkd3d_meta_get_clear_image_uav_pipeline(struct vkd3d_meta_ops *meta_ops,
-        VkImageViewType image_view_type, bool as_uint)
+        VkImageViewType image_view_type, bool as_uint, bool heap)
 {
-    struct vkd3d_clear_uav_ops *meta_clear_uav_ops = &meta_ops->clear_uav;
+    struct vkd3d_clear_uav_ops *meta_clear_uav_ops = heap ? &meta_ops->clear_uav_heap : &meta_ops->clear_uav_legacy;
     struct vkd3d_clear_uav_pipeline info;
 
     const struct vkd3d_clear_uav_pipelines *pipelines = as_uint
@@ -569,7 +666,7 @@ static void vkd3d_copy_image_ops_cleanup(struct vkd3d_copy_image_ops *meta_copy_
 }
 
 static HRESULT vkd3d_copy_image_ops_init(struct vkd3d_copy_image_ops *meta_copy_image_ops,
-        struct d3d12_device *device)
+        struct d3d12_device *device, bool use_heap)
 {
     VkDescriptorSetLayoutBinding set_binding;
     VkPushConstantRange push_constant_range;
@@ -584,24 +681,27 @@ static HRESULT vkd3d_copy_image_ops_init(struct vkd3d_copy_image_ops *meta_copy_
         return hresult_from_errno(rc);
     }
 
-    set_binding.binding = 0;
-    set_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    set_binding.descriptorCount = 1;
-    set_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    set_binding.pImmutableSamplers = NULL;
-
-    if ((vr = vkd3d_meta_create_descriptor_set_layout(device, 1, &set_binding, true, &meta_copy_image_ops->vk_set_layout)) < 0)
+    if (!use_heap)
     {
-        ERR("Failed to create descriptor set layout, vr %d.\n", vr);
-        goto fail;
+        set_binding.binding = 0;
+        set_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        set_binding.descriptorCount = 1;
+        set_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        set_binding.pImmutableSamplers = NULL;
+
+        if ((vr = vkd3d_meta_create_descriptor_set_layout(device, 1, &set_binding, true, &meta_copy_image_ops->vk_set_layout)) < 0)
+        {
+            ERR("Failed to create descriptor set layout, vr %d.\n", vr);
+            goto fail;
+        }
     }
 
     push_constant_range.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     push_constant_range.offset = 0;
     push_constant_range.size = sizeof(struct vkd3d_copy_image_args);
 
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 1, &meta_copy_image_ops->vk_set_layout,
-            1, &push_constant_range, &meta_copy_image_ops->vk_pipeline_layout)))
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, use_heap ? 0 : 1, &meta_copy_image_ops->vk_set_layout,
+            &push_constant_range, &meta_copy_image_ops->vk_pipeline_layout)))
     {
         ERR("Failed to create pipeline layout, vr %d.\n", vr);
         goto fail;
@@ -664,9 +764,9 @@ static HRESULT vkd3d_meta_create_swapchain_pipeline(struct vkd3d_meta_ops *meta_
 }
 
 static HRESULT vkd3d_meta_create_copy_image_pipeline(struct vkd3d_meta_ops *meta_ops,
-        const struct vkd3d_copy_image_pipeline_key *key, struct vkd3d_copy_image_pipeline *pipeline)
+        const struct vkd3d_copy_image_pipeline_key *key, struct vkd3d_copy_image_pipeline *pipeline, bool heap)
 {
-    struct vkd3d_copy_image_ops *meta_copy_image_ops = &meta_ops->copy_image;
+    struct vkd3d_copy_image_ops *meta_copy_image_ops = heap ? &meta_ops->copy_image_heap : &meta_ops->copy_image_legacy;
     VkPipelineDepthStencilStateCreateInfo ds_state;
     unsigned int dynamic_state_count;
     VkSpecializationInfo spec_info;
@@ -782,9 +882,9 @@ static HRESULT vkd3d_meta_create_copy_image_pipeline(struct vkd3d_meta_ops *meta
 }
 
 HRESULT vkd3d_meta_get_copy_image_pipeline(struct vkd3d_meta_ops *meta_ops,
-        const struct vkd3d_copy_image_pipeline_key *key, struct vkd3d_copy_image_info *info)
+        const struct vkd3d_copy_image_pipeline_key *key, struct vkd3d_copy_image_info *info, bool heap)
 {
-    struct vkd3d_copy_image_ops *meta_copy_image_ops = &meta_ops->copy_image;
+    struct vkd3d_copy_image_ops *meta_copy_image_ops = heap ? &meta_ops->copy_image_heap : &meta_ops->copy_image_legacy;
     struct vkd3d_copy_image_pipeline *pipeline;
     HRESULT hr;
     size_t i;
@@ -822,7 +922,7 @@ HRESULT vkd3d_meta_get_copy_image_pipeline(struct vkd3d_meta_ops *meta_ops,
 
     pipeline = &meta_copy_image_ops->pipelines[meta_copy_image_ops->pipeline_count++];
 
-    if (FAILED(hr = vkd3d_meta_create_copy_image_pipeline(meta_ops, key, pipeline)))
+    if (FAILED(hr = vkd3d_meta_create_copy_image_pipeline(meta_ops, key, pipeline, heap)))
     {
         pthread_mutex_unlock(&meta_copy_image_ops->mutex);
         return hr;
@@ -906,7 +1006,8 @@ static void vkd3d_resolve_image_ops_cleanup(struct vkd3d_resolve_image_ops *meta
     vkd3d_free(meta_resolve_image_ops->pipelines);
 }
 
-static HRESULT vkd3d_resolve_image_ops_init(struct vkd3d_resolve_image_ops *meta_resolve_image_ops, struct d3d12_device *device)
+static HRESULT vkd3d_resolve_image_ops_init(struct vkd3d_resolve_image_ops *meta_resolve_image_ops,
+        struct d3d12_device *device, bool use_heap)
 {
     VkDescriptorSetLayoutBinding set_bindings[2];
     VkPushConstantRange push_constant_range;
@@ -922,40 +1023,43 @@ static HRESULT vkd3d_resolve_image_ops_init(struct vkd3d_resolve_image_ops *meta
         return hresult_from_errno(rc);
     }
 
-    memset(set_bindings, 0, sizeof(set_bindings));
-
-    for (i = 0; i < ARRAY_SIZE(set_bindings); i++)
+    if (!use_heap)
     {
-        set_bindings[i].binding = i;
-        set_bindings[i].descriptorCount = 1;
-    }
+        memset(set_bindings, 0, sizeof(set_bindings));
 
-    set_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    set_bindings[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        for (i = 0; i < ARRAY_SIZE(set_bindings); i++)
+        {
+            set_bindings[i].binding = i;
+            set_bindings[i].descriptorCount = 1;
+        }
 
-    if ((vr = vkd3d_meta_create_descriptor_set_layout(device, 1, set_bindings, true, &meta_resolve_image_ops->vk_graphics_set_layout)) < 0)
-    {
-        ERR("Failed to create descriptor set layout, vr %d.\n", vr);
-        goto fail;
-    }
+        set_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        set_bindings[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-    set_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    set_bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    set_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    set_bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        if ((vr = vkd3d_meta_create_descriptor_set_layout(device, 1, set_bindings, true, &meta_resolve_image_ops->vk_graphics_set_layout)) < 0)
+        {
+            ERR("Failed to create descriptor set layout, vr %d.\n", vr);
+            goto fail;
+        }
 
-    if ((vr = vkd3d_meta_create_descriptor_set_layout(device, ARRAY_SIZE(set_bindings), set_bindings, true, &meta_resolve_image_ops->vk_compute_set_layout)) < 0)
-    {
-        ERR("Failed to create descriptor set layout, vr %d.\n", vr);
-        goto fail;
+        set_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        set_bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        set_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        set_bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+        if ((vr = vkd3d_meta_create_descriptor_set_layout(device, ARRAY_SIZE(set_bindings), set_bindings, true, &meta_resolve_image_ops->vk_compute_set_layout)) < 0)
+        {
+            ERR("Failed to create descriptor set layout, vr %d.\n", vr);
+            goto fail;
+        }
     }
 
     push_constant_range.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     push_constant_range.offset = 0;
     push_constant_range.size = sizeof(struct vkd3d_resolve_image_args);
 
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 1, &meta_resolve_image_ops->vk_graphics_set_layout,
-            1, &push_constant_range, &meta_resolve_image_ops->vk_graphics_pipeline_layout)))
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, use_heap ? 0 : 1, &meta_resolve_image_ops->vk_graphics_set_layout,
+            &push_constant_range, &meta_resolve_image_ops->vk_graphics_pipeline_layout)))
     {
         ERR("Failed to create pipeline layout, vr %d.\n", vr);
         goto fail;
@@ -965,8 +1069,8 @@ static HRESULT vkd3d_resolve_image_ops_init(struct vkd3d_resolve_image_ops *meta
     push_constant_range.offset = 0;
     push_constant_range.size = sizeof(struct vkd3d_resolve_image_compute_args);
 
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 1, &meta_resolve_image_ops->vk_compute_set_layout,
-            1, &push_constant_range, &meta_resolve_image_ops->vk_compute_pipeline_layout)))
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, use_heap ? 0 : 1, &meta_resolve_image_ops->vk_compute_set_layout,
+            &push_constant_range, &meta_resolve_image_ops->vk_compute_pipeline_layout)))
     {
         ERR("Failed to create pipeline layout, vr %d.\n", vr);
         goto fail;
@@ -1027,9 +1131,11 @@ fail:
 }
 
 static HRESULT vkd3d_meta_create_resolve_image_graphics_pipeline(struct vkd3d_meta_ops *meta_ops,
-        const struct vkd3d_resolve_image_graphics_pipeline_key *key, struct vkd3d_resolve_image_pipeline *pipeline)
+        const struct vkd3d_resolve_image_graphics_pipeline_key *key, struct vkd3d_resolve_image_pipeline *pipeline,
+        bool heap)
 {
-    struct vkd3d_resolve_image_ops *meta_resolve_image_ops = &meta_ops->resolve_image;
+    struct vkd3d_resolve_image_ops *meta_resolve_image_ops =
+        heap ? &meta_ops->resolve_image_heap : &meta_ops->resolve_image_legacy;
     VkPipelineDepthStencilStateCreateInfo ds_state;
     unsigned int dynamic_state_count;
     VkSpecializationInfo spec_info;
@@ -1135,9 +1241,11 @@ static HRESULT vkd3d_meta_create_resolve_image_graphics_pipeline(struct vkd3d_me
 }
 
 static HRESULT vkd3d_meta_create_resolve_image_compute_pipeline(struct vkd3d_meta_ops *meta_ops,
-        const struct vkd3d_resolve_image_compute_pipeline_key *key, struct vkd3d_resolve_image_pipeline *pipeline)
+        const struct vkd3d_resolve_image_compute_pipeline_key *key, struct vkd3d_resolve_image_pipeline *pipeline,
+        bool heap)
 {
-    struct vkd3d_resolve_image_ops *meta_resolve_image_ops = &meta_ops->resolve_image;
+    struct vkd3d_resolve_image_ops *meta_resolve_image_ops =
+        heap ? &meta_ops->resolve_image_heap : &meta_ops->resolve_image_legacy;
     VkSpecializationInfo spec_info;
     const void *cs_code;
     size_t cs_size;
@@ -1197,9 +1305,11 @@ static HRESULT vkd3d_meta_create_resolve_image_compute_pipeline(struct vkd3d_met
 }
 
 HRESULT vkd3d_meta_get_resolve_image_pipeline(struct vkd3d_meta_ops *meta_ops,
-        const struct vkd3d_resolve_image_pipeline_key *key, struct vkd3d_resolve_image_info *info)
+        const struct vkd3d_resolve_image_pipeline_key *key, struct vkd3d_resolve_image_info *info,
+        bool heap)
 {
-    struct vkd3d_resolve_image_ops *meta_resolve_image_ops = &meta_ops->resolve_image;
+    struct vkd3d_resolve_image_ops *meta_resolve_image_ops =
+        heap ? &meta_ops->resolve_image_heap : &meta_ops->resolve_image_legacy;
     struct vkd3d_resolve_image_pipeline *pipeline;
     HRESULT hr;
     size_t i;
@@ -1247,9 +1357,9 @@ HRESULT vkd3d_meta_get_resolve_image_pipeline(struct vkd3d_meta_ops *meta_ops,
     pipeline = &meta_resolve_image_ops->pipelines[meta_resolve_image_ops->pipeline_count];
 
     if (key->path == VKD3D_RESOLVE_IMAGE_PATH_RENDER_PASS_PIPELINE)
-        hr = vkd3d_meta_create_resolve_image_graphics_pipeline(meta_ops, &key->graphics, pipeline);
+        hr = vkd3d_meta_create_resolve_image_graphics_pipeline(meta_ops, &key->graphics, pipeline, heap);
     else
-        hr = vkd3d_meta_create_resolve_image_compute_pipeline(meta_ops, &key->compute, pipeline);
+        hr = vkd3d_meta_create_resolve_image_compute_pipeline(meta_ops, &key->compute, pipeline, heap);
 
     if (FAILED(hr))
     {
@@ -1360,7 +1470,7 @@ static HRESULT vkd3d_swapchain_ops_init(struct vkd3d_swapchain_ops *meta_swapcha
         }
 
         if ((vr = vkd3d_meta_create_pipeline_layout(device, 1, &meta_swapchain_ops->vk_set_layouts[i],
-                0, NULL, &meta_swapchain_ops->vk_pipeline_layouts[i])))
+                NULL, &meta_swapchain_ops->vk_pipeline_layouts[i])))
         {
             ERR("Failed to create pipeline layout, vr %d.\n", vr);
             goto fail;
@@ -1465,7 +1575,7 @@ static HRESULT vkd3d_query_ops_init(struct vkd3d_query_ops *meta_query_ops,
     push_constant_range.size = sizeof(struct vkd3d_query_gather_args);
 
     if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL,
-            1, &push_constant_range, &meta_query_ops->vk_gather_pipeline_layout)) < 0)
+            &push_constant_range, &meta_query_ops->vk_gather_pipeline_layout)) < 0)
         goto fail;
 
     spec_info.mapEntryCount = 1;
@@ -1488,7 +1598,7 @@ static HRESULT vkd3d_query_ops_init(struct vkd3d_query_ops *meta_query_ops,
     push_constant_range.size = sizeof(struct vkd3d_query_resolve_args);
 
     if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL,
-            1, &push_constant_range, &meta_query_ops->vk_resolve_pipeline_layout)) < 0)
+            &push_constant_range, &meta_query_ops->vk_resolve_pipeline_layout)) < 0)
         goto fail;
 
     if ((vr = vkd3d_meta_create_compute_pipeline(device, sizeof(cs_resolve_binary_queries), cs_resolve_binary_queries,
@@ -1546,7 +1656,7 @@ static HRESULT vkd3d_multi_dispatch_indirect_ops_init(
     push_constant_range.offset = 0;
     push_constant_range.size = sizeof(struct vkd3d_multi_dispatch_indirect_args);
 
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL, 1,
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL,
             &push_constant_range, &meta_multi_dispatch_indirect_ops->vk_multi_dispatch_indirect_layout)) < 0)
         goto fail;
 
@@ -1611,12 +1721,12 @@ static HRESULT vkd3d_predicate_ops_init(struct vkd3d_predicate_ops *meta_predica
     push_constant_range.offset = 0;
     push_constant_range.size = sizeof(struct vkd3d_predicate_command_args);
 
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL, 1,
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL,
             &push_constant_range, &meta_predicate_ops->vk_command_pipeline_layout)) < 0)
         return hresult_from_vk_result(vr);
 
     push_constant_range.size = sizeof(struct vkd3d_predicate_resolve_args);
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL, 1,
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL,
             &push_constant_range, &meta_predicate_ops->vk_resolve_pipeline_layout)) < 0)
         return hresult_from_vk_result(vr);
 
@@ -1679,7 +1789,7 @@ static HRESULT vkd3d_execute_indirect_ops_init(struct vkd3d_execute_indirect_ops
     push_constant_range.size = sizeof(struct vkd3d_execute_indirect_args);
     push_constant_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL, 1,
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL,
             &push_constant_range, &meta_indirect_ops->vk_pipeline_layout)) < 0)
     {
         pthread_mutex_destroy(&meta_indirect_ops->mutex);
@@ -1823,7 +1933,7 @@ static HRESULT vkd3d_dstorage_ops_init(struct vkd3d_dstorage_ops *dstorage_ops, 
     push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     push_range.size = sizeof(struct vkd3d_dstorage_decompress_args);
 
-    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL, 1, &push_range,
+    if ((vr = vkd3d_meta_create_pipeline_layout(device, 0, NULL, &push_range,
             &dstorage_ops->vk_dstorage_layout)))
         return hresult_from_vk_result(vr);
 
@@ -1885,7 +1995,7 @@ static void vkd3d_dstorage_ops_cleanup(struct vkd3d_dstorage_ops *dstorage_ops, 
 }
 
 static HRESULT vkd3d_sampler_feedback_ops_init(struct vkd3d_sampler_feedback_resolve_ops *sampler_feedback_ops,
-        struct d3d12_device *device)
+        struct d3d12_device *device, bool use_heap)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkDescriptorSetLayoutBinding decode_bindings[2];
@@ -1943,72 +2053,75 @@ static HRESULT vkd3d_sampler_feedback_ops_init(struct vkd3d_sampler_feedback_res
         },
     };
 
-    memset(decode_bindings, 0, sizeof(decode_bindings));
-    memset(encode_bindings, 0, sizeof(encode_bindings));
+    if (!use_heap)
+    {
+        memset(decode_bindings, 0, sizeof(decode_bindings));
+        memset(encode_bindings, 0, sizeof(encode_bindings));
 
-    if ((vr = vkd3d_meta_create_sampler(device, VK_FILTER_NEAREST, &vk_sampler)))
-        return hresult_from_vk_result(vr);
+        if ((vr = vkd3d_meta_create_sampler(device, VK_FILTER_NEAREST, &vk_sampler)))
+            return hresult_from_vk_result(vr);
 
-    decode_bindings[0].binding = 0;
-    decode_bindings[0].descriptorCount = 1;
-    decode_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
-    decode_bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        decode_bindings[0].binding = 0;
+        decode_bindings[0].descriptorCount = 1;
+        decode_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+        decode_bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
-    decode_bindings[1].binding = 1;
-    decode_bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_COMPUTE_BIT;
-    decode_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    decode_bindings[1].descriptorCount = 1;
-    decode_bindings[1].pImmutableSamplers = &vk_sampler;
+        decode_bindings[1].binding = 1;
+        decode_bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_COMPUTE_BIT;
+        decode_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        decode_bindings[1].descriptorCount = 1;
+        decode_bindings[1].pImmutableSamplers = &vk_sampler;
 
-    encode_bindings[0].binding = 0;
-    encode_bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    encode_bindings[0].descriptorCount = 1;
-    encode_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        encode_bindings[0].binding = 0;
+        encode_bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        encode_bindings[0].descriptorCount = 1;
+        encode_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
 
-    encode_bindings[1].binding = 1;
-    encode_bindings[1].descriptorCount = 1;
-    encode_bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    encode_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    encode_bindings[1].pImmutableSamplers = &vk_sampler;
+        encode_bindings[1].binding = 1;
+        encode_bindings[1].descriptorCount = 1;
+        encode_bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        encode_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        encode_bindings[1].pImmutableSamplers = &vk_sampler;
 
-    encode_bindings[2].binding = 2;
-    encode_bindings[2].descriptorCount = 1;
-    encode_bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    encode_bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+        encode_bindings[2].binding = 2;
+        encode_bindings[2].descriptorCount = 1;
+        encode_bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        encode_bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
 
-    if ((vr = vkd3d_meta_create_descriptor_set_layout(device,
-            ARRAY_SIZE(decode_bindings), decode_bindings,
-            true, &sampler_feedback_ops->vk_decode_set_layout)))
-        return hresult_from_vk_result(vr);
+        if ((vr = vkd3d_meta_create_descriptor_set_layout(device,
+                ARRAY_SIZE(decode_bindings), decode_bindings,
+                true, &sampler_feedback_ops->vk_decode_set_layout)))
+            return hresult_from_vk_result(vr);
 
-    if ((vr = vkd3d_meta_create_descriptor_set_layout(device,
-            ARRAY_SIZE(encode_bindings), encode_bindings,
-            true, &sampler_feedback_ops->vk_encode_set_layout)))
-        return hresult_from_vk_result(vr);
+        if ((vr = vkd3d_meta_create_descriptor_set_layout(device,
+                ARRAY_SIZE(encode_bindings), encode_bindings,
+                true, &sampler_feedback_ops->vk_encode_set_layout)))
+            return hresult_from_vk_result(vr);
+    }
 
     push_range.offset = 0;
 
     push_range.size = sizeof(struct vkd3d_sampler_feedback_resolve_encode_args);
     push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     if ((vr = vkd3d_meta_create_pipeline_layout(device,
-            1, &sampler_feedback_ops->vk_encode_set_layout,
-            1, &push_range,
+            use_heap ? 0 : 1, &sampler_feedback_ops->vk_encode_set_layout,
+            &push_range,
             &sampler_feedback_ops->vk_compute_encode_layout)))
         return hresult_from_vk_result(vr);
 
     push_range.size = sizeof(struct vkd3d_sampler_feedback_resolve_decode_args);
     push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     if ((vr = vkd3d_meta_create_pipeline_layout(device,
-            1, &sampler_feedback_ops->vk_decode_set_layout,
-            1, &push_range,
+            use_heap ? 0 : 1, &sampler_feedback_ops->vk_decode_set_layout,
+            &push_range,
             &sampler_feedback_ops->vk_compute_decode_layout)))
         return hresult_from_vk_result(vr);
 
     push_range.size = sizeof(struct vkd3d_sampler_feedback_resolve_decode_args);
     push_range.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     if ((vr = vkd3d_meta_create_pipeline_layout(device,
-            1, &sampler_feedback_ops->vk_decode_set_layout,
-            1, &push_range,
+            use_heap ? 0 : 1, &sampler_feedback_ops->vk_decode_set_layout,
+            &push_range,
             &sampler_feedback_ops->vk_graphics_decode_layout)))
         return hresult_from_vk_result(vr);
 
@@ -2066,25 +2179,25 @@ static HRESULT vkd3d_workgraph_ops_init(struct vkd3d_workgraph_indirect_ops *wor
 
     push_range.size = sizeof(struct vkd3d_workgraph_workgroups_args);
     if ((vr = vkd3d_meta_create_pipeline_layout(device,
-            0, NULL, 1, &push_range,
+            0, NULL, &push_range,
             &workgraph_ops->vk_workgroup_layout)))
         return hresult_from_vk_result(vr);
 
     push_range.size = sizeof(struct vkd3d_workgraph_payload_offsets_args);
     if ((vr = vkd3d_meta_create_pipeline_layout(device,
-            0, NULL, 1, &push_range,
+            0, NULL, &push_range,
             &workgraph_ops->vk_payload_offset_layout)))
         return hresult_from_vk_result(vr);
 
     push_range.size = sizeof(struct vkd3d_workgraph_complete_compaction_args);
     if ((vr = vkd3d_meta_create_pipeline_layout(device,
-            0, NULL, 1, &push_range,
+            0, NULL, &push_range,
             &workgraph_ops->vk_complete_compaction_layout)))
         return hresult_from_vk_result(vr);
 
     push_range.size = sizeof(struct vkd3d_workgraph_setup_gpu_input_args);
     if ((vr = vkd3d_meta_create_pipeline_layout(device,
-            0, NULL, 1, &push_range,
+            0, NULL, &push_range,
             &workgraph_ops->vk_setup_gpu_input_layout)))
         return hresult_from_vk_result(vr);
 
@@ -2142,23 +2255,26 @@ static HRESULT vkd3d_workgraph_ops_init(struct vkd3d_workgraph_indirect_ops *wor
 }
 
 void vkd3d_meta_get_sampler_feedback_resolve_pipeline(struct vkd3d_meta_ops *meta_ops,
-        enum vkd3d_sampler_feedback_resolve_type type, struct vkd3d_sampler_feedback_resolve_info *info)
+        enum vkd3d_sampler_feedback_resolve_type type, struct vkd3d_sampler_feedback_resolve_info *info, bool heap)
 {
-    info->vk_pipeline = meta_ops->sampler_feedback.vk_pipelines[type];
+    struct vkd3d_sampler_feedback_resolve_ops *ops =
+        heap ? &meta_ops->sampler_feedback_heap : &meta_ops->sampler_feedback_legacy;
+
+    info->vk_pipeline = ops->vk_pipelines[type];
 
     switch (type)
     {
         case VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE:
         case VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE:
-            info->vk_layout = meta_ops->sampler_feedback.vk_graphics_decode_layout;
+            info->vk_layout = ops->vk_graphics_decode_layout;
             break;
 
         case VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER:
-            info->vk_layout = meta_ops->sampler_feedback.vk_compute_decode_layout;
+            info->vk_layout = ops->vk_compute_decode_layout;
             break;
 
         default:
-            info->vk_layout = meta_ops->sampler_feedback.vk_compute_encode_layout;
+            info->vk_layout = ops->vk_compute_encode_layout;
             break;
     }
 }
@@ -2235,14 +2351,26 @@ HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device
     if (FAILED(hr = vkd3d_meta_ops_common_init(&meta_ops->common, device)))
         goto fail_common;
 
-    if (FAILED(hr = vkd3d_clear_uav_ops_init(&meta_ops->clear_uav, device)))
-        goto fail_clear_uav_ops;
+    if (d3d12_device_use_descriptor_heap(device))
+        if (FAILED(hr = vkd3d_clear_uav_ops_init(&meta_ops->clear_uav_heap, device, true)))
+            goto fail_clear_uav_ops_heap;
 
-    if (FAILED(hr = vkd3d_copy_image_ops_init(&meta_ops->copy_image, device)))
-        goto fail_copy_image_ops;
+    if (FAILED(hr = vkd3d_clear_uav_ops_init(&meta_ops->clear_uav_legacy, device, false)))
+        goto fail_clear_uav_ops_legacy;
 
-    if (FAILED(hr = vkd3d_resolve_image_ops_init(&meta_ops->resolve_image, device)))
-        goto fail_resolve_image_ops;
+    if (d3d12_device_use_descriptor_heap(device))
+        if (FAILED(hr = vkd3d_copy_image_ops_init(&meta_ops->copy_image_heap, device, true)))
+            goto fail_copy_image_heap_ops;
+
+    if (FAILED(hr = vkd3d_copy_image_ops_init(&meta_ops->copy_image_legacy, device, false)))
+        goto fail_copy_image_legacy_ops;
+
+    if (d3d12_device_use_descriptor_heap(device))
+        if (FAILED(hr = vkd3d_resolve_image_ops_init(&meta_ops->resolve_image_heap, device, true)))
+            goto fail_resolve_image_heap_ops;
+
+    if (FAILED(hr = vkd3d_resolve_image_ops_init(&meta_ops->resolve_image_legacy, device, false)))
+        goto fail_resolve_image_legacy_ops;
 
     if (FAILED(hr = vkd3d_swapchain_ops_init(&meta_ops->swapchain, device)))
         goto fail_swapchain_ops;
@@ -2262,8 +2390,12 @@ HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device
     if (FAILED(hr = vkd3d_dstorage_ops_init(&meta_ops->dstorage, device)))
         goto fail_dstorage_ops;
 
-    if (FAILED(hr = vkd3d_sampler_feedback_ops_init(&meta_ops->sampler_feedback, device)))
-        goto fail_sampler_feedback;
+    if (d3d12_device_use_descriptor_heap(device))
+        if (FAILED(hr = vkd3d_sampler_feedback_ops_init(&meta_ops->sampler_feedback_heap, device, true)))
+            goto fail_sampler_feedback_heap;
+
+    if (FAILED(hr = vkd3d_sampler_feedback_ops_init(&meta_ops->sampler_feedback_legacy, device, false)))
+        goto fail_sampler_feedback_legacy;
 
     if (FAILED(hr = vkd3d_workgraph_ops_init(&meta_ops->workgraph, device)))
         goto fail_workgraphs;
@@ -2271,8 +2403,10 @@ HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device
     return S_OK;
 
 fail_workgraphs:
-    vkd3d_sampler_feedback_ops_cleanup(&meta_ops->sampler_feedback, device);
-fail_sampler_feedback:
+    vkd3d_sampler_feedback_ops_cleanup(&meta_ops->sampler_feedback_legacy, device);
+fail_sampler_feedback_legacy:
+    vkd3d_sampler_feedback_ops_cleanup(&meta_ops->sampler_feedback_heap, device);
+fail_sampler_feedback_heap:
     vkd3d_dstorage_ops_cleanup(&meta_ops->dstorage, device);
 fail_dstorage_ops:
     vkd3d_multi_dispatch_indirect_ops_cleanup(&meta_ops->multi_dispatch_indirect, device);
@@ -2285,12 +2419,18 @@ fail_predicate_ops:
 fail_query_ops:
     vkd3d_swapchain_ops_cleanup(&meta_ops->swapchain, device);
 fail_swapchain_ops:
-    vkd3d_resolve_image_ops_cleanup(&meta_ops->resolve_image, device);
-fail_resolve_image_ops:
-    vkd3d_copy_image_ops_cleanup(&meta_ops->copy_image, device);
-fail_copy_image_ops:
-    vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav, device);
-fail_clear_uav_ops:
+    vkd3d_resolve_image_ops_cleanup(&meta_ops->resolve_image_legacy, device);
+fail_resolve_image_legacy_ops:
+    vkd3d_resolve_image_ops_cleanup(&meta_ops->resolve_image_heap, device);
+fail_resolve_image_heap_ops:
+    vkd3d_copy_image_ops_cleanup(&meta_ops->copy_image_legacy, device);
+fail_copy_image_legacy_ops:
+    vkd3d_copy_image_ops_cleanup(&meta_ops->copy_image_heap, device);
+fail_copy_image_heap_ops:
+    vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav_legacy, device);
+fail_clear_uav_ops_legacy:
+    vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav_heap, device);
+fail_clear_uav_ops_heap:
     vkd3d_meta_ops_common_cleanup(&meta_ops->common, device);
 fail_common:
     return hr;
@@ -2299,16 +2439,20 @@ fail_common:
 HRESULT vkd3d_meta_ops_cleanup(struct vkd3d_meta_ops *meta_ops, struct d3d12_device *device)
 {
     vkd3d_workgraph_ops_cleanup(&meta_ops->workgraph, device);
-    vkd3d_sampler_feedback_ops_cleanup(&meta_ops->sampler_feedback, device);
+    vkd3d_sampler_feedback_ops_cleanup(&meta_ops->sampler_feedback_heap, device);
+    vkd3d_sampler_feedback_ops_cleanup(&meta_ops->sampler_feedback_legacy, device);
     vkd3d_dstorage_ops_cleanup(&meta_ops->dstorage, device);
     vkd3d_multi_dispatch_indirect_ops_cleanup(&meta_ops->multi_dispatch_indirect, device);
     vkd3d_execute_indirect_ops_cleanup(&meta_ops->execute_indirect, device);
     vkd3d_predicate_ops_cleanup(&meta_ops->predicate, device);
     vkd3d_query_ops_cleanup(&meta_ops->query, device);
     vkd3d_swapchain_ops_cleanup(&meta_ops->swapchain, device);
-    vkd3d_copy_image_ops_cleanup(&meta_ops->copy_image, device);
-    vkd3d_resolve_image_ops_cleanup(&meta_ops->resolve_image, device);
-    vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav, device);
+    vkd3d_copy_image_ops_cleanup(&meta_ops->copy_image_heap, device);
+    vkd3d_copy_image_ops_cleanup(&meta_ops->copy_image_legacy, device);
+    vkd3d_resolve_image_ops_cleanup(&meta_ops->resolve_image_heap, device);
+    vkd3d_resolve_image_ops_cleanup(&meta_ops->resolve_image_legacy, device);
+    vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav_heap, device);
+    vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav_legacy, device);
     vkd3d_meta_ops_common_cleanup(&meta_ops->common, device);
     return S_OK;
 }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3488,6 +3488,8 @@ void d3d12_command_list_meta_push_data(struct d3d12_command_list *list,
         VkCommandBuffer vk_command_buffer,
         VkPipelineLayout vk_pipeline_layout, VkShaderStageFlags stages,
         uint32_t size, const void *data);
+void d3d12_command_list_meta_push_descriptor_index(struct d3d12_command_list *list,
+        VkCommandBuffer vk_command_buffer, uint32_t binding, uint32_t heap_index);
 
 #define VKD3D_DESCRIPTOR_HEAP_META_PUSH_DATA_OFFSET 64
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3489,6 +3489,8 @@ void d3d12_command_list_meta_push_data(struct d3d12_command_list *list,
         VkPipelineLayout vk_pipeline_layout, VkShaderStageFlags stages,
         uint32_t size, const void *data);
 
+#define VKD3D_DESCRIPTOR_HEAP_META_PUSH_DATA_OFFSET 64
+
 union vkd3d_root_parameter_data
 {
     uint32_t root_constants[D3D12_MAX_ROOT_COST];
@@ -5087,16 +5089,20 @@ struct vkd3d_meta_ops
 {
     struct d3d12_device *device;
     struct vkd3d_meta_ops_common common;
-    struct vkd3d_clear_uav_ops clear_uav;
-    struct vkd3d_copy_image_ops copy_image;
-    struct vkd3d_resolve_image_ops resolve_image;
+    struct vkd3d_clear_uav_ops clear_uav_heap;
+    struct vkd3d_clear_uav_ops clear_uav_legacy;
+    struct vkd3d_copy_image_ops copy_image_heap;
+    struct vkd3d_copy_image_ops copy_image_legacy;
+    struct vkd3d_resolve_image_ops resolve_image_heap;
+    struct vkd3d_resolve_image_ops resolve_image_legacy;
     struct vkd3d_swapchain_ops swapchain;
     struct vkd3d_query_ops query;
     struct vkd3d_predicate_ops predicate;
     struct vkd3d_execute_indirect_ops execute_indirect;
     struct vkd3d_multi_dispatch_indirect_ops multi_dispatch_indirect;
     struct vkd3d_dstorage_ops dstorage;
-    struct vkd3d_sampler_feedback_resolve_ops sampler_feedback;
+    struct vkd3d_sampler_feedback_resolve_ops sampler_feedback_heap;
+    struct vkd3d_sampler_feedback_resolve_ops sampler_feedback_legacy;
     struct vkd3d_workgraph_indirect_ops workgraph;
 };
 
@@ -5104,9 +5110,9 @@ HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device
 HRESULT vkd3d_meta_ops_cleanup(struct vkd3d_meta_ops *meta_ops, struct d3d12_device *device);
 
 struct vkd3d_clear_uav_pipeline vkd3d_meta_get_clear_buffer_uav_pipeline(struct vkd3d_meta_ops *meta_ops,
-        bool as_uint, bool raw);
+        bool as_uint, bool raw, bool heap);
 struct vkd3d_clear_uav_pipeline vkd3d_meta_get_clear_image_uav_pipeline(struct vkd3d_meta_ops *meta_ops,
-        VkImageViewType image_view_type, bool as_uint);
+        VkImageViewType image_view_type, bool as_uint, bool heap);
 VkExtent3D vkd3d_meta_get_clear_image_uav_workgroup_size(VkImageViewType view_type);
 
 static inline VkExtent3D vkd3d_meta_get_clear_buffer_uav_workgroup_size()
@@ -5116,13 +5122,13 @@ static inline VkExtent3D vkd3d_meta_get_clear_buffer_uav_workgroup_size()
 }
 
 HRESULT vkd3d_meta_get_copy_image_pipeline(struct vkd3d_meta_ops *meta_ops,
-        const struct vkd3d_copy_image_pipeline_key *key, struct vkd3d_copy_image_info *info);
+        const struct vkd3d_copy_image_pipeline_key *key, struct vkd3d_copy_image_info *info, bool heap);
 VkImageViewType vkd3d_meta_get_copy_image_view_type(D3D12_RESOURCE_DIMENSION dim);
 const struct vkd3d_format *vkd3d_meta_get_copy_image_attachment_format(struct vkd3d_meta_ops *meta_ops,
         const struct vkd3d_format *dst_format, const struct vkd3d_format *src_format,
         VkImageAspectFlags dst_aspect, VkImageAspectFlags src_aspect);
 HRESULT vkd3d_meta_get_resolve_image_pipeline(struct vkd3d_meta_ops *meta_ops,
-        const struct vkd3d_resolve_image_pipeline_key *key, struct vkd3d_resolve_image_info *info);
+        const struct vkd3d_resolve_image_pipeline_key *key, struct vkd3d_resolve_image_info *info, bool heap);
 HRESULT vkd3d_meta_get_swapchain_pipeline(struct vkd3d_meta_ops *meta_ops,
         const struct vkd3d_swapchain_pipeline_key *key, struct vkd3d_swapchain_info *info);
 
@@ -5144,7 +5150,7 @@ HRESULT vkd3d_meta_get_execute_indirect_pipeline(struct vkd3d_meta_ops *meta_ops
         uint32_t patch_command_count, struct vkd3d_execute_indirect_info *info);
 
 void vkd3d_meta_get_sampler_feedback_resolve_pipeline(struct vkd3d_meta_ops *meta_ops,
-        enum vkd3d_sampler_feedback_resolve_type type, struct vkd3d_sampler_feedback_resolve_info *info);
+        enum vkd3d_sampler_feedback_resolve_type type, struct vkd3d_sampler_feedback_resolve_info *info, bool heap);
 
 static inline VkExtent3D vkd3d_meta_get_sampler_feedback_workgroup_size(void)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2710,6 +2710,12 @@ struct d3d12_command_allocator_command_pool
     struct d3d12_command_allocator_command_pool_list recycled, pending;
 };
 
+struct vkd3d_descriptor_heap_meta_allocation
+{
+    struct d3d12_descriptor_heap *heap;
+    uint32_t index;
+};
+
 /* ID3D12CommandAllocator */
 struct d3d12_command_allocator
 {
@@ -2745,6 +2751,10 @@ struct d3d12_command_allocator
     size_t query_pools_size;
     size_t query_pool_count;
 
+    struct vkd3d_descriptor_heap_meta_allocation *meta_allocs;
+    size_t meta_allocs_size;
+    size_t meta_allocs_count;
+
     struct vkd3d_query_pool active_query_pools[VKD3D_VIRTUAL_QUERY_TYPE_COUNT];
 
     struct d3d12_command_list *current_command_list;
@@ -2767,6 +2777,8 @@ HRESULT d3d12_command_allocator_create(struct d3d12_device *device,
 bool d3d12_command_allocator_allocate_query_from_type_index(
         struct d3d12_command_allocator *allocator,
         uint32_t type_index, VkQueryPool *query_pool, uint32_t *query_index);
+uint32_t d3d12_command_allocator_allocate_meta_index(
+        struct d3d12_command_allocator *allocator, struct d3d12_descriptor_heap *heap);
 
 struct d3d12_command_list *d3d12_command_list_from_iface(ID3D12CommandList *iface);
 void d3d12_command_list_decay_tracked_state(struct d3d12_command_list *list);


### PR DESCRIPTION
Starts to ponder meta descriptors and heap, everyone's favorite topic.

It's not a very clean setup since we have to support legacy and heap paths no matter what ...

First, we add helpers that place views on the user heap inside the "meta" region.

Second, add heap paths for meta shaders. For any meta shaders that take descriptors and not just pure push constants, we need to setup two sets of meta pipelines. The code fortunately wasn't *that* horrible ...

The final part adds a heap path to ClearUAV. Other meta paths to follow in Phase 12.