### PR TITLE
VK_KHR_opacity_micromap - Phase 4

### DIFF
--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -21,7 +21,7 @@
 
 #define RT_TRACE TRACE
 
-static VkBuildAccelerationStructureFlagsKHR d3d12_build_flags_to_vk(
+static VkBuildAccelerationStructureFlagsKHR d3d12_build_flags_to_vk_ext(
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS flags)
 {
     VkBuildAccelerationStructureFlagsKHR vk_flags = 0;
@@ -44,6 +44,32 @@ static VkBuildAccelerationStructureFlagsKHR d3d12_build_flags_to_vk(
     }
     if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS)
         vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_DISABLE_OPACITY_MICROMAPS_BIT_EXT;
+
+    return vk_flags;
+}
+
+static VkBuildAccelerationStructureFlagsKHR d3d12_build_flags_to_vk_khr(
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS flags)
+{
+    VkBuildAccelerationStructureFlagsKHR vk_flags = 0;
+
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR;
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_LOW_MEMORY_BIT_KHR;
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_BUILD_BIT_KHR;
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_LINKAGE_UPDATE)
+    {
+        /* D3D12 spec isn't clear on what is allowed to be updated and when */
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_OPACITY_MICROMAP_UPDATE_BIT_KHR;
+    }
+    if (flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS)
+        vk_flags |= VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_DISABLE_OPACITY_MICROMAPS_BIT_KHR;
 
     return vk_flags;
 }
@@ -118,11 +144,10 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *desc,
         VkAccelerationStructureBuildGeometryInfoKHR *build_info,
         VkAccelerationStructureGeometryKHR *geometry_infos,
-        VkAccelerationStructureTrianglesOpacityMicromapEXT *omm_infos,
+        union vkd3d_omm_triangles_info omm_triangles_infos,
         VkAccelerationStructureBuildRangeInfoKHR *range_infos,
         uint32_t *primitive_counts)
 {
-    VkAccelerationStructureTrianglesOpacityMicromapEXT *omm;
     VkAccelerationStructureGeometryAabbsDataKHR *aabbs;
     const D3D12_RAYTRACING_GEOMETRY_DESC *geom_desc;
     bool have_triangles, have_aabbs;
@@ -146,7 +171,9 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
         RT_TRACE("Bottom level build.\n");
     }
 
