### PR TITLE
Descriptor heap - Phase 15/16

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -1053,6 +1053,8 @@ struct vkd3d_shader_node_input_push_signature
     VkDeviceAddress local_root_signature_bda;
     uint32_t node_payload_output_offset;
     uint32_t node_remaining_recursion_levels;
+    /* Used by heap path. */
+    VkDeviceAddress root_parameter_bda;
 };
 
 struct vkd3d_shader_node_input_data

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -9916,8 +9916,9 @@ bool d3d12_device_supports_workgraphs(const struct d3d12_device *device)
 {
     /* Thread nodes currently need wave32 to function correctly since the API limits for thread nodes
      * match wave32 expectations (8 nodes per thread * 32 threads = 256 max nodes). */
-    return (VKD3D_CONFIG_FLAG_IS_SET(ENABLE_EXPERIMENTAL_FEATURES) /* ||
-            vkd3d_debug_control_is_test_suite() */) &&
+    return (VKD3D_CONFIG_FLAG_IS_SET(ENABLE_EXPERIMENTAL_FEATURES) ||
+            vkd3d_debug_control_is_test_suite()) &&
+            d3d12_device_use_descriptor_heap(device) &&
             device->device_info.shader_maximal_reconvergence_features.shaderMaximalReconvergence &&
             device->device_info.vulkan_1_2_features.vulkanMemoryModel &&
             device->device_info.vulkan_1_3_features.subgroupSizeControl &&

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -8088,7 +8088,8 @@ static HRESULT vkd3d_bindless_state_init_heap(struct vkd3d_bindless_state *bindl
     if ((1u << minimum_unified_buffer_descriptor_size_log2) * ((1 << 20) - (1 << 15)) <=
         device->device_info.descriptor_heap_properties.maxResourceHeapSize)
     {
-        bindless_state->cbv_srv_uav_size_log2 = minimum_unified_buffer_descriptor_size_log2;
+        bindless_state->cbv_srv_uav_size_log2 =
+            max(minimum_unified_buffer_descriptor_size_log2, bindless_state->cbv_srv_uav_size_log2);
         unified_buffer_descriptor = true;
     }
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2054,69 +2054,6 @@ HRESULT d3d12_root_signature_create_local_static_samplers_layout(struct d3d12_ro
     return S_OK;
 }
 
-HRESULT d3d12_root_signature_create_work_graph_layout(struct d3d12_root_signature *root_signature,
-        VkDescriptorSetLayout *vk_push_set_layout, VkPipelineLayout *vk_pipeline_layout)
-{
-    VkDescriptorSetLayout set_layouts[VKD3D_MAX_DESCRIPTOR_SETS];
-    struct d3d12_bind_point_layout bind_point_layout;
-    VkDescriptorSetLayoutBinding binding;
-    VkPushConstantRange range;
-    bool uses_push_ubo;
-    HRESULT hr;
-
-    /* If we're already using push UBO block, we just need to modify the push range. */
-    /* TODO: Local sampler set. */
-    uses_push_ubo = !!(root_signature->compute.flags & VKD3D_ROOT_SIGNATURE_USE_PUSH_CONSTANT_UNIFORM_BLOCK);
-    range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    range.offset = 0;
-    range.size = sizeof(struct vkd3d_shader_node_input_push_signature);
-
-    if (root_signature->root_descriptor_push_mask)
-    {
-        FIXME("The root signature is already using push descriptors, cannot add another push descriptor set. Make sure to use VKD3D_CONFIG=force_raw_va_cbv on NVIDIA.\n");
-        return E_INVALIDARG;
-    }
-
-    if (uses_push_ubo || root_signature->compute.push_constant_range.size == 0)
-    {
-        if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
-                root_signature->device, root_signature->compute.num_set_layouts, root_signature->set_layouts,
-                &range, VK_SHADER_STAGE_COMPUTE_BIT, &bind_point_layout)))
-            return hr;
-
-        *vk_push_set_layout = VK_NULL_HANDLE;
-        *vk_pipeline_layout = bind_point_layout.vk_pipeline_layout;
-    }
-    else
-    {
-        binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        binding.descriptorCount = 1;
-        binding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-        binding.binding = 0;
-        binding.pImmutableSamplers = NULL;
-
-        memcpy(set_layouts, root_signature->set_layouts,
-                root_signature->compute.num_set_layouts * sizeof(VkDescriptorSetLayout));
-
-        if (FAILED(hr = vkd3d_create_descriptor_set_layout(
-                root_signature->device, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR,
-                1, &binding,
-                VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT, vk_push_set_layout)))
-            return hr;
-
-        set_layouts[root_signature->compute.num_set_layouts] = *vk_push_set_layout;
-
-        if (FAILED(hr = vkd3d_create_pipeline_layout_for_stage_mask(
-                root_signature->device, root_signature->compute.num_set_layouts + 1, set_layouts,
-                &range, VK_SHADER_STAGE_COMPUTE_BIT, &bind_point_layout)))
-            return hr;
-
-        *vk_pipeline_layout = bind_point_layout.vk_pipeline_layout;
-    }
-
-    return S_OK;
-}
-
 static HRESULT d3d12_root_signature_init(struct d3d12_root_signature *root_signature,
         struct d3d12_device *device, const D3D12_ROOT_SIGNATURE_DESC2 *desc)
 {

--- a/libs/vkd3d/state_object_common.c
+++ b/libs/vkd3d/state_object_common.c
@@ -239,3 +239,98 @@ struct vkd3d_fused_root_signature_mappings *d3d12_state_object_fuse_root_signatu
 
     return fused;
 }
