### PR TITLE
Descriptor heap - Phase 12

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -11924,10 +11924,10 @@ static void d3d12_command_list_execute_resolve(struct d3d12_command_list *list,
     VkDescriptorImageInfo vk_src_image_info, vk_dst_image_info;
     struct vkd3d_resolve_image_info resolve_pipeline_info;
     struct vkd3d_resolve_image_compute_args compute_args;
+    struct vkd3d_view *dst_view = NULL, *src_view = NULL;
     struct vkd3d_resolve_image_args resolve_args;
     VkWriteDescriptorSet vk_descriptor_writes[2];
     VkRenderingAttachmentInfo attachment_info;
-    struct vkd3d_view *dst_view, *src_view;
     const struct vkd3d_format *vk_format;
     VkResolveImageInfo2 resolve_info;
     VkRenderingInfo rendering_info;
@@ -11973,18 +11973,11 @@ static void d3d12_command_list_execute_resolve(struct d3d12_command_list *list,
         resolve_pipeline_key.compute.mode = mode;
         resolve_pipeline_key.compute.srgb = dst_view_desc.format != vk_format;
 
-        if (FAILED(vkd3d_meta_get_resolve_image_pipeline(
-            &list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info, false)))
-        {
-            ERR("Failed to get resolve pipeline.\n");
-            return;
-        }
-
-        VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, resolve_pipeline_info.vk_pipeline));
-
         for (i = 0; i < region_count; i++)
         {
             const VkImageResolve2 *region = &regions[i];
+            uint32_t src_index, dst_index;
+            bool use_heap;
 
             dst_view_desc.miplevel_idx = region->dstSubresource.mipLevel;
             dst_view_desc.miplevel_count = 1;
@@ -11998,45 +11991,68 @@ static void d3d12_command_list_execute_resolve(struct d3d12_command_list *list,
             src_view_desc.layer_count = region->srcSubresource.layerCount;
             src_view_desc.aspect_mask = region->srcSubresource.aspectMask;
 
-            if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view) ||
-                    !vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
+            src_index = d3d12_command_list_allocate_meta_image_view(list, &src_view_desc,
+                d3d12_resource_pick_layout(src_resource, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
+            dst_index = d3d12_command_list_allocate_meta_image_view(list, &dst_view_desc, VK_IMAGE_LAYOUT_GENERAL);
+            use_heap = src_index != UINT32_MAX && dst_index != UINT32_MAX;
+
+            if (FAILED(vkd3d_meta_get_resolve_image_pipeline(
+                &list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info, use_heap)))
             {
-                ERR("Failed to create image views.\n");
-                goto cleanup_compute;
+                ERR("Failed to get resolve pipeline.\n");
+                return;
             }
 
-            if (!d3d12_command_allocator_add_view(list->allocator, dst_view) ||
-                    !d3d12_command_allocator_add_view(list->allocator, src_view))
+            VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, resolve_pipeline_info.vk_pipeline));
+
+            if (use_heap)
             {
-                ERR("Failed to add views.\n");
-                goto cleanup_compute;
+                d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 0, src_index);
+                d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 1, dst_index);
             }
+            else
+            {
+                if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view) ||
+                        !vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
+                {
+                    ERR("Failed to create image views.\n");
+                    goto cleanup_compute;
+                }
 
