### PR TITLE
VK_KHR_opacity_micromap - Phase 5

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -2549,9 +2549,6 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     VK_CALL(vkGetPhysicalDeviceFeatures2(device->vk_physical_device, &info->features2));
     VK_CALL(vkGetPhysicalDeviceProperties2(device->vk_physical_device, &info->properties2));
 
-    /* TODO: Until KHR is fully plumbed in, we will only support EXT */
-    info->opacity_micromap_features_khr.micromap = VK_FALSE;
-
     /* Prefer KHR_opacity_micromap over EXT_opacity_micromap, and only load one. */
     info->using_khr_opacity_micromap = info->opacity_micromap_features_khr.micromap;
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -134,7 +134,6 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION_COND(EXT_DEVICE_ADDRESS_BINDING_REPORT, EXT_device_address_binding_report, VKD3D_CONFIG_FLAG_STATIC(FAULT)),
     VK_EXTENSION(EXT_DEPTH_BIAS_CONTROL, EXT_depth_bias_control),
     VK_EXTENSION(EXT_ZERO_INITIALIZE_DEVICE_MEMORY, EXT_zero_initialize_device_memory),
-    VK_EXTENSION_COND(EXT_OPACITY_MICROMAP, EXT_opacity_micromap, VKD3D_CONFIG_FLAG_STATIC(DXR_1_2)),
     VK_EXTENSION(EXT_SHADER_FLOAT8, EXT_shader_float8),
     VK_EXTENSION_COND(EXT_DESCRIPTOR_HEAP, EXT_descriptor_heap, VKD3D_CONFIG_FLAG_STATIC(DESCRIPTOR_HEAP)),
     /* AMD extensions */
@@ -2473,12 +2472,6 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
         vk_prepend_struct(&info->features2, &info->opacity_micromap_features_khr);
     }
 
