### PR TITLE
maintenance5+6 cleanup

### DIFF
--- a/VP_D3D12_VKD3D_PROTON_profile.json
+++ b/VP_D3D12_VKD3D_PROTON_profile.json
@@ -6,6 +6,8 @@
                 "VK_KHR_push_descriptor": 1,
                 "VK_KHR_swapchain": 1,
                 "VK_KHR_calibrated_timestamps" : 1,
+                "VK_KHR_maintenance5": 1,
+                "VK_KHR_maintenance6": 1,
                 "VK_EXT_custom_border_color" : 1,
                 "VK_EXT_depth_clip_enable": 1,
                 "VK_EXT_robustness2": 1,
@@ -103,6 +105,12 @@
                 },
                 "VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT": {
                     "dynamicRenderingUnusedAttachments": true
+                },
+                "VkPhysicalDeviceMaintenance5FeaturesKHR": {
+                    "maintenance5": true
+                },
+                "VkPhysicalDeviceMaintenance6FeaturesKHR": {
+                    "maintenance6": true
                 }
             },
             "properties": {
@@ -543,8 +551,6 @@
                 "VK_EXT_image_sliced_view_of_3d": 1,
                 "VK_EXT_memory_priority": 1,
                 "VK_EXT_device_generated_commands": 1,
-                "VK_KHR_maintenance5": 1,
-                "VK_KHR_maintenance6": 1,
                 "VK_KHR_maintenance7": 1,
                 "VK_EXT_depth_bias_control": 1,
                 "VK_EXT_zero_initialize_device_memory" : 1,
@@ -576,12 +582,6 @@
                 "VkPhysicalDeviceVulkan12Features": {
                     "shaderFloat16": true,
                     "shaderSubgroupExtendedTypes": true
-                },
-                "VkPhysicalDeviceMaintenance5FeaturesKHR": {
-                    "maintenance5": true
-                },
-                "VkPhysicalDeviceMaintenance6FeaturesKHR": {
-                    "maintenance6": true
                 },
                 "VkPhysicalDeviceMaintenance7FeaturesKHR": {
                     "maintenance7": true

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -9314,30 +9314,14 @@ static bool d3d12_command_list_update_index_buffer(struct d3d12_command_list *li
 
     if (list->index_buffer.is_dirty)
     {
-        if (!list->index_buffer.buffer)
-        {
-            if (list->device->device_info.maintenance_6_features.maintenance6)
-            {
-                VK_CALL(vkCmdBindIndexBuffer2KHR(list->cmd.vk_command_buffer, VK_NULL_HANDLE, 0, 0, VK_INDEX_TYPE_UINT16));
-            }
-            else
-            {
-                /* NULL index buffers are expected to behave as if all indices are 0. Since this is only
-                 * observable in edge cases involving streamout or geometry shaders, skip the draw call
-                 * for now if the Vulkan implementation does not support this. */
-                FIXME_ONCE("Application attempts to perform an indexed draw call without index buffer bound.\n");
-                return false;
-            }
-        }
-        else if (list->device->device_info.maintenance_5_features.maintenance5)
+        if (list->index_buffer.buffer)
         {
             VK_CALL(vkCmdBindIndexBuffer2KHR(list->cmd.vk_command_buffer, list->index_buffer.buffer,
                     list->index_buffer.offset, list->index_buffer.size, list->index_buffer.vk_type));
         }
         else
         {
-            VK_CALL(vkCmdBindIndexBuffer(list->cmd.vk_command_buffer, list->index_buffer.buffer,
-                    list->index_buffer.offset, list->index_buffer.vk_type));
+            VK_CALL(vkCmdBindIndexBuffer2KHR(list->cmd.vk_command_buffer, VK_NULL_HANDLE, 0, 0, VK_INDEX_TYPE_UINT16));
         }
         list->index_buffer.is_dirty = false;
     }

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3367,6 +3367,13 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
         return E_INVALIDARG;
     }
 
+    if (!physical_device_info->maintenance_5_features.maintenance5 ||
+            !physical_device_info->maintenance_6_features.maintenance6)
+    {
+        ERR("maintenance5 and/or maintenance6 not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
     if (physical_device_info->cooperative_matrix_features.cooperativeMatrix)
     {
         if (!vkd3d_supports_minimum_coopmat_caps(device))

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -191,9 +191,11 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
         return vr;
     }
 
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+
+    memset(&pipeline_info, 0, sizeof(pipeline_info));
     pipeline_info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    pipeline_info.pNext = NULL;
-    pipeline_info.flags = 0;
     pipeline_info.layout = layout;
     pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
     pipeline_info.basePipelineIndex = -1;
@@ -202,7 +204,7 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
         d3d12_device_uses_descriptor_buffers(device) &&
         descriptor_buffer_compatible)
     {
-        pipeline_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
     }
 
     vkd3d_meta_make_shader_stage(&pipeline_info.stage,
@@ -212,15 +214,14 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
 
     if (layout == VK_NULL_HANDLE)
     {
-        memset(&flags2, 0, sizeof(flags2));
-        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
-        flags2.flags = pipeline_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
-        pipeline_info.flags = 0;
-        vk_prepend_struct(&pipeline_info, &flags2);
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
 
         vkd3d_meta_init_heap_mappings(device, &mapping_info);
         vk_prepend_struct(&pipeline_info.stage, &mapping_info.mapping_info);
     }
+
+    if (flags2.flags)
+        vk_prepend_struct(&pipeline_info, &flags2);
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&device->queue_timeline_trace);
     vr = VK_CALL(vkCreateComputePipelines(device->vk_device, VK_NULL_HANDLE, 1, &pipeline_info, NULL, pipeline));
@@ -344,10 +345,11 @@ static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_
     cb_state.pAttachments = &blend_attachment;
     memset(&cb_state.blendConstants, 0, sizeof(cb_state.blendConstants));
 
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+
+    memset(&pipeline_info, 0, sizeof(pipeline_info));
     pipeline_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    pipeline_info.pNext = &rendering_info;
-    pipeline_info.flags = 0;
-    pipeline_info.stageCount = 0;
     pipeline_info.pStages = shader_stages;
     pipeline_info.pVertexInputState = &vi_state;
     pipeline_info.pInputAssemblyState = &ia_state;
@@ -359,16 +361,15 @@ static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_
     pipeline_info.pColorBlendState = rendering_info.colorAttachmentCount ? &cb_state : NULL;
     pipeline_info.pDynamicState = &dyn_state;
     pipeline_info.layout = layout;
-    pipeline_info.renderPass = VK_NULL_HANDLE;
-    pipeline_info.subpass = 0;
-    pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
     pipeline_info.basePipelineIndex = -1;
+
+    vk_prepend_struct(&pipeline_info, &rendering_info);
 
     if (!d3d12_device_use_descriptor_heap(meta_ops->device) &&
         d3d12_device_uses_descriptor_buffers(meta_ops->device) &&
         descriptor_buffer_compatible)
     {
-        pipeline_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
     }
 
     vkd3d_meta_make_shader_stage(&shader_stages[pipeline_info.stageCount++],
@@ -390,15 +391,14 @@ static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_
 
     if (layout == VK_NULL_HANDLE)
     {
-        memset(&flags2, 0, sizeof(flags2));
-        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
-        flags2.flags = pipeline_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
-        pipeline_info.flags = 0;
-        vk_prepend_struct(&pipeline_info, &flags2);
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
 
         vkd3d_meta_init_heap_mappings(meta_ops->device, &mapping_info);
         vk_prepend_struct(&shader_stages[pipeline_info.stageCount - 1], &mapping_info.mapping_info);
     }
+
+    if (flags2.flags)
+        vk_prepend_struct(&pipeline_info, &flags2);
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&meta_ops->device->queue_timeline_trace);
     if ((vr = VK_CALL(vkCreateGraphicsPipelines(meta_ops->device->vk_device,

--- a/libs/vkd3d/meta.c
+++ b/libs/vkd3d/meta.c
@@ -23,19 +23,13 @@
 
 #define SPIRV_CODE(name) name, sizeof(name)
 
-static VkResult vkd3d_meta_create_shader_module(struct d3d12_device *device,
-        const uint32_t *code, size_t code_size, VkShaderModule *module)
+static void vkd3d_meta_setup_shader_module(VkShaderModuleCreateInfo *create_info,
+        const uint32_t *code, size_t code_size)
 {
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    VkShaderModuleCreateInfo shader_module_info;
-
-    shader_module_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    shader_module_info.pNext = NULL;
-    shader_module_info.flags = 0;
-    shader_module_info.codeSize = code_size;
-    shader_module_info.pCode = code;
-
-    return VK_CALL(vkCreateShaderModule(device->vk_device, &shader_module_info, NULL, module));
+    memset(create_info, 0, sizeof(*create_info));
+    create_info->sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    create_info->codeSize = code_size;
+    create_info->pCode = code;
 }
 
 static VkResult vkd3d_meta_create_descriptor_set_layout(struct d3d12_device *device,
@@ -113,13 +107,12 @@ static VkResult vkd3d_meta_create_pipeline_layout(struct d3d12_device *device,
 }
 
 static void vkd3d_meta_make_shader_stage(VkPipelineShaderStageCreateInfo *info, VkShaderStageFlagBits stage,
-        VkShaderModule module, const char* entry_point, const VkSpecializationInfo *spec_info)
+        const VkShaderModuleCreateInfo *module_info, const char* entry_point, const VkSpecializationInfo *spec_info)
 {
+    memset(info, 0, sizeof(*info));
     info->sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    info->pNext = NULL;
-    info->flags = 0;
+    info->pNext = module_info;
     info->stage = stage;
-    info->module = module;
     info->pName = entry_point;
     info->pSpecializationInfo = spec_info;
 }
@@ -182,14 +175,10 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
     struct vkd3d_queue_timeline_trace_cookie cookie;
     VkComputePipelineCreateInfo pipeline_info;
     VkPipelineCreateFlags2CreateInfo flags2;
-    VkShaderModule module;
+    VkShaderModuleCreateInfo module_info;
     VkResult vr;
 
-    if ((vr = vkd3d_meta_create_shader_module(device, code, code_size, &module)) < 0)
-    {
-        ERR("Failed to create shader module, vr %d.\n", vr);
-        return vr;
-    }
+    vkd3d_meta_setup_shader_module(&module_info, code, code_size);
 
     memset(&flags2, 0, sizeof(flags2));
     flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
@@ -208,9 +197,9 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
     }
 
     vkd3d_meta_make_shader_stage(&pipeline_info.stage,
-            VK_SHADER_STAGE_COMPUTE_BIT, module, "main", specialization_info);
+            VK_SHADER_STAGE_COMPUTE_BIT, &module_info, "main", specialization_info);
 
-    pipeline_info.stage.pNext = required_size;
+    module_info.pNext = required_size;
 
     if (layout == VK_NULL_HANDLE)
     {
@@ -226,14 +215,13 @@ static VkResult vkd3d_meta_create_compute_pipeline(struct d3d12_device *device,
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&device->queue_timeline_trace);
     vr = VK_CALL(vkCreateComputePipelines(device->vk_device, VK_NULL_HANDLE, 1, &pipeline_info, NULL, pipeline));
     vkd3d_queue_timeline_trace_complete_pso_compile(&device->queue_timeline_trace, cookie, 0, "META COMP");
-    VK_CALL(vkDestroyShaderModule(device->vk_device, module, NULL));
 
     return vr;
 }
 
 static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_ops,
         VkPipelineLayout layout, VkFormat color_format, VkFormat ds_format, VkImageAspectFlags vk_aspect_mask,
-        VkShaderModule vs_module, VkShaderModule fs_module, VkSampleCountFlagBits samples,
+        const VkShaderModuleCreateInfo *vs_module, const VkShaderModuleCreateInfo *fs_module, VkSampleCountFlagBits samples,
         const VkPipelineDepthStencilStateCreateInfo *ds_state, uint32_t dynamic_state_count, const VkDynamicState *dynamic_states,
         const VkSpecializationInfo *spec_info, bool descriptor_buffer_compatible, VkPipeline *vk_pipeline)
 {
@@ -374,13 +362,13 @@ static VkResult vkd3d_meta_create_graphics_pipeline(struct vkd3d_meta_ops *meta_
 
     vkd3d_meta_make_shader_stage(&shader_stages[pipeline_info.stageCount++],
             VK_SHADER_STAGE_VERTEX_BIT,
-            vs_module ? vs_module : meta_ops->common.vk_module_fullscreen_vs,
+            vs_module ? vs_module : &meta_ops->common.vk_fullscreen_vs,
             "main", NULL);
 
-    if (meta_ops->common.vk_module_fullscreen_gs && vs_module == VK_NULL_HANDLE)
+    if (meta_ops->common.vk_fullscreen_gs.codeSize && !vs_module)
     {
         vkd3d_meta_make_shader_stage(&shader_stages[pipeline_info.stageCount++],
-                VK_SHADER_STAGE_GEOMETRY_BIT, meta_ops->common.vk_module_fullscreen_gs, "main", NULL);
+                VK_SHADER_STAGE_GEOMETRY_BIT, &meta_ops->common.vk_fullscreen_gs, "main", NULL);
     }
 
     if (fs_module)
@@ -659,9 +647,6 @@ static void vkd3d_copy_image_ops_cleanup(struct vkd3d_copy_image_ops *meta_copy_
 
     VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, meta_copy_image_ops->vk_set_layout, NULL));
     VK_CALL(vkDestroyPipelineLayout(device->vk_device, meta_copy_image_ops->vk_pipeline_layout, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_copy_image_ops->vk_fs_float_module, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_copy_image_ops->vk_fs_uint_module, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_copy_image_ops->vk_fs_stencil_module, NULL));
 
     pthread_mutex_destroy(&meta_copy_image_ops->mutex);
 
@@ -710,38 +695,13 @@ static HRESULT vkd3d_copy_image_ops_init(struct vkd3d_copy_image_ops *meta_copy_
         goto fail;
     }
 
-    if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_copy_image_float),
-            &meta_copy_image_ops->vk_fs_float_module)) < 0)
-    {
-        ERR("Failed to create shader modules, vr %d.\n", vr);
-        goto fail;
-    }
-
-    if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_copy_image_uint),
-            &meta_copy_image_ops->vk_fs_uint_module)) < 0)
-    {
-        ERR("Failed to create shader modules, vr %d.\n", vr);
-        goto fail;
-    }
+    vkd3d_meta_setup_shader_module(&meta_copy_image_ops->vk_fs_float_module, SPIRV_CODE(fs_copy_image_float));
+    vkd3d_meta_setup_shader_module(&meta_copy_image_ops->vk_fs_uint_module, SPIRV_CODE(fs_copy_image_uint));
 
     if (device->vk_info.EXT_shader_stencil_export)