-            memset(&vk_src_image_info, 0, sizeof(vk_src_image_info));
-            vk_src_image_info.imageView = src_view->vk_image_view;
-            vk_src_image_info.imageLayout = d3d12_resource_pick_layout(src_resource, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                if (!d3d12_command_allocator_add_view(list->allocator, dst_view) ||
+                        !d3d12_command_allocator_add_view(list->allocator, src_view))
+                {
+                    ERR("Failed to add views.\n");
+                    goto cleanup_compute;
+                }
 
-            memset(&vk_dst_image_info, 0, sizeof(vk_dst_image_info));
-            vk_dst_image_info.imageView = dst_view->vk_image_view;
-            vk_dst_image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+                memset(&vk_src_image_info, 0, sizeof(vk_src_image_info));
+                vk_src_image_info.imageView = src_view->vk_image_view;
+                vk_src_image_info.imageLayout = d3d12_resource_pick_layout(src_resource, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-            memset(&vk_descriptor_writes, 0, sizeof(vk_descriptor_writes));
-            vk_descriptor_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-            vk_descriptor_writes[0].dstBinding = 0;
-            vk_descriptor_writes[0].dstArrayElement = 0;
-            vk_descriptor_writes[0].descriptorCount = 1;
-            vk_descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-            vk_descriptor_writes[0].pImageInfo = &vk_src_image_info;
+                memset(&vk_dst_image_info, 0, sizeof(vk_dst_image_info));
+                vk_dst_image_info.imageView = dst_view->vk_image_view;
+                vk_dst_image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-            vk_descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-            vk_descriptor_writes[1].dstBinding = 1;
-            vk_descriptor_writes[1].dstArrayElement = 0;
-            vk_descriptor_writes[1].descriptorCount = 1;
-            vk_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-            vk_descriptor_writes[1].pImageInfo = &vk_dst_image_info;
+                memset(&vk_descriptor_writes, 0, sizeof(vk_descriptor_writes));
+                vk_descriptor_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                vk_descriptor_writes[0].dstBinding = 0;
+                vk_descriptor_writes[0].dstArrayElement = 0;
+                vk_descriptor_writes[0].descriptorCount = 1;
+                vk_descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+                vk_descriptor_writes[0].pImageInfo = &vk_src_image_info;
 
-            VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                            resolve_pipeline_info.vk_pipeline_layout, 0, ARRAY_SIZE(vk_descriptor_writes), vk_descriptor_writes));
+                vk_descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                vk_descriptor_writes[1].dstBinding = 1;
+                vk_descriptor_writes[1].dstArrayElement = 0;
+                vk_descriptor_writes[1].descriptorCount = 1;
+                vk_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+                vk_descriptor_writes[1].pImageInfo = &vk_dst_image_info;
+
+                VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                        resolve_pipeline_info.vk_pipeline_layout, 0,
+                        ARRAY_SIZE(vk_descriptor_writes), vk_descriptor_writes));
+            }
 
             compute_args.src_offset.x = region->srcOffset.x;
             compute_args.src_offset.y = region->srcOffset.y;
@@ -12101,6 +12117,8 @@ cleanup_compute:
         for (i = 0; i < region_count; i++)
         {
             const VkImageResolve2 *region = &regions[i];
+            uint32_t src_index;
+            bool use_heap;
 
             rendering_info.renderArea.offset.x = region->dstOffset.x;
             rendering_info.renderArea.offset.y = region->dstOffset.y;
@@ -12138,26 +12156,34 @@ cleanup_compute:
             {
                 src_view_desc.aspect_mask = vk_format->vk_aspect_mask;
                 src_view_desc.image_usage = dst_view_desc.image_usage;
+                src_index = UINT32_MAX;
             }
             else
             {
                 src_view_desc.aspect_mask = region->srcSubresource.aspectMask;
                 src_view_desc.image_usage = VK_IMAGE_USAGE_SAMPLED_BIT;
                 src_view_desc.allowed_swizzle = true;
+                src_index = d3d12_command_list_allocate_meta_image_view(list, &src_view_desc,
+                        d3d12_resource_pick_layout(src_resource, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
             }
 
             if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view) ||
-                    !vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
+                !d3d12_command_allocator_add_view(list->allocator, dst_view))
             {
                 ERR("Failed to create image views.\n");
                 goto cleanup_graphics;
             }
 
-            if (!d3d12_command_allocator_add_view(list->allocator, dst_view) ||
-                    !d3d12_command_allocator_add_view(list->allocator, src_view))
+            use_heap = src_index != UINT32_MAX;
+
+            if (!use_heap)
             {
-                ERR("Failed to add views.\n");
-                goto cleanup_graphics;
+                if (!vkd3d_create_texture_view(list->device, &src_view_desc, &src_view) ||
+                    !d3d12_command_allocator_add_view(list->allocator, src_view))
+                {
+                    ERR("Failed to create image views.\n");
+                    goto cleanup_graphics;
+                }
             }
 
             if (path == VKD3D_RESOLVE_IMAGE_PATH_RENDER_PASS_ATTACHMENT)
@@ -12176,7 +12202,7 @@ cleanup_compute:
                 resolve_pipeline_key.graphics.mode = mode;
 
                 if (FAILED(vkd3d_meta_get_resolve_image_pipeline(
-                    &list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info, false)))
+                    &list->device->meta_ops, &resolve_pipeline_key, &resolve_pipeline_info, use_heap)))
                 {
                     ERR("Failed to get resolve pipeline.\n");
                     return;
@@ -12203,23 +12229,31 @@ cleanup_compute:
                 resolve_args.offset.x = region->srcOffset.x - region->dstOffset.x;
                 resolve_args.offset.y = region->srcOffset.y - region->dstOffset.y;
 
-                memset(&vk_src_image_info, 0, sizeof(vk_src_image_info));
-                vk_src_image_info.imageView = src_view->vk_image_view;
-                vk_src_image_info.imageLayout = d3d12_resource_pick_layout(src_resource, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                if (use_heap)
+                {
+                    d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 0, src_index);
+                }
+                else
+                {
+                    memset(&vk_src_image_info, 0, sizeof(vk_src_image_info));
+                    vk_src_image_info.imageView = src_view->vk_image_view;
+                    vk_src_image_info.imageLayout = d3d12_resource_pick_layout(src_resource, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-                memset(&vk_descriptor_writes, 0, sizeof(vk_descriptor_writes));
-                vk_descriptor_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-                vk_descriptor_writes[0].dstBinding = 0;
-                vk_descriptor_writes[0].dstArrayElement = 0;
-                vk_descriptor_writes[0].descriptorCount = 1;
-                vk_descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-                vk_descriptor_writes[0].pImageInfo = &vk_src_image_info;
+                    memset(&vk_descriptor_writes, 0, sizeof(vk_descriptor_writes));
+                    vk_descriptor_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                    vk_descriptor_writes[0].dstBinding = 0;
+                    vk_descriptor_writes[0].dstArrayElement = 0;
+                    vk_descriptor_writes[0].descriptorCount = 1;
+                    vk_descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+                    vk_descriptor_writes[0].pImageInfo = &vk_src_image_info;
+
+                    VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            resolve_pipeline_info.vk_pipeline_layout, 0, 1, &vk_descriptor_writes[0]));
+                }
 
                 VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, resolve_pipeline_info.vk_pipeline));
                 VK_CALL(vkCmdSetViewport(list->cmd.vk_command_buffer, 0, 1, &viewport));
                 VK_CALL(vkCmdSetScissor(list->cmd.vk_command_buffer, 0, 1, &rendering_info.renderArea));