+
+struct vkd3d_fused_root_signature_mappings *d3d12_state_object_build_workgraph_root_signature_mappings(
+        struct d3d12_root_signature *global, struct d3d12_root_signature *local)
+{
+    struct vkd3d_fused_root_signature_mappings *fused;
+    uint32_t num_mappings = 0;
+    uint32_t i;
+
+    if (global)
+        num_mappings += global->heap.mapping_info.mappingCount;
+    if (local)
+        num_mappings += local->heap.mapping_info.mappingCount;
+
+    fused = vkd3d_calloc(1, offsetof(struct vkd3d_fused_root_signature_mappings, mappings) +
+            num_mappings * sizeof(VkDescriptorSetAndBindingMappingEXT));
+    fused->mapping_info.sType = VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT;
+    fused->mapping_info.mappingCount = num_mappings;
+    fused->mapping_info.pMappings = fused->mappings;
+
+    if (global)
+    {
+        memcpy(fused->mappings,
+                global->heap.mapping_info.pMappings,
+                global->heap.mapping_info.mappingCount * sizeof(*fused->mappings));
+    }
+
+    if (local)
+    {
+        memcpy(fused->mappings + (global ? global->heap.mapping_info.mappingCount : 0),
+                local->heap.mapping_info.pMappings,
+                local->heap.mapping_info.mappingCount * sizeof(*fused->mappings));
+    }
+
+    /* Reroute to INDIRECT tokens instead. Gotta love how flexible this is :3 */
+    for (i = 0; i < num_mappings; i++)
+    {
+        VkDescriptorSetAndBindingMappingEXT tmp = fused->mappings[i];
+        switch (tmp.source)
+        {
+            case VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT:
+                fused->mappings[i].source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT;
+                fused->mappings[i].sourceData.pushAddressOffset =
+                        offsetof(struct vkd3d_shader_node_input_push_signature, root_parameter_bda);
+                break;
+
+            case VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT:
+                fused->mappings[i].source = VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT;
+                fused->mappings[i].sourceData.indirectAddress.pushOffset =
+                        offsetof(struct vkd3d_shader_node_input_push_signature, root_parameter_bda);
+                fused->mappings[i].sourceData.indirectAddress.addressOffset = tmp.sourceData.pushAddressOffset;
+                break;
+
+            case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT:
+                fused->mappings[i].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT;
+                memset(&fused->mappings[i].sourceData.indirectIndex, 0, sizeof(fused->mappings[i].sourceData.indirectIndex));
+                fused->mappings[i].sourceData.indirectIndex.pushOffset =
+                        offsetof(struct vkd3d_shader_node_input_push_signature, root_parameter_bda);
+                fused->mappings[i].sourceData.indirectIndex.heapOffset = tmp.sourceData.pushIndex.heapOffset;
+                fused->mappings[i].sourceData.indirectIndex.heapIndexStride = tmp.sourceData.pushIndex.heapIndexStride;
+                fused->mappings[i].sourceData.indirectIndex.heapArrayStride = tmp.sourceData.pushIndex.heapArrayStride;
+                fused->mappings[i].sourceData.indirectIndex.addressOffset = tmp.sourceData.pushIndex.pushOffset;
+                break;
+
+            case VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_DATA_EXT:
+                fused->mappings[i].source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT;
+                fused->mappings[i].sourceData.pushAddressOffset =
+                        offsetof(struct vkd3d_shader_node_input_push_signature, local_root_signature_bda);
+                if (tmp.sourceData.shaderRecordDataOffset != 0)
+                    FIXME("WorkGraph with SHADER_RECORD_DATA_EXT needs explicit local root signature lowering.\n");
+                break;
+
+            case VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_ADDRESS_EXT:
+                fused->mappings[i].source = VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT;
+                fused->mappings[i].sourceData.indirectAddress.pushOffset =
+                        offsetof(struct vkd3d_shader_node_input_push_signature, local_root_signature_bda);
+                fused->mappings[i].sourceData.indirectAddress.addressOffset = tmp.sourceData.pushAddressOffset;
+                break;
+
+            case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT:
+                fused->mappings[i].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT;
+                fused->mappings[i].sourceData.indirectIndex.pushOffset =
+                        offsetof(struct vkd3d_shader_node_input_push_signature, local_root_signature_bda);
+                fused->mappings[i].sourceData.indirectIndex.heapOffset = tmp.sourceData.shaderRecordIndex.heapOffset;
+                fused->mappings[i].sourceData.indirectIndex.heapIndexStride = tmp.sourceData.shaderRecordIndex.heapIndexStride;
+                fused->mappings[i].sourceData.indirectIndex.heapArrayStride = tmp.sourceData.shaderRecordIndex.heapArrayStride;
+                fused->mappings[i].sourceData.indirectIndex.addressOffset = tmp.sourceData.shaderRecordIndex.shaderRecordOffset;
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    return fused;
+}

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2061,8 +2061,6 @@ unsigned int d3d12_root_signature_get_shader_interface_flags(const struct d3d12_
         enum vkd3d_pipeline_type pipeline_type);
 HRESULT d3d12_root_signature_create_local_static_samplers_layout(struct d3d12_root_signature *root_signature,
         VkDescriptorSetLayout vk_set_layout, VkPipelineLayout *vk_pipeline_layout);
-HRESULT d3d12_root_signature_create_work_graph_layout(struct d3d12_root_signature *root_signature,
-        VkDescriptorSetLayout *vk_push_set_layout, VkPipelineLayout *vk_pipeline_layout);
 HRESULT vkd3d_create_pipeline_layout(struct d3d12_device *device,
         unsigned int set_layout_count, const VkDescriptorSetLayout *set_layouts,
         unsigned int push_constant_count, const VkPushConstantRange *push_constants,
@@ -6314,6 +6312,8 @@ struct vkd3d_fused_root_signature_mappings
 };
 
 struct vkd3d_fused_root_signature_mappings *d3d12_state_object_fuse_root_signature_mappings(
+        struct d3d12_root_signature *global, struct d3d12_root_signature *local);
+struct vkd3d_fused_root_signature_mappings *d3d12_state_object_build_workgraph_root_signature_mappings(
         struct d3d12_root_signature *global, struct d3d12_root_signature *local);
 
 static inline struct d3d12_rt_state_object *rt_impl_from_ID3D12StateObject(ID3D12StateObject *iface)

--- a/libs/vkd3d/workgraphs.c
+++ b/libs/vkd3d/workgraphs.c
@@ -144,10 +144,8 @@ struct d3d12_wg_state_object_program
 struct d3d12_wg_state_object_module
 {
     VkShaderModule vk_module;
-    VkDescriptorSetLayout vk_set_layout;
-    VkPipelineLayout vk_pipeline_layout;
     struct d3d12_root_signature *root_signature;
-    uint32_t push_set_index;
+    struct vkd3d_fused_root_signature_mappings *mappings;
 };
 
 struct d3d12_wg_state_object_data
@@ -1213,8 +1211,7 @@ static void d3d12_wg_state_object_cleanup(struct d3d12_wg_state_object *state_ob
     for (i = 0; i < state_object->modules_count; i++)
     {
         VK_CALL(vkDestroyShaderModule(state_object->device->vk_device, state_object->modules[i].vk_module, NULL));
-        VK_CALL(vkDestroyDescriptorSetLayout(state_object->device->vk_device, state_object->modules[i].vk_set_layout, NULL));
-        VK_CALL(vkDestroyPipelineLayout(state_object->device->vk_device, state_object->modules[i].vk_pipeline_layout, NULL));
+        vkd3d_free(state_object->modules[i].mappings);
         if (state_object->modules[i].root_signature)
             d3d12_root_signature_dec_ref(state_object->modules[i].root_signature);
     }
@@ -1772,6 +1769,7 @@ static HRESULT d3d12_wg_state_object_compile_pipeline(
     const struct vkd3d_vk_device_procs *vk_procs = &object->device->vk_procs;
     const struct vkd3d_shader_library_entry_point *entry;
     VkComputePipelineCreateInfo pipeline_info;
+    VkPipelineCreateFlags2CreateInfo flags2;
     VkSpecializationInfo spec_info;
     uint32_t spec_constant_index;
     bool is_broadcast;
@@ -1820,9 +1818,15 @@ static HRESULT d3d12_wg_state_object_compile_pipeline(
     vkd3d_array_reserve((void **)&tmp->map_entries, &tmp->map_entries_size, tmp->spec_data_count, sizeof(*tmp->map_entries));
 
     pipeline_info.stage.module = object->modules[entry_point_index].vk_module;
-    pipeline_info.layout = object->modules[entry_point_index].vk_pipeline_layout;
-    if (d3d12_device_uses_descriptor_buffers(object->device))
-        pipeline_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    if (object->modules[entry_point_index].mappings)
+        pipeline_info.stage.pNext = &object->modules[entry_point_index].mappings->mapping_info;
+
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+    flags2.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT | pipeline_info.flags;
+    pipeline_info.flags = 0;
+    vk_prepend_struct(&pipeline_info, &flags2);
+
     spec_info.pData = tmp->spec_data;
     spec_info.dataSize = tmp->spec_data_count * sizeof(uint32_t);
     spec_info.pMapEntries = tmp->map_entries;
@@ -2229,12 +2233,6 @@ static HRESULT d3d12_wg_state_object_convert_entry_point(
         d3d12_root_signature_inc_ref(module->root_signature = global_rs_assoc->root_signature);
     }
 
-    /* Create a modified pipeline layout which uses the work graph layout.
-     * It uses push constants for various metadata, and moves root parameters to push UBO. */
-    if (FAILED(hr = d3d12_root_signature_create_work_graph_layout(
-            module->root_signature, &module->vk_set_layout, &module->vk_pipeline_layout)))
-        return hr;
-
     if (module->root_signature)
     {
         struct d3d12_root_signature *rs = module->root_signature;
@@ -2255,19 +2253,11 @@ static HRESULT d3d12_wg_state_object_convert_entry_point(
         shader_interface_info.descriptor_qa_control_binding = &rs->descriptor_qa_control_binding;
 #endif
 
-        if (!(shader_interface_info.flags & VKD3D_ROOT_SIGNATURE_USE_PUSH_CONSTANT_UNIFORM_BLOCK))
-        {
-            push_ubo_binding.binding = 0;
-            push_ubo_binding.set = rs->compute.num_set_layouts;
-            shader_interface_info.push_constant_ubo_binding = &push_ubo_binding;
-            shader_interface_info.flags |= VKD3D_ROOT_SIGNATURE_USE_PUSH_CONSTANT_UNIFORM_BLOCK;
-        }
-
-        module->push_set_index = rs->compute.push_constant_range.size ? push_ubo_binding.set : UINT32_MAX;
-    }
-    else
-    {
-        module->push_set_index = UINT32_MAX;
+        /* We map the root parameters as a PUSH_ADDRESS_EXT. */
+        push_ubo_binding.set = VKD3D_SHADER_ROOT_CONSTANTS_VIRTUAL_DESCRIPTOR_SET;
+        push_ubo_binding.binding = 0;
+        shader_interface_info.push_constant_ubo_binding = &push_ubo_binding;
+        shader_interface_info.flags |= VKD3D_ROOT_SIGNATURE_USE_PUSH_CONSTANT_UNIFORM_BLOCK;
     }
 
     if (local_rs_assoc)
@@ -2277,20 +2267,29 @@ static HRESULT d3d12_wg_state_object_convert_entry_point(
         shader_interface_local_info.local_root_parameter_count = rs->parameter_count;
         shader_interface_local_info.shader_record_constant_buffers = rs->root_constants;
         shader_interface_local_info.shader_record_buffer_count = rs->root_constant_count;
-
-        if (rs->static_sampler_count)
-        {
-            FIXME("Static samplers not implemented yet.\n");
-            return E_NOTIMPL;
-        }
-
         shader_interface_local_info.bindings = rs->bindings;
         shader_interface_local_info.binding_count = rs->binding_count;
 
         /* Promote state which might only be active in local root signature. */
         shader_interface_info.flags |= d3d12_root_signature_get_shader_interface_flags(rs, VKD3D_PIPELINE_TYPE_COMPUTE);
-        if (rs->compute.flags & (VKD3D_ROOT_SIGNATURE_USE_SSBO_OFFSET_BUFFER | VKD3D_ROOT_SIGNATURE_USE_TYPED_OFFSET_BUFFER))
-            shader_interface_info.offset_buffer_binding = &rs->offset_buffer_binding;
+    }
+
+    /* Just fallback to normal heap descriptor if needed. */
+    shader_interface_info.flags &= ~VKD3D_SHADER_INTERFACE_INLINE_REDZONE_CBV;
+
+    if (module->root_signature)
+    {
+        module->mappings = d3d12_state_object_build_workgraph_root_signature_mappings(module->root_signature,
+            local_rs_assoc ? local_rs_assoc->root_signature : NULL);
+    }
+    else if (local_rs_assoc)
+    {
+        module->mappings = d3d12_state_object_build_workgraph_root_signature_mappings(NULL,
+            local_rs_assoc->root_signature);
+    }
+    else
+    {
+        module->mappings = NULL;
     }
 
     memset(&dxil, 0, sizeof(dxil));
@@ -2572,73 +2571,6 @@ void d3d12_command_list_workgraph_initialize_scratch(struct d3d12_command_list *
     d3d12_command_list_debug_mark_end_region(list);
 }
 
-static void d3d12_command_list_workgraph_bind_resources(struct d3d12_command_list *list,
-        const struct d3d12_wg_state_object *state,
-        const struct d3d12_wg_state_object_program *program,
-        const struct d3d12_wg_state_object_module *module,
-        VkBuffer vk_root_parameter_buffer, VkDeviceSize vk_root_parameter_buffer_offset)
-{
-    const struct vkd3d_bindless_state *bindless_state = &list->device->bindless_state;
-    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
-    VkDescriptorBufferInfo buffer_info;
-    VkWriteDescriptorSet write;
-    unsigned int i;
-
-    if (d3d12_device_uses_descriptor_buffers(list->device))
-    {
-        VK_CALL(vkCmdSetDescriptorBufferOffsetsEXT(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                module->vk_pipeline_layout, 0, bindless_state->legacy.set_count,
-                bindless_state->legacy.vk_descriptor_buffer_indices,
-                list->descriptor_heap.buffers.db.vk_offsets));
-    }
-    else
-    {
-        for (i = 0; i < bindless_state->legacy.set_count; i++)
-        {
-            if (list->descriptor_heap.sets.vk_sets[i])
-            {
-                VK_CALL(vkCmdBindDescriptorSets(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                        module->vk_pipeline_layout, i, 1,
-                        &list->descriptor_heap.sets.vk_sets[i], 0, NULL));
-            }
-        }
-    }
-
-    if (module->push_set_index != UINT32_MAX)
-    {
-        memset(&write, 0, sizeof(write));
-        write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        write.descriptorCount = 1;
-        write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        write.pBufferInfo = &buffer_info;
-
-        buffer_info.offset = vk_root_parameter_buffer_offset;
-        buffer_info.buffer = vk_root_parameter_buffer;
-        buffer_info.range = sizeof(union vkd3d_root_parameter_data);
-
-        VK_CALL(vkCmdPushDescriptorSetKHR(list->cmd.vk_command_buffer,
-                VK_PIPELINE_BIND_POINT_COMPUTE, module->vk_pipeline_layout, module->push_set_index, 1, &write));
-    }
-
-    if (module->root_signature)
-    {
-        if (module->root_signature->vk_sampler_set)
-        {
-            VK_CALL(vkCmdBindDescriptorSets(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                    module->vk_pipeline_layout,
-                    module->root_signature->sampler_descriptor_set,
-                    1, &module->root_signature->vk_sampler_set, 0, NULL));
-        }
-        else if (module->root_signature->vk_sampler_descriptor_layout)
-        {
-            VK_CALL(vkCmdBindDescriptorBufferEmbeddedSamplersEXT(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                    module->vk_pipeline_layout, module->root_signature->sampler_descriptor_set));
-        }
-    }
-
-    /* TODO: Bind local sampler set. */
-}
-
 static unsigned int d3d12_command_list_workgraph_remaining_levels(
         const struct d3d12_wg_state_object_program *program,
         unsigned int level,
@@ -2676,23 +2608,21 @@ static void d3d12_command_list_workgraph_execute_node_cpu_entry(struct d3d12_com
         const struct d3d12_wg_state_object_program *program,
         uint32_t node_index, const D3D12_NODE_CPU_INPUT *desc,
         VkDeviceAddress output_payload, VkDeviceAddress input_payload,
-        VkBuffer vk_root_parameter_buffer, VkDeviceSize vk_root_parameter_buffer_offset)
+        VkDeviceAddress vk_root_parameter_buffer_va)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     const struct vkd3d_shader_node_input_data *node_input;
     struct vkd3d_shader_node_input_push_signature push;
     struct vkd3d_scratch_allocation offset_scratch;
-    VkPipelineLayout vk_layout;
+    VkPushDataInfoEXT push_info;
     uint32_t table_index;
 
     memset(&push, 0, sizeof(push));
-    vk_layout = state->modules[node_index].vk_pipeline_layout;
 
     /* Just rebind resources every time. We have to execute intermediate shaders anyway,
      * which clobbers all descriptor state. */
-    d3d12_command_list_workgraph_bind_resources(list, state, program,
-            &state->modules[node_index],
-            vk_root_parameter_buffer, vk_root_parameter_buffer_offset);
+    d3d12_command_list_update_global_descriptor_heap(list);
+    push.root_parameter_bda = vk_root_parameter_buffer_va;
 
     node_input = state->entry_points[node_index].node_input;
 
@@ -2729,9 +2659,12 @@ static void d3d12_command_list_workgraph_execute_node_cpu_entry(struct d3d12_com
             program->pipelines[node_index].vk_static_cpu_node_entry_pipeline :
             program->pipelines[node_index].vk_cpu_node_entry_pipeline));
 
-    VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
-            vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
-            0, sizeof(push), &push));
+    memset(&push_info, 0, sizeof(push_info));
+    push_info.sType = VK_STRUCTURE_TYPE_PUSH_DATA_INFO_EXT;
+    push_info.data.address = &push;
+    push_info.data.size = sizeof(push);
+    push_info.offset = 0;
+    VK_CALL(vkCmdPushDataEXT(list->cmd.vk_command_buffer, &push_info));
 
     if (desc->NumRecords == 1 && node_input->launch_type == VKD3D_SHADER_NODE_LAUNCH_TYPE_BROADCASTING)
     {
@@ -2843,10 +2776,7 @@ static void d3d12_command_list_workgraph_execute_node_cpu_entry(struct d3d12_com
             VK_CALL(vkCmdDispatch(list->cmd.vk_command_buffer, WG_DIVIDER, num_wgs_x / WG_DIVIDER, amplification));
 
         push.node_linear_offset_bda += sizeof(uint32_t);
-        VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
-                vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
-                offsetof(struct vkd3d_shader_node_input_push_signature, node_linear_offset_bda),
-                sizeof(uint32_t), &push.node_linear_offset_bda));
+        VK_CALL(vkCmdPushDataEXT(list->cmd.vk_command_buffer, &push_info));
 
         /* Secondary offset */
         if (num_wgs_x % WG_DIVIDER)
@@ -2873,10 +2803,7 @@ static void d3d12_command_list_workgraph_execute_node_cpu_entry(struct d3d12_com
             VK_CALL(vkCmdDispatch(list->cmd.vk_command_buffer, WG_DIVIDER, num_wgs_x / WG_DIVIDER, 1));
 
         push.node_linear_offset_bda += sizeof(uint32_t);
-        VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
-                vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
-                offsetof(struct vkd3d_shader_node_input_push_signature, node_linear_offset_bda),
-                sizeof(uint32_t), &push.node_linear_offset_bda));
+        VK_CALL(vkCmdPushDataEXT(list->cmd.vk_command_buffer, &push_info));
 
         /* Secondary offset */
         if (num_wgs_x % WG_DIVIDER)
@@ -2931,9 +2858,9 @@ static void d3d12_command_list_emit_distribute_workgroups(struct d3d12_command_l
     args.node_share_mapping_va = program->share_mapping_scratch_offset + list->wg_state.BackingMemory.StartAddress;
     args.num_nodes = state->entry_points_count;
 
-    VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
+    d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
             program->workgroup_distributor.vk_pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT,
-            0, sizeof(args), &args));
+            sizeof(args), &args);
 
     if (list->device->vk_info.EXT_debug_utils)
         d3d12_command_list_debug_mark_label(list, "Distribute Work Groups", 1.0f, 0.8f, 0.8f, 1.0f);
