### PR TITLE
 VK_KHR_opacity_micromap - Phase 7

### DIFF
--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -430,7 +430,7 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkAccelerationStructureKHR vk_acceleration_structure;
-    VkAccelerationStructureKHR vk_opacity_micromap;
+    bool is_micromap;
     VkDependencyInfo dep_info;
     VkMemoryBarrier2 barrier;
     VkDeviceSize stride;
@@ -458,16 +458,14 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
         if (d3d12_device_supports_ray_tracing_tier_1_2(list->device))
         {
             vkd3d_va_map_try_read_rtas(&list->device->memory_allocator.va_map,
-                    list->device, addresses[i], &vk_acceleration_structure, &vk_opacity_micromap);
+                    list->device, addresses[i], &vk_acceleration_structure, &is_micromap);
 
             if (vk_acceleration_structure != VK_NULL_HANDLE)
             {
-                vkd3d_acceleration_structure_write_postbuild_info(list, desc, i * stride, vk_acceleration_structure);
-                continue;
-            }
-            else if (vk_opacity_micromap != VK_NULL_HANDLE)
-            {
-                vkd3d_opacity_micromap_write_postbuild_info(list, desc, i * stride, vk_opacity_micromap);
+                if (is_micromap)
+                    vkd3d_opacity_micromap_write_postbuild_info(list, desc, i * stride, vk_acceleration_structure);
+                else
+                    vkd3d_acceleration_structure_write_postbuild_info(list, desc, i * stride, vk_acceleration_structure);
                 continue;
             }
             else
@@ -475,7 +473,7 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
         }
 
         vk_acceleration_structure = vkd3d_va_map_place_acceleration_structure(
-                &list->device->memory_allocator.va_map, list->device, addresses[i]);
+                &list->device->memory_allocator.va_map, list->device, addresses[i], false);
         if (vk_acceleration_structure != VK_NULL_HANDLE)
             vkd3d_acceleration_structure_write_postbuild_info(list, desc, i * stride, vk_acceleration_structure);
         else
@@ -550,7 +548,7 @@ void vkd3d_acceleration_structure_copy(
     VkCopyAccelerationStructureInfoKHR info;
     VkAccelerationStructureKHR dst_as;
 
-    dst_as = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device, dst);
+    dst_as = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device, dst, false);
     if (dst_as == VK_NULL_HANDLE)
     {
         ERR("Invalid dst address #%"PRIx64" for RTAS copy.\n", dst);

--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -542,25 +542,31 @@ static bool convert_copy_mode(
 void vkd3d_acceleration_structure_copy(
         struct d3d12_command_list *list,
         D3D12_GPU_VIRTUAL_ADDRESS dst, VkAccelerationStructureKHR src_as,
-        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode)
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode,
+        bool rtas_is_omm)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkCopyAccelerationStructureInfoKHR info;
     VkAccelerationStructureKHR dst_as;
 
-    dst_as = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device, dst, false);
+    dst_as = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device, dst, rtas_is_omm);
+
     if (dst_as == VK_NULL_HANDLE)
     {
-        ERR("Invalid dst address #%"PRIx64" for RTAS copy.\n", dst);
+        ERR("Invalid dst address #%"PRIx64" for %s copy.\n", dst, rtas_is_omm ? "OMM" : "RTAS");
         return;
     }
 
+    memset(&info, 0, sizeof(info));
+
+    if (!convert_copy_mode(mode, &info.mode))
+        return;
+
     info.sType = VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR;
-    info.pNext = NULL;
     info.dst = dst_as;
     info.src = src_as;