-                VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                        resolve_pipeline_info.vk_pipeline_layout, 0, 1, &vk_descriptor_writes[0]));
 
                 if (resolve_pipeline_info.needs_stencil_mask)
                 {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -10096,6 +10096,7 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
     VkRenderingInfo rendering_info;
     VkCopyImageInfo2 copy_info;
     VkViewport viewport;
+    uint32_t src_index;
     unsigned int i;
     bool unified;
     HRESULT hr;
@@ -10144,13 +10145,6 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         pipeline_key.sample_count = vk_samples_from_dxgi_sample_desc(&dst_resource->desc.SampleDesc);
         pipeline_key.dst_aspect_mask = region->dstSubresource.aspectMask;
 
-        if (FAILED(hr = vkd3d_meta_get_copy_image_pipeline(&list->device->meta_ops, &pipeline_key, &pipeline_info, false)))
-        {
-            ERR("Failed to obtain pipeline, format %u, view_type %u, sample_count %u.\n",
-                    pipeline_key.format->vk_format, pipeline_key.view_type, pipeline_key.sample_count);
-            goto cleanup;
-        }
-
         d3d12_command_list_invalidate_current_pipeline(list, true);
         d3d12_command_list_update_global_descriptor_buffer_meta(list);
 
@@ -10181,16 +10175,28 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         src_view_desc.allowed_swizzle = false;
 
         if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view) ||
-                !vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
+            !d3d12_command_allocator_add_view(list->allocator, dst_view))
         {
             ERR("Failed to create image views.\n");
             goto cleanup;
         }
 
-        if (!d3d12_command_allocator_add_view(list->allocator, dst_view) ||
-                !d3d12_command_allocator_add_view(list->allocator, src_view))
+        src_index = d3d12_command_list_allocate_meta_image_view(list, &src_view_desc, barrier.src.layout);
+        if (src_index == UINT32_MAX)
         {
-            ERR("Failed to add views.\n");
+            if (!vkd3d_create_texture_view(list->device, &src_view_desc, &src_view) ||
+                !d3d12_command_allocator_add_view(list->allocator, src_view))
+            {
+                ERR("Failed to create image views.\n");
+                goto cleanup;
+            }
+        }
+
+        if (FAILED(hr = vkd3d_meta_get_copy_image_pipeline(
+            &list->device->meta_ops, &pipeline_key, &pipeline_info, src_index != UINT32_MAX)))
+        {
+            ERR("Failed to obtain pipeline, format %u, view_type %u, sample_count %u.\n",
+                    pipeline_key.format->vk_format, pipeline_key.view_type, pipeline_key.sample_count);
             goto cleanup;
         }
 