@@ -2972,10 +2899,10 @@ static void d3d12_command_list_emit_distribute_payload_offsets(struct d3d12_comm
     args.unrolled_offsets = state->unrolled_offsets.va;
     args.packed_offset_counts = list->wg_state.BackingMemory.StartAddress + program->required_scratch_size;
 
-    VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
+    d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
             program->payload_offset_expander.vk_pipeline_layout,
             VK_SHADER_STAGE_COMPUTE_BIT,
-            0, sizeof(args), &args));
+            sizeof(args), &args);
 
     if (list->device->vk_info.EXT_debug_utils)
     {
@@ -3006,10 +2933,10 @@ static void d3d12_command_list_emit_distribute_payload_offsets(struct d3d12_comm
         VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                 program->complete_compaction.vk_pipeline));
 
-        VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
+        d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
                 program->complete_compaction.vk_pipeline_layout,
                 VK_SHADER_STAGE_COMPUTE_BIT,
-                0, sizeof(complete_args), &complete_args));
+                sizeof(complete_args), &complete_args);
 
         wgx = complete_args.node_count;
         wgx = align(complete_args.node_count, vkd3d_meta_get_workgraph_complete_compaction_workgroup_size()) /
@@ -3041,7 +2968,7 @@ static void d3d12_command_list_workgraph_execute_node_gpu(
         const struct d3d12_wg_state_object_program *program,
         D3D12_GPU_VIRTUAL_ADDRESS output_va, D3D12_GPU_VIRTUAL_ADDRESS input_va,
         unsigned int level, unsigned int node_index, const struct vkd3d_scratch_allocation *indirect_scratch,
-        VkBuffer vk_root_parameter_buffer, VkDeviceSize vk_root_parameter_buffer_offset)
+        VkDeviceAddress vk_root_parameter_buffer_va)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     const struct vkd3d_shader_node_input_data *node_input;
@@ -3050,19 +2977,17 @@ static void d3d12_command_list_workgraph_execute_node_gpu(
     VkDeviceAddress primary_linear_offset_bda;
     VkDeviceSize vk_secondary_indirect_offset;
     VkDeviceSize vk_primary_indirect_offset;
+    VkPushDataInfoEXT push_info;
     VkBuffer vk_indirect_buffer;
-    VkPipelineLayout vk_layout;
     unsigned int table_index;
 
     memset(&push, 0, sizeof(push));
-    vk_layout = state->modules[node_index].vk_pipeline_layout;
     node_input = state->entry_points[node_index].node_input;
 
     /* Just rebind resources every time. We have to execute intermediate shaders anyway,
      * which clobbers all descriptor state. */
-    d3d12_command_list_workgraph_bind_resources(list, state, program,
-            &state->modules[node_index],
-            vk_root_parameter_buffer, vk_root_parameter_buffer_offset);
+    d3d12_command_list_update_global_descriptor_heap(list);
+    push.root_parameter_bda = vk_root_parameter_buffer_va;
 
     push.node_payload_output_bda = output_va;
     push.node_remaining_recursion_levels = d3d12_command_list_workgraph_remaining_levels(program, level, node_index);
@@ -3137,9 +3062,13 @@ static void d3d12_command_list_workgraph_execute_node_gpu(
     }
 
     push.node_linear_offset_bda = primary_linear_offset_bda;
-    VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
-            vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
-            0, sizeof(push), &push));
+
+    memset(&push_info, 0, sizeof(push_info));
+    push_info.sType = VK_STRUCTURE_TYPE_PUSH_DATA_INFO_EXT;
+    push_info.data.address = &push;
+    push_info.data.size = sizeof(push);
+    push_info.offset = 0;
+    VK_CALL(vkCmdPushDataEXT(list->cmd.vk_command_buffer, &push_info));
 
     if (list->device->vk_info.EXT_debug_utils)
     {
@@ -3149,20 +3078,10 @@ static void d3d12_command_list_workgraph_execute_node_gpu(
     }
 
     if (d3d12_wg_requires_primary_execution(state))
-    {
-        VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
-                vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
-                offsetof(struct vkd3d_shader_node_input_push_signature, node_linear_offset_bda),
-                sizeof(VkDeviceAddress), &push.node_linear_offset_bda));
-
         VK_CALL(vkCmdDispatchIndirect(list->cmd.vk_command_buffer, vk_indirect_buffer, vk_primary_indirect_offset));