-    {
-        if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_copy_image_stencil),
-                &meta_copy_image_ops->vk_fs_stencil_module)) < 0)
-        {
-            ERR("Failed to create shader modules, vr %d.\n", vr);
-            goto fail;
-        }
-    }
+        vkd3d_meta_setup_shader_module(&meta_copy_image_ops->vk_fs_stencil_module, SPIRV_CODE(fs_copy_image_stencil));
     else
-    {
-        if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_copy_image_stencil_no_export),
-                &meta_copy_image_ops->vk_fs_stencil_module)) < 0)
-        {
-            ERR("Failed to create shader modules, vr %d.\n", vr);
-            goto fail;
-        }
-    }
+        vkd3d_meta_setup_shader_module(&meta_copy_image_ops->vk_fs_stencil_module, SPIRV_CODE(fs_copy_image_stencil_no_export));
 
     return S_OK;
 
@@ -758,7 +718,7 @@ static HRESULT vkd3d_meta_create_swapchain_pipeline(struct vkd3d_meta_ops *meta_
 
     if ((vr = vkd3d_meta_create_graphics_pipeline(meta_ops,
             meta_swapchain_ops->vk_pipeline_layouts[key->filter], key->format, VK_FORMAT_UNDEFINED, VK_IMAGE_ASPECT_COLOR_BIT,
-            meta_swapchain_ops->vk_vs_module, meta_swapchain_ops->vk_fs_module, 1,
+            &meta_swapchain_ops->vk_vs_module, &meta_swapchain_ops->vk_fs_module, 1,
             NULL, 0, NULL, NULL, false, &pipeline->vk_pipeline)) < 0)
         return hresult_from_vk_result(vr);
 
@@ -771,9 +731,9 @@ static HRESULT vkd3d_meta_create_copy_image_pipeline(struct vkd3d_meta_ops *meta
 {
     struct vkd3d_copy_image_ops *meta_copy_image_ops = heap ? &meta_ops->copy_image_heap : &meta_ops->copy_image_legacy;
     VkPipelineDepthStencilStateCreateInfo ds_state;
+    const VkShaderModuleCreateInfo *module_info;
     unsigned int dynamic_state_count;
     VkSpecializationInfo spec_info;
-    VkShaderModule vk_module;
     bool has_depth_target;
     VkResult vr;
 
@@ -853,12 +813,12 @@ static HRESULT vkd3d_meta_create_copy_image_pipeline(struct vkd3d_meta_ops *meta
     if (key->format->vk_format == VK_FORMAT_R8_UINT)
     {
         /* Special path when copying stencil -> color. */
-        vk_module = meta_copy_image_ops->vk_fs_uint_module;
+        module_info = &meta_copy_image_ops->vk_fs_uint_module;
     }
     else if (key->dst_aspect_mask == VK_IMAGE_ASPECT_STENCIL_BIT)
     {
         /* FragStencilRef path. */
-        vk_module = meta_copy_image_ops->vk_fs_stencil_module;
+        module_info = &meta_copy_image_ops->vk_fs_stencil_module;
 
         if (!meta_ops->device->vk_info.EXT_shader_stencil_export)
             dynamic_state_count = ARRAY_SIZE(dynamic_states);
@@ -866,7 +826,7 @@ static HRESULT vkd3d_meta_create_copy_image_pipeline(struct vkd3d_meta_ops *meta
     else
     {
         /* Depth or float color path. */
-        vk_module = meta_copy_image_ops->vk_fs_float_module;
+        module_info = &meta_copy_image_ops->vk_fs_float_module;
     }
 
     if ((vr = vkd3d_meta_create_graphics_pipeline(meta_ops,
@@ -874,7 +834,7 @@ static HRESULT vkd3d_meta_create_copy_image_pipeline(struct vkd3d_meta_ops *meta
             has_depth_target ? VK_FORMAT_UNDEFINED : key->format->vk_format,
             has_depth_target ? key->format->vk_format : VK_FORMAT_UNDEFINED,
             key->format->vk_aspect_mask,
-            VK_NULL_HANDLE, vk_module, key->sample_count,
+            VK_NULL_HANDLE, module_info, key->sample_count,
             has_depth_target ? &ds_state : NULL,
             dynamic_state_count, dynamic_states,
             &spec_info, true, &pipeline->vk_pipeline)) < 0)
@@ -994,11 +954,6 @@ static void vkd3d_resolve_image_ops_cleanup(struct vkd3d_resolve_image_ops *meta
     for (i = 0; i < meta_resolve_image_ops->pipeline_count; i++)
         VK_CALL(vkDestroyPipeline(device->vk_device, meta_resolve_image_ops->pipelines[i].vk_pipeline, NULL));
 
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_resolve_image_ops->vk_fs_float_module, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_resolve_image_ops->vk_fs_uint_module, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_resolve_image_ops->vk_fs_sint_module, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_resolve_image_ops->vk_fs_depth_module, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_resolve_image_ops->vk_fs_stencil_module, NULL));
     VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, meta_resolve_image_ops->vk_graphics_set_layout, NULL));
     VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, meta_resolve_image_ops->vk_compute_set_layout, NULL));
     VK_CALL(vkDestroyPipelineLayout(device->vk_device, meta_resolve_image_ops->vk_graphics_pipeline_layout, NULL));
@@ -1079,52 +1034,15 @@ static HRESULT vkd3d_resolve_image_ops_init(struct vkd3d_resolve_image_ops *meta
         goto fail;
     }
 
-    if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_resolve_color_float),
-            &meta_resolve_image_ops->vk_fs_float_module)) < 0)
-    {
-        ERR("Failed to create shader modules, vr %d.\n", vr);
-        goto fail;
-    }
-
-    if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_resolve_color_uint),
-            &meta_resolve_image_ops->vk_fs_uint_module)) < 0)
-    {
-        ERR("Failed to create shader modules, vr %d.\n", vr);
-        goto fail;
-    }
-
-    if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_resolve_color_sint),
-            &meta_resolve_image_ops->vk_fs_sint_module)) < 0)
-    {
-        ERR("Failed to create shader modules, vr %d.\n", vr);
-        goto fail;
-    }
-
-    if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_resolve_depth),
-            &meta_resolve_image_ops->vk_fs_depth_module)) < 0)
-    {
-        ERR("Failed to create shader modules, vr %d.\n", vr);
-        goto fail;
-    }
+    vkd3d_meta_setup_shader_module(&meta_resolve_image_ops->vk_fs_float_module, SPIRV_CODE(fs_resolve_color_float));
+    vkd3d_meta_setup_shader_module(&meta_resolve_image_ops->vk_fs_uint_module, SPIRV_CODE(fs_resolve_color_uint));
+    vkd3d_meta_setup_shader_module(&meta_resolve_image_ops->vk_fs_sint_module, SPIRV_CODE(fs_resolve_color_sint));
+    vkd3d_meta_setup_shader_module(&meta_resolve_image_ops->vk_fs_depth_module, SPIRV_CODE(fs_resolve_depth));
 
     if (device->vk_info.EXT_shader_stencil_export)