@@ -10238,28 +10244,36 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         push_args.offset.x = region->srcOffset.x - region->dstOffset.x;
         push_args.offset.y = region->srcOffset.y - region->dstOffset.y;
 
-        vk_image_info.sampler = VK_NULL_HANDLE;
-        vk_image_info.imageView = src_view->vk_image_view;
-        vk_image_info.imageLayout = barrier.src.layout;
+        if (src_index == UINT32_MAX)
+        {
+            vk_image_info.sampler = VK_NULL_HANDLE;
+            vk_image_info.imageView = src_view->vk_image_view;
+            vk_image_info.imageLayout = barrier.src.layout;
 
-        vk_descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        vk_descriptor_write.pNext = NULL;
-        vk_descriptor_write.dstSet = VK_NULL_HANDLE;
-        vk_descriptor_write.dstBinding = 0;
-        vk_descriptor_write.dstArrayElement = 0;
-        vk_descriptor_write.descriptorCount = 1;
-        vk_descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-        vk_descriptor_write.pImageInfo = &vk_image_info;
-        vk_descriptor_write.pBufferInfo = NULL;
-        vk_descriptor_write.pTexelBufferView = NULL;
+            vk_descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            vk_descriptor_write.pNext = NULL;
+            vk_descriptor_write.dstSet = VK_NULL_HANDLE;
+            vk_descriptor_write.dstBinding = 0;
+            vk_descriptor_write.dstArrayElement = 0;
+            vk_descriptor_write.descriptorCount = 1;
+            vk_descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+            vk_descriptor_write.pImageInfo = &vk_image_info;
+            vk_descriptor_write.pBufferInfo = NULL;
+            vk_descriptor_write.pTexelBufferView = NULL;
+
+            VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                    pipeline_info.vk_pipeline_layout, 0, 1, &vk_descriptor_write));
+        }
+        else
+        {
+            d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 0, src_index);
+        }
 
         d3d12_command_list_debug_mark_begin_region(list, "CopyRenderPass");
         VK_CALL(vkCmdBeginRendering(list->cmd.vk_command_buffer, &rendering_info));
         VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_info.vk_pipeline));
         VK_CALL(vkCmdSetViewport(list->cmd.vk_command_buffer, 0, 1, &viewport));
         VK_CALL(vkCmdSetScissor(list->cmd.vk_command_buffer, 0, 1, &rendering_info.renderArea));
-        VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                pipeline_info.vk_pipeline_layout, 0, 1, &vk_descriptor_write));
 
         if (pipeline_info.needs_stencil_mask)
         {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -8084,6 +8084,13 @@ void d3d12_command_list_update_global_descriptor_heap(struct d3d12_command_list 
     }
 }
 
+/* Only updates for legacy paths. Heap path will gracefully pick whichever model is active. */
+static void d3d12_command_list_update_global_descriptor_buffer_meta(struct d3d12_command_list *list)
+{
+    if (!d3d12_device_use_descriptor_heap(list->device))
+        d3d12_command_list_update_global_descriptor_heap(list);
+}
+
 static void d3d12_command_list_update_descriptor_heaps(struct d3d12_command_list *list,
         struct vkd3d_pipeline_bindings *bindings, VkPipelineBindPoint vk_bind_point,
         VkPipelineLayout layout)
@@ -10145,7 +10152,7 @@ static void d3d12_command_list_copy_image(struct d3d12_command_list *list,
         }
 
         d3d12_command_list_invalidate_current_pipeline(list, true);
-        d3d12_command_list_update_global_descriptor_heap(list);
+        d3d12_command_list_update_global_descriptor_buffer_meta(list);
 
         memset(&dst_view_desc, 0, sizeof(dst_view_desc));
         dst_view_desc.image = dst_resource->res.vk_image;