-    if (convert_copy_mode(mode, &info.mode))
-        VK_CALL(vkCmdCopyAccelerationStructureKHR(list->cmd.vk_command_buffer, &info));
+
+    VK_CALL(vkCmdCopyAccelerationStructureKHR(list->cmd.vk_command_buffer, &info));
 }
 
 struct vkd3d_empty_rtas_build_info

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20495,8 +20495,8 @@ static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3
     micromap = VK_NULL_HANDLE;
     if (desc->DestAccelerationStructureData)
     {
-        micromap = vkd3d_va_map_place_opacity_micromap(&list->device->memory_allocator.va_map,
-                        list->device, desc->DestAccelerationStructureData);
+        micromap = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map,
+                        list->device, desc->DestAccelerationStructureData, true);
         build_info->dstAccelerationStructure = micromap;
         if (build_info->dstAccelerationStructure == VK_NULL_HANDLE)
         {
@@ -20600,7 +20600,7 @@ static void d3d12_command_list_build_raytracing_blas_and_tlas(struct d3d12_comma
     {
         build_info->dstAccelerationStructure =
                 vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map,
-                        list->device, desc->DestAccelerationStructureData);
+                        list->device, desc->DestAccelerationStructureData, false);
         if (build_info->dstAccelerationStructure == VK_NULL_HANDLE)
         {
             ERR("Failed to place destAccelerationStructure. Dropping call.\n");
@@ -20613,7 +20613,7 @@ static void d3d12_command_list_build_raytracing_blas_and_tlas(struct d3d12_comma
     {
         build_info->srcAccelerationStructure =
                 vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map,
-                        list->device, desc->SourceAccelerationStructureData);
+                        list->device, desc->SourceAccelerationStructureData, false);
         if (build_info->srcAccelerationStructure == VK_NULL_HANDLE)
         {
             ERR("Failed to place srcAccelerationStructure. Dropping call.\n");
@@ -20807,8 +20807,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
-    VkAccelerationStructureKHR src_omm;
     VkAccelerationStructureKHR src_as;
+    bool is_micromap;
 
     TRACE("iface %p, dst_data %#"PRIx64", src_data %#"PRIx64", mode %u\n",
           iface, dst_data, src_data, mode);
@@ -20840,24 +20840,21 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
     if (d3d12_device_supports_ray_tracing_tier_1_2(list->device))
     {
         vkd3d_va_map_try_read_rtas(&list->device->memory_allocator.va_map,
-                list->device, src_data, &src_as, &src_omm);
+                list->device, src_data, &src_as, &is_micromap);
 
         if (src_as != VK_NULL_HANDLE)
         {
-            vkd3d_acceleration_structure_copy(list, dst_data, src_as, mode);
+            if (is_micromap)
+                vkd3d_opacity_micromap_copy(list, dst_data, src_as, mode);
+            else
+                vkd3d_acceleration_structure_copy(list, dst_data, src_as, mode);
             VKD3D_BREADCRUMB_AUX64(dst_data);
             VKD3D_BREADCRUMB_AUX64(src_data);
             VKD3D_BREADCRUMB_AUX32(mode);
-            VKD3D_BREADCRUMB_COMMAND(COPY_RTAS);
-            return;
-        }
-        else if (src_omm != VK_NULL_HANDLE)
-        {
-            vkd3d_opacity_micromap_copy(list, dst_data, src_omm, mode);
-            VKD3D_BREADCRUMB_AUX64(dst_data);
-            VKD3D_BREADCRUMB_AUX64(src_data);
-            VKD3D_BREADCRUMB_AUX32(mode);
-            VKD3D_BREADCRUMB_COMMAND(COPY_OMM);
+            if (is_micromap)
+                VKD3D_BREADCRUMB_COMMAND(COPY_OMM);
+            else
+                VKD3D_BREADCRUMB_COMMAND(COPY_RTAS);
             return;
         }
         else
@@ -20865,7 +20862,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
     }
 
     src_as = vkd3d_va_map_place_acceleration_structure(
-            &list->device->memory_allocator.va_map, list->device, src_data);
+            &list->device->memory_allocator.va_map, list->device, src_data, false);
 
     if (src_as != VK_NULL_HANDLE)
     {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20844,10 +20844,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
 
         if (src_as != VK_NULL_HANDLE)
         {
-            if (is_micromap)
-                vkd3d_opacity_micromap_copy(list, dst_data, src_as, mode);
-            else
-                vkd3d_acceleration_structure_copy(list, dst_data, src_as, mode);
+            vkd3d_acceleration_structure_copy(list, dst_data, src_as, mode, is_micromap);
             VKD3D_BREADCRUMB_AUX64(dst_data);
             VKD3D_BREADCRUMB_AUX64(src_data);
             VKD3D_BREADCRUMB_AUX32(mode);
@@ -20866,7 +20863,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
 
     if (src_as != VK_NULL_HANDLE)
     {
-        vkd3d_acceleration_structure_copy(list, dst_data, src_as, mode);
+        vkd3d_acceleration_structure_copy(list, dst_data, src_as, mode, false);
         VKD3D_BREADCRUMB_AUX64(dst_data);
         VKD3D_BREADCRUMB_AUX64(src_data);
         VKD3D_BREADCRUMB_AUX32(mode);

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -266,51 +266,6 @@ void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
     vkd3d_opacity_micromap_end_barrier(list);
 }
 
-static bool convert_copy_mode(
-        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode,
-        VkCopyAccelerationStructureModeKHR *vk_mode)
-{
-    switch (mode)
-    {
-        case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_CLONE:
-            *vk_mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
-            return true;
-        case D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT:
-            *vk_mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR;
-            return true;
-        default:
-            FIXME("Unsupported OMM copy mode #%x.\n", mode);
-            return false;
-    }
-}
-
-void vkd3d_opacity_micromap_copy(
-        struct d3d12_command_list *list,
-        D3D12_GPU_VIRTUAL_ADDRESS dst, VkAccelerationStructureKHR src_omm,
-        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode)
-{
-    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
-    VkCopyAccelerationStructureInfoKHR info;
-    VkAccelerationStructureKHR dst_omm;
-
-    dst_omm = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device, dst,
-            true);
-    if (dst_omm == VK_NULL_HANDLE)
-    {
-        ERR("Invalid dst address #%"PRIx64" for OMM copy.\n", dst);
-        return;
-    }
-    memset(&info, 0, sizeof(info));
-
-    if (!convert_copy_mode(mode, &info.mode))
-        return;
-
-    info.sType = VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR;
-    info.dst = dst_omm;
-    info.src = src_omm;
-    VK_CALL(vkCmdCopyAccelerationStructureKHR(list->cmd.vk_command_buffer, &info));
-}
-
 static bool vkd3d_acceleration_structure_convert_opacity_micromap_index_type(DXGI_FORMAT format, VkIndexType *result)
 {
     switch (format)

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -293,7 +293,8 @@ void vkd3d_opacity_micromap_copy(
     VkCopyAccelerationStructureInfoKHR info;
     VkAccelerationStructureKHR dst_omm;
 
-    dst_omm = vkd3d_va_map_place_opacity_micromap(&list->device->memory_allocator.va_map, list->device, dst);
+    dst_omm = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device, dst,
+            true);
     if (dst_omm == VK_NULL_HANDLE)
     {
         ERR("Invalid dst address #%"PRIx64" for OMM copy.\n", dst);
@@ -353,9 +354,9 @@ bool vkd3d_acceleration_structure_convert_opacity_micromap(struct d3d12_device *
 
     if (geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray)
     {
-        omm_triangles_info->micromap = vkd3d_va_map_place_opacity_micromap(
+        omm_triangles_info->micromap = vkd3d_va_map_place_acceleration_structure(
                 &device->memory_allocator.va_map, device,
-                geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);
+                geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray, true);
 
         if (omm_triangles_info->micromap == VK_NULL_HANDLE)
             ERR("Failed to place OMM at VA 0x%"PRIx64".\n", geom_desc->OmmTriangles.pOmmLinkage->OpacityMicromapArray);

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5143,7 +5143,7 @@ bool vkd3d_create_buffer_view(struct d3d12_device *device, const struct vkd3d_bu
     object->format = desc->format;
     object->info.buffer.offset = desc->offset;
     object->info.buffer.size = desc->size;
-    object->info.buffer.rtas_is_micromap = false;
+    object->info.buffer.rtas_is_micromap = 0; /* Pre-publish, no atomic store required */
     *view = object;
     return true;
 }
@@ -5223,7 +5223,7 @@ bool vkd3d_create_acceleration_structure_view(struct d3d12_device *device, const
     object->format = desc->format;
     object->info.buffer.offset = desc->offset;
     object->info.buffer.size = desc->size;
-    object->info.buffer.rtas_is_micromap = rtas_is_micromap;
+    object->info.buffer.rtas_is_micromap = rtas_is_micromap; /* Pre-publish, no atomic store required */
     *view = object;
     return true;
 }

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -1564,9 +1564,7 @@ struct vkd3d_view *vkd3d_view_map_create_view2(struct vkd3d_view_map *view_map,
             break;
 
         case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE:
-            success = rtas_is_omm
-                ? vkd3d_create_opacity_micromap_view(device, &key->u.buffer, &view)
-                : vkd3d_create_acceleration_structure_view(device, &key->u.buffer, &view);
+            success = vkd3d_create_acceleration_structure_view(device, &key->u.buffer, &view, rtas_is_omm);
             break;
 
         default:
@@ -5151,7 +5149,7 @@ bool vkd3d_create_buffer_view(struct d3d12_device *device, const struct vkd3d_bu
 }
 
 bool vkd3d_create_acceleration_structure_view(struct d3d12_device *device, const struct vkd3d_buffer_view_desc *desc,
-        struct vkd3d_view **view)
+        struct vkd3d_view **view, bool rtas_is_micromap)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkAccelerationStructureKHR vk_acceleration_structure;
@@ -5225,43 +5223,7 @@ bool vkd3d_create_acceleration_structure_view(struct d3d12_device *device, const
     object->format = desc->format;
     object->info.buffer.offset = desc->offset;
     object->info.buffer.size = desc->size;
-    object->info.buffer.rtas_is_micromap = false;
-    *view = object;
-    return true;
-}
-
-bool vkd3d_create_opacity_micromap_view(struct d3d12_device *device, const struct vkd3d_buffer_view_desc *desc,
-        struct vkd3d_view **view)
-{
-    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-    VkAccelerationStructureCreateInfo2KHR create_info;
-    VkAccelerationStructureKHR vk_acceleration_structure;
-    struct vkd3d_view *object;
-    VkResult vr;
-
-    memset(&create_info, 0, sizeof(create_info));
-
-    create_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_2_KHR;
-    create_info.type = VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
-    create_info.addressRange.address = vkd3d_get_buffer_device_address(device, desc->buffer) + desc->offset;
-    create_info.addressRange.size = desc->size;
-
-    vr = VK_CALL(vkCreateAccelerationStructure2KHR(device->vk_device, &create_info, NULL, &vk_acceleration_structure));
-
-    if (vr != VK_SUCCESS)
-        return false;
-
-    if (!(object = vkd3d_view_create(VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE)))
-    {
-        VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, vk_acceleration_structure, NULL));
-        return false;
-    }
-
-    object->vk_acceleration_structure = vk_acceleration_structure;
-    object->format = desc->format;
-    object->info.buffer.offset = desc->offset;
-    object->info.buffer.size = desc->size;
-    object->info.buffer.rtas_is_micromap = true;
+    object->info.buffer.rtas_is_micromap = rtas_is_micromap;
     *view = object;
     return true;
 }

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -1338,7 +1338,7 @@ static uint32_t vkd3d_view_entry_hash(const void *key)
     switch (k->view_type)
     {
         case VKD3D_VIEW_TYPE_BUFFER:
-        case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP:
+        case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE:
             hash = hash_uint64((uint64_t)k->u.buffer.buffer);
             hash = hash_combine(hash, hash_uint64(k->u.buffer.offset));
             hash = hash_combine(hash, hash_uint64(k->u.buffer.size));
@@ -1406,7 +1406,7 @@ static bool vkd3d_view_entry_compare(const void *key, const struct hash_map_entr
     switch (k->view_type)
     {
         case VKD3D_VIEW_TYPE_BUFFER:
-        case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP:
+        case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE:
             return k->u.buffer.buffer == e->key.u.buffer.buffer &&
                     k->u.buffer.format == e->key.u.buffer.format &&
                     k->u.buffer.offset == e->key.u.buffer.offset &&
@@ -1563,7 +1563,7 @@ struct vkd3d_view *vkd3d_view_map_create_view2(struct vkd3d_view_map *view_map,
                     SUCCEEDED(d3d12_create_sampler(device, &key->u.sampler, &view->vk_sampler));
             break;
 
-        case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP:
+        case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE:
             success = rtas_is_omm
                 ? vkd3d_create_opacity_micromap_view(device, &key->u.buffer, &view)
                 : vkd3d_create_acceleration_structure_view(device, &key->u.buffer, &view);
@@ -4844,11 +4844,8 @@ static void vkd3d_view_destroy(struct vkd3d_view *view, struct d3d12_device *dev
         case VKD3D_VIEW_TYPE_SAMPLER:
             VK_CALL(vkDestroySampler(device->vk_device, view->vk_sampler, NULL));
             break;
-        case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP:
-            if (view->info.buffer.rtas_is_micromap)
-                VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, view->vk_micromap, NULL));
-            else
-                VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, view->vk_acceleration_structure, NULL));
+        case VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE:
+            VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, view->vk_acceleration_structure, NULL));
             break;
         default:
             WARN("Unhandled view type %d.\n", view->type);
@@ -5205,7 +5202,7 @@ bool vkd3d_create_acceleration_structure_view(struct d3d12_device *device, const
     if (result != VK_SUCCESS)
         return false;
 
-    if (!(object = vkd3d_view_create(VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP)))
+    if (!(object = vkd3d_view_create(VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE)))
     {
         VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, vk_acceleration_structure, NULL));
         return false;
@@ -5238,7 +5235,7 @@ bool vkd3d_create_opacity_micromap_view(struct d3d12_device *device, const struc
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkAccelerationStructureCreateInfo2KHR create_info;
-    VkAccelerationStructureKHR vk_micromap;
+    VkAccelerationStructureKHR vk_acceleration_structure;
     struct vkd3d_view *object;
     VkResult vr;
 
@@ -5249,18 +5246,18 @@ bool vkd3d_create_opacity_micromap_view(struct d3d12_device *device, const struc
     create_info.addressRange.address = vkd3d_get_buffer_device_address(device, desc->buffer) + desc->offset;
     create_info.addressRange.size = desc->size;
 
-    vr = VK_CALL(vkCreateAccelerationStructure2KHR(device->vk_device, &create_info, NULL, &vk_micromap));
+    vr = VK_CALL(vkCreateAccelerationStructure2KHR(device->vk_device, &create_info, NULL, &vk_acceleration_structure));
 
     if (vr != VK_SUCCESS)
         return false;
 
-    if (!(object = vkd3d_view_create(VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP)))
+    if (!(object = vkd3d_view_create(VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE)))
     {
-        VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, vk_micromap, NULL));
+        VK_CALL(vkDestroyAccelerationStructureKHR(device->vk_device, vk_acceleration_structure, NULL));
         return false;
     }
 
-    object->vk_micromap = vk_micromap;
+    object->vk_acceleration_structure = vk_acceleration_structure;
     object->format = desc->format;
     object->info.buffer.offset = desc->offset;
     object->info.buffer.size = desc->size;

--- a/libs/vkd3d/va_map.c
+++ b/libs/vkd3d/va_map.c
@@ -268,7 +268,7 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
     if (!view_map)
         return;
 
-    key.view_type = VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP;
+    key.view_type = VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE;
     key.u.buffer.buffer = resource->vk_buffer;
     key.u.buffer.offset = va - resource->va;
     key.u.buffer.size = resource->size - key.u.buffer.offset;
@@ -280,7 +280,7 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
         return;
 
     if (view->info.buffer.rtas_is_micromap)
-        *micromap = view->vk_micromap;
+        *micromap = view->vk_acceleration_structure;
     else
         *acceleration_structure = view->vk_acceleration_structure;
 }
@@ -330,7 +330,7 @@ static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
         }
     }
 
