### PR TITLE
Descriptor heap - Phase 13

### DIFF
--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -316,6 +316,8 @@ static dxil_spv_bool dxil_remap(const struct vkd3d_dxil_remap_userdata *remap,
             /* Not relevant. */
             remap_info.descriptor_table_offset_words = 0;
             remap_info.num_root_descriptors = 0;
+            /* TODO: Remove this. */
+            remap_info.skip_heap_lowering = true;
             return dxil_remap_inner(&remap_info, descriptor_type, d3d_binding, vk_binding, resource_flags);
         }
         else

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -157,6 +157,7 @@ struct vkd3d_dxil_remap_info
     unsigned int min_ssbo_alignment;
     vkd3d_shader_quirks_t quirks;
     bool skip_heap_lowering;
+    bool local_root_signature;
 };
 
 static dxil_spv_bool dxil_remap_inner(
@@ -232,7 +233,11 @@ static dxil_spv_bool dxil_remap_inner(
                         !(binding->flags & VKD3D_SHADER_BINDING_FLAG_RAW_VA))
                     {
                         vk_binding->bindless.use_heap = DXIL_SPV_FALSE;
-                        vk_binding->set = VKD3D_SHADER_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE + binding->descriptor_table;
+                        if (remap->local_root_signature)
+                            vk_binding->set = VKD3D_SHADER_LOCAL_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE;
+                        else
+                            vk_binding->set = VKD3D_SHADER_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE;
+                        vk_binding->set += binding->descriptor_table;
                         vk_binding->binding = vk_binding->bindless.heap_root_offset;
                     }
                     else
@@ -303,6 +308,7 @@ static dxil_spv_bool dxil_remap(const struct vkd3d_dxil_remap_userdata *remap,
     remap_info.min_ssbo_alignment = shader_interface_info->min_ssbo_alignment;
     remap_info.quirks = remap->quirks;
     remap_info.skip_heap_lowering = remap->skip_heap_lowering;
+    remap_info.local_root_signature = false;
 
     if (!dxil_remap_inner(&remap_info, descriptor_type, d3d_binding, vk_binding, resource_flags))
     {
@@ -316,8 +322,16 @@ static dxil_spv_bool dxil_remap(const struct vkd3d_dxil_remap_userdata *remap,
             /* Not relevant. */
             remap_info.descriptor_table_offset_words = 0;
             remap_info.num_root_descriptors = 0;
-            /* TODO: Remove this. */
-            remap_info.skip_heap_lowering = true;
+            remap_info.local_root_signature = true;
+
+            /* For local table UAVs, we have to be conservative since we globally
+             * opted into legacy-style remapping. */
+            if (descriptor_type == VKD3D_SHADER_DESCRIPTOR_TYPE_UAV &&
+                shader_interface_info->raw_uav_counter_offset != 0)
+            {
+                remap_info.skip_heap_lowering = true;
+            }
+
             return dxil_remap_inner(&remap_info, descriptor_type, d3d_binding, vk_binding, resource_flags);
         }
         else
@@ -1652,8 +1666,10 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
     dxil_spv_converter converter = NULL;
     dxil_spv_parsed_blob blob = NULL;
     dxil_spv_compiled_spirv compiled;
+    bool root_desc_heap_lowering;
     vkd3d_shader_quirks_t quirks;
     unsigned int i, j, max_size;
+    bool table_heap_lowering;
     vkd3d_shader_hash_t hash;
     int ret = VKD3D_OK;
     void *code;
@@ -1721,6 +1737,12 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
         if (vkd3d_shader_binding_is_root_descriptor(&shader_interface_info->bindings[i]))
             num_root_descriptors++;
 
+    table_heap_lowering =
+            !!(shader_interface_info->flags & VKD3D_SHADER_INTERFACE_HEAP_LOWERING) &&
+            !(quirks & VKD3D_SHADER_QUIRK_DESCRIPTOR_HEAP_ROBUSTNESS);
+    root_desc_heap_lowering =
+            !!(shader_interface_info->flags & VKD3D_SHADER_INTERFACE_HEAP_LOWERING);
+
     /* Push local root parameters. We cannot rely on callbacks here
      * since the local root signature has a physical layout in ShaderRecordKHR
      * which needs to be precisely specified up front. */
@@ -1730,6 +1752,7 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
         switch (root_parameter->parameter_type)
         {
             case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
+                /* Always lower to shader record buffer for these. Concerns about OOB behavior on root CBVs. */
                 record_constant_buffer =
                         &shader_interface_local_info->shader_record_constant_buffers[root_parameter->constant.constant_index];
                 dxil_spv_converter_add_local_root_constants(converter,
@@ -1738,6 +1761,9 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
                 break;
 
             case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
+            {
+                bool has_entry = false;
+
                 if (dxil_spv_converter_begin_local_root_descriptor_table(converter) != DXIL_SPV_SUCCESS)
                 {
                     ret = VKD3D_ERROR_INVALID_ARGUMENT;
@@ -1748,6 +1774,20 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
                 {
                     dxil_spv_resource_class resource_class;
                     resource_binding = &root_parameter->descriptor_table.first_binding[j];
+
+                    if (resource_binding->type == VKD3D_SHADER_DESCRIPTOR_TYPE_UAV)
+                    {
+                        /* For bindless UAV counters we risk having to force lowering.
+                         * If that lowering means raw VA shenanigans, we have to force shader record
+                         * table path for all UAVs just in case. */
+                        if (table_heap_lowering && shader_interface_info->raw_uav_counter_offset == 0)
+                            continue;
+                    }
+                    else
+                    {
+                        if (table_heap_lowering)
+                            continue;
+                    }
 
                     switch (resource_binding->type)
                     {
@@ -1776,6 +1816,15 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
                             resource_class,
                             resource_binding->register_space, resource_binding->register_index,
                             resource_binding->register_count, resource_binding->descriptor_offset);
+
+                    has_entry = true;
+                }
+
+                if (!has_entry)
+                {
+                    /* Dummy parameters to make dxil-spirv happy. These are mapped with proper API elsewhere. */
+                    dxil_spv_converter_add_local_root_descriptor_table(converter,
+                            DXIL_SPV_RESOURCE_CLASS_UAV, UINT32_MAX, 0, 0, 0);
                 }
 
                 if (dxil_spv_converter_end_local_root_descriptor_table(converter) != DXIL_SPV_SUCCESS)
@@ -1784,23 +1833,51 @@ int vkd3d_shader_compile_dxil_export(const struct vkd3d_shader_code *dxil,
                     goto end;
                 }
                 break;
+            }
 
             case D3D12_ROOT_PARAMETER_TYPE_CBV:
-                dxil_spv_converter_add_local_root_descriptor(converter,
-                        DXIL_SPV_RESOURCE_CLASS_CBV, root_parameter->descriptor.binding->register_space,
-                        root_parameter->descriptor.binding->register_index);
+                if (root_desc_heap_lowering)
+                {
+                    /* Dummy parameters to make dxil-spirv happy. These are mapped with proper API elsewhere. */
+                    dxil_spv_converter_add_local_root_descriptor(converter,
+                            DXIL_SPV_RESOURCE_CLASS_SAMPLER, UINT32_MAX, UINT32_MAX);
+                }
+                else
+                {
+                    dxil_spv_converter_add_local_root_descriptor(converter,
+                            DXIL_SPV_RESOURCE_CLASS_CBV, root_parameter->descriptor.binding->register_space,
+                            root_parameter->descriptor.binding->register_index);
+                }
                 break;
 
             case D3D12_ROOT_PARAMETER_TYPE_SRV:
-                dxil_spv_converter_add_local_root_descriptor(converter,
-                        DXIL_SPV_RESOURCE_CLASS_SRV, root_parameter->descriptor.binding->register_space,
-                        root_parameter->descriptor.binding->register_index);
+                if (root_desc_heap_lowering && shader_interface_info->min_ssbo_alignment == 1)
+                {
+                    /* If we risk having to fallback to raw BDA due to alignment rules, we just force BDA path. */
+                    dxil_spv_converter_add_local_root_descriptor(converter,
+                            DXIL_SPV_RESOURCE_CLASS_SAMPLER, UINT32_MAX, UINT32_MAX);
+                }
+                else
+                {
+                    dxil_spv_converter_add_local_root_descriptor(converter,
+                            DXIL_SPV_RESOURCE_CLASS_SRV, root_parameter->descriptor.binding->register_space,
+                            root_parameter->descriptor.binding->register_index);
+                }
                 break;
 
             case D3D12_ROOT_PARAMETER_TYPE_UAV:
-                dxil_spv_converter_add_local_root_descriptor(converter,
-                        DXIL_SPV_RESOURCE_CLASS_UAV, root_parameter->descriptor.binding->register_space,
-                        root_parameter->descriptor.binding->register_index);
+                if (root_desc_heap_lowering && shader_interface_info->min_ssbo_alignment == 1)
+                {
+                    /* If we risk having to fallback to raw BDA due to alignment rules, we just force BDA path. */
+                    dxil_spv_converter_add_local_root_descriptor(converter,
+                            DXIL_SPV_RESOURCE_CLASS_SAMPLER, UINT32_MAX, UINT32_MAX);
+                }
+                else
+                {
+                    dxil_spv_converter_add_local_root_descriptor(converter,
+                            DXIL_SPV_RESOURCE_CLASS_UAV, root_parameter->descriptor.binding->register_space,
+                            root_parameter->descriptor.binding->register_index);
+                }
                 break;
 
             default:

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -1900,11 +1900,16 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
     VkPipelineLibraryCreateInfoKHR library_info;
     size_t local_static_sampler_bindings_count;
     size_t local_static_sampler_bindings_size;
+    VkPipelineCreateFlags2CreateInfo flags2;
     VkPipelineShaderStageCreateInfo *stage;
     uint32_t pgroup_offset, pstage_offset;
     unsigned int num_groups_to_export;
+    size_t scratch_allocs_count = 0;
+    size_t scratch_allocs_size = 0;
     struct vkd3d_shader_code spirv;
     struct vkd3d_shader_code dxil;
+    void **scratch_allocs = NULL;
+    bool creating_library;
     size_t i, j;
     VkResult vr;
     HRESULT hr;
@@ -1940,6 +1945,7 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
 
     shader_interface_info.descriptor_size_cbv_srv_uav = d3d12_device_get_descriptor_handle_increment_size(
             object->device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    shader_interface_info.raw_uav_counter_offset = object->device->bindless_state.heap.uav_counter_embedded_offset;
     shader_interface_info.descriptor_size_sampler = d3d12_device_get_descriptor_handle_increment_size(
             object->device, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
@@ -2032,7 +2038,7 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
             shader_interface_local_info.shader_record_constant_buffers = local_signature->root_constants;
             shader_interface_local_info.shader_record_buffer_count = local_signature->root_constant_count;
 
-            if (local_signature->static_sampler_count)
+            if (!d3d12_device_use_descriptor_heap(object->device) && local_signature->static_sampler_count)
             {
                 /* If we have static samplers, we need to add additional bindings. */
                 shader_interface_local_info.binding_count = local_signature->binding_count + local_signature->static_sampler_count;
@@ -2051,6 +2057,7 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
             }
             else
             {
+                /* Heap already bakes in static sampler binding information at root signature time. */
                 shader_interface_local_info.bindings = local_signature->bindings;
                 shader_interface_local_info.binding_count = local_signature->binding_count;
             }
@@ -2133,6 +2140,35 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
         stage->module = VK_NULL_HANDLE;
         stage->pName = "main";
         stage->pSpecializationInfo = NULL;
+
+        if (d3d12_device_use_descriptor_heap(object->device))
+        {
+            /* Need mapping structs. This is rather rare, so don't refactor a bunch of stuff
+             * to support inline append these mappings. */
+            struct d3d12_root_signature *empty_rs = NULL;
+            if (!per_entry_global_signature && local_signature)
+                if (FAILED(d3d12_root_signature_create_empty(object->device, &empty_rs)))
+                    return E_OUTOFMEMORY;
+
+            if (local_signature)
+            {
+                /* Need a fused mapping table. */
+                struct vkd3d_fused_root_signature_mappings *fused =
+                        d3d12_state_object_fuse_root_signature_mappings(
+                            empty_rs ? empty_rs : per_entry_global_signature, local_signature);
+                vk_prepend_struct(stage, &fused->mapping_info);
+                vkd3d_array_reserve((void **)&scratch_allocs, &scratch_allocs_size,
+                    scratch_allocs_count + 1, sizeof(*scratch_allocs));
+                scratch_allocs[scratch_allocs_count++] = fused;
+            }
+            else if (per_entry_global_signature)
+            {
+                stage->pNext = &per_entry_global_signature->heap.mapping_info;
+            }
+
+            if (empty_rs)
+                ID3D12RootSignature_Release(&empty_rs->ID3D12RootSignature_iface);
+        }
 
         memset(&dxil, 0, sizeof(dxil));
         memset(&spirv, 0, sizeof(spirv));
@@ -2376,7 +2412,8 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
         pstage_offset += collection_variant->stages_count;
     }
 
-    if (local_static_sampler_bindings_count)
+    /* Descriptor heaps deal with local root signature samplers entirely through mappings. */
+    if (!d3d12_device_use_descriptor_heap(object->device) && local_static_sampler_bindings_count)
     {
         uint64_t hash = hash_fnv1_init();
         hash = hash_fnv1_iterate_u32(hash, local_static_sampler_bindings_count);
@@ -2442,6 +2479,8 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
             continue;
 
         collection_variant = &child->pipelines[collection_variant_index];
+
+        /* All of this is irrelevant in descriptor heap since it's all layout-less. */
 
         if (collection_variant->local_static_sampler.pipeline_layout && !variant->local_static_sampler.pipeline_layout)
         {
@@ -2531,21 +2570,34 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
     dynamic_state.dynamicStateCount = 1;
     dynamic_state.pDynamicStates = dynamic_states;
 
-    if (d3d12_device_uses_descriptor_buffers(object->device))
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+    creating_library = !!(pipeline_create_info.flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR);
+
+    if (d3d12_device_use_descriptor_heap(object->device))
+    {
+        flags2.flags = pipeline_create_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+        pipeline_create_info.flags = 0;
+        vk_prepend_struct(&pipeline_create_info, &flags2);
+    }
+    else if (d3d12_device_uses_descriptor_buffers(object->device))
+    {
         pipeline_create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    }
 
     TRACE("Calling vkCreateRayTracingPipelinesKHR.\n");
 
     vr = VK_CALL(vkCreateRayTracingPipelinesKHR(object->device->vk_device, VK_NULL_HANDLE,
             VK_NULL_HANDLE, 1, &pipeline_create_info, NULL,
-            (pipeline_create_info.flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) ?
-                    &variant->pipeline_library : &variant->pipeline));
+            creating_library ? &variant->pipeline_library : &variant->pipeline));
 
     if (vr == VK_SUCCESS && (object->flags & D3D12_STATE_OBJECT_FLAG_ALLOW_STATE_OBJECT_ADDITIONS) &&
             object->type == D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE)
     {
         /* It is valid to inherit pipeline libraries into other pipeline libraries. */
         pipeline_create_info.flags &= ~VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
+        flags2.flags &= ~VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR;
+
         pipeline_create_info.pStages = NULL;
         pipeline_create_info.pGroups = NULL;
         pipeline_create_info.stageCount = 0;
@@ -2557,6 +2609,10 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
         vr = VK_CALL(vkCreateRayTracingPipelinesKHR(object->device->vk_device, VK_NULL_HANDLE,
                 VK_NULL_HANDLE, 1, &pipeline_create_info, NULL, &variant->pipeline));
     }
+
+    for (i = 0; i < scratch_allocs_count; i++)
+        vkd3d_free(scratch_allocs[i]);
+    vkd3d_free(scratch_allocs);
 
     TRACE("Completed vkCreateRayTracingPipelinesKHR.\n");
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -581,6 +581,11 @@ static HRESULT d3d12_root_signature_info_from_desc(struct d3d12_root_signature_i
         if (vkd3d_descriptor_debug_active_instruction_qa_checks())
             info->push_descriptor_count += 2;
     }
+    else if (d3d12_device_use_descriptor_heap(device))
+    {
+        /* We can bake bindings up front since it's all virtual. */
+        info->binding_count += desc->NumStaticSamplers;
+    }
 
     info->parameter_count = desc->NumParameters + info->hoist_descriptor_count;
     return S_OK;
@@ -870,6 +875,7 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
     struct vkd3d_shader_descriptor_table *table;
     unsigned int i, j, t, range_count;
     uint32_t range_descriptor_offset;
+    uint32_t local_table_offset = 0;
     bool local_root_signature;
     bool heap;
 
@@ -887,7 +893,15 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
     {
         const D3D12_ROOT_PARAMETER1 *p = &desc->pParameters[i];
         if (p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
+        {
+            if (p->ParameterType == D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS)
+                local_table_offset += p->Constants.Num32BitValues * sizeof(uint32_t);
+            else
+                local_table_offset = align(local_table_offset, sizeof(VkDeviceAddress)) + sizeof(VkDeviceAddress);
             continue;
+        }
+
+        local_table_offset = align(local_table_offset, sizeof(VkDeviceAddress));
 
         if (!local_root_signature)
             root_signature->descriptor_table_mask |= 1ull << i;
@@ -906,31 +920,54 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
         table->binding_count = 0;
         table->first_binding = &root_signature->bindings[context->binding_index];
 
-        /* TODO: Add local root signature support. */
-        if (heap && !local_root_signature)
+        if (heap)
         {
             VkDescriptorSetAndBindingMappingEXT *vk_mapping;
+            VkDescriptorMappingSourceEXT source;
+            uint32_t set_index;
 
             vkd3d_array_reserve((void **) &root_signature->heap.mappings,
                     &root_signature->heap.mappings_size,
                     root_signature->heap.mappings_count + 3,
                     sizeof(*root_signature->heap.mappings));
 
+            source = local_root_signature ?
+                    VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT :
+                    VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
+
+            set_index = local_root_signature ?
+                    VKD3D_SHADER_LOCAL_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE :
+                    VKD3D_SHADER_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE;
+            set_index += table->table_index;
+
             /* Sampler mappings. */
             vk_mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
             memset(vk_mapping, 0, sizeof(*vk_mapping));
             vk_mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
             vk_mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_SAMPLER_BIT_EXT;
-            vk_mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
-            vk_mapping->descriptorSet = VKD3D_SHADER_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE;
-            vk_mapping->descriptorSet += table->table_index;
+            vk_mapping->source = source;
+            vk_mapping->descriptorSet = set_index;
             vk_mapping->firstBinding = 0;
             vk_mapping->bindingCount = UINT32_MAX;
-            vk_mapping->sourceData.pushIndex.heapArrayStride = bindless_state->sampler_size;
-            vk_mapping->sourceData.pushIndex.heapIndexStride = bindless_state->sampler_size;
-            vk_mapping->sourceData.pushIndex.heapOffset = 0;
-            vk_mapping->sourceData.pushIndex.pushOffset =
-                    root_signature->descriptor_table_offset + table->table_index * sizeof(uint32_t);
+
+            if (local_root_signature)
+            {
+                vk_mapping->sourceData.shaderRecordIndex.heapArrayStride = bindless_state->sampler_size;
+                /* 1 is intentional. The SBT pointers are provided in terms of bytes.
+                 * The only requirement is that the final offset is aligned.
+                 * A stride of 1 is explicitly allowed by specification to support SBT cases like these. */
+                vk_mapping->sourceData.shaderRecordIndex.heapIndexStride = 1;
+                vk_mapping->sourceData.shaderRecordIndex.heapOffset = 0;
+                vk_mapping->sourceData.shaderRecordIndex.shaderRecordOffset = local_table_offset;
+            }
+            else
+            {
+                vk_mapping->sourceData.pushIndex.heapArrayStride = bindless_state->sampler_size;
+                vk_mapping->sourceData.pushIndex.heapIndexStride = bindless_state->sampler_size;
+                vk_mapping->sourceData.pushIndex.heapOffset = 0;
+                vk_mapping->sourceData.pushIndex.pushOffset =
+                        root_signature->descriptor_table_offset + table->table_index * sizeof(uint32_t);
+            }
 
             /* Image mappings */
             vk_mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
@@ -939,16 +976,26 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
             vk_mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_SAMPLED_IMAGE_BIT_EXT |
                     VK_SPIRV_RESOURCE_TYPE_READ_ONLY_IMAGE_BIT_EXT |
                     VK_SPIRV_RESOURCE_TYPE_READ_WRITE_IMAGE_BIT_EXT;
-            vk_mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
-            vk_mapping->descriptorSet = VKD3D_SHADER_TABLES_VIRTUAL_DESCRIPTOR_SET_BASE;
-            vk_mapping->descriptorSet += table->table_index;
+            vk_mapping->source = source;
+            vk_mapping->descriptorSet = set_index;
             vk_mapping->firstBinding = 0;
             vk_mapping->bindingCount = UINT32_MAX;
-            vk_mapping->sourceData.pushIndex.heapArrayStride = bindless_state->cbv_srv_uav_size;
-            vk_mapping->sourceData.pushIndex.heapIndexStride = bindless_state->cbv_srv_uav_size;
-            vk_mapping->sourceData.pushIndex.heapOffset = bindless_state->heap.redzone_size;
-            vk_mapping->sourceData.pushIndex.pushOffset =
-                    root_signature->descriptor_table_offset + table->table_index * sizeof(uint32_t);
+
+            if (local_root_signature)
+            {
+                vk_mapping->sourceData.shaderRecordIndex.heapArrayStride = bindless_state->cbv_srv_uav_size;
+                vk_mapping->sourceData.shaderRecordIndex.heapIndexStride = 1;
+                vk_mapping->sourceData.shaderRecordIndex.heapOffset = bindless_state->heap.redzone_size;
+                vk_mapping->sourceData.shaderRecordIndex.shaderRecordOffset = local_table_offset;
+            }
+            else
+            {
+                vk_mapping->sourceData.pushIndex.heapArrayStride = bindless_state->cbv_srv_uav_size;
+                vk_mapping->sourceData.pushIndex.heapIndexStride = bindless_state->cbv_srv_uav_size;
+                vk_mapping->sourceData.pushIndex.heapOffset = bindless_state->heap.redzone_size;
+                vk_mapping->sourceData.pushIndex.pushOffset =
+                        root_signature->descriptor_table_offset + table->table_index * sizeof(uint32_t);
+            }
 
             /* Raw buffer mappings */
             vk_mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
@@ -958,7 +1005,11 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
                     VK_SPIRV_RESOURCE_TYPE_READ_ONLY_STORAGE_BUFFER_BIT_EXT;
             if (d3d12_device_supports_ray_tracing_tier_1_0(root_signature->device))
                 vk_mapping->resourceMask |= VK_SPIRV_RESOURCE_TYPE_ACCELERATION_STRUCTURE_BIT_EXT;
-            vk_mapping->sourceData.pushIndex.heapOffset += bindless_state->packed_raw_buffer_offset;
+
+            if (local_root_signature)
+                vk_mapping->sourceData.shaderRecordIndex.heapOffset += bindless_state->packed_raw_buffer_offset;
+            else
+                vk_mapping->sourceData.pushIndex.heapOffset += bindless_state->packed_raw_buffer_offset;
         }
 
         for (j = 0; j < range_count; ++j)
@@ -1010,6 +1061,7 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
         }
 
         context->binding_index += table->binding_count;
+        local_table_offset += sizeof(VkDeviceAddress);
     }
 
     return S_OK;
@@ -1061,9 +1113,18 @@ static HRESULT d3d12_root_signature_init_shader_record_descriptors(
         const D3D12_ROOT_SIGNATURE_DESC2 *desc, const struct d3d12_root_signature_info *info,
         struct vkd3d_descriptor_set_context *context)
 {
+    bool heap = d3d12_device_use_descriptor_heap(root_signature->device);
+    VkDescriptorSetAndBindingMappingEXT *vk_mapping;
     struct vkd3d_shader_resource_binding *binding;
     struct vkd3d_shader_root_parameter *param;
+    uint32_t local_root_size = 0;
     unsigned int i;
+
+    if (heap)
+    {
+        context->vk_set = VKD3D_SHADER_LOCAL_ROOT_DESCRIPTORS_VIRTUAL_DESCRIPTOR_SET;
+        context->vk_binding = 0;
+    }
 
     for (i = 0; i < desc->NumParameters; ++i)
     {
@@ -1072,7 +1133,15 @@ static HRESULT d3d12_root_signature_init_shader_record_descriptors(
         if (p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_CBV
             && p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_SRV
             && p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_UAV)
+        {
+            if (p->ParameterType == D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS)
+                local_root_size += p->Constants.Num32BitValues * sizeof(uint32_t);
+            else
+                local_root_size = align(local_root_size, sizeof(VkDeviceAddress)) + sizeof(VkDeviceAddress);
             continue;
+        }
+
+        local_root_size = align(local_root_size, sizeof(VkDeviceAddress));
 
         binding = &root_signature->bindings[context->binding_index];
         binding->type = vkd3d_descriptor_type_from_d3d12_root_parameter_type(p->ParameterType);
@@ -1083,15 +1152,38 @@ static HRESULT d3d12_root_signature_init_shader_record_descriptors(
         binding->descriptor_offset = 0; /* ignored */
         binding->shader_visibility = vkd3d_shader_visibility_from_d3d12(p->ShaderVisibility);
         binding->flags = VKD3D_SHADER_BINDING_FLAG_BUFFER;
-        binding->binding.binding = 0; /* ignored */
-        binding->binding.set = 0; /* ignored */
+        binding->binding.binding = context->vk_binding; /* ignored unless heap */
+        binding->binding.set = context->vk_set; /* ignored unless heap */
         binding->flags |= VKD3D_SHADER_BINDING_FLAG_RAW_VA;
+
+        if (heap)
+        {
+            if (p->ParameterType != D3D12_ROOT_PARAMETER_TYPE_CBV)
+                binding->flags |= VKD3D_SHADER_BINDING_FLAG_RAW_SSBO;
+
+            vkd3d_array_reserve((void **)&root_signature->heap.mappings, &root_signature->heap.mappings_size,
+                    root_signature->heap.mappings_count + 1,
+                    sizeof(*root_signature->heap.mappings));
+
+            vk_mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+            memset(vk_mapping, 0, sizeof(*vk_mapping));
+            vk_mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+            vk_mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_ALL_EXT;
+            vk_mapping->descriptorSet = context->vk_set;
+            vk_mapping->firstBinding = context->vk_binding;
+            vk_mapping->bindingCount = 1;
+            vk_mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_ADDRESS_EXT;
+            vk_mapping->sourceData.pushAddressOffset = local_root_size;
+
+            context->vk_binding++;
+        }
 
         param = &root_signature->parameters[i];
         param->parameter_type = p->ParameterType;
         param->descriptor.binding = binding;
 
         context->binding_index++;
+        local_root_size += sizeof(VkDeviceAddress);
     }
 
     return S_OK;
@@ -1336,24 +1428,79 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
 }
 
 static HRESULT d3d12_root_signature_init_local_static_samplers(struct d3d12_root_signature *root_signature,
-        const D3D12_ROOT_SIGNATURE_DESC2 *desc)
+        const D3D12_ROOT_SIGNATURE_DESC2 *desc, struct vkd3d_descriptor_set_context *context)
 {
+    VkDescriptorSetAndBindingMappingEXT *vk_mapping;
+    struct vkd3d_shader_resource_binding *binding;
     unsigned int i;
     HRESULT hr;
+    bool heap;
 
     if (!desc->NumStaticSamplers)
         return S_OK;
 
+    heap = d3d12_device_use_descriptor_heap(root_signature->device);
+
+    if (heap)
+    {
+        context->vk_set = VKD3D_SHADER_STATIC_LOCAL_SAMPLERS_VIRTUAL_DESCRIPTOR_SET;
+        context->vk_binding = 0;
+
+        if (!vkd3d_array_reserve((void **)&root_signature->heap.mappings, &root_signature->heap.mappings_size,
+                root_signature->heap.mappings_count + desc->NumStaticSamplers,
+                sizeof(*root_signature->heap.mappings)))
+            return E_OUTOFMEMORY;
+
+        root_signature->heap.vk_static_samplers_desc = vkd3d_calloc(
+            desc->NumStaticSamplers, sizeof(*root_signature->heap.vk_static_samplers_desc));
+        if (!root_signature->heap.vk_static_samplers_desc)
+            return E_OUTOFMEMORY;
+    }
+
     for (i = 0; i < desc->NumStaticSamplers; i++)
     {
         const D3D12_STATIC_SAMPLER_DESC1 *s = &desc->pStaticSamplers[i];
-        if (FAILED(hr = vkd3d_sampler_state_create_static_sampler(&root_signature->device->sampler_state,
-                root_signature->device, s, &root_signature->static_samplers[i])))
-            return hr;
+
+        if (heap)
+        {
+            d3d12_setup_static_sampler_info(root_signature->device, s,
+                    &root_signature->heap.vk_static_samplers_desc[i]);
+
+            vk_mapping = &root_signature->heap.mappings[root_signature->heap.mappings_count++];
+            memset(vk_mapping, 0, sizeof(*vk_mapping));
+            vk_mapping->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+            vk_mapping->descriptorSet = context->vk_set;
+            vk_mapping->firstBinding = context->vk_binding;
+            vk_mapping->bindingCount = 1;
+            vk_mapping->resourceMask = VK_SPIRV_RESOURCE_TYPE_SAMPLER_BIT_EXT;
+            vk_mapping->source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+            vk_mapping->sourceData.constantOffset.pEmbeddedSampler = &root_signature->heap.vk_static_samplers_desc[i].desc;
+
+            binding = &root_signature->bindings[context->binding_index];
+            binding->type = VKD3D_SHADER_DESCRIPTOR_TYPE_SAMPLER;
+            binding->register_space = s->RegisterSpace;
+            binding->register_index = s->ShaderRegister;
+            binding->register_count = 1;
+            binding->descriptor_table = 0;  /* ignored */
+            binding->descriptor_offset = 0; /* ignored */
+            binding->shader_visibility = vkd3d_shader_visibility_from_d3d12(s->ShaderVisibility);
+            binding->flags = VKD3D_SHADER_BINDING_FLAG_IMAGE;
+            binding->binding.binding = context->vk_binding;
+            binding->binding.set = context->vk_set;
+
+            context->binding_index += 1;
+            context->vk_binding += 1;
+        }
+        else
+        {
+            /* Cannot assign bindings until we've seen all local root signatures which go into an RTPSO.
+             * For now, just copy the static samplers. RTPSO creation will build appropriate bindings. */
+            if (FAILED(hr = vkd3d_sampler_state_create_static_sampler(&root_signature->device->sampler_state,
+                    root_signature->device, s, &root_signature->static_samplers[i])))
+                return hr;
+        }
     }
 
-    /* Cannot assign bindings until we've seen all local root signatures which go into an RTPSO.
-     * For now, just copy the static samplers. RTPSO creation will build appropriate bindings. */
     memcpy(root_signature->static_samplers_desc, desc->pStaticSamplers,
             sizeof(*root_signature->static_samplers_desc) * desc->NumStaticSamplers);
 
@@ -1381,6 +1528,7 @@ static HRESULT d3d12_root_signature_init_static_samplers(struct d3d12_root_signa
     if (heap)
     {
         context->vk_set = VKD3D_SHADER_STATIC_SAMPLERS_VIRTUAL_DESCRIPTOR_SET;
+        context->vk_binding = 0;
 
         if (!vkd3d_array_reserve((void **)&root_signature->heap.mappings, &root_signature->heap.mappings_size,
                 root_signature->heap.mappings_count + desc->NumStaticSamplers,
@@ -1509,7 +1657,7 @@ static HRESULT d3d12_root_signature_init_local(struct d3d12_root_signature *root
             sizeof(*root_signature->static_samplers_desc))))
         return hr;
 
-    if (FAILED(hr = d3d12_root_signature_init_local_static_samplers(root_signature, desc)))
+    if (FAILED(hr = d3d12_root_signature_init_local_static_samplers(root_signature, desc, &context)))
         return hr;
 
     d3d12_root_signature_init_extra_bindings(root_signature, &info);
@@ -1677,10 +1825,6 @@ static HRESULT d3d12_root_signature_init_global_mappings(struct d3d12_root_signa
              * Slower, but it will always work. */
         }
     }
-
-    root_signature->heap.mapping_info.sType = VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT;
-    root_signature->heap.mapping_info.mappingCount = root_signature->heap.mappings_count;
-    root_signature->heap.mapping_info.pMappings = root_signature->heap.mappings;
 
     return S_OK;
 }
@@ -1992,6 +2136,10 @@ static HRESULT d3d12_root_signature_init(struct d3d12_root_signature *root_signa
     else
         hr = d3d12_root_signature_init_global(root_signature, device, desc);
 
+    root_signature->heap.mapping_info.sType = VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT;
+    root_signature->heap.mapping_info.mappingCount = root_signature->heap.mappings_count;
+    root_signature->heap.mapping_info.pMappings = root_signature->heap.mappings;
+
     if (FAILED(hr))
         goto fail;
 
@@ -2080,8 +2228,18 @@ static HRESULT d3d12_root_signature_create_from_blob(struct d3d12_device *device
     /* For pipeline libraries, (and later DXR to some degree), we need a way to
      * compare root signature objects. */
     object->pso_compatibility_hash = compatibility_hash;
-    object->layout_compatibility_hash = vkd3d_root_signature_v_1_2_compute_layout_compat_hash(
-            &root_signature_desc.vkd3d.v_1_2);
+
+    if (d3d12_device_use_descriptor_heap(device))
+    {
+        /* In descriptor heap there are no concerns with compatibility, since there is no pipeline layout.
+         * 0 is used as a sentinel for "no root signature", so just pick a different static hash value. */
+        object->layout_compatibility_hash = UINT64_MAX;
+    }
+    else
+    {
+        object->layout_compatibility_hash = vkd3d_root_signature_v_1_2_compute_layout_compat_hash(
+                &root_signature_desc.vkd3d.v_1_2);
+    }
 
     /* Inline the root signature blob inside the SPIR-V. */
     if (SUCCEEDED(hr) && !raw_payload &&

--- a/libs/vkd3d/state_object_common.c
+++ b/libs/vkd3d/state_object_common.c
@@ -217,4 +217,25 @@ const struct d3d12_state_object_association *d3d12_state_object_find_association
     return association;
 }
 
+struct vkd3d_fused_root_signature_mappings *d3d12_state_object_fuse_root_signature_mappings(
+    struct d3d12_root_signature *global, struct d3d12_root_signature *local)
+{
+    /* Need a fused mapping table. */
+    uint32_t num_mappings = global->heap.mapping_info.mappingCount + local->heap.mapping_info.mappingCount;
+    struct vkd3d_fused_root_signature_mappings *fused;
 
+    fused = vkd3d_calloc(1, offsetof(struct vkd3d_fused_root_signature_mappings, mappings) +
+            num_mappings * sizeof(VkDescriptorSetAndBindingMappingEXT));
+    fused->mapping_info.sType = VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT;
+    fused->mapping_info.mappingCount = num_mappings;
+    fused->mapping_info.pMappings = fused->mappings;
+
+    memcpy(fused->mappings, global->heap.mapping_info.pMappings,
+            global->heap.mapping_info.mappingCount * sizeof(*fused->mappings));
+
+    memcpy(fused->mappings + global->heap.mapping_info.mappingCount,
+            local->heap.mapping_info.pMappings,
+            local->heap.mapping_info.mappingCount * sizeof(*fused->mappings));
+
+    return fused;
+}

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -6307,6 +6307,15 @@ HRESULT d3d12_rt_state_object_add(struct d3d12_device *device, const D3D12_STATE
         struct d3d12_rt_state_object *parent,
         struct d3d12_rt_state_object **object);
 
+struct vkd3d_fused_root_signature_mappings
+{
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info;
+    VkDescriptorSetAndBindingMappingEXT mappings[];
+};
+
+struct vkd3d_fused_root_signature_mappings *d3d12_state_object_fuse_root_signature_mappings(
+        struct d3d12_root_signature *global, struct d3d12_root_signature *local);
+
 static inline struct d3d12_rt_state_object *rt_impl_from_ID3D12StateObject(ID3D12StateObject *iface)
 {
     return CONTAINING_RECORD(iface, struct d3d12_rt_state_object, ID3D12StateObject_iface);

--- a/tests/d3d12_raytracing.c
+++ b/tests/d3d12_raytracing.c
@@ -2491,9 +2491,10 @@ static void test_raytracing_local_rs_static_sampler_inner(bool use_libraries)
         rt_pso_factory_add_global_root_signature(&factory, global_rs);
         rt_pso_factory_add_dxil_library(&factory, get_static_sampler_rt_lib(), ARRAY_SIZE(export_descs), export_descs);
         rt_pso = rt_pso_factory_compile(&context, &factory, D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE);
-        /* Currently, we expect this to fail on vkd3d-proton since the local sampler sets definitions diverge
+        /* Without heap, we expect this to fail on vkd3d-proton since the local sampler sets definitions diverge
          * in the different collections. */
-        todo ok(!!rt_pso, "Failed to compile RTPSO.\n");
+        todo_if(!is_vk_device_extension_supported(context.context.device, "VK_EXT_descriptor_heap"))
+        ok(!!rt_pso, "Failed to compile RTPSO.\n");
         for (i = 0; i < 2; i++)
             ID3D12StateObject_Release(collections[i]);
 


### PR DESCRIPTION
Ray-tracing support.

The root signature setup is fairly straight forward and mirrors the global root sig setup with some minor differences that are commented.

Since we no longer have to faff around with local static sampler VkPipelineLayout compatibility shenanigans we fix a long-standing bug where certain valid D3D12 patterns now become implementable.