@@ -11929,7 +11936,7 @@ static void d3d12_command_list_execute_resolve(struct d3d12_command_list *list,
     else if (path == VKD3D_RESOLVE_IMAGE_PATH_COMPUTE_PIPELINE)
     {
         d3d12_command_list_invalidate_current_pipeline(list, true);
-        d3d12_command_list_update_global_descriptor_heap(list);
+        d3d12_command_list_update_global_descriptor_buffer_meta(list);
 
         vk_format = d3d12_command_list_get_resolve_format(list, dst_resource, src_resource, format);
 
@@ -12043,7 +12050,7 @@ cleanup_compute:
     else
     {
         d3d12_command_list_invalidate_current_pipeline(list, true);
-        d3d12_command_list_update_global_descriptor_heap(list);
+        d3d12_command_list_update_global_descriptor_buffer_meta(list);
 
         vk_format = d3d12_command_list_get_resolve_format(list, dst_resource, src_resource, format);
 
@@ -15330,7 +15337,7 @@ static void d3d12_command_list_clear_uav(struct d3d12_command_list *list,
     d3d12_command_list_debug_mark_begin_region(list, "ClearUAV");
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_update_global_descriptor_heap(list);
+    d3d12_command_list_update_global_descriptor_buffer_meta(list);
 
     sampler_feedback_clear = d3d12_resource_desc_is_sampler_feedback(&resource->desc);
 
@@ -15541,7 +15548,7 @@ static void d3d12_command_list_clear_uav_with_copy(struct d3d12_command_list *li
     d3d12_command_list_debug_mark_begin_region(list, "ClearUAVWithCopy");
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_update_global_descriptor_heap(list);
+    d3d12_command_list_update_global_descriptor_buffer_meta(list);
 
     assert(!args->view && !args->use_heap);
     assert(d3d12_resource_is_texture(resource));
@@ -18083,7 +18090,7 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
         return;
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_update_global_descriptor_heap(list);
+    d3d12_command_list_update_global_descriptor_buffer_meta(list);
     d3d12_command_list_debug_mark_begin_region(list, "SamplerFeedbackEncode");
 
     /* Fixup subresource indices. */
@@ -18432,7 +18439,7 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
         return;
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_update_global_descriptor_heap(list);
+    d3d12_command_list_update_global_descriptor_buffer_meta(list);
     d3d12_command_list_debug_mark_begin_region(list, "SamplerFeedbackDecode");
 
     /* Fixup subresource indices. */

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -18200,8 +18200,8 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
 
     if (src->desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {
-        vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
-                VKD3D_SAMPLER_FEEDBACK_RESOLVE_BUFFER_TO_MIN_MIP, &pipeline_info, false);
+        uint32_t src_index = UINT32_MAX, dst_index = UINT32_MAX;
+        bool use_heap;
 
         dst_view_desc.view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
 
@@ -18218,18 +18218,38 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
         src_buffer_view_desc.buffer = src->res.vk_buffer;
         src_buffer_view_desc.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
-        if (!vkd3d_create_buffer_view(list->device, &src_buffer_view_desc, &src_view))
-            goto cleanup;
-        if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view))
-            goto cleanup;
+        dst_index = d3d12_command_list_allocate_meta_image_view(list, &dst_view_desc, VK_IMAGE_LAYOUT_GENERAL);
+        src_index = d3d12_command_list_allocate_meta_buffer_view(list,
+            src->res.va, src_buffer_view_desc.size, VK_FORMAT_R8_UINT,
+            VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
 
-        vk_image_info[0].imageView = dst_view->vk_image_view;
+        use_heap = src_index != UINT32_MAX && dst_index != UINT32_MAX;
 
-        vk_descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        vk_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
-        vk_descriptor_writes[1].dstBinding = 2;
-        vk_descriptor_writes[1].pTexelBufferView = &src_view->vk_buffer_view;
-        vk_descriptor_writes[1].descriptorCount = 1;
+        vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
+                VKD3D_SAMPLER_FEEDBACK_RESOLVE_BUFFER_TO_MIN_MIP, &pipeline_info, use_heap);
+
+        if (use_heap)
+        {
+            d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 0, dst_index);
+            d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 2, src_index);
+        }
+        else
+        {
+            if (!vkd3d_create_buffer_view(list->device, &src_buffer_view_desc, &src_view))
+                goto cleanup;
+            if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view))
+                goto cleanup;
+
+            vk_image_info[0].imageView = dst_view->vk_image_view;
+
+            vk_descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            vk_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+            vk_descriptor_writes[1].dstBinding = 2;
+            vk_descriptor_writes[1].pTexelBufferView = &src_view->vk_buffer_view;
+            vk_descriptor_writes[1].descriptorCount = 1;
+            VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                    pipeline_info.vk_layout, 0, ARRAY_SIZE(vk_descriptor_writes), vk_descriptor_writes));
+        }
 
         /* MinMip does not support rect semantics, so go ahead. */
 