-    key.view_type = VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP;
+    key.view_type = VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE;
     key.u.buffer.buffer = resource->vk_buffer;
     key.u.buffer.offset = va - resource->va;
     key.u.buffer.size = resource->size - key.u.buffer.offset;
@@ -342,7 +342,7 @@ static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
         return;
 
     if (view->info.buffer.rtas_is_micromap)
-        *micromap = view->vk_micromap;
+        *micromap = view->vk_acceleration_structure;
     else
         *acceleration_structure = view->vk_acceleration_structure;
 }

--- a/libs/vkd3d/va_map.c
+++ b/libs/vkd3d/va_map.c
@@ -250,7 +250,7 @@ const struct vkd3d_unique_resource *vkd3d_va_map_deref(struct vkd3d_va_map *va_m
 void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
         struct d3d12_device *device, VkDeviceAddress va,
         VkAccelerationStructureKHR *acceleration_structure,
-        VkAccelerationStructureKHR *micromap)
+        bool *is_micromap)
 {
     const struct vkd3d_unique_resource *resource;
     struct vkd3d_view_map *view_map;
@@ -258,7 +258,7 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
     struct vkd3d_view_key key;
 
     *acceleration_structure = VK_NULL_HANDLE;
-    *micromap = VK_NULL_HANDLE;
+    *is_micromap = false;
 
     resource = vkd3d_va_map_deref(va_map, va);
     if (!resource || !resource->va)
@@ -279,29 +279,25 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
     if (!view)
         return;
 
-    if (view->info.buffer.rtas_is_micromap)
-        *micromap = view->vk_acceleration_structure;
-    else
-        *acceleration_structure = view->vk_acceleration_structure;
+    *acceleration_structure = view->vk_acceleration_structure;
+    *is_micromap =
+            (bool)vkd3d_atomic_uint32_load_explicit(&view->info.buffer.rtas_is_micromap, vkd3d_memory_order_relaxed);
 }
 
