### PR TITLE
Document some NVK behaviors

### DIFF
--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -565,6 +565,11 @@ static inline bool is_nvidia_device(ID3D12Device *device)
     return false;
 }
 
+static inline bool is_nvk_device(ID3D12Device *device)
+{
+    return false;
+}
+
 static inline bool is_radv_device(ID3D12Device *device)
 {
     return false;
@@ -783,6 +788,14 @@ static inline bool is_nvidia_device(ID3D12Device *device)
 
     get_driver_properties(device, &properties);
     return properties.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR;
+}
+
+static inline bool is_nvk_device(ID3D12Device *device)
+{
+    VkPhysicalDeviceDriverPropertiesKHR properties;
+
+    get_driver_properties(device, &properties);
+    return properties.driverID == VK_DRIVER_ID_MESA_NVK;
 }
 
 static inline bool is_radv_device(ID3D12Device *device)

--- a/tests/d3d12_descriptors.c
+++ b/tests/d3d12_descriptors.c
@@ -4929,7 +4929,7 @@ void test_undefined_descriptor_heap_mismatch_types(void)
 
             /* On current NVIDIA, images are 4 byte, but texel buffers are 16 byte,
              * but we have to alias them together. */
-            if (!is_nvidia_windows_device(context.device) && is_nvidia_device(context.device))
+            if (!is_nvidia_windows_device(context.device) && (is_nvidia_device(context.device) || is_nvk_device(context.device)))
             {
                 if ((access_type == SRV_TEX || access_type == UAV_TEX) &&
                         (descriptor_type == SRV_TYPED_BUFFER || descriptor_type == UAV_TYPED_BUFFER))

--- a/tests/d3d12_robustness.c
+++ b/tests/d3d12_robustness.c
@@ -89,7 +89,8 @@ void test_buffers_oob_behavior_vectorized_structured_16bit(void)
     heap = create_gpu_descriptor_heap(context.device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, ARRAY_SIZE(output_buffers));
 
     if (is_mesa_intel_device(context.device) ||
-        (is_nvidia_device(context.device) && is_vk_device_extension_supported(context.device, "VK_EXT_descriptor_heap")))
+        ((is_nvidia_device(context.device) || is_nvk_device(context.device)) &&
+         is_vk_device_extension_supported(context.device, "VK_EXT_descriptor_heap")))
     {
         /* There appears to be driver issues.
          * SSBO not aligned to the advertised 4 bytes seems to break down for unknown reasons.
@@ -1046,7 +1047,7 @@ static void test_undefined_structured_raw_read_typed(bool use_dxil)
     /* AMD behavior: RAW emits a descriptor without stride. Typed always reads same value at offset = 0.
      * Structured: Passed down as stride to typed. */
     is_amd_win = is_amd_windows_device(context.device);
-    is_nv_heap = is_nvidia_device(context.device) &&
+    is_nv_heap = (is_nvidia_device(context.device) || is_nvk_device(context.device)) &&
             is_vk_device_extension_supported(context.device, "VK_EXT_descriptor_heap");
 
     /* Validate structured. */
@@ -1338,7 +1339,7 @@ static void test_undefined_typed_read_structured_raw(bool use_dxil)
      * RAW access works as expected, except that robustness is completely disabled. */
     is_amd_win = is_amd_windows_device(context.device);
     is_nv_win = is_nvidia_windows_device(context.device);
-    is_nv_heap = is_nvidia_device(context.device) &&
+    is_nv_heap = (is_nvidia_device(context.device) || is_nvk_device(context.device)) &&
             is_vk_device_extension_supported(context.device, "VK_EXT_descriptor_heap");
 
     /* Validate the buffer read. */

--- a/tests/d3d12_shaders.c
+++ b/tests/d3d12_shaders.c
@@ -14994,7 +14994,7 @@ static void test_derivative_hoisting(bool use_dxil)
             v = get_readback_vec4(&rb, y * 2 + x, 0);
 
             /* NV is not conformant with D3D11.3 16.8.2 here, so we're justified in app-opting instead of pessimizing all shaders. */
-            is_bug = (is_nvidia_windows_device(context.device) || is_nvidia_device(context.device)) && x + y != 1;
+            is_bug = (is_nvidia_windows_device(context.device) || is_nvidia_device(context.device) || is_nvk_device(context.device)) && x + y != 1;
             bug_if(is_bug)
             ok(compare_vec4(&expected, v, 0), "(%u, %u): Expected (%f, %f, %f, %f), got (%f, %f, %f, %f)\n", x, y,
                 expected.x, expected.y, expected.z, expected.w,


### PR DESCRIPTION
This document NVK behaviors under `VK_EXT_descriptor_heap` and `update test_derivative_hoisting` as we have the same issue as NV blobs.