@@ -18238,11 +18258,10 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
 
         VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                 pipeline_info.vk_pipeline));
-        VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                pipeline_info.vk_layout, 0, ARRAY_SIZE(vk_descriptor_writes), vk_descriptor_writes));
+
         d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
-                pipeline_info.vk_layout,
-                VK_SHADER_STAGE_COMPUTE_BIT, sizeof(args), &args);
+                pipeline_info.vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
+                sizeof(args), &args);
 
         extent.width = vkd3d_compute_workgroup_count(extent.width,
                 vkd3d_meta_get_sampler_feedback_workgroup_size().width);
@@ -18262,10 +18281,8 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
     }
     else
     {
-        vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
-                dst->desc.Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ?
-                        VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIN_MIP :
-                        VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIP_USED, &pipeline_info, false);
+        uint32_t src_index = UINT32_MAX, dst_index = UINT32_MAX;
+        bool use_heap;
 
         memset(&src_image_view_desc, 0, sizeof(src_image_view_desc));
         src_image_view_desc.image = src->res.vk_image;
@@ -18336,21 +18353,45 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
         dep_info.pImageMemoryBarriers = &vk_image_barrier;
         VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
 
-        if (!vkd3d_create_texture_view(list->device, &src_image_view_desc, &src_view))
-            goto cleanup;
-        if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view))
-            goto cleanup;
+        dst_index = d3d12_command_list_allocate_meta_image_view(list, &dst_view_desc, VK_IMAGE_LAYOUT_GENERAL);
+        src_index = d3d12_command_list_allocate_meta_image_view(list, &src_image_view_desc,
+                d3d12_resource_pick_layout(src, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
+        use_heap = src_index != UINT32_MAX && dst_index != UINT32_MAX;
 
-        vk_image_info[0].imageView = dst_view->vk_image_view;
-        vk_image_info[1].imageView = src_view->vk_image_view;
-        vk_image_info[1].sampler = VK_NULL_HANDLE;
-        vk_image_info[1].imageLayout = d3d12_resource_pick_layout(src, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
+                dst->desc.Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ?
+                VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIN_MIP :
+                VKD3D_SAMPLER_FEEDBACK_RESOLVE_IMAGE_TO_MIP_USED, &pipeline_info, use_heap);
 
-        vk_descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        vk_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-        vk_descriptor_writes[1].dstBinding = 1;
-        vk_descriptor_writes[1].pImageInfo = &vk_image_info[1];
-        vk_descriptor_writes[1].descriptorCount = 1;
+        if (use_heap)
+        {
+            d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 0, dst_index);
+            d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 1, src_index);
+        }
+        else
+        {
+            if (!vkd3d_create_texture_view(list->device, &src_image_view_desc, &src_view))
+                goto cleanup;
+            if (!vkd3d_create_texture_view(list->device, &dst_view_desc, &dst_view))
+                goto cleanup;
+
+            vk_image_info[0].imageView = dst_view->vk_image_view;
+            vk_image_info[1].imageView = src_view->vk_image_view;
+            vk_image_info[1].sampler = VK_NULL_HANDLE;
+            vk_image_info[1].imageLayout = d3d12_resource_pick_layout(src, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+            vk_descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            vk_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+            vk_descriptor_writes[1].dstBinding = 1;
+            vk_descriptor_writes[1].pImageInfo = &vk_image_info[1];
+            vk_descriptor_writes[1].descriptorCount = 1;
+
+            VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                    pipeline_info.vk_layout, 0, ARRAY_SIZE(vk_descriptor_writes), vk_descriptor_writes));
+        }
+
+        VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                pipeline_info.vk_pipeline));
 
         if (dst->desc.Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE)
         {
@@ -18395,13 +18436,9 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
             args.resolve_width = transcoded_width;
             args.resolve_height = transcoded_height;
 
-            VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                    pipeline_info.vk_pipeline));
-            VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                    pipeline_info.vk_layout, 0, ARRAY_SIZE(vk_descriptor_writes), vk_descriptor_writes));
             d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