-    build_info->flags = d3d12_build_flags_to_vk(desc->Flags);
+    build_info->flags = device->device_info.using_khr_opacity_micromap ?
+        d3d12_build_flags_to_vk_khr(desc->Flags) :
+        d3d12_build_flags_to_vk_ext(desc->Flags);
 
     if (desc->Flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE)
     {
@@ -161,8 +188,16 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
         /* There is risk of desc->NumDescs being != 1, although it should not happen. */
         memset(geometry_infos, 0, sizeof(*geometry_infos));
         /* Safety since we check for sentinel when completing batch. */
-        if (omm_infos)
-            memset(omm_infos, 0, sizeof(*omm_infos));
+        if (device->device_info.using_khr_opacity_micromap)
+        {
+            if (omm_triangles_infos.khr)
+                memset(omm_triangles_infos.khr, 0, sizeof(*omm_triangles_infos.khr));
+        }
+        else
+        {
+            if (omm_triangles_infos.ext)
+                memset(omm_triangles_infos.ext, 0, sizeof(*omm_triangles_infos.ext));
+        }
         geometry_infos[0].sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
         geometry_infos[0].geometryType = VK_GEOMETRY_TYPE_INSTANCES_KHR;
         geometry_infos[0].geometry.instances.sType =
@@ -194,9 +229,16 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
 
         /* Don't hoist this memset since top-level geometries forces NumDescs == 1 assumption. */
         memset(geometry_infos, 0, sizeof(*geometry_infos) * desc->NumDescs);
-
-        if (omm_infos)
-            memset(omm_infos, 0, sizeof(*omm_infos) * desc->NumDescs);
+        if (device->device_info.using_khr_opacity_micromap)
+        {
+            if (omm_triangles_infos.khr)
+                memset(omm_triangles_infos.khr, 0, sizeof(*omm_triangles_infos.khr) * desc->NumDescs);
+        }
+        else
+        {
+            if (omm_triangles_infos.ext)
+                memset(omm_triangles_infos.ext, 0, sizeof(*omm_triangles_infos.ext) * desc->NumDescs);
+        }
 
         if (primitive_counts)
             memset(primitive_counts, 0, sizeof(*primitive_counts) * desc->NumDescs);
@@ -273,52 +315,12 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
                     vkd3d_acceleration_structure_convert_triangles(device,
                             geom_desc->OmmTriangles.pTriangles, &geometry_infos[i], &primitive_count);
 
-                    /* This pointer may be invalidated later when batching.
-                     * Patch this in late right before the batch is committed.
-                     * For prebuild info, we need the pointers right away however. */
-                    omm = &omm_infos[i];
-                    vk_prepend_struct(&geometry_infos[i].geometry.triangles, omm);
-                    omm->sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT;
-
-                    switch (geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexFormat)
+                    if (!vkd3d_acceleration_structure_convert_opacity_micromap(device,
+                            geom_desc, &geometry_infos[i], omm_triangles_infos, i))
                     {
-                        case DXGI_FORMAT_UNKNOWN:
-                            omm->indexType = VK_INDEX_TYPE_NONE_KHR;
-                            break;
-                        case DXGI_FORMAT_R32_UINT:
-                            omm->indexType = VK_INDEX_TYPE_UINT32;
-                            break;
-                        case DXGI_FORMAT_R16_UINT:
-                            omm->indexType = VK_INDEX_TYPE_UINT16;
-                            break;
-                        case DXGI_FORMAT_R8_UINT:
-                            FIXME_ONCE("Using UINT8 as OMM index format is technically out of spec.\n");
-                            omm->indexType = VK_INDEX_TYPE_UINT8;
-                            break;
-                        default:
-                            ERR("Unsupported OMM index format #%x.\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexFormat);
-                            return false;
+                        return false;
                     }
 
-                    omm->indexBuffer.deviceAddress = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StartAddress;
-                    omm->indexStride = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StrideInBytes;
-                    omm->baseTriangle = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapBaseLocation;
-
-                    if (geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray)
-                    {
-                        omm->micromap = vkd3d_va_map_place_opacity_micromap(
-                                &device->memory_allocator.va_map, device,
-                                geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray).ext;
-
-                        if (omm->micromap == VK_NULL_HANDLE)
-                            ERR("Failed to place OMM at VA 0x%"PRIx64".\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);
-                    }
-
-                    RT_TRACE("  OMM Index type: %s\n", debug_dxgi_format(geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexFormat));
-                    RT_TRACE("  OMM IBO VA: %"PRIx64"\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StartAddress);
-                    RT_TRACE("  OMM Index stride: %"PRIu64" bytes\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StrideInBytes);
-                    RT_TRACE("  OMM Base: %u\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapBaseLocation);
-                    RT_TRACE("  OMM Micromap VA: %"PRIx64"\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);
                     break;
 
                 default:

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20220,16 +20220,17 @@ static void d3d12_command_list_free_rtas_batch(struct d3d12_command_list *list)
 
     vkd3d_free(rtas_batch->build_infos);
     vkd3d_free(rtas_batch->geometry_infos);
-    vkd3d_free(rtas_batch->omm_infos);
     vkd3d_free(rtas_batch->range_infos);
     vkd3d_free(rtas_batch->range_ptrs);
     if (list->device->device_info.using_khr_opacity_micromap)
     {
+        vkd3d_free(rtas_batch->omm_triangles_infos.khr);
         vkd3d_free(rtas_batch->omm_build_infos.khr);
         vkd3d_free(rtas_batch->omm_usage_infos.khr);
     }
     else
     {
+        vkd3d_free(rtas_batch->omm_triangles_infos.ext);
         vkd3d_free(rtas_batch->omm_build_infos.ext);
         vkd3d_free(rtas_batch->omm_usage_infos.ext);
     }
@@ -20238,7 +20239,7 @@ static void d3d12_command_list_free_rtas_batch(struct d3d12_command_list *list)
 static bool d3d12_command_list_allocate_rtas_build_info(struct d3d12_command_list *list, uint32_t geometry_count,
         VkAccelerationStructureBuildGeometryInfoKHR **build_info,
         VkAccelerationStructureGeometryKHR **geometry_infos,
-        VkAccelerationStructureTrianglesOpacityMicromapEXT **omm_infos,
+        union vkd3d_omm_triangles_info *omm_triangles_infos,
         VkAccelerationStructureBuildRangeInfoKHR **range_infos)
 {
     struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
@@ -20257,12 +20258,26 @@ static bool d3d12_command_list_allocate_rtas_build_info(struct d3d12_command_lis
         return false;
     }
 
-    if (d3d12_device_supports_ray_tracing_tier_1_2(list->device) &&
-            !vkd3d_array_reserve((void **)&rtas_batch->omm_infos, &rtas_batch->omm_info_size,
-            rtas_batch->geometry_info_count + geometry_count, sizeof(*rtas_batch->omm_infos)))
+    if (d3d12_device_supports_ray_tracing_tier_1_2(list->device))
     {
-        ERR("Failed to allocate opacity micromap info array.\n");
-        return false;
+        if (list->device->device_info.using_khr_opacity_micromap)
+        {
+            if (!vkd3d_array_reserve((void **)&rtas_batch->omm_triangles_infos.khr, &rtas_batch->omm_triangles_info_size,
+                    rtas_batch->geometry_info_count + geometry_count, sizeof(*rtas_batch->omm_triangles_infos.khr)))
+            {
+                ERR("Failed to allocate opacity micromap info array.\n");
+                return false;
+            }
+        }
+        else
+        {
+            if (!vkd3d_array_reserve((void **)&rtas_batch->omm_triangles_infos.ext, &rtas_batch->omm_triangles_info_size,
+                    rtas_batch->geometry_info_count + geometry_count, sizeof(*rtas_batch->omm_triangles_infos.ext)))
+            {
+                ERR("Failed to allocate opacity micromap info array.\n");
+                return false;
+            }
+        }
     }
 
     if (!vkd3d_array_reserve((void **)&rtas_batch->range_infos, &rtas_batch->range_info_size,
@@ -20275,9 +20290,19 @@ static bool d3d12_command_list_allocate_rtas_build_info(struct d3d12_command_lis
     *build_info = &rtas_batch->build_infos[rtas_batch->build_info_count];
     *geometry_infos = &rtas_batch->geometry_infos[rtas_batch->geometry_info_count];
     if (d3d12_device_supports_ray_tracing_tier_1_2(list->device))
-        *omm_infos = &rtas_batch->omm_infos[rtas_batch->geometry_info_count];
+    {
+        if (list->device->device_info.using_khr_opacity_micromap)
+            omm_triangles_infos->khr = &rtas_batch->omm_triangles_infos.khr[rtas_batch->geometry_info_count];
+        else
+            omm_triangles_infos->ext = &rtas_batch->omm_triangles_infos.ext[rtas_batch->geometry_info_count];
+    }
     else
-        *omm_infos = NULL;
+    {
+        if (list->device->device_info.using_khr_opacity_micromap)
+            omm_triangles_infos->khr = NULL;
+        else
+            omm_triangles_infos->ext = NULL;
+    }
     *range_infos = &rtas_batch->range_infos[rtas_batch->geometry_info_count];
 
     rtas_batch->build_info_count += 1;
@@ -20446,6 +20471,26 @@ static void d3d12_command_list_fixup_rtas_batch(struct d3d12_command_list *list)
 
                 usage_index += usage_count;
             }
+
+            /* pNext pointers on Geometry AS. Currently limited to Opacity micromaps */
+            if (rtas_batch->omm_triangles_infos.khr)
+            {
+                for (i = 0; i < rtas_batch->geometry_info_count; i++)
+                {
+                    VkAccelerationStructureGeometryKHR *geometry = &rtas_batch->geometry_infos[i];
+                    VkAccelerationStructureTrianglesOpacityMicromapKHR *omm_khr = &rtas_batch->omm_triangles_infos.khr[i];
+
+                    if (geometry->geometry.triangles.pNext)
+                    {
+                        assert(geometry->geometry.triangles.sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR);
+                        assert(geometry->sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR);
+                        assert(geometry->geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR);
+                        assert(omm_khr->sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_KHR);
+                        geometry->geometry.triangles.pNext = NULL;
+                        vk_prepend_struct(&geometry->geometry.triangles, omm_khr);
+                    }
+                }
+            }
         }
         else
         {
@@ -20463,21 +20508,21 @@ static void d3d12_command_list_fixup_rtas_batch(struct d3d12_command_list *list)
             }
 
             /* pNext pointers on Geometry AS. Currently limited to Opacity micromaps */
-            if (rtas_batch->omm_infos)
+            if (rtas_batch->omm_triangles_infos.ext)
             {
                 for (i = 0; i < rtas_batch->geometry_info_count; i++)
                 {
                     /* oom_infos is cleared to zero if not used. Can use sType as sentinel. */
-                    VkAccelerationStructureTrianglesOpacityMicromapEXT *omm = &rtas_batch->omm_infos[i];
                     VkAccelerationStructureGeometryKHR *geometry = &rtas_batch->geometry_infos[i];
+                    VkAccelerationStructureTrianglesOpacityMicromapEXT *omm_ext = &rtas_batch->omm_triangles_infos.ext[i];
 
-                    if (omm->sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT)
+                    if (omm_ext->sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT)
                     {
                         /* The pNext may have been invalidated. Just verify something is there. */
                         assert(geometry->geometry.triangles.pNext);
                         assert(geometry->geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR);
                         geometry->geometry.triangles.pNext = NULL;
-                        vk_prepend_struct(&geometry->geometry.triangles, omm);
+                        vk_prepend_struct(&geometry->geometry.triangles, omm_ext);
                     }
                 }
             }
@@ -20726,7 +20771,7 @@ static void d3d12_command_list_build_raytracing_blas_and_tlas(struct d3d12_comma
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *desc, UINT num_postbuild_info_descs,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *postbuild_info_descs)
 {
-    VkAccelerationStructureTrianglesOpacityMicromapEXT *omm_infos = NULL;
+    union vkd3d_omm_triangles_info omm_triangles_infos;
     VkAccelerationStructureBuildGeometryInfoKHR *build_info;
     VkAccelerationStructureBuildRangeInfoKHR *range_infos;
     VkAccelerationStructureGeometryKHR *geometry_infos;
@@ -20741,11 +20786,11 @@ static void d3d12_command_list_build_raytracing_blas_and_tlas(struct d3d12_comma
 #endif
 
     if (!d3d12_command_list_allocate_rtas_build_info(list, geometry_count,
-            &build_info, &geometry_infos, &omm_infos, &range_infos))
+            &build_info, &geometry_infos, &omm_triangles_infos, &range_infos))
         return;
 
     if (!vkd3d_acceleration_structure_convert_inputs(list->device, &desc->Inputs,
-            build_info, geometry_infos, omm_infos, range_infos, primitive_counts))
+            build_info, geometry_infos, omm_triangles_infos, range_infos, primitive_counts))
     {
         ERR("Failed to convert inputs.\n");
         return;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -8352,11 +8352,19 @@ static void d3d12_device_get_raytracing_opacity_micromap_array_prebuild_info(str
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *desc,
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO *info)
 {
+    VkAccelerationStructureGeometryMicromapDataKHR geometry_micromap_data_khr;
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    VkMicromapUsageEXT usages_stack[VKD3D_BUILD_INFO_STACK_COUNT];
-    VkMicromapBuildSizesInfoEXT size_info;
-    VkMicromapBuildInfoEXT build_info;
-    VkMicromapUsageEXT *usages;
+    VkAccelerationStructureBuildGeometryInfoKHR build_info_khr;
+    union
+    {
+        VkMicromapUsageEXT ext[VKD3D_BUILD_INFO_STACK_COUNT];
+        VkMicromapUsageKHR khr[VKD3D_BUILD_INFO_STACK_COUNT];
+    } usages_stack;
+    VkAccelerationStructureBuildSizesInfoKHR size_info_khr;
+    VkAccelerationStructureGeometryKHR geometry_info_khr;
+    VkMicromapBuildSizesInfoEXT size_info_ext;
+    VkMicromapBuildInfoEXT build_info_ext;
+    union vkd3d_omm_usage_info usages;
     uint32_t usages_count;
 
     if (!d3d12_device_supports_ray_tracing_tier_1_2(device))
@@ -8369,26 +8377,58 @@ static void d3d12_device_get_raytracing_opacity_micromap_array_prebuild_info(str
     usages_count = desc->pOpacityMicromapArrayDesc->NumOmmHistogramEntries;
 
     if (usages_count > VKD3D_BUILD_INFO_STACK_COUNT)
-        usages = vkd3d_malloc(usages_count * sizeof(*usages));
-    else
-        usages = usages_stack;
-
-    if (!vkd3d_opacity_micromap_convert_inputs_ext(device, desc, &build_info, usages))
     {
-        ERR("Failed to convert inputs.\n");
-        memset(info, 0, sizeof(*info));
-        goto cleanup;
+        if (device->device_info.using_khr_opacity_micromap)
+            usages.khr = vkd3d_malloc(usages_count * sizeof(*usages.khr));
+        else
+            usages.ext = vkd3d_malloc(usages_count * sizeof(*usages.ext));
+    }
+    else
+    {
+        if (device->device_info.using_khr_opacity_micromap)
+            usages.khr = usages_stack.khr;
+        else
+            usages.ext = usages_stack.ext;
     }
 
-    memset(&size_info, 0, sizeof(size_info));
-    size_info.sType = VK_STRUCTURE_TYPE_MICROMAP_BUILD_SIZES_INFO_EXT;
+    if (device->device_info.using_khr_opacity_micromap)
+    {
+        if (!vkd3d_opacity_micromap_convert_inputs_khr(device, desc, &build_info_khr, &geometry_info_khr,
+                &geometry_micromap_data_khr, usages.khr))
+        {
+            ERR("Failed to convert inputs.\n");
+            memset(info, 0, sizeof(*info));
+            goto cleanup;
+        }
 
-    VK_CALL(vkGetMicromapBuildSizesEXT(device->vk_device,
-            VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
-            &build_info, &size_info));
+        memset(&size_info_khr, 0, sizeof(size_info_khr));
+        size_info_khr.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
 
-    info->ResultDataMaxSizeInBytes = size_info.micromapSize;
-    info->ScratchDataSizeInBytes = size_info.buildScratchSize;
+        VK_CALL(vkGetAccelerationStructureBuildSizesKHR(device->vk_device,
+                VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &build_info_khr, NULL, &size_info_khr));
+
+        info->ResultDataMaxSizeInBytes = size_info_khr.accelerationStructureSize;
+        info->ScratchDataSizeInBytes = size_info_khr.buildScratchSize;
+    }
+    else
+    {
+        if (!vkd3d_opacity_micromap_convert_inputs_ext(device, desc, &build_info_ext, usages.ext))
+        {
+            ERR("Failed to convert inputs.\n");
+            memset(info, 0, sizeof(*info));
+            goto cleanup;
+        }
+
+        memset(&size_info_ext, 0, sizeof(size_info_ext));
+        size_info_ext.sType = VK_STRUCTURE_TYPE_MICROMAP_BUILD_SIZES_INFO_EXT;
+
+        VK_CALL(vkGetMicromapBuildSizesEXT(device->vk_device,
+                VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &build_info_ext, &size_info_ext));
+
+        info->ResultDataMaxSizeInBytes = size_info_ext.micromapSize;
+        info->ScratchDataSizeInBytes = size_info_ext.buildScratchSize;
+    }
+
     info->UpdateScratchDataSizeInBytes = 0;
 
     TRACE("ResultDataMaxSizeInBytes: %"PRIu64".\n", (uint64_t)info->ResultDataMaxSizeInBytes);
@@ -8397,7 +8437,12 @@ static void d3d12_device_get_raytracing_opacity_micromap_array_prebuild_info(str
 cleanup:
 
     if (usages_count > VKD3D_BUILD_INFO_STACK_COUNT)
-        vkd3d_free(usages);
+    {
+        if (device->device_info.using_khr_opacity_micromap)
+            vkd3d_free(usages.khr);
+        else
+            vkd3d_free(usages.ext);
+    }
 }
 
 static void STDMETHODCALLTYPE d3d12_device_GetRaytracingAccelerationStructurePrebuildInfo(d3d12_device_iface *iface,

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -8406,11 +8406,15 @@ static void STDMETHODCALLTYPE d3d12_device_GetRaytracingAccelerationStructurePre
 {
     struct d3d12_device *device = impl_from_ID3D12Device(iface);
 
-    VkAccelerationStructureTrianglesOpacityMicromapEXT omms_stack[VKD3D_BUILD_INFO_STACK_COUNT];
+    union
+    {
+        VkAccelerationStructureTrianglesOpacityMicromapEXT ext[VKD3D_BUILD_INFO_STACK_COUNT];
+        VkAccelerationStructureTrianglesOpacityMicromapKHR khr[VKD3D_BUILD_INFO_STACK_COUNT];
+    } omm_triangles_infos_stack;
     VkAccelerationStructureGeometryKHR geometries_stack[VKD3D_BUILD_INFO_STACK_COUNT];
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     uint32_t primitive_counts_stack[VKD3D_BUILD_INFO_STACK_COUNT];
-    VkAccelerationStructureTrianglesOpacityMicromapEXT *omms;
+    union vkd3d_omm_triangles_info omm_triangles_infos;
     VkAccelerationStructureBuildGeometryInfoKHR build_info;
     VkAccelerationStructureBuildSizesInfoKHR size_info;
     VkAccelerationStructureGeometryKHR *geometries;
@@ -8435,17 +8439,26 @@ static void STDMETHODCALLTYPE d3d12_device_GetRaytracingAccelerationStructurePre
     geometry_count = vkd3d_acceleration_structure_get_geometry_count(desc);
     primitive_counts = primitive_counts_stack;
     geometries = geometries_stack;
-    omms = omms_stack;
 
     if (geometry_count > VKD3D_BUILD_INFO_STACK_COUNT)
     {
         primitive_counts = vkd3d_malloc(geometry_count * sizeof(*primitive_counts));
         geometries = vkd3d_malloc(geometry_count * sizeof(*geometries));
-        omms = vkd3d_malloc(geometry_count * sizeof(*omms));
+        if (device->device_info.using_khr_opacity_micromap)
+            omm_triangles_infos.khr = vkd3d_malloc(geometry_count * sizeof(*omm_triangles_infos.khr));
+        else
+            omm_triangles_infos.ext = vkd3d_malloc(geometry_count * sizeof(*omm_triangles_infos.ext));
+    }
+    else
+    {
+        if (device->device_info.using_khr_opacity_micromap)
+            omm_triangles_infos.khr = omm_triangles_infos_stack.khr;
+        else
+            omm_triangles_infos.ext = omm_triangles_infos_stack.ext;
     }
 
     if (!vkd3d_acceleration_structure_convert_inputs(device,
-            desc, &build_info, geometries, omms, NULL, primitive_counts))
+            desc, &build_info, geometries, omm_triangles_infos, NULL, primitive_counts))
     {
         ERR("Failed to convert inputs.\n");
         memset(info, 0, sizeof(*info));
@@ -8475,7 +8488,10 @@ cleanup:
     {
         vkd3d_free(primitive_counts);
         vkd3d_free(geometries);
-        vkd3d_free(omms);
+        if (device->device_info.using_khr_opacity_micromap)
+            vkd3d_free(omm_triangles_infos.khr);
+        else
+            vkd3d_free(omm_triangles_infos.ext);
     }
 }
 

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -391,7 +391,7 @@ void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
     vkd3d_opacity_micromap_end_barrier(list);
 }
 
-static bool convert_copy_mode(
+static bool convert_copy_mode_ext(
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode,
         VkCopyMicromapModeEXT *vk_mode)
 {
@@ -409,14 +409,33 @@ static bool convert_copy_mode(
     }
 }
 
+static bool convert_copy_mode_khr(
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode,
+        VkCopyAccelerationStructureModeKHR *vk_mode)
+{
+    switch (mode)
+    {
+        case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_CLONE:
+            *vk_mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
+            return true;
+        case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT:
+            *vk_mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR;
+            return true;
+        default:
+            FIXME("Unsupported OMM copy mode #%x.\n", mode);
+            return false;
+    }
+}
+
 void vkd3d_opacity_micromap_copy(
         struct d3d12_command_list *list,
         D3D12_GPU_VIRTUAL_ADDRESS dst, union vkd3d_opacity_micromap src_omm,
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    VkCopyAccelerationStructureInfoKHR info_khr;
     union vkd3d_opacity_micromap dst_omm;
-    VkCopyMicromapInfoEXT info;
+    VkCopyMicromapInfoEXT info_ext;
 
     dst_omm = vkd3d_va_map_place_opacity_micromap(&list->device->memory_allocator.va_map, list->device, dst);
     if (dst_omm.any_handle == (uint64_t)VK_NULL_HANDLE)
@@ -424,13 +443,30 @@ void vkd3d_opacity_micromap_copy(
         ERR("Invalid dst address #%"PRIx64" for OMM copy.\n", dst);
         return;
     }
+    if (list->device->device_info.using_khr_opacity_micromap)
+    {
+        memset(&info_khr, 0, sizeof(info_khr));
 
-    info.sType = VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT;
-    info.pNext = NULL;
-    info.dst = dst_omm.ext;
-    info.src = src_omm.ext;
-    if (convert_copy_mode(mode, &info.mode))
-        VK_CALL(vkCmdCopyMicromapEXT(list->cmd.vk_command_buffer, &info));
+        if (!convert_copy_mode_khr(mode, &info_khr.mode))
+            return;
+
+        info_khr.sType = VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR;
+        info_khr.dst = dst_omm.khr;
+        info_khr.src = src_omm.khr;
+        VK_CALL(vkCmdCopyAccelerationStructureKHR(list->cmd.vk_command_buffer, &info_khr));
+    }
+    else
+    {
+        memset(&info_ext, 0, sizeof(info_ext));
+
+        if (!convert_copy_mode_ext(mode, &info_ext.mode))
+            return;
+
+        info_ext.sType = VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT;
+        info_ext.dst = dst_omm.ext;
+        info_ext.src = src_omm.ext;
+        VK_CALL(vkCmdCopyMicromapEXT(list->cmd.vk_command_buffer, &info_ext));
+    }
 }
 
 static bool vkd3d_acceleration_structure_convert_opacity_micromap_index_type(DXGI_FORMAT format, VkIndexType *result)

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -432,3 +432,116 @@ void vkd3d_opacity_micromap_copy(
     if (convert_copy_mode(mode, &info.mode))
         VK_CALL(vkCmdCopyMicromapEXT(list->cmd.vk_command_buffer, &info));
 }
+
+static bool vkd3d_acceleration_structure_convert_opacity_micromap_index_type(DXGI_FORMAT format, VkIndexType *result)
+{
+    switch (format)
+    {
+        case DXGI_FORMAT_UNKNOWN:
+            *result = VK_INDEX_TYPE_NONE_KHR;
+            return true;
+        case DXGI_FORMAT_R32_UINT:
+            *result = VK_INDEX_TYPE_UINT32;
+            return true;
+        case DXGI_FORMAT_R16_UINT:
+            *result = VK_INDEX_TYPE_UINT16;
+            return true;
+        case DXGI_FORMAT_R8_UINT:
+            FIXME_ONCE("Using UINT8 as OMM index format is technically out of spec.\n");
+            *result = VK_INDEX_TYPE_UINT8;
+            return true;
+        default:
+            ERR("Unsupported OMM index format #%x.\n", format);
+            return false;
+    }
+}
+
+static bool vkd3d_acceleration_structure_convert_opacity_micromap_ext(struct d3d12_device *device,
+        const D3D12_RAYTRACING_GEOMETRY_DESC *geom_desc,
+        VkAccelerationStructureGeometryKHR *geometry_info,
+        VkAccelerationStructureTrianglesOpacityMicromapEXT *omm_triangles_info)
+{
+    /* This pointer may be invalidated later when batching.
+     * Patch this in late right before the batch is committed.
+     * For prebuild info, we need the pointers right away however. */
+    vk_prepend_struct(&geometry_info->geometry.triangles, omm_triangles_info);
+    omm_triangles_info->sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT;
+    omm_triangles_info->pNext = NULL;
+
+    if (!vkd3d_acceleration_structure_convert_opacity_micromap_index_type(
+            geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexFormat, &omm_triangles_info->indexType))
+    {
+        return false;
+    }
+    omm_triangles_info->indexBuffer.deviceAddress = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StartAddress;
+    omm_triangles_info->indexStride = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StrideInBytes;
+    omm_triangles_info->baseTriangle = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapBaseLocation;
+
+    if (geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray)
+    {
+        omm_triangles_info->micromap = vkd3d_va_map_place_opacity_micromap(
+                &device->memory_allocator.va_map, device,
+                geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray).ext;
+
+        if (omm_triangles_info->micromap == VK_NULL_HANDLE)
+            ERR("Failed to place OMM at VA 0x%"PRIx64".\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);
+    }
+
+    return true;
+}
+
+static bool vkd3d_acceleration_structure_convert_opacity_micromap_khr(struct d3d12_device *device,
+        const D3D12_RAYTRACING_GEOMETRY_DESC *geom_desc,
+        VkAccelerationStructureGeometryKHR *geometry_info,
+        VkAccelerationStructureTrianglesOpacityMicromapKHR *omm_triangles_info)
+{
+    vk_prepend_struct(&geometry_info->geometry.triangles, omm_triangles_info);
+    omm_triangles_info->sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_KHR;
+    omm_triangles_info->pNext = NULL;
+
+    if (!vkd3d_acceleration_structure_convert_opacity_micromap_index_type(
+            geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexFormat, &omm_triangles_info->indexType))
+    {
+        return false;
+    }
+    omm_triangles_info->indexBuffer = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StartAddress;
+    omm_triangles_info->indexStride = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StrideInBytes;
+    omm_triangles_info->baseTriangle = geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapBaseLocation;
+
+    if (geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray)
+    {
+        omm_triangles_info->micromap = vkd3d_va_map_place_opacity_micromap(
+                &device->memory_allocator.va_map, device,
+                geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray).khr;
+
+        if (omm_triangles_info->micromap == VK_NULL_HANDLE)
+            ERR("Failed to place OMM at VA 0x%"PRIx64".\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);
+    }
+    return true;
+}
+
+bool vkd3d_acceleration_structure_convert_opacity_micromap(struct d3d12_device *device,
+        const D3D12_RAYTRACING_GEOMETRY_DESC *geom_desc,
+        VkAccelerationStructureGeometryKHR *geometry_info,
+        union vkd3d_omm_triangles_info omm_triangles_infos,
+        uint32_t omm_info_index)
+{
+    bool result;
+    if (device->device_info.using_khr_opacity_micromap)
+        result = vkd3d_acceleration_structure_convert_opacity_micromap_khr(device,
+                geom_desc, geometry_info, &omm_triangles_infos.khr[omm_info_index]);
+    else
+        result = vkd3d_acceleration_structure_convert_opacity_micromap_ext(device,
+                geom_desc, geometry_info, &omm_triangles_infos.ext[omm_info_index]);
+
+    if (result)
+    {
+        RT_TRACE("  OMM Index type: %s\n", debug_dxgi_format(geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexFormat));
+        RT_TRACE("  OMM IBO VA: %"PRIx64"\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StartAddress);
+        RT_TRACE("  OMM Index stride: %"PRIu64" bytes\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapIndexBuffer.StrideInBytes);
+        RT_TRACE("  OMM Base: %u\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapBaseLocation);
+        RT_TRACE("  OMM Micromap VA: %"PRIx64"\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);
+    }
+
+    return result;
+}

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4863,7 +4863,12 @@ static void vkd3d_view_destroy(struct vkd3d_view *view, struct d3d12_device *dev
             break;
         case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP:
             if (view->info.buffer.rtas_is_micromap)
-                VK_CALL(vkDestroyMicromapEXT(device->vk_device, view->vk_micromap.ext, NULL));
+            {
+                if (device->device_info.using_khr_opacity_micromap)
+                    VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, view->vk_micromap.khr, NULL));
+                else
+                    VK_CALL(vkDestroyMicromapEXT(device->vk_device, view->vk_micromap.ext, NULL));
+            }
             else
                 VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, view->vk_acceleration_structure, NULL));
             break;
@@ -5258,27 +5263,45 @@ bool vkd3d_create_opacity_micromap_view(struct d3d12_device *device, const struc
         struct vkd3d_view **view)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    VkAccelerationStructureCreateInfo2KHR create_info_khr;
     union vkd3d_opacity_micromap vk_micromap;
-    VkMicromapCreateInfoEXT create_info;
+    VkMicromapCreateInfoEXT create_info_ext;
     struct vkd3d_view *object;
     VkResult vr;
 
-    create_info.sType = VK_STRUCTURE_TYPE_MICROMAP_CREATE_INFO_EXT;
-    create_info.pNext = NULL;
-    create_info.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
-    create_info.createFlags = 0;
-    create_info.deviceAddress = 0;
-    create_info.buffer = desc->buffer;
-    create_info.offset = desc->offset;
-    create_info.size = desc->size;
+    if (device->device_info.using_khr_opacity_micromap)
+    {
+        memset(&create_info_khr, 0, sizeof(create_info_khr));
 
-    vr = VK_CALL(vkCreateMicromapEXT(device->vk_device, &create_info, NULL, &vk_micromap.ext));
+        create_info_khr.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_2_KHR;
+        create_info_khr.type = VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
+        create_info_khr.addressRange.address = vkd3d_get_buffer_device_address(device, desc->buffer) + desc->offset;
+        create_info_khr.addressRange.size = desc->size;
+
+        vr = VK_CALL(vkCreateAccelerationStructure2KHR(device->vk_device, &create_info_khr, NULL, &vk_micromap.khr));
+    }
+    else
+    {
+        memset(&create_info_ext, 0, sizeof(create_info_ext));
+
+        create_info_ext.sType = VK_STRUCTURE_TYPE_MICROMAP_CREATE_INFO_EXT;
+        create_info_ext.buffer = desc->buffer;
+        create_info_ext.offset = desc->offset;
+        create_info_ext.size = desc->size;
+        create_info_ext.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+
+        vr = VK_CALL(vkCreateMicromapEXT(device->vk_device, &create_info_ext, NULL, &vk_micromap.ext));
+    }
+
     if (vr != VK_SUCCESS)
         return false;
 
     if (!(object = vkd3d_view_create(VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP)))
     {
-        VK_CALL(vkDestroyMicromapEXT(device->vk_device, vk_micromap.ext, NULL));
+        if (device->device_info.using_khr_opacity_micromap)
+            VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, vk_micromap.khr, NULL));
+        else
+            VK_CALL(vkDestroyMicromapEXT(device->vk_device, vk_micromap.ext, NULL));
         return false;
     }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3097,6 +3097,12 @@ union vkd3d_omm_build_info
     VkAccelerationStructureGeometryMicromapDataKHR *khr;
 };
 
+union vkd3d_omm_triangles_info
+{
+    VkAccelerationStructureTrianglesOpacityMicromapEXT *ext;
+    VkAccelerationStructureTrianglesOpacityMicromapKHR *khr;
+};
+
 union vkd3d_omm_usage_info
 {
     VkMicromapUsageEXT *ext;
@@ -3115,8 +3121,8 @@ struct d3d12_rtas_batch_state
     size_t geometry_info_count;
     size_t geometry_info_size;
 
-    VkAccelerationStructureTrianglesOpacityMicromapEXT *omm_infos;
-    size_t omm_info_size;
+    union vkd3d_omm_triangles_info omm_triangles_infos;
+    size_t omm_triangles_info_size;
 
     VkAccelerationStructureBuildRangeInfoKHR *range_infos;
     size_t range_info_size;
@@ -6883,7 +6889,7 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *desc,
         VkAccelerationStructureBuildGeometryInfoKHR *build_info,
         VkAccelerationStructureGeometryKHR *geometry_infos,
-        VkAccelerationStructureTrianglesOpacityMicromapEXT *omm_infos,
+        union vkd3d_omm_triangles_info omm_triangles_infos,
         VkAccelerationStructureBuildRangeInfoKHR *range_infos,
         uint32_t *primitive_counts);
 void vkd3d_acceleration_structure_emit_postbuild_info(
@@ -6922,6 +6928,11 @@ void vkd3d_opacity_micromap_copy(
         struct d3d12_command_list *list,
         D3D12_GPU_VIRTUAL_ADDRESS dst, union vkd3d_opacity_micromap src_omm,
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode);
+bool vkd3d_acceleration_structure_convert_opacity_micromap(struct d3d12_device *device,
+        const D3D12_RAYTRACING_GEOMETRY_DESC *geom_desc,
+        VkAccelerationStructureGeometryKHR *geometry_info,
+        union vkd3d_omm_triangles_info omm_triangles_infos,
+        uint32_t omm_info_index);
 
 typedef enum D3D11_USAGE
 {


### PR DESCRIPTION
This is the last set before we can enable `VK_KHR_opacity_micromap`. However, `VK_KHR_opacity_micromap` requires `SPIR-V` changes. There is a dependent commit we may be blocked on (https://github.com/KhronosGroup/SPIRV-Tools/pull/6670).

I will test tomorrow if we can live without it. Without the `SPIR-V` changes, `traceRay` calls will simply pass through OMM. So it is less than ideal. We could also continue to commit the removal commits, but leave `KHR_omm` disabled.