-    {
-        if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_resolve_stencil),
-                &meta_resolve_image_ops->vk_fs_stencil_module)) < 0)
-        {
-            ERR("Failed to create shader modules, vr %d.\n", vr);
-            goto fail;
-        }
-    }
+        vkd3d_meta_setup_shader_module(&meta_resolve_image_ops->vk_fs_stencil_module, SPIRV_CODE(fs_resolve_stencil));
     else
-    {
-        if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_resolve_stencil_no_export),
-                &meta_resolve_image_ops->vk_fs_stencil_module)) < 0)
-        {
-            ERR("Failed to create shader modules, vr %d.\n", vr);
-            goto fail;
-        }
-    }
+        vkd3d_meta_setup_shader_module(&meta_resolve_image_ops->vk_fs_stencil_module, SPIRV_CODE(fs_resolve_stencil_no_export));
 
     return S_OK;
 
@@ -1140,9 +1058,9 @@ static HRESULT vkd3d_meta_create_resolve_image_graphics_pipeline(struct vkd3d_me
     struct vkd3d_resolve_image_ops *meta_resolve_image_ops =
         heap ? &meta_ops->resolve_image_heap : &meta_ops->resolve_image_legacy;
     VkPipelineDepthStencilStateCreateInfo ds_state;
+    const VkShaderModuleCreateInfo *module_info;
     unsigned int dynamic_state_count;
     VkSpecializationInfo spec_info;
-    VkShaderModule vk_module;
     bool has_depth_target;
     VkResult vr;
 
@@ -1195,14 +1113,14 @@ static HRESULT vkd3d_meta_create_resolve_image_graphics_pipeline(struct vkd3d_me
         ds_state.front.compareOp = VK_COMPARE_OP_ALWAYS;
         ds_state.back = ds_state.front;
 
-        vk_module = meta_resolve_image_ops->vk_fs_stencil_module;
+        module_info = &meta_resolve_image_ops->vk_fs_stencil_module;
 
         if (!meta_ops->device->vk_info.EXT_shader_stencil_export)
             dynamic_state_count = ARRAY_SIZE(dynamic_states);
     }
     else if (key->dst_aspect == VK_IMAGE_ASPECT_DEPTH_BIT)
     {
-        vk_module = meta_resolve_image_ops->vk_fs_depth_module;
+        module_info = &meta_resolve_image_ops->vk_fs_depth_module;
     }
     else
     {
@@ -1213,15 +1131,15 @@ static HRESULT vkd3d_meta_create_resolve_image_graphics_pipeline(struct vkd3d_me
                 return E_INVALIDARG;
 
             case VKD3D_FORMAT_TYPE_SINT:
-                vk_module = meta_resolve_image_ops->vk_fs_sint_module;
+                module_info = &meta_resolve_image_ops->vk_fs_sint_module;
                 break;
 
             case VKD3D_FORMAT_TYPE_UINT:
-                vk_module = meta_resolve_image_ops->vk_fs_uint_module;
+                module_info = &meta_resolve_image_ops->vk_fs_uint_module;
                 break;
 
             default:
-                vk_module = meta_resolve_image_ops->vk_fs_float_module;
+                module_info = &meta_resolve_image_ops->vk_fs_float_module;
                 break;
         }
     }
@@ -1231,7 +1149,7 @@ static HRESULT vkd3d_meta_create_resolve_image_graphics_pipeline(struct vkd3d_me
             has_depth_target ? VK_FORMAT_UNDEFINED : key->format->vk_format,
             has_depth_target ? key->format->vk_format : VK_FORMAT_UNDEFINED,
             key->format->vk_aspect_mask,
-            VK_NULL_HANDLE, vk_module, VK_SAMPLE_COUNT_1_BIT,
+            VK_NULL_HANDLE, module_info, VK_SAMPLE_COUNT_1_BIT,
             has_depth_target ? &ds_state : NULL,
             dynamic_state_count, dynamic_states,
             &spec_info, true, &pipeline->vk_pipeline)) < 0)