-                    pipeline_info.vk_layout,
-                    VK_SHADER_STAGE_COMPUTE_BIT, sizeof(args), &args);
+                    pipeline_info.vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
+                    sizeof(args), &args);
 
             extent.width = vkd3d_compute_workgroup_count(args.resolve_width,
                     vkd3d_meta_get_sampler_feedback_workgroup_size().width);
@@ -18438,8 +18475,10 @@ static void d3d12_command_list_encode_sampler_feedback(struct d3d12_command_list
         VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
     }
 
-    d3d12_command_allocator_add_view(list->allocator, src_view);
-    d3d12_command_allocator_add_view(list->allocator, dst_view);
+    if (src_view)
+        d3d12_command_allocator_add_view(list->allocator, src_view);
+    if (dst_view)
+        d3d12_command_allocator_add_view(list->allocator, dst_view);
 
     /* Resolve does not count as a placed initialization,
      * so don't try to be clever here and compute writes_full_subresource.
@@ -18554,12 +18593,12 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
 
     if (dst->desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {
+        uint32_t src_index = UINT32_MAX, dst_index = UINT32_MAX;
+        bool use_heap;
+
         vk_image_barrier[0].dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
         vk_image_barrier[0].subresourceRange.layerCount = src_view_desc.layer_count;
         vk_image_barrier[0].subresourceRange.levelCount = src_view_desc.miplevel_count;
-
-        vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
-                VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER, &pipeline_info, false);
 
         src_view_desc.view_type = VK_IMAGE_VIEW_TYPE_2D;
 
@@ -18576,18 +18615,38 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
         dst_buffer_view_desc.buffer = dst->res.vk_buffer;
         dst_buffer_view_desc.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
 
-        if (!vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
-            goto cleanup;
-        if (!vkd3d_create_buffer_view(list->device, &dst_buffer_view_desc, &dst_view))
-            goto cleanup;
+        src_index = d3d12_command_list_allocate_meta_image_view(list,
+                &src_view_desc, d3d12_resource_pick_layout(src, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
+        dst_index = d3d12_command_list_allocate_meta_buffer_view(list,
+                dst->res.va, dst_buffer_view_desc.size, VK_FORMAT_R8_UINT,
+                VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+        use_heap = src_index != UINT32_MAX && dst_index != UINT32_MAX;
 
-        vk_image_info.imageView = src_view->vk_image_view;
+        vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
+                VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_BUFFER, &pipeline_info, use_heap);
 
-        vk_descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        vk_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
-        vk_descriptor_writes[1].dstBinding = 0;
-        vk_descriptor_writes[1].pTexelBufferView = &dst_view->vk_buffer_view;
-        vk_descriptor_writes[1].descriptorCount = 1;
+        if (use_heap)
+        {
+            d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 0, dst_index);
+            d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 1, src_index);
+        }
+        else
+        {
+            if (!vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
+                goto cleanup;
+            if (!vkd3d_create_buffer_view(list->device, &dst_buffer_view_desc, &dst_view))
+                goto cleanup;
+
+            vk_image_info.imageView = src_view->vk_image_view;
+
+            vk_descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            vk_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+            vk_descriptor_writes[1].dstBinding = 0;
+            vk_descriptor_writes[1].pTexelBufferView = &dst_view->vk_buffer_view;
+            vk_descriptor_writes[1].descriptorCount = 1;
+            VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                    pipeline_info.vk_layout, 0, ARRAY_SIZE(vk_descriptor_writes), vk_descriptor_writes));
+        }
 
         args.resolve_width = extent.width;
         args.resolve_height = extent.height;
@@ -18612,11 +18671,10 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
 
         VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                 pipeline_info.vk_pipeline));
-        VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                pipeline_info.vk_layout, 0, ARRAY_SIZE(vk_descriptor_writes), vk_descriptor_writes));
+
         d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
-                pipeline_info.vk_layout,
-                VK_SHADER_STAGE_COMPUTE_BIT, sizeof(args), &args);
+                pipeline_info.vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
+                sizeof(args), &args);
 
         extent.width = vkd3d_compute_workgroup_count(extent.width,
                 vkd3d_meta_get_sampler_feedback_workgroup_size().width);
@@ -18637,17 +18695,14 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
         vk_image_barrier[0].dstAccessMask = 0;
         VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
 
-        d3d12_command_allocator_add_view(list->allocator, src_view);
-        d3d12_command_allocator_add_view(list->allocator, dst_view);
+        if (src_view)
+            d3d12_command_allocator_add_view(list->allocator, src_view);
+        if (dst_view)
+            d3d12_command_allocator_add_view(list->allocator, dst_view);
     }
     else
     {
         vk_image_barrier[0].dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
-
-        vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
-                src->desc.Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ?
-                        VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE :
-                        VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE, &pipeline_info, false);
 
         memset(&dst_image_view_desc, 0, sizeof(dst_image_view_desc));
         dst_image_view_desc.image = dst->res.vk_image;
@@ -18763,6 +18818,9 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
 
         for (i = 0; i < num_mip_iterations; i++)
         {
+            uint32_t src_index = UINT32_MAX;
+            bool use_heap;
+
             if (dst_view)
             {
                 vkd3d_view_decref(dst_view, list->device);
@@ -18775,10 +18833,30 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
                 src_view = NULL;
             }
 
-            if (!vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
-                goto cleanup;
+            src_index = d3d12_command_list_allocate_meta_image_view(list, &src_view_desc,
+                    d3d12_resource_pick_layout(src, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
+            use_heap = src_index != UINT32_MAX;
+
+            vkd3d_meta_get_sampler_feedback_resolve_pipeline(&list->device->meta_ops,
+                    src->desc.Format == DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE ?
+                    VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIN_MIP_TO_IMAGE :
+                    VKD3D_SAMPLER_FEEDBACK_RESOLVE_MIP_USED_TO_IMAGE, &pipeline_info, use_heap);
+
             if (!vkd3d_create_texture_view(list->device, &dst_image_view_desc, &dst_view))
                 goto cleanup;
+
+            if (use_heap)
+            {
+                d3d12_command_list_meta_push_descriptor_index(list, list->cmd.vk_command_buffer, 1, src_index);
+            }
+            else
+            {
+                if (!vkd3d_create_texture_view(list->device, &src_view_desc, &src_view))
+                    goto cleanup;
+                vk_image_info.imageView = src_view->vk_image_view;
+                VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                        pipeline_info.vk_layout, 0, 1, vk_descriptor_writes));
+            }
 
             /* Transcoded output doesn't have to cover everything. Cover minimum. */
             extent = d3d12_resource_desc_get_subresource_extent(&dst->desc, dst->format, dst_image_view_desc.miplevel_idx);
