### PR TITLE
vkd3d: Massively simplify anti-lag implementation.

### DIFF
--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -1324,33 +1324,28 @@ static HRESULT STDMETHODCALLTYPE d3d12_amd_ext_anti_lag_UpdateAntiLagState(
     if (!pData)
     {
         struct vkd3d_queue_timeline_trace_cookie cookie = { 0 };
-        VkAntiLagPresentationInfoAMD present_info;
         VkAntiLagDataAMD anti_lag;
 
-        /* Purely inserts a delay. The API wrapper never seems to pass down anything useful for
-         * frame IDs, so just invent them ourselves. */
-
         memset(&anti_lag, 0, sizeof(anti_lag));
-        memset(&present_info, 0, sizeof(present_info));
         anti_lag.sType = VK_STRUCTURE_TYPE_ANTI_LAG_DATA_AMD;
         anti_lag.mode = device->swapchain_info.mode ? VK_ANTI_LAG_MODE_ON_AMD : VK_ANTI_LAG_MODE_OFF_AMD;
         anti_lag.maxFPS = device->swapchain_info.max_fps;
-        anti_lag.pPresentationInfo = &present_info;
 
-        present_info.sType = VK_STRUCTURE_TYPE_ANTI_LAG_PRESENTATION_INFO_AMD;
-        present_info.frameIndex = device->frame_markers.present + 1;
-        present_info.stage = VK_ANTI_LAG_STAGE_INPUT_AMD;
+        /* The AntiLag API has no useful present IDs we can correlate with.
+         * The Vulkan API allows not passing down presentation information at all, which
+         * means that in this mode we give the driver the full responsibility of figuring out how to
+         * deal with frame boundaries. The expectation is that the driver can use vkQueuePresentKHR as
+         * a split point. Any submits happening after QueuePresentKHR would be assumed to belong to a future frame. */
 
-        TRACE("AntiLag input timeline, frame %"PRIu64".\n", present_info.frameIndex);
+        /* There is no robust way to keep track of frame indices ourselves, since application can do threaded presents
+         * and end up with INPUT -> INPUT -> PRESENT -> PRESENT patterns which just break.
+         * Even if we try to keep track of this, INPUT and PRESENT can get out of sync, which is terrible too. */
+
         if (device->swapchain_info.mode)
-            cookie = vkd3d_queue_timeline_trace_register_low_latency_sleep(&device->queue_timeline_trace, present_info.frameIndex);
+            cookie = vkd3d_queue_timeline_trace_register_low_latency_sleep(&device->queue_timeline_trace, 0);
         VK_CALL(vkAntiLagUpdateAMD(device->vk_device, &anti_lag));
         if (device->swapchain_info.mode)
             vkd3d_queue_timeline_trace_complete_low_latency_sleep(&device->queue_timeline_trace, cookie);
-
-        /* Any present after this point will map to this frameIndex. */
-        vkd3d_atomic_uint64_store_explicit(&device->frame_markers.present,
-                present_info.frameIndex, vkd3d_memory_order_release);
     }
     else if (v1->uiVersion == 1)
     {

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -1194,13 +1194,10 @@ static HRESULT STDMETHODCALLTYPE dxgi_vk_swap_chain_Present(IDXGIVkSwapChain2 *i
     }
     else if (chain->queue->device->device_info.anti_lag_amd.antiLag)
     {
-        request->low_latency_frame_id = vkd3d_atomic_uint64_load_explicit(
-                &chain->queue->device->frame_markers.present, vkd3d_memory_order_acquire);
-
         spinlock_acquire(&chain->queue->device->low_latency_swapchain_spinlock);
-        request->requested_anti_lag_state.mode = chain->queue->device->swapchain_info.mode;
-        request->requested_anti_lag_state.max_fps = chain->queue->device->swapchain_info.max_fps;
-        low_latency_enable = request->requested_anti_lag_state.mode;
+        /* dxgi_vk_swap_chain_wait_internal_handle needs to know if it should
+         * use backoff algorithm when GPU is under pressure. */
+        low_latency_enable = chain->queue->device->swapchain_info.mode;
         spinlock_release(&chain->queue->device->low_latency_swapchain_spinlock);
     }
     else
@@ -1950,49 +1947,6 @@ static void dxgi_vk_swap_chain_low_latency_state_update(struct dxgi_vk_swap_chai
                 chain->present.low_latency_state.mode ? "ON" : "OFF",
                 chain->present.low_latency_state.boost ? " (+ boost)" : "",
                 chain->present.low_latency_state.minimum_interval_us);
-    }
-}
-
-static void dxgi_vk_swap_chain_anti_lag_state_update(struct dxgi_vk_swap_chain *chain)
-{
-    struct d3d12_device *device = chain->queue->device;
-
-    if (chain->request.low_latency_frame_id)
-    {
-        const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
-        VkAntiLagPresentationInfoAMD present_info;
-        VkAntiLagDataAMD anti_lag;
-        bool should_signal;
-
-        memset(&anti_lag, 0, sizeof(anti_lag));
-        memset(&present_info, 0, sizeof(present_info));
-        anti_lag.sType = VK_STRUCTURE_TYPE_ANTI_LAG_DATA_AMD;
-        anti_lag.mode = chain->request.requested_anti_lag_state.mode ?
-                VK_ANTI_LAG_MODE_ON_AMD : VK_ANTI_LAG_MODE_OFF_AMD;
-        anti_lag.maxFPS = chain->request.requested_anti_lag_state.max_fps;
-        anti_lag.pPresentationInfo = &present_info;
-
-        present_info.sType = VK_STRUCTURE_TYPE_ANTI_LAG_PRESENTATION_INFO_AMD;
-        present_info.frameIndex = chain->request.low_latency_frame_id;
-        present_info.stage = VK_ANTI_LAG_STAGE_PRESENT_AMD;
-
-        /* Don't submit the same frame marker over and over. This will probably matter for frame-gen. */
-        spinlock_acquire(&chain->queue->device->low_latency_swapchain_spinlock);
-        should_signal = present_info.frameIndex > device->frame_markers.consumed_present_id;
-        if (should_signal)
-            device->frame_markers.consumed_present_id = present_info.frameIndex;
-        spinlock_release(&chain->queue->device->low_latency_swapchain_spinlock);
-
-        /* There is no strong requirement that frame index is submitted monotonically,
-         * so it should be fine to drop the lock while calling UpdateAMD.
-         * We don't want to hold a lock while calling AntiLagUpdateAMD.
-         * This is only a theoretical problem if there are two physical queues that concurrently call
-         * QueuePresentKHR. */
-        if (should_signal)
-        {
-            TRACE("AntiLag present timeline, frame %"PRIu64".\n", present_info.frameIndex);
-            VK_CALL(vkAntiLagUpdateAMD(device->vk_device, &anti_lag));
-        }
     }
 }
 
@@ -3060,11 +3014,6 @@ static void dxgi_vk_swap_chain_present_iteration(struct dxgi_vk_swap_chain *chai
 
     if (!dxgi_vk_swap_chain_submit_blit(chain, swapchain_index))
         return;
-
-    /* Only mark anti-lag update after we have submitted blit
-     * so we don't get wrong associations. */
-    if (chain->queue->device->device_info.anti_lag_amd.antiLag)
-        dxgi_vk_swap_chain_anti_lag_state_update(chain);
 
     memset(&present_info, 0, sizeof(present_info));
     present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;


### PR DESCRIPTION
The current implementation where we try to keep track of frame counters is fundamentally broken and there is no good fix. Just make use of the simplified API since it seems to map better to DX12 AntiLag API.