@@ -1377,38 +1295,18 @@ HRESULT vkd3d_meta_get_resolve_image_pipeline(struct vkd3d_meta_ops *meta_ops,
     return S_OK;
 }
 
-static HRESULT vkd3d_meta_ops_common_init(struct vkd3d_meta_ops_common *meta_ops_common, struct d3d12_device *device)
+static void vkd3d_meta_ops_common_init(struct vkd3d_meta_ops_common *meta_ops_common, struct d3d12_device *device)
 {
-    VkResult vr;
-
     if (device->device_info.vulkan_1_2_features.shaderOutputViewportIndex &&
             device->device_info.vulkan_1_2_features.shaderOutputLayer)
     {
-        if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(vs_fullscreen_layer), &meta_ops_common->vk_module_fullscreen_vs)) < 0)
-        {
-            ERR("Failed to create shader modules, vr %d.\n", vr);
-            return hresult_from_vk_result(vr);
-        }
+        vkd3d_meta_setup_shader_module(&meta_ops_common->vk_fullscreen_vs, SPIRV_CODE(vs_fullscreen_layer));
     }
     else
     {
-        if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(vs_fullscreen), &meta_ops_common->vk_module_fullscreen_vs)) < 0 ||
-            (vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(gs_fullscreen), &meta_ops_common->vk_module_fullscreen_gs)) < 0)
-        {
-            ERR("Failed to create shader modules, vr %d.\n", vr);
-            return hresult_from_vk_result(vr);
-        }
+        vkd3d_meta_setup_shader_module(&meta_ops_common->vk_fullscreen_vs, SPIRV_CODE(vs_fullscreen));
+        vkd3d_meta_setup_shader_module(&meta_ops_common->vk_fullscreen_gs, SPIRV_CODE(gs_fullscreen));
     }
-
-    return S_OK;
-}
-
-static void vkd3d_meta_ops_common_cleanup(struct vkd3d_meta_ops_common *meta_ops_common, struct d3d12_device *device)
-{
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_ops_common->vk_module_fullscreen_vs, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_ops_common->vk_module_fullscreen_gs, NULL));
 }
 
 static void vkd3d_swapchain_ops_cleanup(struct vkd3d_swapchain_ops *meta_swapchain_ops, struct d3d12_device *device)
@@ -1428,9 +1326,6 @@ static void vkd3d_swapchain_ops_cleanup(struct vkd3d_swapchain_ops *meta_swapcha
         VK_CALL(vkDestroyDescriptorSetLayout(device->vk_device, meta_swapchain_ops->vk_set_layouts[i], NULL));
         VK_CALL(vkDestroyPipelineLayout(device->vk_device, meta_swapchain_ops->vk_pipeline_layouts[i], NULL));
     }