-    }
 
     push.node_linear_offset_bda = secondary_linear_offset_bda;
-    VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer,
-            vk_layout, VK_SHADER_STAGE_COMPUTE_BIT,
-            offsetof(struct vkd3d_shader_node_input_push_signature, node_linear_offset_bda),
-            sizeof(VkDeviceAddress), &push.node_linear_offset_bda));
+    VK_CALL(vkCmdPushDataEXT(list->cmd.vk_command_buffer, &push_info));
 
     VK_CALL(vkCmdDispatchIndirect(list->cmd.vk_command_buffer, vk_indirect_buffer, vk_secondary_indirect_offset));
 
@@ -3177,7 +3096,7 @@ static void d3d12_command_list_workgraph_execute_level(struct d3d12_command_list
         const struct d3d12_wg_state_object *state,
         const struct d3d12_wg_state_object_program *program,
         uint32_t level, VkDeviceAddress output_payload, VkDeviceAddress input_payload,
-        VkBuffer vk_root_parameter_buffer, VkDeviceSize vk_root_parameter_buffer_offset)
+        VkDeviceAddress vk_root_parameter_buffer_va)
 {
     uint32_t i;
 
@@ -3189,7 +3108,7 @@ static void d3d12_command_list_workgraph_execute_level(struct d3d12_command_list
     {
         d3d12_command_list_workgraph_execute_node_gpu(list, state, program,
                 output_payload, input_payload, level, program->levels[level].nodes[i], NULL,
-                vk_root_parameter_buffer, vk_root_parameter_buffer_offset);
+                vk_root_parameter_buffer_va);
     }
 
     /* Execute shared nodes. Distribute workgroups already handled the mapping. */
@@ -3197,7 +3116,7 @@ static void d3d12_command_list_workgraph_execute_level(struct d3d12_command_list
     {
         d3d12_command_list_workgraph_execute_node_gpu(list, state, program,
                 output_payload, input_payload, level, program->levels[level].shared_nodes[i].node_pipeline_index, NULL,
-                vk_root_parameter_buffer, vk_root_parameter_buffer_offset);
+                vk_root_parameter_buffer_va);
     }
 }
 
