### PR TITLE
Descriptor heap - Phase 14

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -1191,7 +1191,8 @@ vkd3d_shader_quirks_t vkd3d_shader_compile_arguments_select_quirks(
         const struct vkd3d_shader_compile_arguments *args,
         vkd3d_shader_hash_t hash, const char *entry);
 
-uint64_t vkd3d_shader_get_revision(void);
+/* Also returns global shader quirks which are added through config files. */
+uint64_t vkd3d_shader_get_revision(vkd3d_shader_quirks_t *aux_quirks);
 
 int vkd3d_shader_parse_root_signature_v_1_0(const struct vkd3d_shader_code *dxbc,
         struct vkd3d_versioned_root_signature_desc *desc,

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -509,8 +509,9 @@ vkd3d_shader_quirks_t vkd3d_shader_compile_arguments_select_quirks(
         return quirks;
 }
 
-uint64_t vkd3d_shader_get_revision(void)
+uint64_t vkd3d_shader_get_revision(vkd3d_shader_quirks_t *aux_quirks)
 {
+    vkd3d_shader_quirks_t quirks = 0;
     uint64_t quirk_hash = 0;
     size_t i;
 
@@ -524,6 +525,7 @@ uint64_t vkd3d_shader_get_revision(void)
             quirk_hash = hash_fnv1_iterate_u64(quirk_hash, vkd3d_shader_quirk_entries[i].lo);
             quirk_hash = hash_fnv1_iterate_u64(quirk_hash, vkd3d_shader_quirk_entries[i].hi);
             quirk_hash = hash_fnv1_iterate_u64(quirk_hash, vkd3d_shader_quirk_entries[i].quirks);
+            quirks |= vkd3d_shader_quirk_entries[i].quirks;
         }
     }
 
@@ -531,6 +533,9 @@ uint64_t vkd3d_shader_get_revision(void)
      * Might get nuked later ...
      * It's not immediately useful for invalidating pipeline caches, since that would mostly be covered
      * by vkd3d-proton Git hash. */
+    if (aux_quirks)
+        *aux_quirks = quirks;
+
     return quirk_hash ^ 1;
 }
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -10576,6 +10576,15 @@ static void vkd3d_compute_shader_interface_key(struct d3d12_device *device)
         key = hash_fnv1_iterate_u32(key, device->bindless_state.heap.supports_universal_structured_ssbo);
         key = hash_fnv1_iterate_u32(key, device->bindless_state.heap.uav_counter_embedded_offset);
         key = hash_fnv1_iterate_u32(key, device->bindless_state.heap.min_ssbo_alignment);
+
+        /* We only get to know this very late after we've checked quirk override files and workaround setup. */
+        if (!d3d12_descriptor_heap_require_padding_descriptors(device) &&
+                !device->bindless_state.heap.uav_counter_embedded_offset)
+        {
+            INFO("Disabling heap redzone.\n");
+            device->bindless_state.heap.redzone_size = 0;
+        }
+
         key = hash_fnv1_iterate_u32(key, device->bindless_state.heap.redzone_size);
     }
     else

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -10565,7 +10565,7 @@ static void vkd3d_compute_shader_interface_key(struct d3d12_device *device)
     /* Technically, any changes in vkd3d-shader will be reflected in the vkd3d-proton Git hash,
      * but it is useful to be able to modify the internal revision while developing since
      * we have no mechanism for emitting dirty Git revisions. */