-
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_swapchain_ops->vk_vs_module, NULL));
-    VK_CALL(vkDestroyShaderModule(device->vk_device, meta_swapchain_ops->vk_fs_module, NULL));
 
     pthread_mutex_destroy(&meta_swapchain_ops->mutex);
     vkd3d_free(meta_swapchain_ops->pipelines);
@@ -1480,18 +1375,8 @@ static HRESULT vkd3d_swapchain_ops_init(struct vkd3d_swapchain_ops *meta_swapcha
         }
     }
 
-    if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(vs_swapchain_fullscreen), &meta_swapchain_ops->vk_vs_module)) < 0)
-    {
-        ERR("Failed to create shader modules, vr %d.\n", vr);
-        goto fail;
-    }
-
-    if ((vr = vkd3d_meta_create_shader_module(device, SPIRV_CODE(fs_swapchain_fullscreen), &meta_swapchain_ops->vk_fs_module)) < 0)
-    {
-        ERR("Failed to create shader modules, vr %d.\n", vr);
-        goto fail;
-    }
-
+    vkd3d_meta_setup_shader_module(&meta_swapchain_ops->vk_vs_module, SPIRV_CODE(vs_swapchain_fullscreen));
+    vkd3d_meta_setup_shader_module(&meta_swapchain_ops->vk_fs_module, SPIRV_CODE(fs_swapchain_fullscreen));
     return S_OK;
 
 fail:
@@ -2000,12 +1885,11 @@ static void vkd3d_dstorage_ops_cleanup(struct vkd3d_dstorage_ops *dstorage_ops, 
 static HRESULT vkd3d_sampler_feedback_ops_init(struct vkd3d_sampler_feedback_resolve_ops *sampler_feedback_ops,
         struct d3d12_device *device, bool use_heap)
 {
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkDescriptorSetLayoutBinding decode_bindings[2];
     VkDescriptorSetLayoutBinding encode_bindings[3];
+    VkShaderModuleCreateInfo module_info;
     VkPushConstantRange push_range;
     VkPipelineLayout vk_layout;
-    VkShaderModule vk_module;
     VkSampler vk_sampler;
     unsigned int i;
     VkResult vr;
@@ -2143,20 +2027,14 @@ static HRESULT vkd3d_sampler_feedback_ops_init(struct vkd3d_sampler_feedback_res
         }
         else
         {
-            if ((vr = vkd3d_meta_create_shader_module(device, pipelines[i].code, pipelines[i].code_size, &vk_module)))
-                return hresult_from_vk_result(vr);
+            vkd3d_meta_setup_shader_module(&module_info, pipelines[i].code, pipelines[i].code_size);
 
             if ((vr = vkd3d_meta_create_graphics_pipeline(&device->meta_ops,
                     sampler_feedback_ops->vk_graphics_decode_layout,
-                    VK_FORMAT_R8_UINT, VK_FORMAT_UNDEFINED, VK_IMAGE_ASPECT_COLOR_BIT, VK_NULL_HANDLE, vk_module,
+                    VK_FORMAT_R8_UINT, VK_FORMAT_UNDEFINED, VK_IMAGE_ASPECT_COLOR_BIT, VK_NULL_HANDLE, &module_info,
                     VK_SAMPLE_COUNT_1_BIT, NULL, 0, NULL, NULL, true,
                     &sampler_feedback_ops->vk_pipelines[pipelines[i].type])))
-            {
-                VK_CALL(vkDestroyShaderModule(device->vk_device, vk_module, NULL));
                 return hresult_from_vk_result(vr);
-            }
-
-            VK_CALL(vkDestroyShaderModule(device->vk_device, vk_module, NULL));
         }
     }
 
@@ -2351,8 +2229,7 @@ HRESULT vkd3d_meta_ops_init(struct vkd3d_meta_ops *meta_ops, struct d3d12_device
     memset(meta_ops, 0, sizeof(*meta_ops));
     meta_ops->device = device;
 
-    if (FAILED(hr = vkd3d_meta_ops_common_init(&meta_ops->common, device)))
-        goto fail_common;
+    vkd3d_meta_ops_common_init(&meta_ops->common, device);
 
     if (d3d12_device_use_descriptor_heap(device))
         if (FAILED(hr = vkd3d_clear_uav_ops_init(&meta_ops->clear_uav_heap, device, true)))
@@ -2434,8 +2311,6 @@ fail_copy_image_heap_ops:
 fail_clear_uav_ops_legacy:
     vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav_heap, device);
 fail_clear_uav_ops_heap:
-    vkd3d_meta_ops_common_cleanup(&meta_ops->common, device);
-fail_common:
     return hr;
 }
 
@@ -2456,6 +2331,5 @@ HRESULT vkd3d_meta_ops_cleanup(struct vkd3d_meta_ops *meta_ops, struct d3d12_dev
     vkd3d_resolve_image_ops_cleanup(&meta_ops->resolve_image_legacy, device);
     vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav_heap, device);
     vkd3d_clear_uav_ops_cleanup(&meta_ops->clear_uav_legacy, device);
-    vkd3d_meta_ops_common_cleanup(&meta_ops->common, device);
     return S_OK;
 }

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -2503,15 +2503,18 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
         }
     }
 
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+
+    memset(&pipeline_create_info, 0, sizeof(pipeline_create_info));
     pipeline_create_info.sType = VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR;
-    pipeline_create_info.pNext = NULL;
 
     /* If we allow state object additions, we must first lower this pipeline to a library, and
      * then link it to itself so we can use it a library in subsequent PSO creations, but we
      * must also be able to trace rays from the library. */
-    pipeline_create_info.flags = (object->type == D3D12_STATE_OBJECT_TYPE_COLLECTION ||
-            (object->flags & D3D12_STATE_OBJECT_FLAG_ALLOW_STATE_OBJECT_ADDITIONS)) ?
-            VK_PIPELINE_CREATE_LIBRARY_BIT_KHR : 0;
+    if (object->type == D3D12_STATE_OBJECT_TYPE_COLLECTION ||
+            (object->flags & D3D12_STATE_OBJECT_FLAG_ALLOW_STATE_OBJECT_ADDITIONS))
+        flags2.flags |= VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR;
 
     if (variant->local_static_sampler.pipeline_layout)
         pipeline_create_info.layout = variant->local_static_sampler.pipeline_layout;
@@ -2530,11 +2533,11 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
     pipeline_create_info.maxPipelineRayRecursionDepth = object->pipeline_config.MaxTraceRecursionDepth;
 
     if (object->pipeline_config.Flags & D3D12_RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES)
-        pipeline_create_info.flags |= VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR;
+        flags2.flags |= VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR;
     if (object->pipeline_config.Flags & D3D12_RAYTRACING_PIPELINE_FLAG_SKIP_PROCEDURAL_PRIMITIVES)
-        pipeline_create_info.flags |= VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR;
+        flags2.flags |= VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_AABBS_BIT_KHR;
     if (object->pipeline_config.Flags & D3D12_RAYTRACING_PIPELINE_FLAG_ALLOW_OPACITY_MICROMAPS)
-        pipeline_create_info.flags |= VK_PIPELINE_CREATE_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT;
 
     library_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR;
     library_info.pNext = NULL;
@@ -2570,20 +2573,15 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
     dynamic_state.dynamicStateCount = 1;
     dynamic_state.pDynamicStates = dynamic_states;
 
