### PR TITLE
vkd3d: Fix heap flags check for VK_EXT_zero_initialize_device_memory

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -926,7 +926,7 @@ static HRESULT vkd3d_get_image_create_info(struct d3d12_device *device,
 
     if (resource && (resource->flags & VKD3D_RESOURCE_COMMITTED) &&
             device->device_info.zero_initialize_device_memory_features.zeroInitializeDeviceMemory &&
-            !(heap_flags & (D3D12_HEAP_FLAG_CREATE_NOT_ZEROED | D3D12_HEAP_FLAG_SHARED)))
+            !(resource->heap_flags & (D3D12_HEAP_FLAG_CREATE_NOT_ZEROED | D3D12_HEAP_FLAG_SHARED)))
     {
         image_info->initialLayout = VK_IMAGE_LAYOUT_ZERO_INITIALIZED_EXT;
         resource->flags |= VKD3D_RESOURCE_ZERO_INITIALIZED;


### PR DESCRIPTION
`VkExternalMemoryImageCreateInfo` can be inserted into the `pNext` chain and then initialized to zero here, because `heap_flags` != `resource->heap_flags`. 

See the check above at line 763.

`heap_flags` is `0` / `D3D12_HEAP_FLAG_NONE` at all call sites. Should this parameter be removed altogether?

vvl:
> 0210:err:vkd3d_debug_messenger_callback: VUID-VkImageCreateInfo-pNext-01443: vkCreateImage(): pCreateInfo->pNext<VkExternalMemoryImageCreateInfo>.handleTypes is VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT (non-zero) but the initialLayout is VK_IMAGE_LAYOUT_ZERO_INITIALIZED_EXT.
The Vulkan spec states: If the pNext chain includes a VkExternalMemoryImageCreateInfo or VkExternalMemoryImageCreateInfoNV structure whose handleTypes member is not 0, initialLayout must be VK_IMAGE_LAYOUT_UNDEFINED (https://docs.vulkan.org/spec/latest/chapters/resources.html#VUID-VkImageCreateInfo-pNext-01443)
