### PR TITLE
VK_KHR_opacity_micromap - Phase 9 (NVAPI)

### DIFF
--- a/include/vkd3d_command_list_vkd3d_ext.idl
+++ b/include/vkd3d_command_list_vkd3d_ext.idl
@@ -40,3 +40,14 @@ interface ID3D12GraphicsCommandListExt1 : ID3D12GraphicsCommandListExt
 {
    HRESULT LaunchCubinShaderEx(D3D12_CUBIN_DATA_HANDLE *handle, UINT32 block_x, UINT32 block_y, UINT32 block_z, UINT32 smem_size, const void *params, UINT32 param_size, const void *raw_params, UINT32 raw_params_count);
 }
+
+[
+    uuid(3bb8ce38-abef-484f-8f88-d5af90ac19fb),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12GraphicsCommandListExt2 : ID3D12GraphicsCommandListExt1
+{
+    BOOL VerifyOpacityMicromapArrayNVAPI(D3D12_GPU_VIRTUAL_ADDRESS opacity_micromap_array);
+}

--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -18,6 +18,12 @@
 import "vkd3d_d3d12.idl";
 import "vkd3d_vk_includes.h";
 
+typedef enum D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG
+{
+    D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_NONE = 0x0,
+    D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT = 0x1
+} D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG;
+
 [
     uuid(11ea7a1a-0f6a-49bf-b612-3e30f8e201dd),
     object,
@@ -162,6 +168,18 @@ interface ID3D12DeviceExt4 : ID3D12DeviceExt3
     BOOL IsNvShaderExtnOpCodeSupported(UINT32 op_code);
     HRESULT SetNvShaderExtnSlotSpace(UINT32 uav_slot, UINT32 uav_space, BOOL local_thread);
 }
+
+[
+    uuid(e51323f6-3541-4ddf-894d-8a8c70e3e427),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12DeviceExt5 : ID3D12DeviceExt4
+{
+    BOOL SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG pipeline_state_flags);
+}
+
 
 /* 1:1 implementation of ffx_antilag2_dx12.h */
 struct AmdAntiLagAPIData_v1

--- a/include/vkd3d_vk_includes.h
+++ b/include/vkd3d_vk_includes.h
@@ -41,6 +41,7 @@ typedef enum VkImageLayout VkImageLayout;
 
 typedef enum D3D12_VK_EXTENSION
 {
+    D3D12_VK_EXT_OPACITY_MICROMAP   = 0x0,
     D3D12_VK_NVX_BINARY_IMPORT      = 0x1,
     D3D12_VK_NVX_IMAGE_VIEW_HANDLE  = 0x2,
     D3D12_VK_NV_LOW_LATENCY_2       = 0x3,

--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -260,7 +260,7 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
                     }
                     have_triangles = true;
 
-                    if (!d3d12_device_supports_ray_tracing_tier_1_2(device))
+                    if (!device->device_info.supports_opacity_micromap)
                     {
                         ERR("Opacity micromap is not supported.\n");
                         return false;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -22033,7 +22033,7 @@ static struct d3d12_command_list *unsafe_impl_from_ID3D12CommandList(ID3D12Comma
     return CONTAINING_RECORD(iface, struct d3d12_command_list, ID3D12GraphicsCommandList_iface);
 }
 
-extern CONST_VTBL struct ID3D12GraphicsCommandListExt1Vtbl d3d12_command_list_vkd3d_ext_vtbl;
+extern CONST_VTBL struct ID3D12GraphicsCommandListExt2Vtbl d3d12_command_list_vkd3d_ext_vtbl;
 
 static void d3d12_command_list_init_attachment_info(VkRenderingAttachmentInfo *attachment_info)
 {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20218,7 +20218,7 @@ static bool d3d12_command_list_allocate_rtas_build_info(struct d3d12_command_lis
         return false;
     }
 
-    if (d3d12_device_supports_ray_tracing_tier_1_2(list->device))
+    if (list->device->device_info.supports_opacity_micromap)
     {
         if (!vkd3d_array_reserve((void **)&rtas_batch->omm_triangles_infos, &rtas_batch->omm_triangles_info_size,
                 rtas_batch->geometry_info_count + geometry_count, sizeof(*rtas_batch->omm_triangles_infos)))
@@ -20237,7 +20237,7 @@ static bool d3d12_command_list_allocate_rtas_build_info(struct d3d12_command_lis
 
     *build_info = &rtas_batch->build_infos[rtas_batch->build_info_count];
     *geometry_infos = &rtas_batch->geometry_infos[rtas_batch->geometry_info_count];
-    if (d3d12_device_supports_ray_tracing_tier_1_2(list->device))
+    if (list->device->device_info.supports_opacity_micromap)
         *omm_triangles_infos = &rtas_batch->omm_triangles_infos[rtas_batch->geometry_info_count];
     else
         *omm_triangles_infos = NULL;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -6698,7 +6698,8 @@ HRESULT STDMETHODCALLTYPE d3d12_command_list_QueryInterface(d3d12_command_list_i
     }
 
     if (IsEqualGUID(iid, &IID_ID3D12GraphicsCommandListExt)
-            || IsEqualGUID(iid, &IID_ID3D12GraphicsCommandListExt1))
+            || IsEqualGUID(iid, &IID_ID3D12GraphicsCommandListExt1)
+            || IsEqualGUID(iid, &IID_ID3D12GraphicsCommandListExt2))
     {
         d3d12_command_list_vkd3d_ext_AddRef(&command_list->ID3D12GraphicsCommandListExt_iface);
         *object = &command_list->ID3D12GraphicsCommandListExt_iface;

--- a/libs/vkd3d/command_list_vkd3d_ext.c
+++ b/libs/vkd3d/command_list_vkd3d_ext.c
@@ -123,7 +123,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_vkd3d_ext_LaunchCubinShader(
                                                             0 /* raw_params_count */);
 }
 
-CONST_VTBL struct ID3D12GraphicsCommandListExt1Vtbl d3d12_command_list_vkd3d_ext_vtbl =
+CONST_VTBL struct ID3D12GraphicsCommandListExt2Vtbl d3d12_command_list_vkd3d_ext_vtbl =
 {
     /* IUnknown methods */
     d3d12_command_list_vkd3d_ext_QueryInterface,
@@ -136,5 +136,8 @@ CONST_VTBL struct ID3D12GraphicsCommandListExt1Vtbl d3d12_command_list_vkd3d_ext
 
     /* ID3D12GraphicsCommandListExt1 methods */
     d3d12_command_list_vkd3d_ext_LaunchCubinShaderEx,
+
+    /* ID3D12GraphicsCommandListExt2 methods */
+    NULL,
 };
 

--- a/libs/vkd3d/command_list_vkd3d_ext.c
+++ b/libs/vkd3d/command_list_vkd3d_ext.c
@@ -123,6 +123,20 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_list_vkd3d_ext_LaunchCubinShader(
                                                             0 /* raw_params_count */);
 }
 
+static BOOL STDMETHODCALLTYPE d3d12_command_list_vkd3d_ext_VerifyOpacityMicromapArrayNVAPI(d3d12_command_list_vkd3d_ext_iface *iface,
+    D3D12_GPU_VIRTUAL_ADDRESS opacity_micromap_array)
+{
+    struct d3d12_command_list *list = d3d12_command_list_from_ID3D12GraphicsCommandListExt(iface);
+    enum vkd3d_rtas_kind rtas_kind;
+    VkAccelerationStructureKHR as;
+
+    TRACE("iface %p, opacity_micromap_array %#"PRIx64".\n", iface, opacity_micromap_array);
+
+    vkd3d_va_map_try_read_rtas(&list->device->memory_allocator.va_map, list->device,
+                opacity_micromap_array, &as, &rtas_kind);
+    return as != VK_NULL_HANDLE && (rtas_kind == VKD3D_RTAS_KIND_NON_TLAS || rtas_kind == VKD3D_RTAS_KIND_MUTATED);
+}
+
 CONST_VTBL struct ID3D12GraphicsCommandListExt2Vtbl d3d12_command_list_vkd3d_ext_vtbl =
 {
     /* IUnknown methods */
@@ -138,6 +152,6 @@ CONST_VTBL struct ID3D12GraphicsCommandListExt2Vtbl d3d12_command_list_vkd3d_ext
     d3d12_command_list_vkd3d_ext_LaunchCubinShaderEx,
 
     /* ID3D12GraphicsCommandListExt2 methods */
-    NULL,
+    d3d12_command_list_vkd3d_ext_VerifyOpacityMicromapArrayNVAPI,
 };
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -10977,6 +10977,9 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
 
     device->adapter_luid = create_info->adapter_luid;
     device->removed_reason = S_OK;
+    vkd3d_atomic_uint32_store_explicit(
+            &device->vendor_hacks.global_ray_tracing_pipeline_create_flags, 0,
+            vkd3d_memory_order_relaxed);
 
     device->vk_device = VK_NULL_HANDLE;
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -95,7 +95,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_PRESENT_WAIT_2, KHR_present_wait2),
     VK_EXTENSION(EXT_PRESENT_TIMING, EXT_present_timing),
     VK_EXTENSION(KHR_DEVICE_ADDRESS_COMMANDS, KHR_device_address_commands),
-    VK_EXTENSION_COND(KHR_OPACITY_MICROMAP, KHR_opacity_micromap, VKD3D_CONFIG_FLAG_STATIC(DXR_1_2)),
+    VK_EXTENSION_DISABLE_COND(KHR_OPACITY_MICROMAP, KHR_opacity_micromap, VKD3D_CONFIG_FLAG_STATIC(NO_DXR)),
 #ifdef _WIN32
     VK_EXTENSION(KHR_EXTERNAL_MEMORY_WIN32, KHR_external_memory_win32),
     VK_EXTENSION(KHR_EXTERNAL_SEMAPHORE_WIN32, KHR_external_semaphore_win32),
@@ -1697,12 +1697,6 @@ bool d3d12_device_supports_ray_tracing_tier_1_0(const struct d3d12_device *devic
     return device->device_info.acceleration_structure_features.accelerationStructure &&
             device->device_info.ray_tracing_pipeline_features.rayTracingPipeline &&
             device->d3d12_caps.options5.RaytracingTier >= D3D12_RAYTRACING_TIER_1_0;
-}
-
-bool d3d12_device_supports_ray_tracing_tier_1_2(const struct d3d12_device *device)
-{
-    return device->device_info.supports_opacity_micromap &&
-            device->d3d12_caps.options5.RaytracingTier >= D3D12_RAYTRACING_TIER_1_2;
 }
 
 bool d3d12_device_supports_variable_shading_rate_tier_1(struct d3d12_device *device)
@@ -8458,7 +8452,7 @@ static void d3d12_device_get_raytracing_opacity_micromap_array_prebuild_info(str
     VkMicromapUsageKHR *usages;
     uint32_t usages_count;
 
-    if (!d3d12_device_supports_ray_tracing_tier_1_2(device))
+    if (!device->device_info.supports_opacity_micromap)
     {
         ERR("Opacity micromap is not supported. Calling this is invalid.\n");
         memset(info, 0, sizeof(*info));

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4610,7 +4610,8 @@ HRESULT STDMETHODCALLTYPE d3d12_device_QueryInterface(d3d12_device_iface *iface,
             || IsEqualGUID(riid, &IID_ID3D12DeviceExt1)
             || IsEqualGUID(riid, &IID_ID3D12DeviceExt2)
             || IsEqualGUID(riid, &IID_ID3D12DeviceExt3)
-            || IsEqualGUID(riid, &IID_ID3D12DeviceExt4))
+            || IsEqualGUID(riid, &IID_ID3D12DeviceExt4)
+            || IsEqualGUID(riid, &IID_ID3D12DeviceExt5))
     {
         d3d12_device_vkd3d_ext_AddRef(&device->ID3D12DeviceExt_iface);
         *object = &device->ID3D12DeviceExt_iface;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -10896,7 +10896,7 @@ static void d3d12_device_replace_vtable(struct d3d12_device *device)
     }
 }
 
-extern CONST_VTBL struct ID3D12DeviceExt4Vtbl d3d12_device_vkd3d_ext_vtbl;
+extern CONST_VTBL struct ID3D12DeviceExt5Vtbl d3d12_device_vkd3d_ext_vtbl;
 extern CONST_VTBL struct ID3D12DXVKInteropDevice3Vtbl d3d12_dxvk_interop_device_vtbl;
 extern CONST_VTBL struct ID3DLowLatencyDeviceVtbl d3d_low_latency_device_vtbl;
 extern CONST_VTBL struct IAmdExtAntiLagApiVtbl d3d_amd_ext_anti_lag_vtbl;

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -147,6 +147,9 @@ static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetExtensionSupport(d3d12_d
     TRACE("iface %p, extension %u\n", iface, extension);
     switch (extension)
     {
+        case D3D12_VK_EXT_OPACITY_MICROMAP:
+            ret_val = device->device_info.supports_opacity_micromap;
+            break;
         case D3D12_VK_NVX_BINARY_IMPORT:
             ret_val = device->vk_info.NVX_binary_import;
             break;

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -726,7 +726,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace
     return S_OK;
 }
 
-CONST_VTBL struct ID3D12DeviceExt4Vtbl d3d12_device_vkd3d_ext_vtbl =
+CONST_VTBL struct ID3D12DeviceExt5Vtbl d3d12_device_vkd3d_ext_vtbl =
 {
     /* IUnknown methods */
     d3d12_device_vkd3d_ext_QueryInterface,
@@ -759,6 +759,9 @@ CONST_VTBL struct ID3D12DeviceExt4Vtbl d3d12_device_vkd3d_ext_vtbl =
     /* ID3D12DeviceExt4 methods */
     d3d12_device_vkd3d_ext_IsNvShaderExtnOpCodeSupported,
     d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace,
+
+    /* ID3D12DeviceExt5 methods */
+    NULL,
 };
 
 static inline struct d3d12_device *d3d12_device_from_ID3D12DXVKInteropDevice(d3d12_dxvk_interop_device_iface *iface)

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -425,6 +425,41 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetVulkanQueueInfoEx(d3d
     return S_OK;
 }
 
+static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SetCreatePipelineStateFlagsNVAPI(d3d12_device_vkd3d_ext_iface *iface,
+        D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG pipeline_state_flags)
+{
+    struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
+    VKD3D_UNUSED VkPipelineCreateFlags ray_tracing_pipeline_create_flags;
+    bool enable_opacity_micromap;
+
+    TRACE("iface %p, pipeline_state_flags %d.\n", iface, pipeline_state_flags);
+
+    enable_opacity_micromap = (pipeline_state_flags & D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT) != 0;
+
+    if (enable_opacity_micromap)
+    {
+        if (!device->device_info.supports_opacity_micromap)
+        {
+            ERR("Opacity micromap is not supported.\n");
+            return FALSE;
+        }
+
+        ray_tracing_pipeline_create_flags = vkd3d_atomic_uint32_or(&device->vendor_hacks.global_ray_tracing_pipeline_create_flags,
+                VK_PIPELINE_CREATE_RAY_TRACING_OPACITY_MICROMAP_BIT_KHR, vkd3d_memory_order_relaxed) |
+                VK_PIPELINE_CREATE_RAY_TRACING_OPACITY_MICROMAP_BIT_KHR;
+    }
+    else
+    {
+        ray_tracing_pipeline_create_flags = vkd3d_atomic_uint32_and(&device->vendor_hacks.global_ray_tracing_pipeline_create_flags,
+                ~VK_PIPELINE_CREATE_RAY_TRACING_OPACITY_MICROMAP_BIT_KHR, vkd3d_memory_order_relaxed) &
+                ~VK_PIPELINE_CREATE_RAY_TRACING_OPACITY_MICROMAP_BIT_KHR;
+    }
+
+    TRACE("flags #%x.\n", ray_tracing_pipeline_create_flags);
+
+    return TRUE;
+}
+
 static BOOL STDMETHODCALLTYPE d3d12_device_vkd3d_ext_SupportsCubin64bit(d3d12_device_vkd3d_ext_iface *iface)
 {
     struct d3d12_device *device = d3d12_device_from_ID3D12DeviceExt(iface);
@@ -761,7 +796,7 @@ CONST_VTBL struct ID3D12DeviceExt5Vtbl d3d12_device_vkd3d_ext_vtbl =
     d3d12_device_vkd3d_ext_SetNvShaderExtnSlotSpace,
 
     /* ID3D12DeviceExt5 methods */
-    NULL,
+    d3d12_device_vkd3d_ext_SetCreatePipelineStateFlagsNVAPI,
 };
 
 static inline struct d3d12_device *d3d12_device_from_ID3D12DXVKInteropDevice(d3d12_dxvk_interop_device_iface *iface)

--- a/libs/vkd3d/raytracing_pipeline.c
+++ b/libs/vkd3d/raytracing_pipeline.c
@@ -2539,6 +2539,10 @@ static HRESULT d3d12_state_object_compile_pipeline_variant(struct d3d12_rt_state
     if (object->pipeline_config.Flags & D3D12_RAYTRACING_PIPELINE_FLAG_ALLOW_OPACITY_MICROMAPS)
         flags2.flags |= VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_KHR;
 
+    pipeline_create_info.flags |=
+            vkd3d_atomic_uint32_load_explicit(&object->device->vendor_hacks.global_ray_tracing_pipeline_create_flags,
+                    vkd3d_memory_order_relaxed);
+
     library_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR;
     library_info.pNext = NULL;
     library_info.libraryCount = data->vk_libraries_count;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -2985,7 +2985,7 @@ struct vkd3d_rendering_info
 };
 
 /* ID3D12CommandListExt */
-typedef ID3D12GraphicsCommandListExt1 d3d12_command_list_vkd3d_ext_iface;
+typedef ID3D12GraphicsCommandListExt2 d3d12_command_list_vkd3d_ext_iface;
 
 struct d3d12_rt_state_object;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5837,6 +5837,11 @@ struct d3d12_device
         HMODULE amdxc64;
 #endif
         struct vkd3d_nv_shader nv_shader;
+
+        /* Set by SetCreatePipelineStateOptions (NVAPI). NVAPI has no per-pipeline OMM opt-in
+         * (unlike DXR 1.2's ALLOW_OPACITY_MICROMAPS flag), so this global is OR'd into every
+         * RT pipeline creation to implement the device-wide enable/disable semantic. */
+        VkPipelineCreateFlags global_ray_tracing_pipeline_create_flags;
     } vendor_hacks;
 
     bool independent_device;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5442,7 +5442,7 @@ struct vkd3d_descriptor_qa_heap_buffer_data;
 struct vkd3d_timestamp_profiler;
 
 /* ID3D12DeviceExt */
-typedef ID3D12DeviceExt4 d3d12_device_vkd3d_ext_iface;
+typedef ID3D12DeviceExt5 d3d12_device_vkd3d_ext_iface;
 
 /* ID3D12DXVKInteropDevice */
 typedef ID3D12DXVKInteropDevice3 d3d12_dxvk_interop_device_iface;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -6097,7 +6097,6 @@ static inline bool d3d12_device_use_ssbo_root_descriptors(struct d3d12_device *d
 bool d3d12_device_supports_variable_shading_rate_tier_1(struct d3d12_device *device);
 bool d3d12_device_supports_variable_shading_rate_tier_2(struct d3d12_device *device);
 bool d3d12_device_supports_ray_tracing_tier_1_0(const struct d3d12_device *device);
-bool d3d12_device_supports_ray_tracing_tier_1_2(const struct d3d12_device *device);
 UINT d3d12_determine_shading_rate_image_tile_size(struct d3d12_device *device);
 bool d3d12_device_supports_required_subgroup_size_for_stage(
         struct d3d12_device *device, VkShaderStageFlagBits stage);


### PR DESCRIPTION
This PR will commit all the changes for NVAPI support. This change interoperates with https://github.com/jp7677/dxvk-nvapi/pull/371. Since the PR to dxvk-nvapi appears to be down to a few minor issues, I am putting this change into review as I do not expect API changes at this point. These changes are expected to be able to land in either order. For example, vkd3d-proton will not crash if the dxvk-nvapi changes have not been merged, and vice versa.

After this PR only one minor change is left: bumping dxil-spirv, and enabling `ray_query_force_omm` on NVIDIA hardware. I will post this as a separate phase to keep things concise.