-    if (vulkan_info->EXT_opacity_micromap)
-    {
-        info->opacity_micromap_features_ext.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT;
-        vk_prepend_struct(&info->features2, &info->opacity_micromap_features_ext);
-    }
-
     if (vulkan_info->EXT_shader_float8)
     {
         info->shader_float8_features.sType =
@@ -2552,10 +2545,7 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     /* Prefer KHR_opacity_micromap over EXT_opacity_micromap, and only load one. */
     info->using_khr_opacity_micromap = info->opacity_micromap_features_khr.micromap;
 
-    if (info->using_khr_opacity_micromap)
-        info->opacity_micromap_features_ext.micromap = VK_FALSE;
-
-    info->supports_opacity_micromap = info->using_khr_opacity_micromap || info->opacity_micromap_features_ext.micromap;
+    info->supports_opacity_micromap = info->using_khr_opacity_micromap;
 
     /* if nonzero, this is a layered implementation */
     if (real_driver_props.driverID)
@@ -2969,12 +2959,6 @@ static void vkd3d_trace_physical_device_features(const struct vkd3d_physical_dev
     TRACE("  VkPhysicalDeviceLineRasterizationFeaturesEXT:\n");
     TRACE("    rectangularLines: %u\n", info->line_rasterization_features.rectangularLines);
     TRACE("    smoothLines: %u\n", info->line_rasterization_features.smoothLines);
-
-    TRACE("  VkPhysicalDeviceOpacityMicromapFeaturesEXT:\n");
-
-    TRACE("    micromap: %#x\n", info->opacity_micromap_features_ext.micromap);
-    TRACE("    micromapCaptureReplay: %#x\n", info->opacity_micromap_features_ext.micromapCaptureReplay);
-    TRACE("    micromapHostCommands: %#x\n", info->opacity_micromap_features_ext.micromapHostCommands);
 
     TRACE("  VkPhysicalDeviceOpacityMicromapFeaturesKHR:\n");
     TRACE("    micromap: %#x\n", info->opacity_micromap_features_khr.micromap);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -191,7 +191,6 @@ struct vkd3d_vulkan_info
     bool EXT_device_address_binding_report;
     bool EXT_depth_bias_control;
     bool EXT_zero_initialize_device_memory;
-    bool EXT_opacity_micromap;
     bool EXT_shader_float8;
     bool EXT_present_timing;
     bool EXT_descriptor_heap;

--- a/tests/d3d12_raytracing.c
+++ b/tests/d3d12_raytracing.c
@@ -4499,7 +4499,7 @@ void test_raytracing_opacity_micro_map(void)
             va = ID3D12Resource_GetGPUVirtualAddress(test_rtases.omm);
             ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo(context.list4, &postbuild_info, 1, &va);
 
-            postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE;
+            postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE;
             postbuild_info.DestBuffer = ID3D12Resource_GetGPUVirtualAddress(test_rtases.query) + 64 + 8;
             va = ID3D12Resource_GetGPUVirtualAddress(test_rtases.omm);
             ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo(context.list4, &postbuild_info, 1, &va);
@@ -4509,7 +4509,7 @@ void test_raytracing_opacity_micro_map(void)
             va = ID3D12Resource_GetGPUVirtualAddress(test_rtases.omm_base.rtas);
             ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo(context.list4, &postbuild_info, 1, &va);
 
-            postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE;
+            postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE;
             postbuild_info.DestBuffer = ID3D12Resource_GetGPUVirtualAddress(test_rtases.query) + 64 + 24;
             va = ID3D12Resource_GetGPUVirtualAddress(test_rtases.omm_base.rtas);
             ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo(context.list4, &postbuild_info, 1, &va);
@@ -4660,9 +4660,9 @@ void test_raytracing_opacity_micro_map(void)
             query_base_size = get_readback_uint64(&rb, 64 / 8 + 3, 0);
 
             /* After compaction, sizes should remain the same. */
-            todo ok(postbuild_compacted == postbuild_size, "Expected %u == %u\n", (unsigned int)postbuild_compacted, (unsigned int)postbuild_size);
-            todo ok(query_compacted == query_size, "Expected %u == %u\n", (unsigned int)query_compacted, (unsigned int)query_size);
-            todo ok(query_base_compacted <= query_base_size, "Expected %u <= %u\n", (unsigned int)query_base_compacted, (unsigned int)query_base_size);
+            ok(postbuild_compacted == postbuild_size, "Expected %u == %u\n", (unsigned int)postbuild_compacted, (unsigned int)postbuild_size);
+            ok(query_compacted == query_size, "Expected %u == %u\n", (unsigned int)query_compacted, (unsigned int)query_size);
+            ok(query_base_compacted <= query_base_size, "Expected %u <= %u\n", (unsigned int)query_base_compacted, (unsigned int)query_base_size);
 
             /* postbuild query and normal query should both work. */
             ok(postbuild_compacted == query_compacted, "Expected %u == %u\n", (unsigned int)postbuild_compacted, (unsigned int)query_compacted);
@@ -4670,14 +4670,14 @@ void test_raytracing_opacity_micro_map(void)
 
             /* Sizes should not be 0. */
             ok(postbuild_compacted != 0, "Expected %u != 0\n", (unsigned int)postbuild_compacted);
-            todo ok(postbuild_size != 0, "Expected %u != 0\n", (unsigned int)postbuild_size);
+            ok(postbuild_size != 0, "Expected %u != 0\n", (unsigned int)postbuild_size);
             ok(query_compacted != 0, "Expected %u != 0\n", (unsigned int)query_compacted);
-            todo ok(query_size != 0, "Expected %u != 0\n", (unsigned int)query_size);
+            ok(query_size != 0, "Expected %u != 0\n", (unsigned int)query_size);
             ok(query_base_compacted != 0, "Expected %u != 0\n", (unsigned int)query_base_compacted);
-            todo ok(query_base_size != 0, "Expected %u != 0\n", (unsigned int)query_base_size);
+            ok(query_base_size != 0, "Expected %u != 0\n", (unsigned int)query_base_size);
 
             /* Expect that size remains invariant after compaction */
-            todo ok(query_size == query_base_compacted, "Expected %u == %u\n", (unsigned int)query_size, (unsigned int)query_base_compacted);
+            ok(query_size == query_base_compacted, "Expected %u == %u\n", (unsigned int)query_size, (unsigned int)query_base_compacted);
 
             release_resource_readback(&rb);
         }


### PR DESCRIPTION
This is a big change in the phasing. We actually now switch from using EXT_omm to using KHR_omm. In addition when OMM several tests are moved out of todo. In addition, a small bug is fixed in the tests as well.

Sample of tests runs for `VKD3D_CONFIG=dxr12 VKD3D_TEST_FILTER=test_raytracing_opacity_micro_map` when running each commit in this set, and TOT as of the last rebase.

```
HEAD is now at 492fda465 dxil-spirv: Update submodule.
d3d12: 45781 tests executed (9 failures, 12 successful todo, 0 skipped, 9 todo, 0 bugs).

HEAD is now at 1213964d9 vkd3d: Prefer VK_KHR_opacity_micromap when available.
d3d12: 45781 tests executed (0 failures, 21 successful todo, 0 skipped, 0 todo, 0 bugs).

HEAD is now at a6e487a3d vkd3d: Stop enabling VK_EXT_opacity_micromap.
d3d12: 45781 tests executed (0 failures, 21 successful todo, 0 skipped, 0 todo, 0 bugs).

HEAD is now at c0e16a3f3 tests: Fix opacity micromap postbuild CURRENT_SIZE queries.
d3d12: 45781 tests executed (0 failures, 0 successful todo, 0 skipped, 0 todo, 0 bugs).
```

The next phase will remove EXT in 11 commits.