-    key = hash_fnv1_iterate_u64(key, vkd3d_shader_get_revision());
+    key = hash_fnv1_iterate_u64(key, vkd3d_shader_get_revision(NULL));
     key = hash_fnv1_iterate_u32(key, device->device_info.vulkan_1_3_properties.minSubgroupSize);
     key = hash_fnv1_iterate_u32(key, device->device_info.vulkan_1_3_properties.maxSubgroupSize);
     key = hash_fnv1_iterate_u32(key, device->bindless_state.flags);

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -10267,7 +10267,8 @@ void d3d12_descriptor_heap_cleanup(struct d3d12_descriptor_heap *descriptor_heap
 
 bool d3d12_descriptor_heap_require_padding_descriptors(struct d3d12_device *device)
 {
-    uint32_t quirks;
+    vkd3d_shader_quirks_t aux_quirks;
+    vkd3d_shader_quirks_t quirks;
     unsigned int i;
 
     if (vkd3d_descriptor_debug_active_descriptor_qa_checks())
@@ -10278,6 +10279,9 @@ bool d3d12_descriptor_heap_require_padding_descriptors(struct d3d12_device *devi
     quirks = device->workarounds.quirks.default_quirks | device->workarounds.quirks.global_quirks;
     for (i = 0; i < device->workarounds.quirks.num_entry_points; i++)
         quirks |= device->workarounds.quirks.entry_points[i].quirks;
+
+    vkd3d_shader_get_revision(&aux_quirks);
+    quirks |= aux_quirks;
     return !!(quirks & VKD3D_SHADER_QUIRK_DESCRIPTOR_HEAP_ROBUSTNESS);
 }
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -8175,6 +8175,11 @@ static HRESULT vkd3d_bindless_state_init_heap(struct vkd3d_bindless_state *bindl
     bindless_state->flags |= VKD3D_BINDLESS_MUTABLE_EMBEDDED | VKD3D_BINDLESS_HEAP | VKD3D_BINDLESS_RAW_SSBO |
             VKD3D_RAW_VA_ROOT_DESCRIPTOR_SRV_UAV | VKD3D_RAW_VA_ROOT_DESCRIPTOR_CBV;
 
+    INFO("VK_EXT_descriptor_heap enabled (%zu / %zu size, raw uav counter %s).\n",
+        bindless_state->cbv_srv_uav_size,
+        bindless_state->sampler_size,
+        (bindless_state->heap.uav_counter_embedded_offset ? "on" : "off"));
+
     return S_OK;
 }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5946,12 +5946,12 @@ static inline ULONG d3d12_device_release(struct d3d12_device *device)
     return refcount;
 }
 
-static inline bool d3d12_device_use_descriptor_heap(struct d3d12_device *device)
+static inline bool d3d12_device_use_descriptor_heap(const struct d3d12_device *device)
 {
     return (device->bindless_state.flags & VKD3D_BINDLESS_HEAP) != 0;
 }
 
-static inline bool d3d12_device_use_embedded_mutable_descriptors(struct d3d12_device *device)
+static inline bool d3d12_device_use_embedded_mutable_descriptors(const struct d3d12_device *device)
 {
     return (device->bindless_state.flags & VKD3D_BINDLESS_MUTABLE_EMBEDDED) != 0;
 }

--- a/tests/d3d12_descriptors.c
+++ b/tests/d3d12_descriptors.c
@@ -4742,6 +4742,7 @@ void test_undefined_descriptor_heap_mismatch_types(void)
     ID3D12Resource *buf;
     float float_value;
     unsigned int i, j;
+    bool heap;
 
 #include "shaders/descriptors/headers/undefined_descriptor_heap_mismatch_types_srv_raw.h"
 #include "shaders/descriptors/headers/undefined_descriptor_heap_mismatch_types_srv_tex.h"
@@ -4900,6 +4901,8 @@ void test_undefined_descriptor_heap_mismatch_types(void)
              is_vk_device_extension_supported(context.device, "VK_EXT_descriptor_heap")) &&
             ID3D12Device_GetDescriptorHandleIncrementSize(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV) == 32;
 
+    heap = is_vk_device_extension_supported(context.device, "VK_EXT_descriptor_heap");
+
     for (j = 0; j < TYPE_COUNT; j++)
     {
         for (i = 0; i < TYPE_COUNT; i++)
@@ -4943,6 +4946,12 @@ void test_undefined_descriptor_heap_mismatch_types(void)
                 else if ((access_type == SRV_RAW_BUFFER || access_type == UAV_RAW_BUFFER) && descriptor_type == CBV)
                 {
                     skip("Skipping CBV accessed as raw buffer on NVIDIA since it will hang GPU.\n");
+                    continue;
+                }
+
+                if (heap && access_type != descriptor_type && (access_type == CBV || descriptor_type == CBV))
+                {
+                    skip("Skipping CBV mismatch since it will hang GPU.\n");
                     continue;
                 }
             }

--- a/tests/d3d12_tests.h
+++ b/tests/d3d12_tests.h
@@ -303,7 +303,6 @@ decl_test(test_buffers_oob_behavior_vectorized_structured_16bit);
 decl_test(test_typed_buffers_many_objects_dxbc);
 decl_test(test_typed_buffers_many_objects_dxil);
 decl_test(test_create_pipeline_with_null_root_signature);
-decl_test(test_undefined_descriptor_heap_mismatch_types);
 decl_test(test_undefined_read_typed_buffer_as_untyped_simple_dxbc);
 decl_test(test_undefined_read_typed_buffer_as_untyped_simple_dxil);
 decl_test(test_undefined_structured_raw_alias_dxbc);


### PR DESCRIPTION
This is mostly a bunch of very minor cleanup commits that are not very hard to reason about.

The major thing here is that we can dynamically disable the heap redzone if nothing can possibly require extra meta descriptors. On RADV this is the common case unless descriptor heap robustness is enabled.