@@ -3281,8 +3200,11 @@ static bool d3d12_command_list_workgraph_setup_indirect(
     args.entry_point_mapping_va = entry_scratch.va;
     args.num_entry_points = program->num_pipelines;
 
-    VK_CALL(vkCmdPushConstants(list->cmd.vk_command_buffer, program->gpu_input_setup.vk_pipeline_layout,
-            VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(args), &args));
+    d3d12_command_list_meta_push_data(list, list->cmd.vk_command_buffer,
+            program->gpu_input_setup.vk_pipeline_layout,
+            VK_SHADER_STAGE_COMPUTE_BIT,
+            sizeof(args), &args);
+
     VK_CALL(vkCmdBindPipeline(list->cmd.vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, program->gpu_input_setup.vk_pipeline));
 
     num_wgs = align(args.num_entry_points, vkd3d_meta_get_workgraph_setup_gpu_input_workgroup_size()) /
@@ -3315,7 +3237,7 @@ static bool d3d12_command_list_workgraph_setup_indirect(
 static void d3d12_command_list_workgraph_execute_entry_gpu(
         struct d3d12_command_list *list, struct d3d12_wg_state_object *state,
         const struct d3d12_wg_state_object_program *program, D3D12_GPU_VIRTUAL_ADDRESS va,
-        VkBuffer vk_root_param_buffer, VkDeviceSize vk_root_param_offset)
+        VkDeviceAddress vk_root_param_buffer_va)
 {
     struct vkd3d_scratch_allocation indirect_scratch;
     unsigned int i;
@@ -3331,7 +3253,7 @@ static void d3d12_command_list_workgraph_execute_entry_gpu(
     {
         d3d12_command_list_workgraph_execute_node_gpu(
                 list, state, program, state->payload[0].va, va, 0, program->levels[0].nodes[i],
-                &indirect_scratch, vk_root_param_buffer, vk_root_param_offset);
+                &indirect_scratch, vk_root_param_buffer_va);
     }
 
     /* Execute shared nodes. Indirect setup already covered for us. */
@@ -3339,14 +3261,14 @@ static void d3d12_command_list_workgraph_execute_entry_gpu(
     {
         d3d12_command_list_workgraph_execute_node_gpu(
                 list, state, program, state->payload[0].va, va, 0, program->levels[0].shared_nodes[i].node_pipeline_index,
-                &indirect_scratch, vk_root_param_buffer, vk_root_param_offset);
+                &indirect_scratch, vk_root_param_buffer_va);
     }
 }
 
 static void d3d12_command_list_workgraph_execute_entry_cpu(
         struct d3d12_command_list *list, struct d3d12_wg_state_object *wg_state,
         const struct d3d12_wg_state_object_program *program, const D3D12_NODE_CPU_INPUT *desc,
-        VkBuffer vk_root_param_buffer, VkDeviceSize vk_root_param_offset)
+        VkDeviceAddress vk_root_param_buffer_va)
 {
     struct vkd3d_scratch_allocation payload_scratch;
     VkDeviceSize payload_size;
@@ -3376,7 +3298,7 @@ static void d3d12_command_list_workgraph_execute_entry_cpu(
 
     d3d12_command_list_workgraph_execute_node_cpu_entry(list, wg_state, program, node_index, desc,
             wg_state->payload[0].va, payload_scratch.va,
-            vk_root_param_buffer, vk_root_param_offset);
+            vk_root_param_buffer_va);
 
     /* For any shared nodes, just execute those as well. */
     for (i = 0; i < program->levels[0].shared_nodes_count; i++)
@@ -3386,7 +3308,7 @@ static void d3d12_command_list_workgraph_execute_entry_cpu(
             d3d12_command_list_workgraph_execute_node_cpu_entry(list, wg_state, program,
                     program->levels[0].shared_nodes[i].node_pipeline_index, desc,
                     wg_state->payload[0].va, payload_scratch.va,
-                    vk_root_param_buffer, vk_root_param_offset);
+                    vk_root_param_buffer_va);
         }
     }
 }