@@ -18815,25 +18893,26 @@ static void d3d12_command_list_decode_sampler_feedback(struct d3d12_command_list
             viewport.width = (float)rendering_info.renderArea.extent.width;
             viewport.height = (float)rendering_info.renderArea.extent.height;
 
-            vk_image_info.imageView = src_view->vk_image_view;
-
             VK_CALL(vkCmdBeginRendering(list->cmd.vk_command_buffer, &rendering_info));
             VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
                     pipeline_info.vk_pipeline));
             VK_CALL(vkCmdSetViewport(list->cmd.vk_command_buffer, 0, 1, &viewport));
             VK_CALL(vkCmdSetScissor(list->cmd.vk_command_buffer, 0, 1, &rendering_info.renderArea));
-            VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                    pipeline_info.vk_layout, 0, 1, vk_descriptor_writes));
+
             d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
-                    pipeline_info.vk_layout,
-                    VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(args), &args);
+                    pipeline_info.vk_layout, VK_SHADER_STAGE_FRAGMENT_BIT,
+                    sizeof(args), &args);
+
             VK_CALL(vkCmdDraw(list->cmd.vk_command_buffer, 3, dst_image_view_desc.layer_count, 0, 0));
             VK_CALL(vkCmdEndRendering(list->cmd.vk_command_buffer));
 
             dst_image_view_desc.miplevel_idx++;
             args.mip_level++;
-            d3d12_command_allocator_add_view(list->allocator, src_view);
-            d3d12_command_allocator_add_view(list->allocator, dst_view);
+
+            if (src_view)
+                d3d12_command_allocator_add_view(list->allocator, src_view);
+            if (dst_view)
+                d3d12_command_allocator_add_view(list->allocator, dst_view);
         }
 
         vk_image_barrier[0].srcStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;


### PR DESCRIPTION
Completes meta shenanigans. Not the prettiest implementation in history, but such is life :(

First, relax the descriptor heap update to not force a heap change for no good reason. If the heap is already invalidated there's just a penalty to rebind the heap.

Then, complete the meta paths for other APIs. Some are more painful than others. Maybe it's possible to clean up some later, but it's probably best to ponder those cleanups later when the dust has settled rather than cause further rebase hell.