-static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
-        struct d3d12_device *device, VkDeviceAddress va, bool rtas_is_omm,
-        VkAccelerationStructureKHR *acceleration_structure,
-        VkAccelerationStructureKHR *micromap)
+VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3d_va_map *va_map,
+        struct d3d12_device *device,
+        VkDeviceAddress va, bool rtas_is_omm)
 {
     struct vkd3d_unique_resource *resource;
     struct vkd3d_view_map *old_view_map;
     struct vkd3d_view_map *view_map;
-    const struct vkd3d_view *view;
     struct vkd3d_view_key key;
-
-    *acceleration_structure = VK_NULL_HANDLE;
-    *micromap = VK_NULL_HANDLE;
+    bool was_rtas_is_micromap;
+    struct vkd3d_view *view;
 
     resource = vkd3d_va_map_deref_mutable(va_map, va);
     if (!resource || !resource->va)
-        return;
+        return VK_NULL_HANDLE;
 
     view_map = vkd3d_atomic_ptr_load_explicit(&resource->view_map, vkd3d_memory_order_acquire);
     if (!view_map)
@@ -310,12 +306,12 @@ static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
          * CAS in a pointer. */
         view_map = vkd3d_malloc(sizeof(*view_map));
         if (!view_map)
-            return;
+            return VK_NULL_HANDLE;
 
         if (FAILED(vkd3d_view_map_init(view_map)))
         {
             vkd3d_free(view_map);
-            return;
+            return VK_NULL_HANDLE;
         }
 
         /* Need to release in case other RTASes are placed at the same time, so they observe
@@ -339,42 +335,19 @@ static void vkd3d_va_map_try_place_rtas(struct vkd3d_va_map *va_map,
 
     view = vkd3d_view_map_create_view2(view_map, device, &key, rtas_is_omm);
     if (!view)
-        return;
+        return VK_NULL_HANDLE;
 
-    if (view->info.buffer.rtas_is_micromap)
-        *micromap = view->vk_acceleration_structure;
-    else
-        *acceleration_structure = view->vk_acceleration_structure;
-}
+    was_rtas_is_micromap =
+            (bool)vkd3d_atomic_uint32_load_explicit(&view->info.buffer.rtas_is_micromap, vkd3d_memory_order_relaxed);
+    if (rtas_is_omm != was_rtas_is_micromap)
+        FIXME("Attempted to place %s on VA #%"PRIx64" previously used by %s.\n",
+                rtas_is_omm ? "OMM" : "RTAS", va,
+                was_rtas_is_micromap ? "OMM" : "RTAS");
 
-VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3d_va_map *va_map,
-        struct d3d12_device *device,
-        VkDeviceAddress va)
-{
-    VkAccelerationStructureKHR acceleration_structure;
-    VkAccelerationStructureKHR micromap;
+    vkd3d_atomic_uint32_store_explicit(&view->info.buffer.rtas_is_micromap, rtas_is_omm ? 1 : 0,
+            vkd3d_memory_order_relaxed);
 
-    vkd3d_va_map_try_place_rtas(va_map, device, va, false, &acceleration_structure, &micromap);
-
-    if (micromap != VK_NULL_HANDLE)
-        FIXME("Attempted to place RTAS on VA #%"PRIx64" previously used by OMM.\n", va);
-
-    return acceleration_structure;
-}
-
-VkAccelerationStructureKHR vkd3d_va_map_place_opacity_micromap(struct vkd3d_va_map *va_map,
-        struct d3d12_device *device,
-        VkDeviceAddress va)
-{
-    VkAccelerationStructureKHR acceleration_structure;
-    VkAccelerationStructureKHR micromap;
-
-    vkd3d_va_map_try_place_rtas(va_map, device, va, true, &acceleration_structure, &micromap);
-
-    if (acceleration_structure)
-        FIXME("Attempted to place OMM on VA #%"PRIx64" previously used by RTAS.\n", va);
-
-    return micromap;
+    return view->vk_acceleration_structure;
 }
 
 void vkd3d_va_map_init(struct vkd3d_va_map *va_map)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1373,9 +1373,7 @@ bool vkd3d_create_buffer_view(struct d3d12_device *device,
 bool vkd3d_create_raw_r32ui_vk_buffer_view(struct d3d12_device *device,
         VkBuffer vk_buffer, VkDeviceSize offset, VkDeviceSize range, VkBufferView *vk_view);
 bool vkd3d_create_acceleration_structure_view(struct d3d12_device *device,
-        const struct vkd3d_buffer_view_desc *desc, struct vkd3d_view **view);
-bool vkd3d_create_opacity_micromap_view(struct d3d12_device *device,
-        const struct vkd3d_buffer_view_desc *desc, struct vkd3d_view **view);
+        const struct vkd3d_buffer_view_desc *desc, struct vkd3d_view **view, bool rtas_is_micromap);
 bool vkd3d_create_texture_view(struct d3d12_device *device,
         const struct vkd3d_texture_view_desc *desc, struct vkd3d_view **view);
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -392,13 +392,10 @@ const struct vkd3d_unique_resource *vkd3d_va_map_deref(struct vkd3d_va_map *va_m
 void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
         struct d3d12_device *device, VkDeviceAddress va,
         VkAccelerationStructureKHR *acceleration_structure,
-        VkAccelerationStructureKHR *micromap);
+        bool *is_micromap);
 VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3d_va_map *va_map,
         struct d3d12_device *device,
-        VkDeviceAddress va);
-VkAccelerationStructureKHR vkd3d_va_map_place_opacity_micromap(struct vkd3d_va_map *va_map,
-        struct d3d12_device *device,
-        VkDeviceAddress va);
+        VkDeviceAddress va, bool rtas_is_omm);
 void vkd3d_va_map_init(struct vkd3d_va_map *va_map);
 void vkd3d_va_map_cleanup(struct vkd3d_va_map *va_map);
 void vkd3d_va_map_insert_descriptor_heap(struct vkd3d_va_map *va_map,
@@ -1323,7 +1320,7 @@ struct vkd3d_view
         {
             VkDeviceSize offset;
             VkDeviceSize size;
-            bool rtas_is_micromap; /* not hashed */
+            uint32_t rtas_is_micromap; /* not hashed; accessed atomically */
         } buffer;
         struct
         {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -6890,7 +6890,8 @@ void vkd3d_acceleration_structure_emit_immediate_postbuild_info(
 void vkd3d_acceleration_structure_copy(
         struct d3d12_command_list *list,
         D3D12_GPU_VIRTUAL_ADDRESS dst, VkAccelerationStructureKHR src_as,
-        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode);
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode,
+        bool rtas_is_omm);
 
 bool vkd3d_opacity_micromap_convert_inputs(const struct d3d12_device *device,
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *inputs,
@@ -6907,10 +6908,6 @@ void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
         struct d3d12_command_list *list, uint32_t count,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
         VkAccelerationStructureKHR vk_opacity_micromap);
-void vkd3d_opacity_micromap_copy(
-        struct d3d12_command_list *list,
-        D3D12_GPU_VIRTUAL_ADDRESS dst, VkAccelerationStructureKHR src_omm,
-        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode);
 bool vkd3d_acceleration_structure_convert_opacity_micromap(struct d3d12_device *device,
         const D3D12_RAYTRACING_GEOMETRY_DESC *geom_desc,
         VkAccelerationStructureGeometryKHR *geometry_info,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1300,7 +1300,7 @@ enum vkd3d_view_type
     VKD3D_VIEW_TYPE_BUFFER,
     VKD3D_VIEW_TYPE_IMAGE,
     VKD3D_VIEW_TYPE_SAMPLER,
-    VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE_OR_OPACITY_MICROMAP
+    VKD3D_VIEW_TYPE_ACCELERATION_STRUCTURE
 };
 
 struct vkd3d_view
@@ -1315,7 +1315,6 @@ struct vkd3d_view
         VkImageView vk_image_view;
         VkSampler vk_sampler;
         VkAccelerationStructureKHR vk_acceleration_structure;
-        VkAccelerationStructureKHR vk_micromap;
     };
     const struct vkd3d_format *format;
     union


### PR DESCRIPTION
This change cleans up most of the dual-use issues that `VK_EXT_omm` required. One bookkeeping flag remains:

`rtas_is_micromap` exists because my reading of the D3D12 spec is that SERIALIZATION postbuild is permitted on OMM-Arrays, but `VK_KHR_opacity_micromap` disallows the BLP query on non-TLAS (VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-12425). The kind tag lets us fillbuffer(0) the NumBottomLevelPointers field for OMM-Arrays instead of issuing the illegal Vulkan query.