@@ -3394,7 +3316,7 @@ static void d3d12_command_list_workgraph_execute_entry_cpu(
 static void d3d12_command_list_workgraph_execute_entry_level(
         struct d3d12_command_list *list, struct d3d12_wg_state_object *wg_state,
         const struct d3d12_wg_state_object_program *program, const D3D12_DISPATCH_GRAPH_DESC *desc,
-        VkBuffer vk_root_param_buffer, VkDeviceSize vk_root_param_offset)
+        VkDeviceAddress vk_root_param_buffer_va)
 {
     unsigned int i;
     switch (desc->Mode)
@@ -3402,7 +3324,7 @@ static void d3d12_command_list_workgraph_execute_entry_level(
         case D3D12_DISPATCH_MODE_NODE_CPU_INPUT:
             d3d12_command_list_workgraph_execute_entry_cpu(
                     list, wg_state, program, &desc->NodeCPUInput,
-                    vk_root_param_buffer, vk_root_param_offset);
+                    vk_root_param_buffer_va);
             break;
 
         case D3D12_DISPATCH_MODE_MULTI_NODE_CPU_INPUT:
@@ -3413,14 +3335,14 @@ static void d3d12_command_list_workgraph_execute_entry_level(
                         desc->MultiNodeCPUInput.NodeInputStrideInBytes * i);
                 d3d12_command_list_workgraph_execute_entry_cpu(
                         list, wg_state, program, input,
-                        vk_root_param_buffer, vk_root_param_offset);
+                        vk_root_param_buffer_va);
             }
             break;
 
         case D3D12_DISPATCH_MODE_NODE_GPU_INPUT:
             d3d12_command_list_workgraph_execute_entry_gpu(
                     list, wg_state, program, desc->NodeGPUInput,
-                    vk_root_param_buffer, vk_root_param_offset);
+                    vk_root_param_buffer_va);
             break;
 
         default:
