### PR TITLE
VK_KHR_opacity_micromap - Phase 3

### DIFF
--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -308,7 +308,7 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
                     {
                         omm->micromap = vkd3d_va_map_place_opacity_micromap(
                                 &device->memory_allocator.va_map, device,
-                                geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);
+                                geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray).ext;
 
                         if (omm->micromap == VK_NULL_HANDLE)
                             ERR("Failed to place OMM at VA 0x%"PRIx64".\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);
@@ -474,7 +474,7 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkAccelerationStructureKHR vk_acceleration_structure;
-    VkMicromapEXT vk_opacity_micromap;
+    union vkd3d_opacity_micromap vk_opacity_micromap;
     VkDependencyInfo dep_info;
     VkMemoryBarrier2 barrier;
     VkDeviceSize stride;
@@ -509,7 +509,7 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
                 vkd3d_acceleration_structure_write_postbuild_info(list, desc, i * stride, vk_acceleration_structure);
                 continue;
             }
-            else if (vk_opacity_micromap != VK_NULL_HANDLE)
+            else if (vk_opacity_micromap.any_handle != (uint64_t)VK_NULL_HANDLE)
             {
                 vkd3d_opacity_micromap_write_postbuild_info(list, desc, i * stride, vk_opacity_micromap);
                 continue;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20223,8 +20223,16 @@ static void d3d12_command_list_free_rtas_batch(struct d3d12_command_list *list)
     vkd3d_free(rtas_batch->omm_infos);
     vkd3d_free(rtas_batch->range_infos);
     vkd3d_free(rtas_batch->range_ptrs);
-    vkd3d_free(rtas_batch->omm_build_infos);
-    vkd3d_free(rtas_batch->omm_usage_infos);
+    if (list->device->device_info.using_khr_opacity_micromap)
+    {
+        vkd3d_free(rtas_batch->omm_build_infos.khr);
+        vkd3d_free(rtas_batch->omm_usage_infos.khr);
+    }
+    else
+    {
+        vkd3d_free(rtas_batch->omm_build_infos.ext);
+        vkd3d_free(rtas_batch->omm_usage_infos.ext);
+    }
 }
 
 static bool d3d12_command_list_allocate_rtas_build_info(struct d3d12_command_list *list, uint32_t geometry_count,
@@ -20278,29 +20286,86 @@ static bool d3d12_command_list_allocate_rtas_build_info(struct d3d12_command_lis
     return true;
 }
 
-static bool d3d12_command_list_allocate_omm_build_info(struct d3d12_command_list *list, uint32_t usage_count,
+static bool d3d12_command_list_allocate_omm_build_info_ext(struct d3d12_command_list *list, uint32_t usage_count,
         VkMicromapBuildInfoEXT **build_info,
         VkMicromapUsageEXT **usage_infos)
 {
     struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
 
-    if (!vkd3d_array_reserve((void **)&rtas_batch->omm_build_infos, &rtas_batch->omm_build_info_size,
-            rtas_batch->omm_build_info_count + 1, sizeof(*rtas_batch->omm_build_infos)))
+    if (!vkd3d_array_reserve((void **)&rtas_batch->omm_build_infos.ext, &rtas_batch->omm_build_info_size,
+            rtas_batch->omm_build_info_count + 1, sizeof(*rtas_batch->omm_build_infos.ext)))
     {
-        ERR("Failed to allocate build info array.\n");
+        ERR("Failed to allocate omm build info array.\n");
         return false;
     }
 
-    if (!vkd3d_array_reserve((void **)&rtas_batch->omm_usage_infos, &rtas_batch->omm_usage_info_size,
-            rtas_batch->omm_usage_info_count + usage_count, sizeof(*rtas_batch->omm_usage_infos)))
+    if (!vkd3d_array_reserve((void **)&rtas_batch->omm_usage_infos.ext, &rtas_batch->omm_usage_info_size,
+            rtas_batch->omm_usage_info_count + usage_count, sizeof(*rtas_batch->omm_usage_infos.ext)))
     {
         ERR("Failed to allocate usage array.\n");
         return false;
     }
 
-    *build_info = &rtas_batch->omm_build_infos[rtas_batch->omm_build_info_count];
-    *usage_infos = &rtas_batch->omm_usage_infos[rtas_batch->omm_usage_info_count];
+    *build_info = &rtas_batch->omm_build_infos.ext[rtas_batch->omm_build_info_count];
+    *usage_infos = &rtas_batch->omm_usage_infos.ext[rtas_batch->omm_usage_info_count];
 
+    rtas_batch->omm_build_info_count += 1;
+    rtas_batch->omm_usage_info_count += usage_count;
+
+    return true;
+}
+
+static bool d3d12_command_list_allocate_omm_build_info_khr(struct d3d12_command_list *list, uint32_t usage_count,
+        VkAccelerationStructureBuildGeometryInfoKHR **build_info,
+        VkAccelerationStructureGeometryKHR **geometry_info,
+        VkAccelerationStructureGeometryMicromapDataKHR **geometry_micromap_data,
+        VkMicromapUsageKHR **usage_infos)
+{
+    struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
+
+    if (!vkd3d_array_reserve((void **)&rtas_batch->build_infos, &rtas_batch->build_info_size,
+            rtas_batch->build_info_count + 1, sizeof(*rtas_batch->build_infos)))
+    {
+        ERR("Failed to allocate build info array.\n");
+        return false;
+    }
+
+    if (!vkd3d_array_reserve((void **)&rtas_batch->geometry_infos, &rtas_batch->geometry_info_size,
+            rtas_batch->geometry_info_count + 1, sizeof(*rtas_batch->geometry_infos)))
+    {
+        ERR("Failed to allocate geometry info array.\n");
+        return false;
+    }
+
+    if (!vkd3d_array_reserve((void **)&rtas_batch->omm_build_infos.khr, &rtas_batch->omm_build_info_size,
+            rtas_batch->omm_build_info_count + 1, sizeof(*rtas_batch->omm_build_infos.khr)))
+    {
+        ERR("Failed to allocate omm build info array.\n");
+        return false;
+    }
+
+    if (!vkd3d_array_reserve((void **)&rtas_batch->omm_usage_infos.khr, &rtas_batch->omm_usage_info_size,
+            rtas_batch->omm_usage_info_count + usage_count, sizeof(*rtas_batch->omm_usage_infos.khr)))
+    {
+        ERR("Failed to allocate usage array.\n");
+        return false;
+    }
+
+    /* In this case it is just reserved to not interfere with BLAS */
+    if (!vkd3d_array_reserve((void **)&rtas_batch->range_infos, &rtas_batch->range_info_size,
+            rtas_batch->geometry_info_count + 1, sizeof(*rtas_batch->range_infos)))
+    {
+        ERR("Failed to allocate range info array.\n");
+        return false;
+    }
+
+    *build_info = &rtas_batch->build_infos[rtas_batch->build_info_count];
+    *geometry_info = &rtas_batch->geometry_infos[rtas_batch->geometry_info_count];
+    *geometry_micromap_data = &rtas_batch->omm_build_infos.khr[rtas_batch->omm_build_info_count];
+    *usage_infos = &rtas_batch->omm_usage_infos.khr[rtas_batch->omm_usage_info_count];
+
+    rtas_batch->build_info_count += 1;
+    rtas_batch->geometry_info_count += 1;
     rtas_batch->omm_build_info_count += 1;
     rtas_batch->omm_usage_info_count += usage_count;
 
@@ -20339,39 +20404,82 @@ static void d3d12_command_list_fixup_rtas_batch(struct d3d12_command_list *list)
         assert(geometry_index + geometry_count <= rtas_batch->geometry_info_count);
 
         rtas_batch->build_infos[i].pGeometries = &rtas_batch->geometry_infos[geometry_index];
-        rtas_batch->range_ptrs[i] = &rtas_batch->range_infos[geometry_index];
+        if (rtas_batch->geometry_infos[geometry_index].geometryType == VK_GEOMETRY_TYPE_MICROMAP_KHR)
+            rtas_batch->range_ptrs[i] = NULL;
+        else
+            rtas_batch->range_ptrs[i] = &rtas_batch->range_infos[geometry_index];
 
         geometry_index += geometry_count;
     }
 
-    /* Assign usage count pointers */
-    usage_index = 0;
-
-    for (i = 0; i < rtas_batch->omm_build_info_count; i++)
+    if (list->device->device_info.supports_opacity_micromap)
     {
-        uint32_t usage_count = rtas_batch->omm_build_infos[i].usageCountsCount;
-        assert(usage_index + usage_count <= rtas_batch->omm_usage_info_count);
-
-        rtas_batch->omm_build_infos[i].pUsageCounts = &rtas_batch->omm_usage_infos[usage_index];
-
-        usage_index += usage_count;
-    }
-
-    if (rtas_batch->omm_infos)
-    {
-        for (i = 0; i < rtas_batch->geometry_info_count; i++)
+        if (list->device->device_info.using_khr_opacity_micromap)
         {
-            /* oom_infos is cleared to zero if not used. Can use sType as sentinel. */
-            VkAccelerationStructureTrianglesOpacityMicromapEXT *omm = &rtas_batch->omm_infos[i];
-            VkAccelerationStructureGeometryKHR *geometry = &rtas_batch->geometry_infos[i];
+            /* Assign geometry info next pointers */
+            uint32_t omm_index = 0;
+            geometry_index = 0;
 
-            if (omm->sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT)
+            for (i = 0; i < rtas_batch->build_info_count; i++)
             {
-                /* The pNext may have been invalidated. Just verify something is there. */
-                assert(geometry->geometry.triangles.pNext);
-                assert(geometry->geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR);
-                geometry->geometry.triangles.pNext = NULL;
-                vk_prepend_struct(&geometry->geometry.triangles, omm);
+                uint32_t geometry_count = rtas_batch->build_infos[i].geometryCount;
+                assert(geometry_index + geometry_count <= rtas_batch->geometry_info_count);
+
+                if (rtas_batch->geometry_infos[geometry_index].geometryType == VK_GEOMETRY_TYPE_MICROMAP_KHR)
+                {
+                    rtas_batch->geometry_infos[geometry_index].pNext = &rtas_batch->omm_build_infos.khr[omm_index];
+                    omm_index += 1;
+                }
+
+                geometry_index += geometry_count;
+            }
+
+            /* Assign usage count pointers */
+            usage_index = 0;
+
+            for (i = 0; i < rtas_batch->omm_build_info_count; i++)
+            {
+                uint32_t usage_count = rtas_batch->omm_build_infos.khr[i].usageCountsCount;
+                assert(usage_index + usage_count <= rtas_batch->omm_usage_info_count);
+
+                rtas_batch->omm_build_infos.khr[i].pUsageCounts = &rtas_batch->omm_usage_infos.khr[usage_index];
+
+                usage_index += usage_count;
+            }
+        }
+        else
+        {
+            /* Assign usage count pointers */
+            usage_index = 0;
+
+            for (i = 0; i < rtas_batch->omm_build_info_count; i++)
+            {
+                uint32_t usage_count = rtas_batch->omm_build_infos.ext[i].usageCountsCount;
+                assert(usage_index + usage_count <= rtas_batch->omm_usage_info_count);
+
+                rtas_batch->omm_build_infos.ext[i].pUsageCounts = &rtas_batch->omm_usage_infos.ext[usage_index];
+
+                usage_index += usage_count;
+            }
+
+            /* pNext pointers on Geometry AS. Currently limited to Opacity micromaps */
+            if (rtas_batch->omm_infos)
+            {
+                for (i = 0; i < rtas_batch->geometry_info_count; i++)
+                {
+                    /* oom_infos is cleared to zero if not used. Can use sType as sentinel. */
+                    VkAccelerationStructureTrianglesOpacityMicromapEXT *omm = &rtas_batch->omm_infos[i];
+                    VkAccelerationStructureGeometryKHR *geometry = &rtas_batch->geometry_infos[i];
+
+                    if (omm->sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT)
+                    {
+                        /* The pNext may have been invalidated. Just verify something is there. */
+                        assert(geometry->geometry.triangles.pNext);
+                        assert(geometry->geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR);
+                        geometry->geometry.triangles.pNext = NULL;
+                        vk_prepend_struct(&geometry->geometry.triangles, omm);
+                    }
+                }
             }
         }
     }
@@ -20398,51 +20506,44 @@ static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
         VK_CALL(vkCmdBuildAccelerationStructuresKHR(list->cmd.vk_command_buffer,
                 rtas_batch->build_info_count, rtas_batch->build_infos, rtas_batch->range_ptrs));
 
-    if (rtas_batch->omm_build_info_count)
+    if (rtas_batch->omm_build_info_count && !list->device->device_info.using_khr_opacity_micromap)
         VK_CALL(vkCmdBuildMicromapsEXT(list->cmd.vk_command_buffer,
-                rtas_batch->omm_build_info_count, rtas_batch->omm_build_infos));
+                rtas_batch->omm_build_info_count, rtas_batch->omm_build_infos.ext));
 
     d3d12_command_list_clear_rtas_batch(list);
 }
 