-    memset(&flags2, 0, sizeof(flags2));
-    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
-    creating_library = !!(pipeline_create_info.flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR);
+    creating_library = !!(flags2.flags & VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR);
 
     if (d3d12_device_use_descriptor_heap(object->device))
-    {
-        flags2.flags = pipeline_create_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
-        pipeline_create_info.flags = 0;
-        vk_prepend_struct(&pipeline_create_info, &flags2);
-    }
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
     else if (d3d12_device_uses_descriptor_buffers(object->device))
-    {
-        pipeline_create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-    }
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    if (flags2.flags)
+        vk_prepend_struct(&pipeline_create_info, &flags2);
 
     TRACE("Calling vkCreateRayTracingPipelinesKHR.\n");
 
@@ -2595,7 +2593,6 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
             object->type == D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE)
     {
         /* It is valid to inherit pipeline libraries into other pipeline libraries. */
-        pipeline_create_info.flags &= ~VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
         flags2.flags &= ~VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR;
 
         pipeline_create_info.pStages = NULL;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -108,23 +108,14 @@ HRESULT vkd3d_create_buffer_explicit_usage(struct d3d12_device *device,
     VkBufferCreateInfo buffer_info;
     VkResult vr;
 
+    memset(&buffer_info, 0, sizeof(buffer_info));
     buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    buffer_info.pNext = NULL;
-    buffer_info.flags = 0;
     buffer_info.size = size;
 
-    if (device->device_info.maintenance_5_features.maintenance5)
-    {
-        flags2.sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR;
-        flags2.pNext = NULL;
-        flags2.usage = vk_usage_flags;
-        buffer_info.usage = 0;
-        vk_prepend_struct(&buffer_info, &flags2);
-    }
-    else
-    {
-        buffer_info.usage = vk_usage_flags;
-    }
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR;
+    flags2.usage = vk_usage_flags;
+    vk_prepend_struct(&buffer_info, &flags2);
 
     /* Buffers have implicit SIMULTANEOUS_USAGE rules, which imply some level of CONCURRENT access.
      * We'll need to use CONCURRENT here to be fully spec compliant. */
@@ -5134,21 +5125,17 @@ bool vkd3d_create_vk_buffer_view(struct d3d12_device *device,
         return false;
     }
 
+    memset(&view_desc, 0, sizeof(view_desc));
     view_desc.sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO;
-    view_desc.pNext = NULL;
-    view_desc.flags = 0;
     view_desc.buffer = vk_buffer;
     view_desc.format = format->vk_format;
     view_desc.offset = offset;
     view_desc.range = range;
 
-    if (device->device_info.maintenance_5_features.maintenance5)
-    {
-        memset(&flags2, 0, sizeof(flags2));
-        flags2.sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO;
-        flags2.usage = usage;
-        vk_prepend_struct(&view_desc, &flags2);
-    }
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO;
+    flags2.usage = usage;
+    vk_prepend_struct(&view_desc, &flags2);
 
     if ((vr = VK_CALL(vkCreateBufferView(device->vk_device, &view_desc, NULL, vk_view))) < 0)
         WARN("Failed to create Vulkan buffer view, vr %d.\n", vr);

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -3463,9 +3463,11 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     else
         spirv_code_debug = NULL;
 
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+
+    memset(&pipeline_info, 0, sizeof(pipeline_info));
     pipeline_info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    pipeline_info.pNext = NULL;
-    pipeline_info.flags = 0;
 
     if (state->compute.identifier_create_info.identifierSize == 0)
     {
@@ -3491,7 +3493,6 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     }
 
     pipeline_info.layout = state->root_signature->compute.vk_pipeline_layout;
-    pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
     pipeline_info.basePipelineIndex = -1;
 
     if ((spirv_code->meta.flags & VKD3D_SHADER_META_FLAG_REPLACED) && device->debug_ring.active)
@@ -3515,26 +3516,20 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
         feedback_info.pipelineStageCreationFeedbackCount = 0;
 
     if (pipeline_info.stage.module == VK_NULL_HANDLE)
-        pipeline_info.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
     if (state->compute.code.meta.flags & VKD3D_SHADER_META_FLAG_DISABLE_OPTIMIZATIONS)
-        pipeline_info.flags |= VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT;
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&device->queue_timeline_trace);
 
     if (d3d12_device_use_descriptor_heap(device))
-    {
-        memset(&flags2, 0, sizeof(flags2));
-        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
-        vk_prepend_struct(&pipeline_info, &flags2);
-        flags2.flags = pipeline_info.flags;
-        pipeline_info.flags = 0;
         flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
-    }
     else if (d3d12_device_uses_descriptor_buffers(device))
-    {
-        pipeline_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-    }
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    if (flags2.flags)
+        vk_prepend_struct(&pipeline_info, &flags2);
 
     vr = VK_CALL(vkCreateComputePipelines(device->vk_device,
             vk_cache, 1, &pipeline_info, NULL, &state->compute.vk_pipeline));
@@ -3545,7 +3540,7 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
 
         if (vr == VK_SUCCESS)
         {
-            if (pipeline_info.flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
+            if (flags2.flags & VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
                 kind = "COMP IDENT OK";
             else
                 kind = "COMP OK";
@@ -3561,7 +3556,7 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
 
     if (VKD3D_CONFIG_FLAG_IS_SET(PIPELINE_LIBRARY_LOG))
     {
-        if (pipeline_info.flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
+        if (flags2.flags & VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
         {
             if (vr == VK_SUCCESS)
                 INFO("[IDENTIFIER] Successfully created compute pipeline from identifier.\n");
@@ -3575,7 +3570,6 @@ static HRESULT vkd3d_create_compute_pipeline(struct d3d12_pipeline_state *state,
     /* Fallback. */
     if (vr == VK_PIPELINE_COMPILE_REQUIRED)
     {
-        pipeline_info.flags &= ~VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
         flags2.flags &= ~VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
         if (FAILED(hr = vkd3d_compile_shader_stage(state, device,
@@ -4473,29 +4467,24 @@ VkPipeline vkd3d_vertex_input_pipeline_create(struct d3d12_device *device,
     library_create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT;
     library_create_info.flags = VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT;
 
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+    flags2.flags = VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_2_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
+
     memset(&create_info, 0, sizeof(create_info));
     create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    create_info.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
     create_info.pInputAssemblyState = &desc_copy.ia_info;
     create_info.pVertexInputState = &desc_copy.vi_info;
     create_info.pDynamicState = &desc_copy.dy_info;
     create_info.basePipelineIndex = -1;
 
+    vk_prepend_struct(&create_info, &flags2);
     vk_prepend_struct(&create_info, &library_create_info);
 
     if (d3d12_device_use_descriptor_heap(device))
-    {
-        memset(&flags2, 0, sizeof(flags2));
-        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
-        vk_prepend_struct(&create_info, &flags2);
-        flags2.flags = create_info.flags;
-        create_info.flags = 0;
         flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
-    }
     else if (d3d12_device_uses_descriptor_buffers(device))
-    {
-        create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-    }
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
     if ((vr = VK_CALL(vkCreateGraphicsPipelines(device->vk_device,
             VK_NULL_HANDLE, 1, &create_info, NULL, &vk_pipeline))))
@@ -4636,30 +4625,25 @@ VkPipeline vkd3d_fragment_output_pipeline_create(struct d3d12_device *device,
     library_create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT;
     library_create_info.flags = VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT;
 
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+    flags2.flags = VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_2_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
+
     memset(&create_info, 0, sizeof(create_info));
     create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    create_info.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
     create_info.pColorBlendState = &desc_copy.cb_info;
     create_info.pMultisampleState = &desc_copy.ms_info;
     create_info.pDynamicState = &desc_copy.dy_info;
     create_info.basePipelineIndex = -1;
 
+    vk_prepend_struct(&create_info, &flags2);
     vk_prepend_struct(&create_info, &desc_copy.rt_info);
     vk_prepend_struct(&create_info, &library_create_info);
 
     if (d3d12_device_use_descriptor_heap(device))
-    {
-        memset(&flags2, 0, sizeof(flags2));
-        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
-        vk_prepend_struct(&create_info, &flags2);
-        flags2.flags = create_info.flags;
-        create_info.flags = 0;
         flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
-    }
     else if (d3d12_device_uses_descriptor_buffers(device))
-    {
-        create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-    }
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
     if ((vr = VK_CALL(vkCreateGraphicsPipelines(device->vk_device,
             VK_NULL_HANDLE, 1, &create_info, NULL, &vk_pipeline))))
@@ -6709,6 +6693,10 @@ static VkResult d3d12_pipeline_state_link_pipeline_variant(struct d3d12_pipeline
         vk_libraries[library_count++] = d3d12_device_get_or_create_fragment_output_pipeline(state->device, &fragment_output_desc);
     }
 
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+    flags2.flags = graphics->library_create_flags;
+
     memset(&library_info, 0, sizeof(library_info));
     library_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR;
     library_info.libraryCount = library_count;
@@ -6716,35 +6704,29 @@ static VkResult d3d12_pipeline_state_link_pipeline_variant(struct d3d12_pipeline
 
     memset(&create_info, 0, sizeof(create_info));
     create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    create_info.flags = graphics->library_create_flags;
     create_info.layout = graphics->pipeline_layout;
     create_info.basePipelineIndex = -1;
 
     vk_prepend_struct(&create_info, &library_info);
 
     if (graphics->disable_optimization)
-        create_info.flags |= VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT;
 
     /* Only use LINK_TIME_OPTIMIZATION for the primary pipeline for now,
      * accept a small runtime perf hit on subsequent compiles in order
      * to avoid stutter. */
     if (!key)
-        create_info.flags |= VK_PIPELINE_CREATE_LINK_TIME_OPTIMIZATION_BIT_EXT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_LINK_TIME_OPTIMIZATION_BIT_EXT;
 
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&state->device->queue_timeline_trace);
 
     if (d3d12_device_use_descriptor_heap(state->device))
-    {
-        memset(&flags2, 0, sizeof(flags2));
-        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
-        flags2.flags = create_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
-        create_info.flags = 0;
-        vk_prepend_struct(&create_info, &flags2);
-    }
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
     else if (d3d12_device_uses_descriptor_buffers(state->device))
-    {
-        create_info.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-    }
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    if (flags2.flags)
+        vk_prepend_struct(&create_info, &flags2);
 
     vr = VK_CALL(vkCreateGraphicsPipelines(state->device->vk_device,
             vk_cache, 1, &create_info, NULL, vk_pipeline));
@@ -6834,6 +6816,9 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
             key ? key->view_mask : 0, *dynamic_state_flags);
     vkd3d_fragment_output_pipeline_desc_prepare(&fragment_output_desc);
 
+    memset(&flags2, 0, sizeof(flags2));
+    flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+
     memset(&pipeline_desc, 0, sizeof(pipeline_desc));
     pipeline_desc.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
     pipeline_desc.stageCount = graphics->stage_count;
@@ -6848,7 +6833,7 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
     vk_prepend_struct(&pipeline_desc, &fragment_output_desc.rt_info);
 
     if (d3d12_device_supports_variable_shading_rate_tier_2(device))
-        pipeline_desc.flags |= VK_PIPELINE_CREATE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
+        flags2.flags |= VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
 
     if (graphics->stage_flags & VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
         pipeline_desc.pTessellationState = &tessellation_info;
@@ -6881,8 +6866,8 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
         library_create_info.flags = library_flags;
         vk_prepend_struct(&pipeline_desc, &library_create_info);
 
-        pipeline_desc.flags |= VK_PIPELINE_CREATE_LIBRARY_BIT_KHR |
-                VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR |
+                VK_PIPELINE_CREATE_2_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
 
         graphics->library_flags = library_flags;
     }
@@ -6929,10 +6914,10 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
     /* If we're using identifiers, set the appropriate flag. */
     for (i = 0; i < graphics->stage_count; i++)
         if (pipeline_desc.pStages[i].module == VK_NULL_HANDLE)
-            pipeline_desc.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+            flags2.flags |= VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
     if (graphics->disable_optimization)
-        pipeline_desc.flags |= VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
+        flags2.flags |= VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT;
 
     TRACE("Calling vkCreateGraphicsPipelines.\n");
 
@@ -6951,18 +6936,12 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
     cookie = vkd3d_queue_timeline_trace_register_pso_compile(&device->queue_timeline_trace);
 
     if (d3d12_device_use_descriptor_heap(device))
-    {
-        memset(&flags2, 0, sizeof(flags2));
-        flags2.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
-        vk_prepend_struct(&pipeline_desc, &flags2);
-        flags2.flags = pipeline_desc.flags;
-        pipeline_desc.flags = 0;
         flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
-    }
     else if (d3d12_device_uses_descriptor_buffers(device))
-    {
-        pipeline_desc.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-    }
+        flags2.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    if (flags2.flags)
+        vk_prepend_struct(&pipeline_desc, &flags2);
 
     vr = VK_CALL(vkCreateGraphicsPipelines(device->vk_device, vk_cache, 1, &pipeline_desc, NULL, &vk_pipeline));
 
@@ -6972,7 +6951,7 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
 
         if (vr == VK_SUCCESS)
         {
-            if (pipeline_desc.flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
+            if (flags2.flags & VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
                 kind = "GFX IDENT OK";
             else
                 kind = "GFX OK";
@@ -6988,7 +6967,7 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
 
     if (VKD3D_CONFIG_FLAG_IS_SET(PIPELINE_LIBRARY_LOG))
     {
-        if (pipeline_desc.flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
+        if (flags2.flags & VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
         {
             if (vr == VK_SUCCESS)
                 INFO("[IDENTIFIER] Successfully created graphics pipeline from identifier.\n");
@@ -7008,7 +6987,6 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
             goto err;
         }
 
-        pipeline_desc.flags &= ~VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
         flags2.flags &= ~VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
         /* Internal modules are known to be non-null now. */
@@ -7040,7 +7018,7 @@ VkPipeline d3d12_pipeline_state_create_pipeline_variant(struct d3d12_pipeline_st
         vkd3d_report_pipeline_creation_feedback_results(&feedback_info);
 
     if (library_flags)
-        graphics->library_create_flags = pipeline_desc.flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+        graphics->library_create_flags = flags2.flags & VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
 err:
     /* Clean up any temporary SPIR-V modules we created. */

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -771,6 +771,8 @@ static void vkd3d_cleanup_depth_stencil_formats(struct d3d12_device *device)
 static HRESULT vkd3d_init_formats(struct d3d12_device *device)
 {
     const struct vkd3d_format_compatibility_list *list;
+    VkFormatProperties3 a8_properties, r8_properties;
+    VkFormatFeatureFlags r8_unique_features;
     struct vkd3d_format *formats, *format;
     VkFormatProperties3 properties;
     DXGI_FORMAT dxgi_format;
@@ -784,35 +786,27 @@ static HRESULT vkd3d_init_formats(struct d3d12_device *device)
             VK_FORMAT_FEATURE_TRANSFER_SRC_BIT |
             VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
 
+    static const VkFormatFeatureFlags a8_required_features =
+            VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT |
+            VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT |
+            VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT |
+            VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT |
+            VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT |
+            VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT |
+            VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT;
+
     if (!(formats = vkd3d_calloc(VKD3D_MAX_DXGI_FORMAT + 1, sizeof(*formats))))
         return E_OUTOFMEMORY;
 
-    if (device->device_info.maintenance_5_features.maintenance5)
-    {
-        const VkFormatFeatureFlags a8_required_features =
-                VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT |
-                VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT |
-                VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT |
-                VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT |
-                VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT |
-                VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT |
-                VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT;
+    vkd3d_get_vk_format_properties(device, VK_FORMAT_A8_UNORM_KHR, &a8_properties);
+    vkd3d_get_vk_format_properties(device, VK_FORMAT_R8_UNORM, &r8_properties);
 
-        VkFormatProperties3 a8_properties, r8_properties;
-        VkFormatFeatureFlags r8_unique_features;
+    /* Only use the native A8_UNORM format if support is at least as good
+        * as for the R8_UNORM fallback format for relevant features. */
+    r8_unique_features = (r8_properties.optimalTilingFeatures | r8_properties.bufferFeatures) &
+            ~(a8_properties.optimalTilingFeatures | a8_properties.bufferFeatures);
 
-        vkd3d_get_vk_format_properties(device, VK_FORMAT_A8_UNORM_KHR, &a8_properties);
-        vkd3d_get_vk_format_properties(device, VK_FORMAT_R8_UNORM, &r8_properties);
-
-        /* Only use the native A8_UNORM format if support is at least as good
-         * as for the R8_UNORM fallback format for relevant features. */
-        r8_unique_features = (r8_properties.optimalTilingFeatures | r8_properties.bufferFeatures) &
-                ~(a8_properties.optimalTilingFeatures | a8_properties.bufferFeatures);
-
-        emulate_a8 = (r8_unique_features & a8_required_features) != 0;
-    }
-    else
-        emulate_a8 = true;
+    emulate_a8 = (r8_unique_features & a8_required_features) != 0;
 
     if (emulate_a8)
         WARN("Mapping VK_FORMAT_A8_UNORM_KHR to VK_FORMAT_R8_UNORM.\n");

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2340,7 +2340,7 @@ struct d3d12_graphics_pipeline_state
     VkPipeline pipeline;
     VkPipeline library;
     VkGraphicsPipelineLibraryFlagsEXT library_flags;
-    VkPipelineCreateFlags library_create_flags;
+    VkPipelineCreateFlags2 library_create_flags;
     struct list compiled_fallback_pipelines;
 
     unsigned int xfb_buffer_count;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -4731,9 +4731,9 @@ struct vkd3d_copy_image_ops
 {
     VkDescriptorSetLayout vk_set_layout;
     VkPipelineLayout vk_pipeline_layout;
-    VkShaderModule vk_fs_float_module;
-    VkShaderModule vk_fs_uint_module;
-    VkShaderModule vk_fs_stencil_module;
+    VkShaderModuleCreateInfo vk_fs_float_module;
+    VkShaderModuleCreateInfo vk_fs_uint_module;
+    VkShaderModuleCreateInfo vk_fs_stencil_module;
 
     pthread_mutex_t mutex;
 
@@ -4809,11 +4809,11 @@ struct vkd3d_resolve_image_ops
     VkDescriptorSetLayout vk_compute_set_layout;
     VkPipelineLayout vk_graphics_pipeline_layout;
     VkPipelineLayout vk_compute_pipeline_layout;
-    VkShaderModule vk_fs_float_module;
-    VkShaderModule vk_fs_uint_module;
-    VkShaderModule vk_fs_sint_module;
-    VkShaderModule vk_fs_depth_module;
-    VkShaderModule vk_fs_stencil_module;
+    VkShaderModuleCreateInfo vk_fs_float_module;
+    VkShaderModuleCreateInfo vk_fs_uint_module;
+    VkShaderModuleCreateInfo vk_fs_sint_module;
+    VkShaderModuleCreateInfo vk_fs_depth_module;
+    VkShaderModuleCreateInfo vk_fs_stencil_module;
 
     pthread_mutex_t mutex;
 
@@ -4846,8 +4846,8 @@ struct vkd3d_swapchain_ops
 {
     VkDescriptorSetLayout vk_set_layouts[2];
     VkPipelineLayout vk_pipeline_layouts[2];
-    VkShaderModule vk_vs_module;
-    VkShaderModule vk_fs_module;
+    VkShaderModuleCreateInfo vk_vs_module;
+    VkShaderModuleCreateInfo vk_fs_module;
     VkSampler vk_samplers[2];
 
     pthread_mutex_t mutex;
@@ -5031,8 +5031,8 @@ struct vkd3d_dstorage_ops
 
 struct vkd3d_meta_ops_common
 {
-    VkShaderModule vk_module_fullscreen_vs;
-    VkShaderModule vk_module_fullscreen_gs;
+    VkShaderModuleCreateInfo vk_fullscreen_vs;
+    VkShaderModuleCreateInfo vk_fullscreen_gs;
 };
 
 struct vkd3d_sampler_feedback_resolve_info

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 # For maintainers: remember to update vcs_tag(fallback) as well
-project('vkd3d-proton', ['c', 'cpp'], version : '3.0.1', meson_version : '>= 0.49', default_options : [
+project('vkd3d-proton', ['c', 'cpp'], version : '3.1.0', meson_version : '>= 0.49', default_options : [
   'warning_level=2', 'c_std=c11', 'cpp_std=c++17'
 ])
 
@@ -171,7 +171,7 @@ vkd3d_build = vcs_tag(
 vkd3d_version = vcs_tag(
   command : ['git', 'describe', '--always', '--tags', '--dirty=+'],
   input   : 'vkd3d_version.h.in',
-  output  : 'vkd3d_version.h', fallback : '300001')
+  output  : 'vkd3d_version.h', fallback : '301000')
 
 dxil_spirv = subproject('dxil-spirv')
 dxil_spirv_dep = dxil_spirv.get_variable('dxil_spirv_dep')


### PR DESCRIPTION
Nothing spectacular, just removes some fallbacks and gets rid of VkShaderModule for meta stuff.

The regular pipeline code is kinda designed around shader modules and also sets debug info on them, so I didn't touch that.