@@ -3450,7 +3372,6 @@ void d3d12_command_list_workgraph_dispatch(struct d3d12_command_list *list, cons
     d3d12_command_list_debug_mark_begin_region(list, "WGDispatch");
 
     d3d12_command_list_invalidate_current_pipeline(list, true);
-    d3d12_command_list_invalidate_root_parameters(list, &list->compute_bindings, true, &list->graphics_bindings);
     d3d12_command_list_update_global_descriptor_heap(list);
 
     d3d12_command_list_workgraph_barrier(list,
@@ -3469,13 +3390,13 @@ void d3d12_command_list_workgraph_dispatch(struct d3d12_command_list *list, cons
     /* TODO: For mesh nodes, may have to fetch graphics root parameter data. */
 
     d3d12_command_list_workgraph_execute_entry_level(list, wg_state, program, desc,
-            root_param_scratch.buffer, root_param_scratch.offset);
+            root_param_scratch.va);
 
     for (i = 1; i < program->num_levels; i++)
     {
         d3d12_command_list_workgraph_execute_level(list, wg_state, program, i,
                 wg_state->payload[i & 1].va, wg_state->payload[(i & 1) ^ 1].va,
-                root_param_scratch.buffer, root_param_scratch.offset);
+                root_param_scratch.va);
     }
 
     d3d12_command_list_debug_mark_end_region(list);


### PR DESCRIPTION
Getting there. Removes legacy path from workgraphs and adds heap path. Workgraphs never worked well with legacy path anyway, and no games rely on it, so only support it when we can do it somewhat correctly ...

Basic idea for workgraph is to take advantage of INDIRECT mappings in Vulkan heap to combine the system push data along with user root parameters. We can in theory be smarter and more adaptive by fusing them together if the combined size is small enough, but that's an optimization for a future time when content actually ships WGs ...