-static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3d12_command_list *list,
+static bool d3d12_command_list_build_raytracing_opacity_micromap_array_ext(struct d3d12_command_list *list,
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *desc, UINT num_postbuild_info_descs,
-        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *postbuild_info_descs)
+        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *postbuild_info_descs,
+        union vkd3d_opacity_micromap *micromap)
 {
-    union vkd3d_opacity_micromap micromap;
     VkMicromapBuildInfoEXT *build_info;
     VkMicromapUsageEXT *usage_infos;
     uint32_t usage_info_count;
 
-    if (!d3d12_device_supports_ray_tracing_tier_1_2(list->device))
-    {
-        ERR("Opacity micromap is not supported. Calling this is invalid.\n");
-        return;
-    }
-
     usage_info_count = desc->Inputs.pOpacityMicromapArrayDesc->NumOmmHistogramEntries;
 
-    if (!d3d12_command_list_allocate_omm_build_info(list, usage_info_count,
+    if (!d3d12_command_list_allocate_omm_build_info_ext(list, usage_info_count,
             &build_info, &usage_infos))
-        return;
+        return false;
 
-    if (!vkd3d_opacity_micromap_convert_inputs(list->device, &desc->Inputs, build_info, usage_infos))
+    if (!vkd3d_opacity_micromap_convert_inputs_ext(list->device, &desc->Inputs, build_info, usage_infos))
     {
         ERR("Failed to convert inputs.\n");
-        return;
+        return false;
     }
 
-    micromap.ext = VK_NULL_HANDLE;
+    micromap->ext = VK_NULL_HANDLE;
     if (desc->DestAccelerationStructureData)
     {
-        micromap.ext =
-                vkd3d_va_map_place_opacity_micromap(&list->device->memory_allocator.va_map,
-                        list->device, desc->DestAccelerationStructureData).ext;
-        build_info->dstMicromap = micromap.ext;
+        *micromap = vkd3d_va_map_place_opacity_micromap(&list->device->memory_allocator.va_map,
+                        list->device, desc->DestAccelerationStructureData);
+        build_info->dstMicromap = micromap->ext;
         if (build_info->dstMicromap == VK_NULL_HANDLE)
         {
             ERR("Failed to place destMicromap. Dropping call.\n");
-            return;
+            return false;
         }
     }
 
@@ -20492,6 +20593,119 @@ static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3
         }
     }
 #endif
+    return true;
+}
+
+static bool d3d12_command_list_build_raytracing_opacity_micromap_array_khr(struct d3d12_command_list *list,
+        const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *desc, UINT num_postbuild_info_descs,
+        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *postbuild_info_descs,
+        union vkd3d_opacity_micromap *micromap)
+{
+    VkAccelerationStructureBuildGeometryInfoKHR *build_info;
+    VkAccelerationStructureGeometryKHR *geometry_info;
+    VkAccelerationStructureGeometryMicromapDataKHR *geometry_micromap_data;
+    VkMicromapUsageKHR *usage_infos;
+    uint32_t usage_info_count;
+
+    usage_info_count = desc->Inputs.pOpacityMicromapArrayDesc->NumOmmHistogramEntries;
+
+    if (!d3d12_command_list_allocate_omm_build_info_khr(list, usage_info_count,
+            &build_info, &geometry_info, &geometry_micromap_data, &usage_infos))
+        return false;
+
+    if (!vkd3d_opacity_micromap_convert_inputs_khr(list->device, &desc->Inputs, build_info, geometry_info,
+                geometry_micromap_data, usage_infos))
+    {
+        ERR("Failed to convert inputs.\n");
+        return false;
+    }
+
+    micromap->khr = VK_NULL_HANDLE;
+    if (desc->DestAccelerationStructureData)
+    {
+        *micromap = vkd3d_va_map_place_opacity_micromap(&list->device->memory_allocator.va_map,
+                        list->device, desc->DestAccelerationStructureData);
+        build_info->dstAccelerationStructure = micromap->khr;
+        if (build_info->dstAccelerationStructure == VK_NULL_HANDLE)
+        {
+            ERR("Failed to place destMicromap. Dropping call.\n");
+            return false;
+        }
+    }
+
+    build_info->scratchData.deviceAddress = desc->ScratchAccelerationStructureData;
+
+#ifdef VKD3D_ENABLE_BREADCRUMBS
+    /* Immediately record the OMM build command here so that we don't have
+     * to create a deep copy of the entire D3D12 input description */
+    if (VKD3D_CONFIG_FLAG_IS_SET(BREADCRUMBS))
+    {
+        d3d12_command_list_flush_rtas_batch(list);
+
+        VKD3D_BREADCRUMB_TAG("OMM build [Dest VA, Scratch VA]");
+        VKD3D_BREADCRUMB_AUX64(desc->DestAccelerationStructureData);
+        VKD3D_BREADCRUMB_AUX64(desc->ScratchAccelerationStructureData);
+        {
+            const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+            uint32_t i;
+
+            VkAccelerationStructureBuildSizesInfoKHR size_info;
+
+            memset(&size_info, 0, sizeof(size_info));
+            size_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
+            VK_CALL(vkGetAccelerationStructureBuildSizesKHR(list->device->vk_device,
+                    VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, build_info, NULL, &size_info));
+
+            VKD3D_BREADCRUMB_TAG("Build requirements [Size, Build Scratch]");
+            VKD3D_BREADCRUMB_AUX64(size_info.accelerationStructureSize);
+            VKD3D_BREADCRUMB_AUX64(size_info.buildScratchSize);
+
+            VKD3D_BREADCRUMB_TAG("Inputs [Flags, VA, Descs VA, Descs stride]");
+            VKD3D_BREADCRUMB_AUX32(desc->Inputs.Flags);
+            VKD3D_BREADCRUMB_AUX64(desc->Inputs.pOpacityMicromapArrayDesc->InputBuffer);
+            VKD3D_BREADCRUMB_AUX64(desc->Inputs.pOpacityMicromapArrayDesc->PerOmmDescs.StartAddress);
+            VKD3D_BREADCRUMB_AUX64(desc->Inputs.pOpacityMicromapArrayDesc->PerOmmDescs.StrideInBytes);
+
+            for (i = 0; i < desc->Inputs.pOpacityMicromapArrayDesc->NumOmmHistogramEntries; i++)
+            {
+                const D3D12_RAYTRACING_OPACITY_MICROMAP_HISTOGRAM_ENTRY *histogram_entry =
+                        &desc->Inputs.pOpacityMicromapArrayDesc->pOmmHistogram[i];
+
+                VKD3D_BREADCRUMB_TAG("Histogram entry [Count, Subdivision Level, Format]");
+                VKD3D_BREADCRUMB_AUX32(histogram_entry->Count);
+                VKD3D_BREADCRUMB_AUX32(histogram_entry->SubdivisionLevel);
+                VKD3D_BREADCRUMB_AUX32(histogram_entry->Format);
+            }
+        }
+    }
+#endif
+    return true;
+}
+
+static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3d12_command_list *list,
+        const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *desc, UINT num_postbuild_info_descs,
+        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *postbuild_info_descs)
+{
+    union vkd3d_opacity_micromap micromap;
+
+    if (!d3d12_device_supports_ray_tracing_tier_1_2(list->device))
+    {
+        ERR("Opacity micromap is not supported. Calling this is invalid.\n");
+        return;
+    }
+
+    if (list->device->device_info.using_khr_opacity_micromap)
+    {
+        if (!d3d12_command_list_build_raytracing_opacity_micromap_array_khr(list, desc, num_postbuild_info_descs,
+            postbuild_info_descs, &micromap))
+            return;
+    }
+    else
+    {
+        if (!d3d12_command_list_build_raytracing_opacity_micromap_array_ext(list, desc, num_postbuild_info_descs,
+            postbuild_info_descs, &micromap))
+            return;
+    }
 
     if (num_postbuild_info_descs)
     {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20505,73 +20505,16 @@ static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3
     VKD3D_BREADCRUMB_COMMAND(BUILD_OMM);
 }
 
-static void STDMETHODCALLTYPE d3d12_command_list_BuildRaytracingAccelerationStructure(d3d12_command_list_iface *iface,
+static void d3d12_command_list_build_raytracing_blas_and_tlas(struct d3d12_command_list *list,
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *desc, UINT num_postbuild_info_descs,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *postbuild_info_descs)
 {
-    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkAccelerationStructureTrianglesOpacityMicromapEXT *omm_infos = NULL;
-    struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
     VkAccelerationStructureBuildGeometryInfoKHR *build_info;
     VkAccelerationStructureBuildRangeInfoKHR *range_infos;
     VkAccelerationStructureGeometryKHR *geometry_infos;
     uint32_t *primitive_counts = NULL;
-    VkMemoryBarrier2 vk_barrier;
-    VkDependencyInfo dep_info;
     uint32_t geometry_count;
-
-    TRACE("iface %p, desc %p, num_postbuild_info_descs %u, postbuild_info_descs %p\n",
-            iface, desc, num_postbuild_info_descs, postbuild_info_descs);
-
-    d3d12_command_list_check_render_pass_validation(list, "BuildRaytracingAccelerationStructure called within a render pass.\n", true);
-    d3d12_command_list_flush_dgc_batch(list);
-
-    if (!d3d12_device_supports_ray_tracing_tier_1_0(list->device))
-    {
-        WARN("Acceleration structure is not supported. Calling this is invalid.\n");
-        return;
-    }
-
-    list->cmd.estimated_cost += VKD3D_COMMAND_COST_HIGH;
-
-    /* Do not batch TLAS and BLAS builds into the same command, since doing so
-     * is disallowed if there are data dependencies between the builds. This
-     * happens in Cyberpunk 2077, which does not emit appropriate UAV barriers. */
-    if ((rtas_batch->build_info_count || rtas_batch->omm_build_info_count) &&
-            rtas_batch->build_type != desc->Inputs.Type)
-    {
-        d3d12_command_list_flush_rtas_batch(list);
-
-        memset(&vk_barrier, 0, sizeof(vk_barrier));
-        vk_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
-        vk_barrier.srcStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
-        vk_barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
-        vk_barrier.dstStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
-        vk_barrier.dstAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
-
-        if (list->device->device_info.opacity_micromap_features_ext.micromap)
-        {
-            vk_barrier.srcAccessMask |= VK_ACCESS_2_MICROMAP_READ_BIT_EXT | VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT;
-            vk_barrier.dstAccessMask |= VK_ACCESS_2_MICROMAP_READ_BIT_EXT | VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT;
-        }
-
-        memset(&dep_info, 0, sizeof(dep_info));
-        dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
-        dep_info.memoryBarrierCount = 1;
-        dep_info.pMemoryBarriers = &vk_barrier;
-
-        VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
-    }
-
-    rtas_batch->build_type = desc->Inputs.Type;
-
-    if (rtas_batch->build_type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_ARRAY)
-    {
-        d3d12_command_list_build_raytracing_opacity_micromap_array(list,
-                desc, num_postbuild_info_descs, postbuild_info_descs);
-        return;
-    }
 
     geometry_count = vkd3d_acceleration_structure_get_geometry_count(&desc->Inputs);
 
@@ -20633,6 +20576,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_BuildRaytracingAccelerationStru
                 "Update" : "Create");
         VKD3D_BREADCRUMB_TAG(desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL ? "Top" : "Bottom");
         {
+            const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
             VkAccelerationStructureBuildSizesInfoKHR size_info;
 
             memset(&size_info, 0, sizeof(size_info));
@@ -20709,6 +20653,69 @@ static void STDMETHODCALLTYPE d3d12_command_list_BuildRaytracingAccelerationStru
     }
 
     VKD3D_BREADCRUMB_COMMAND(BUILD_RTAS);
+}
+
+static void STDMETHODCALLTYPE d3d12_command_list_BuildRaytracingAccelerationStructure(d3d12_command_list_iface *iface,
+        const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *desc, UINT num_postbuild_info_descs,
+        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *postbuild_info_descs)
+{
+    struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
+    VkMemoryBarrier2 vk_barrier;
+    VkDependencyInfo dep_info;
+
+    TRACE("iface %p, desc %p, num_postbuild_info_descs %u, postbuild_info_descs %p\n",
+            iface, desc, num_postbuild_info_descs, postbuild_info_descs);
+
+    d3d12_command_list_check_render_pass_validation(list, "BuildRaytracingAccelerationStructure called within a render pass.\n", true);
+    d3d12_command_list_flush_dgc_batch(list);
+
+    if (!d3d12_device_supports_ray_tracing_tier_1_0(list->device))
+    {
+        WARN("Acceleration structure is not supported. Calling this is invalid.\n");
+        return;
+    }
+
+    list->cmd.estimated_cost += VKD3D_COMMAND_COST_HIGH;
+
+    /* Do not batch TLAS and BLAS builds into the same command, since doing so
+     * is disallowed if there are data dependencies between the builds. This
+     * happens in Cyberpunk 2077, which does not emit appropriate UAV barriers. */
+    if ((rtas_batch->build_info_count || rtas_batch->omm_build_info_count) &&
+            rtas_batch->build_type != desc->Inputs.Type)
+    {
+        d3d12_command_list_flush_rtas_batch(list);
+
+        memset(&vk_barrier, 0, sizeof(vk_barrier));
+        vk_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
+        vk_barrier.srcStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
+        vk_barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
+        vk_barrier.dstStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
+        vk_barrier.dstAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
+
+        if (list->device->device_info.opacity_micromap_features_ext.micromap)
+        {
+            vk_barrier.srcAccessMask |= VK_ACCESS_2_MICROMAP_READ_BIT_EXT | VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT;
+            vk_barrier.dstAccessMask |= VK_ACCESS_2_MICROMAP_READ_BIT_EXT | VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT;
+        }
+
+        memset(&dep_info, 0, sizeof(dep_info));
+        dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        dep_info.memoryBarrierCount = 1;
+        dep_info.pMemoryBarriers = &vk_barrier;
+
+        VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
+    }
+
+    rtas_batch->build_type = desc->Inputs.Type;
+
+    if (rtas_batch->build_type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_ARRAY)
+        d3d12_command_list_build_raytracing_opacity_micromap_array(list,
+                desc, num_postbuild_info_descs, postbuild_info_descs);
+    else
+        d3d12_command_list_build_raytracing_blas_and_tlas(list,
+                desc, num_postbuild_info_descs, postbuild_info_descs);
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_EmitRaytracingAccelerationStructurePostbuildInfo(d3d12_command_list_iface *iface,

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20409,6 +20409,7 @@ static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *desc, UINT num_postbuild_info_descs,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *postbuild_info_descs)
 {
+    union vkd3d_opacity_micromap micromap;
     VkMicromapBuildInfoEXT *build_info;
     VkMicromapUsageEXT *usage_infos;
     uint32_t usage_info_count;
@@ -20431,11 +20432,13 @@ static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3
         return;
     }
 
+    micromap.ext = VK_NULL_HANDLE;
     if (desc->DestAccelerationStructureData)
     {
-        build_info->dstMicromap =
+        micromap.ext =
                 vkd3d_va_map_place_opacity_micromap(&list->device->memory_allocator.va_map,
-                        list->device, desc->DestAccelerationStructureData);
+                        list->device, desc->DestAccelerationStructureData).ext;
+        build_info->dstMicromap = micromap.ext;
         if (build_info->dstMicromap == VK_NULL_HANDLE)
         {
             ERR("Failed to place destMicromap. Dropping call.\n");
@@ -20499,7 +20502,7 @@ static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3
 
         vkd3d_opacity_micromap_emit_immediate_postbuild_info(list,
                 num_postbuild_info_descs, postbuild_info_descs,
-                build_info->dstMicromap);
+                micromap);
     }
 
     VKD3D_BREADCRUMB_COMMAND(BUILD_OMM);
@@ -20749,8 +20752,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
+    union vkd3d_opacity_micromap src_omm;
     VkAccelerationStructureKHR src_as;
-    VkMicromapEXT src_omm;
 
     TRACE("iface %p, dst_data %#"PRIx64", src_data %#"PRIx64", mode %u\n",
           iface, dst_data, src_data, mode);
@@ -20783,7 +20786,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
             VKD3D_BREADCRUMB_COMMAND(COPY_RTAS);
             return;
         }
-        else if (src_omm != VK_NULL_HANDLE)
+        else if (src_omm.any_handle != (uint64_t)VK_NULL_HANDLE)
         {
             vkd3d_opacity_micromap_copy(list, dst_data, src_omm, mode);
             VKD3D_BREADCRUMB_AUX64(dst_data);

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -8373,7 +8373,7 @@ static void d3d12_device_get_raytracing_opacity_micromap_array_prebuild_info(str
     else
         usages = usages_stack;
 
-    if (!vkd3d_opacity_micromap_convert_inputs(device, desc, &build_info, usages))
+    if (!vkd3d_opacity_micromap_convert_inputs_ext(device, desc, &build_info, usages))
     {
         ERR("Failed to convert inputs.\n");
         memset(info, 0, sizeof(*info));

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -268,27 +268,54 @@ void vkd3d_opacity_micromap_write_postbuild_info(
     vk_buffer = resource->vk_buffer;
     offset = desc->DestBuffer - resource->va;
     offset += desc_offset;
+    stride = sizeof(uint64_t);
 
-    switch (desc->InfoType)
+    if (list->device->device_info.using_khr_opacity_micromap)
     {
-        case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE:
-            vk_query_type = VK_QUERY_TYPE_MICROMAP_COMPACTED_SIZE_EXT;
-            type_index = VKD3D_QUERY_TYPE_INDEX_OMM_COMPACTED_SIZE;
-            stride = sizeof(uint64_t);
-            break;
-        case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION:
-            vk_query_type = VK_QUERY_TYPE_MICROMAP_SERIALIZATION_SIZE_EXT;
-            type_index = VKD3D_QUERY_TYPE_INDEX_OMM_SERIALIZE_SIZE;
-            stride = sizeof(uint64_t);
-            break;
-        default:
-            FIXME("Unsupported InfoType %u.\n", desc->InfoType);
-            /* TODO: CURRENT_SIZE is something we cannot query in Vulkan, so
-                * we'll need to keep around a buffer to handle this.
-                * For now, just clear to 0. */
-            VK_CALL(vkCmdFillBuffer(list->cmd.vk_command_buffer, vk_buffer, offset,
-                    sizeof(uint64_t), 0));
-            return;
+        switch (desc->InfoType)
+        {
+            case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE:
+                vk_query_type = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;
+                type_index = VKD3D_QUERY_TYPE_INDEX_RT_COMPACTED_SIZE;
+                break;
+            case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE:
+                vk_query_type = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SIZE_KHR;
+                type_index = VKD3D_QUERY_TYPE_INDEX_RT_CURRENT_SIZE;
+                break;
+            case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION:
+                vk_query_type = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR;
+                type_index = VKD3D_QUERY_TYPE_INDEX_RT_SERIALIZE_SIZE;
+                break;
+            default:
+                FIXME("Unsupported InfoType %u.\n", desc->InfoType);
+                VK_CALL(vkCmdFillBuffer(list->cmd.vk_command_buffer, vk_buffer, offset,
+                        sizeof(uint64_t), 0));
+                return;
+        }
+    }
+    else
+    {
+        switch (desc->InfoType)
+        {
+            case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE:
+                vk_query_type = VK_QUERY_TYPE_MICROMAP_COMPACTED_SIZE_EXT;
+                type_index = VKD3D_QUERY_TYPE_INDEX_OMM_COMPACTED_SIZE;
+                break;
+            case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION:
+                vk_query_type = VK_QUERY_TYPE_MICROMAP_SERIALIZATION_SIZE_EXT;
+                type_index = VKD3D_QUERY_TYPE_INDEX_OMM_SERIALIZE_SIZE;
+                break;
+            case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE:
+                /* TODO: CURRENT_SIZE is something we cannot query in Vulkan, so
+                 * we'll need to keep around a buffer to handle this.
+                 * For now, just clear to 0. */
+                /* fall through */
+            default:
+                FIXME("Unsupported InfoType %u.\n", desc->InfoType);
+                VK_CALL(vkCmdFillBuffer(list->cmd.vk_command_buffer, vk_buffer, offset,
+                        sizeof(uint64_t), 0));
+                return;
+        }
     }
 
     if (!d3d12_command_allocator_allocate_query_from_type_index(list->allocator,
@@ -298,8 +325,16 @@ void vkd3d_opacity_micromap_write_postbuild_info(
         return;
     }
 
-    VK_CALL(vkCmdWriteMicromapsPropertiesEXT(list->cmd.vk_command_buffer,
-            1, &vk_opacity_micromap.ext, vk_query_type, vk_query_pool, vk_query_index));
+    if (list->device->device_info.using_khr_opacity_micromap)
+    {
+        VK_CALL(vkCmdWriteAccelerationStructuresPropertiesKHR(list->cmd.vk_command_buffer,
+                1, &vk_opacity_micromap.khr, vk_query_type, vk_query_pool, vk_query_index));
+    }
+    else
+    {
+        VK_CALL(vkCmdWriteMicromapsPropertiesEXT(list->cmd.vk_command_buffer,
+                1, &vk_opacity_micromap.ext, vk_query_type, vk_query_pool, vk_query_index));
+    }
     VK_CALL(vkCmdCopyQueryPoolResults(list->cmd.vk_command_buffer,
             vk_query_pool, vk_query_index, 1,
             vk_buffer, offset, stride,
@@ -328,10 +363,20 @@ void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
     memset(&barrier, 0, sizeof(barrier));
     barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
     barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    barrier.srcAccessMask = VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT;
-    /* The query accesses MICROMAP_READ_BIT in BUILD_BIT stage. */
-    barrier.dstStageMask = VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT | VK_PIPELINE_STAGE_2_COPY_BIT;
-    barrier.dstAccessMask = VK_ACCESS_2_MICROMAP_READ_BIT_EXT | VK_ACCESS_2_TRANSFER_WRITE_BIT;
+
+    if (list->device->device_info.using_khr_opacity_micromap)
+    {
+        barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
+        barrier.dstStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR | VK_PIPELINE_STAGE_2_COPY_BIT;
+        barrier.dstAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    }
+    else
+    {
+        barrier.srcAccessMask = VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT;
+        /* The query accesses MICROMAP_READ_BIT in BUILD_BIT stage. */
+        barrier.dstStageMask = VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT | VK_PIPELINE_STAGE_2_COPY_BIT;
+        barrier.dstAccessMask = VK_ACCESS_2_MICROMAP_READ_BIT_EXT | VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    }
 
     memset(&dep_info, 0, sizeof(dep_info));
     dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -21,7 +21,7 @@
 
 #define RT_TRACE TRACE
 
-static VkBuildMicromapFlagsEXT d3d12_build_flags_to_vk(
+static VkBuildMicromapFlagsEXT d3d12_build_flags_to_vk_ext(
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS flags)
 {
     VkBuildMicromapFlagsEXT vk_flags = 0;
@@ -32,6 +32,39 @@ static VkBuildMicromapFlagsEXT d3d12_build_flags_to_vk(
         vk_flags |= VK_BUILD_MICROMAP_PREFER_FAST_TRACE_BIT_EXT;
     if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD)
         vk_flags |= VK_BUILD_MICROMAP_PREFER_FAST_BUILD_BIT_EXT;
+
+    /* MINIMIZE_MEMORY dropped - No such EXT flag. No translation concern, worst case,
+     * excessive memory utilization. */
+
+    /* ALLOW_UPDATE intentionally dropped - VK_EXT_opacity_micromap has no
+     * UPDATE mode (VkBuildMicromapModeEXT only defines BUILD_EXT); micromaps
+     * cannot be incrementally updated, only rebuilt. */
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE)
+        FIXME_ONCE("ALLOW_UPDATE on opacity micromap build is unsupported by Vulkan; ignoring.\n");
+
+    return vk_flags;
+}
+
+static VkBuildAccelerationStructureFlagsKHR d3d12_build_flags_to_vk_khr(
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS flags)
+{
+    VkBuildAccelerationStructureFlagsKHR vk_flags = 0;
+
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR;
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_BUILD_BIT_KHR;
+
+    /* MINIMIZE_MEMORY dropped - VUID-11562 doesn't list LOW_MEMORY_BIT_KHR among
+     * the allowed bits for OPACITY_MICROMAP_KHR builds. No translation concern,
+     * worst case, excessive memory utilization. */
+
+    /* ALLOW_UPDATE intentionally dropped per VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-11562
+     * (OPACITY_MICROMAP_KHR builds may not include ALLOW_UPDATE). */
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE)
+        FIXME_ONCE("ALLOW_UPDATE on opacity micromap build is unsupported by Vulkan; ignoring.\n");
 
     return vk_flags;
 }
@@ -66,25 +99,13 @@ VKD3D_UNUSED static char const* debug_omm_format(
         (uint32_t)format);
 }
 
-bool vkd3d_opacity_micromap_convert_inputs(const struct d3d12_device *device,
-        const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *inputs,
-        VkMicromapBuildInfoEXT *build_info,
+static uint32_t vkd3d_opacity_micromap_convert_inputs_usages_ext(
+        const D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC *desc,
         VkMicromapUsageEXT *usages)
 {
-    const D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC *desc = inputs->pOpacityMicromapArrayDesc;
     const D3D12_RAYTRACING_OPACITY_MICROMAP_HISTOGRAM_ENTRY *histogram_entry;
     VkMicromapUsageEXT *usage;
     unsigned int i;
-
-    RT_TRACE("Converting inputs.\n");
-    RT_TRACE("=====================\n");
-
-    memset(build_info, 0, sizeof(*build_info));
-    build_info->sType = VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT;
-    build_info->type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
-    build_info->flags = d3d12_build_flags_to_vk(inputs->Flags);
-    build_info->mode = VK_BUILD_MICROMAP_MODE_BUILD_EXT;
-    build_info->usageCountsCount = desc->NumOmmHistogramEntries;
 
     for (i = 0; i < desc->NumOmmHistogramEntries; i++)
     {
@@ -101,11 +122,96 @@ bool vkd3d_opacity_micromap_convert_inputs(const struct d3d12_device *device,
         RT_TRACE("  Subdivision level: %u\n", histogram_entry->SubdivisionLevel);
         RT_TRACE("  Format: %s\n", debug_omm_format(histogram_entry->Format));
     }
+    return desc->NumOmmHistogramEntries;
+}
 
+static uint32_t vkd3d_opacity_micromap_convert_inputs_usages_khr(
+        const D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC *desc,
+        VkMicromapUsageKHR *usages)
+{
+    const D3D12_RAYTRACING_OPACITY_MICROMAP_HISTOGRAM_ENTRY *histogram_entry;
+    VkMicromapUsageKHR *usage;
+    unsigned int i;
+
+    for (i = 0; i < desc->NumOmmHistogramEntries; i++)
+    {
+        RT_TRACE(" Histogram entry %u:\n", i);
+
+        histogram_entry = &desc->pOmmHistogram[i];
+        usage = &usages[i];
+
+        usage->count = histogram_entry->Count;
+        usage->subdivisionLevel = histogram_entry->SubdivisionLevel;
+        usage->format = d3d12_format_to_vk(histogram_entry->Format);
+
+        RT_TRACE("  Count: %u\n", histogram_entry->Count);
+        RT_TRACE("  Subdivision level: %u\n", histogram_entry->SubdivisionLevel);
+        RT_TRACE("  Format: %s\n", debug_omm_format(histogram_entry->Format));
+    }
+    return desc->NumOmmHistogramEntries;
+}
+
+bool vkd3d_opacity_micromap_convert_inputs_ext(const struct d3d12_device *device,
+        const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *inputs,
+        VkMicromapBuildInfoEXT *build_info,
+        VkMicromapUsageEXT *usages)
+{
+    const D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC *desc = inputs->pOpacityMicromapArrayDesc;
+
+    RT_TRACE("Converting inputs.\n");
+    RT_TRACE("=====================\n");
+
+    memset(build_info, 0, sizeof(*build_info));
+    build_info->sType = VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT;
+    build_info->type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+    build_info->flags = d3d12_build_flags_to_vk_ext(inputs->Flags);
+    build_info->mode = VK_BUILD_MICROMAP_MODE_BUILD_EXT;
+    build_info->usageCountsCount = vkd3d_opacity_micromap_convert_inputs_usages_ext(desc, usages);
     build_info->pUsageCounts = usages;
     build_info->data.deviceAddress = desc->InputBuffer;
     build_info->triangleArray.deviceAddress = desc->PerOmmDescs.StartAddress;
     build_info->triangleArrayStride = desc->PerOmmDescs.StrideInBytes;
+
+    RT_TRACE(" IBO VA: %"PRIx64"\n", desc->InputBuffer);
+    RT_TRACE(" Triangles VA: %"PRIx64"\n", desc->PerOmmDescs.StartAddress);
+    RT_TRACE(" Triangles stride: %"PRIu64" bytes\n", desc->PerOmmDescs.StrideInBytes);
+
+    RT_TRACE("=====================\n");
+    return true;
+}
+
+bool vkd3d_opacity_micromap_convert_inputs_khr(const struct d3d12_device *device,
+        const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *inputs,
+        VkAccelerationStructureBuildGeometryInfoKHR *build_info,
+        VkAccelerationStructureGeometryKHR *geometry_info,
+        VkAccelerationStructureGeometryMicromapDataKHR *geometry_micromap_data,
+        VkMicromapUsageKHR *usages)
+{
+    const D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC *desc = inputs->pOpacityMicromapArrayDesc;
+
+    RT_TRACE("Converting inputs.\n");
+    RT_TRACE("=====================\n");
+
+    memset(build_info, 0, sizeof(*build_info));
+    build_info->sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+    build_info->type = VK_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_KHR;
+    build_info->flags = d3d12_build_flags_to_vk_khr(inputs->Flags);
+    build_info->mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+    build_info->geometryCount = 1;
+    build_info->pGeometries = geometry_info;
+
+    memset(geometry_info, 0, sizeof(*geometry_info));
+    geometry_info->sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+    geometry_info->geometryType = VK_GEOMETRY_TYPE_MICROMAP_KHR;
+    geometry_info->pNext = geometry_micromap_data;
+
+    memset(geometry_micromap_data, 0, sizeof(*geometry_micromap_data));
+    geometry_micromap_data->sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR;
+    geometry_micromap_data->usageCountsCount = vkd3d_opacity_micromap_convert_inputs_usages_khr(desc, usages);
+    geometry_micromap_data->pUsageCounts = usages;
+    geometry_micromap_data->data = desc->InputBuffer;
+    geometry_micromap_data->triangleArray = desc->PerOmmDescs.StartAddress;
+    geometry_micromap_data->triangleArrayStride = desc->PerOmmDescs.StrideInBytes;
 
     RT_TRACE(" IBO VA: %"PRIx64"\n", desc->InputBuffer);
     RT_TRACE(" Triangles VA: %"PRIx64"\n", desc->PerOmmDescs.StartAddress);

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -140,7 +140,7 @@ void vkd3d_opacity_micromap_write_postbuild_info(
         struct d3d12_command_list *list,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
         VkDeviceSize desc_offset,
-        VkMicromapEXT vk_opacity_micromap)
+        union vkd3d_opacity_micromap vk_opacity_micromap)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     const struct vkd3d_unique_resource *resource;
@@ -193,7 +193,7 @@ void vkd3d_opacity_micromap_write_postbuild_info(
     }
 
     VK_CALL(vkCmdWriteMicromapsPropertiesEXT(list->cmd.vk_command_buffer,
-            1, &vk_opacity_micromap, vk_query_type, vk_query_pool, vk_query_index));
+            1, &vk_opacity_micromap.ext, vk_query_type, vk_query_pool, vk_query_index));
     VK_CALL(vkCmdCopyQueryPoolResults(list->cmd.vk_command_buffer,
             vk_query_pool, vk_query_index, 1,
             vk_buffer, offset, stride,
@@ -209,7 +209,7 @@ void vkd3d_opacity_micromap_write_postbuild_info(
 void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
         struct d3d12_command_list *list, uint32_t count,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        VkMicromapEXT vk_opacity_micromap)
+        union vkd3d_opacity_micromap vk_opacity_micromap)
 {
     /* In D3D12 we are supposed to be able to emit without an explicit barrier,
      * but we need to emit them for Vulkan. */
@@ -260,15 +260,15 @@ static bool convert_copy_mode(
 
 void vkd3d_opacity_micromap_copy(
         struct d3d12_command_list *list,
-        D3D12_GPU_VIRTUAL_ADDRESS dst, VkMicromapEXT src_omm,
+        D3D12_GPU_VIRTUAL_ADDRESS dst, union vkd3d_opacity_micromap src_omm,
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    union vkd3d_opacity_micromap dst_omm;
     VkCopyMicromapInfoEXT info;
-    VkMicromapEXT dst_omm;
 
     dst_omm = vkd3d_va_map_place_opacity_micromap(&list->device->memory_allocator.va_map, list->device, dst);
-    if (dst_omm == VK_NULL_HANDLE)
+    if (dst_omm.any_handle == (uint64_t)VK_NULL_HANDLE)
     {
         ERR("Invalid dst address #%"PRIx64" for OMM copy.\n", dst);
         return;
@@ -276,8 +276,8 @@ void vkd3d_opacity_micromap_copy(
 
     info.sType = VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT;
     info.pNext = NULL;
-    info.dst = dst_omm;
-    info.src = src_omm;
+    info.dst = dst_omm.ext;
+    info.src = src_omm.ext;
     if (convert_copy_mode(mode, &info.mode))
         VK_CALL(vkCmdCopyMicromapEXT(list->cmd.vk_command_buffer, &info));
 }

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4863,7 +4863,7 @@ static void vkd3d_view_destroy(struct vkd3d_view *view, struct d3d12_device *dev
             break;
         case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP:
             if (view->info.buffer.rtas_is_micromap)
-                VK_CALL(vkDestroyMicromapEXT(device->vk_device, view->vk_micromap, NULL));
+                VK_CALL(vkDestroyMicromapEXT(device->vk_device, view->vk_micromap.ext, NULL));
             else
                 VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, view->vk_acceleration_structure, NULL));
             break;
@@ -5258,8 +5258,8 @@ bool vkd3d_create_opacity_micromap_view(struct d3d12_device *device, const struc
         struct vkd3d_view **view)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    union vkd3d_opacity_micromap vk_micromap;
     VkMicromapCreateInfoEXT create_info;
-    VkMicromapEXT vk_micromap;
     struct vkd3d_view *object;
     VkResult vr;
 
@@ -5272,13 +5272,13 @@ bool vkd3d_create_opacity_micromap_view(struct d3d12_device *device, const struc
     create_info.offset = desc->offset;
     create_info.size = desc->size;
 
-    vr = VK_CALL(vkCreateMicromapEXT(device->vk_device, &create_info, NULL, &vk_micromap));
+    vr = VK_CALL(vkCreateMicromapEXT(device->vk_device, &create_info, NULL, &vk_micromap.ext));
     if (vr != VK_SUCCESS)
         return false;
 
     if (!(object = vkd3d_view_create(VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP)))
     {
-        VK_CALL(vkDestroyMicromapEXT(device->vk_device, vk_micromap, NULL));
+        VK_CALL(vkDestroyMicromapEXT(device->vk_device, vk_micromap.ext, NULL));
         return false;
     }
 

--- a/libs/vkd3d/va_map.c
+++ b/libs/vkd3d/va_map.c
@@ -250,7 +250,7 @@ const struct vkd3d_unique_resource *vkd3d_va_map_deref(struct vkd3d_va_map *va_m
 void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
         struct d3d12_device *device, VkDeviceAddress va,
         VkAccelerationStructureKHR *acceleration_structure,
-        VkMicromapEXT *micromap)
+        union vkd3d_opacity_micromap *micromap)
 {
     const struct vkd3d_unique_resource *resource;
     struct vkd3d_view_map *view_map;
@@ -258,7 +258,7 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
     struct vkd3d_view_key key;
 
     *acceleration_structure = VK_NULL_HANDLE;
-    *micromap = VK_NULL_HANDLE;
+    micromap->any_handle = (uint64_t)VK_NULL_HANDLE;
 
     resource = vkd3d_va_map_deref(va_map, va);
     if (!resource || !resource->va)
@@ -278,7 +278,7 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
     view = vkd3d_view_map_get_view(view_map, device, &key);
     if (!view)
         return;
-    
+
     if (view->info.buffer.rtas_is_micromap)
         *micromap = view->vk_micromap;
     else
@@ -288,7 +288,7 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
 static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
         struct d3d12_device *device, VkDeviceAddress va, bool rtas_is_omm,
         VkAccelerationStructureKHR *acceleration_structure,
-        VkMicromapEXT *micromap)
+        union vkd3d_opacity_micromap *micromap)
 {
     struct vkd3d_unique_resource *resource;
     struct vkd3d_view_map *old_view_map;
@@ -297,7 +297,7 @@ static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
     struct vkd3d_view_key key;
 
     *acceleration_structure = VK_NULL_HANDLE;
-    *micromap = VK_NULL_HANDLE;
+    micromap->any_handle = (uint64_t)VK_NULL_HANDLE;
 
     resource = vkd3d_va_map_deref_mutable(va_map, va);
     if (!resource || !resource->va)
@@ -340,7 +340,7 @@ static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
     view = vkd3d_view_map_create_view2(view_map, device, &key, rtas_is_omm);
     if (!view)
         return;
-    
+
     if (view->info.buffer.rtas_is_micromap)
         *micromap = view->vk_micromap;
     else
@@ -352,22 +352,22 @@ VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3
         VkDeviceAddress va)
 {
     VkAccelerationStructureKHR acceleration_structure;
-    VkMicromapEXT micromap;
+    union vkd3d_opacity_micromap micromap;
 
     vkd3d_va_map_try_place_rtas(va_map, device, va, false, &acceleration_structure, &micromap);
 
-    if (micromap)
+    if (micromap.any_handle != (uint64_t)VK_NULL_HANDLE)
         FIXME("Attempted to place RTAS on VA #%"PRIx64" previously used by OMM.\n", va);
 
     return acceleration_structure;
 }
 
-VkMicromapEXT vkd3d_va_map_place_opacity_micromap(struct vkd3d_va_map *va_map,
+union vkd3d_opacity_micromap vkd3d_va_map_place_opacity_micromap(struct vkd3d_va_map *va_map,
         struct d3d12_device *device,
         VkDeviceAddress va)
 {
     VkAccelerationStructureKHR acceleration_structure;
-    VkMicromapEXT micromap;
+    union vkd3d_opacity_micromap micromap;
 
     vkd3d_va_map_try_place_rtas(va_map, device, va, true, &acceleration_structure, &micromap);
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3091,6 +3091,18 @@ struct d3d12_wbi_batch_state
     size_t batch_len;
 };
 
+union vkd3d_omm_build_info
+{
+    VkMicromapBuildInfoEXT *ext;
+    VkAccelerationStructureGeometryMicromapDataKHR *khr;
+};
+
+union vkd3d_omm_usage_info
+{
+    VkMicromapUsageEXT *ext;
+    VkMicromapUsageKHR *khr;
+};
+
 struct d3d12_rtas_batch_state
 {
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE build_type;
@@ -3112,11 +3124,11 @@ struct d3d12_rtas_batch_state
     const VkAccelerationStructureBuildRangeInfoKHR **range_ptrs;
     size_t range_ptr_size;
 
-    VkMicromapBuildInfoEXT *omm_build_infos;
+    union vkd3d_omm_build_info omm_build_infos;
     size_t omm_build_info_count;
     size_t omm_build_info_size;
 
-    VkMicromapUsageEXT *omm_usage_infos;
+    union vkd3d_omm_usage_info omm_usage_infos;
     size_t omm_usage_info_count;
     size_t omm_usage_info_size;
 };
@@ -6887,10 +6899,16 @@ void vkd3d_acceleration_structure_copy(
         D3D12_GPU_VIRTUAL_ADDRESS dst, VkAccelerationStructureKHR src_as,
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode);
 
-bool vkd3d_opacity_micromap_convert_inputs(const struct d3d12_device *device,
+bool vkd3d_opacity_micromap_convert_inputs_ext(const struct d3d12_device *device,
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *inputs,
         VkMicromapBuildInfoEXT *build_info,
         VkMicromapUsageEXT *usages);
+bool vkd3d_opacity_micromap_convert_inputs_khr(const struct d3d12_device *device,
+        const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *inputs,
+        VkAccelerationStructureBuildGeometryInfoKHR *build_info,
+        VkAccelerationStructureGeometryKHR *geometry_info,
+        VkAccelerationStructureGeometryMicromapDataKHR *geometry_micromap_data,
+        VkMicromapUsageKHR *usages);
 void vkd3d_opacity_micromap_write_postbuild_info(
         struct d3d12_command_list *list,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -373,17 +373,24 @@ struct vkd3d_va_map
     size_t small_entries_count;
 };
 
+union vkd3d_opacity_micromap
+{
+    uint64_t any_handle; /* Used to check if any union member is VK_NULL_HANDLE */
+    VkMicromapEXT ext;
+    VkAccelerationStructureKHR khr;
+};
+
 void vkd3d_va_map_insert(struct vkd3d_va_map *va_map, struct vkd3d_unique_resource *resource);
 void vkd3d_va_map_remove(struct vkd3d_va_map *va_map, const struct vkd3d_unique_resource *resource);
 const struct vkd3d_unique_resource *vkd3d_va_map_deref(struct vkd3d_va_map *va_map, VkDeviceAddress va);
 void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
         struct d3d12_device *device, VkDeviceAddress va,
         VkAccelerationStructureKHR *acceleration_structure,
-        VkMicromapEXT *micromap);
+        union vkd3d_opacity_micromap *micromap);
 VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3d_va_map *va_map,
         struct d3d12_device *device,
         VkDeviceAddress va);
-VkMicromapEXT vkd3d_va_map_place_opacity_micromap(struct vkd3d_va_map *va_map,
+union vkd3d_opacity_micromap vkd3d_va_map_place_opacity_micromap(struct vkd3d_va_map *va_map,
         struct d3d12_device *device,
         VkDeviceAddress va);
 void vkd3d_va_map_init(struct vkd3d_va_map *va_map);
@@ -1296,7 +1303,7 @@ struct vkd3d_view
         VkImageView vk_image_view;
         VkSampler vk_sampler;
         VkAccelerationStructureKHR vk_acceleration_structure;
-        VkMicromapEXT vk_micromap;
+        union vkd3d_opacity_micromap vk_micromap;
     };
     const struct vkd3d_format *format;
     union
@@ -6888,14 +6895,14 @@ void vkd3d_opacity_micromap_write_postbuild_info(
         struct d3d12_command_list *list,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
         VkDeviceSize desc_offset,
-        VkMicromapEXT vk_opacity_micromap);
+        union vkd3d_opacity_micromap vk_opacity_micromap);
 void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
         struct d3d12_command_list *list, uint32_t count,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        VkMicromapEXT vk_opacity_micromap);
+        union vkd3d_opacity_micromap vk_opacity_micromap);
 void vkd3d_opacity_micromap_copy(
         struct d3d12_command_list *list,
-        D3D12_GPU_VIRTUAL_ADDRESS dst, VkMicromapEXT src_omm,
+        D3D12_GPU_VIRTUAL_ADDRESS dst, union vkd3d_opacity_micromap src_omm,
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode);
 
 typedef enum D3D11_USAGE


### PR DESCRIPTION
The next phase. This phase may be the most contentious, as it establishes how I plan to rotate from EXT -> KHR OMM. There were two major paths that could have been taken, the first is to remove the EXT code and then rebuild the the KHR from the ground up. The second is to temporarly create the ability for both the KHR and the EXT code to live at the same time. The later has the advantage that the changes can be compared in an inline manner, so I preferred it.

The KHR path is plumbed but dormant — using_khr_opacity_micromap is force-cleared during physical-device init, so EXT remains the only active backend. A later PR flips it.