### PR TITLE
vkd3d: Add some debug tracking to catch potential missing RTAS flags.

### DIFF
--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -487,7 +487,7 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
     for (i = 0; i < count; i++)
     {
         vkd3d_va_map_try_read_rtas(&list->device->memory_allocator.va_map, list->device, addresses[i],
-                &vk_acceleration_structure, &rtas_kind);
+                &vk_acceleration_structure, &rtas_kind, NULL);
 
         if (vk_acceleration_structure == VK_NULL_HANDLE)
         {
@@ -496,7 +496,7 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
             rtas_kind = VKD3D_RTAS_KIND_UNKNOWN;
             vk_acceleration_structure =
                     vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device,
-                    addresses[i], rtas_kind);
+                    addresses[i], rtas_kind, NULL);
         }
         if (vk_acceleration_structure == VK_NULL_HANDLE)
         {
@@ -573,13 +573,15 @@ void vkd3d_acceleration_structure_copy(
         struct d3d12_command_list *list,
         D3D12_GPU_VIRTUAL_ADDRESS dst, VkAccelerationStructureKHR src_as,
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode,
-        enum vkd3d_rtas_kind rtas_kind)
+        enum vkd3d_rtas_kind rtas_kind, uint32_t rtas_meta)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkCopyAccelerationStructureInfoKHR info;
     VkAccelerationStructureKHR dst_as;
 
-    dst_as = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device, dst, rtas_kind);
+    rtas_meta |= VKD3D_RTAS_META_REPLACE;
+    dst_as = vkd3d_va_map_place_acceleration_structure(
+            &list->device->memory_allocator.va_map, list->device, dst, rtas_kind, &rtas_meta);
 
     if (dst_as == VK_NULL_HANDLE)
     {

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20473,8 +20473,12 @@ static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3
     micromap = VK_NULL_HANDLE;
     if (desc->DestAccelerationStructureData)
     {
+        uint32_t rtas_meta = VKD3D_RTAS_META_REPLACE;
+        if (build_info->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)
+            rtas_meta |= VKD3D_RTAS_META_ALLOW_COMPACTION;
+
         micromap = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map,
-                        list->device, desc->DestAccelerationStructureData, VKD3D_RTAS_KIND_NON_TLAS);
+                        list->device, desc->DestAccelerationStructureData, VKD3D_RTAS_KIND_NON_TLAS, &rtas_meta);
         build_info->dstAccelerationStructure = micromap;
         if (build_info->dstAccelerationStructure == VK_NULL_HANDLE)
         {
@@ -20555,6 +20559,7 @@ static void d3d12_command_list_build_raytracing_blas_and_tlas(struct d3d12_comma
     uint32_t *primitive_counts = NULL;
     uint32_t geometry_count;
     enum vkd3d_rtas_kind rtas_kind;
+    uint32_t rtas_meta;
 
     geometry_count = vkd3d_acceleration_structure_get_geometry_count(&desc->Inputs);
 
@@ -20580,28 +20585,47 @@ static void d3d12_command_list_build_raytracing_blas_and_tlas(struct d3d12_comma
 
     rtas_kind = (desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL) ?
         VKD3D_RTAS_KIND_TLAS : VKD3D_RTAS_KIND_NON_TLAS;
-
-    if (desc->DestAccelerationStructureData)
-    {
-        build_info->dstAccelerationStructure =
-                vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map,
-                        list->device, desc->DestAccelerationStructureData, rtas_kind);
-        if (build_info->dstAccelerationStructure == VK_NULL_HANDLE)
-        {
-            ERR("Failed to place destAccelerationStructure. Dropping call.\n");
-            return;
-        }
-    }
+    rtas_meta = 0;
 
     if (build_info->mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR &&
             desc->SourceAccelerationStructureData)
     {
         build_info->srcAccelerationStructure =
                 vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map,
-                        list->device, desc->SourceAccelerationStructureData, rtas_kind);
+                        list->device, desc->SourceAccelerationStructureData, rtas_kind, &rtas_meta);
         if (build_info->srcAccelerationStructure == VK_NULL_HANDLE)
         {
             ERR("Failed to place srcAccelerationStructure. Dropping call.\n");
+            return;
+        }
+
+        if (!(rtas_meta & VKD3D_RTAS_META_ALLOW_UPDATE))
+        {
+            WARN("Source %s %"PRIx64" was likely not built with ALLOW_UPDATE.\n",
+                 desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL ? "TLAS" : "BLAS",
+                 desc->SourceAccelerationStructureData);
+        }
+    }
+
+    if (desc->DestAccelerationStructureData)
+    {
+        rtas_meta |= VKD3D_RTAS_META_REPLACE;
+
+        if (build_info->mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR ||
+            (build_info->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR))
+        {
+            rtas_meta |= VKD3D_RTAS_META_ALLOW_UPDATE;
+        }
+
+        if (build_info->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)
+            rtas_meta |= VKD3D_RTAS_META_ALLOW_COMPACTION;
+
+        build_info->dstAccelerationStructure =
+                vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map,
+                        list->device, desc->DestAccelerationStructureData, rtas_kind, &rtas_meta);
+        if (build_info->dstAccelerationStructure == VK_NULL_HANDLE)
+        {
+            ERR("Failed to place destAccelerationStructure. Dropping call.\n");
             return;
         }
     }
@@ -20796,6 +20820,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
     VkAccelerationStructureKHR src_as;
     enum vkd3d_rtas_kind rtas_kind;
+    uint32_t rtas_meta;
 
     TRACE("iface %p, dst_data %#"PRIx64", src_data %#"PRIx64", mode %u\n",
           iface, dst_data, src_data, mode);
@@ -20825,19 +20850,26 @@ static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStruc
      * Don't consider this pending RTAS work until we have evidence of real-world breakage. */
 
     vkd3d_va_map_try_read_rtas(&list->device->memory_allocator.va_map,
-            list->device, src_data, &src_as, &rtas_kind);
+            list->device, src_data, &src_as, &rtas_kind, &rtas_meta);
 
     if (src_as == VK_NULL_HANDLE)
     {
         WARN("Copy placing unknown AS at #%" PRIx64 " future BLP queries may not be reliable.\n", src_data);
         rtas_kind = VKD3D_RTAS_KIND_UNKNOWN;
         src_as = vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device,
-                src_data, rtas_kind);
+                src_data, rtas_kind, &rtas_meta);
     }
 
     if (src_as != VK_NULL_HANDLE)
     {
-        vkd3d_acceleration_structure_copy(list, dst_data, src_as, mode, rtas_kind);
+        if (mode == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT &&
+            !(rtas_meta & VKD3D_RTAS_META_ALLOW_COMPACTION))
+        {
+            WARN("Application uses compaction for %"PRIx64" -> %"PRIx64", but ALLOW_COMPACTION was likely not used correctly.\n",
+                 src_data, dst_data);
+        }
+
+        vkd3d_acceleration_structure_copy(list, dst_data, src_as, mode, rtas_kind, rtas_meta);
         VKD3D_BREADCRUMB_AUX64(dst_data);
         VKD3D_BREADCRUMB_AUX64(src_data);
         VKD3D_BREADCRUMB_AUX32(mode);

--- a/libs/vkd3d/command_list_vkd3d_ext.c
+++ b/libs/vkd3d/command_list_vkd3d_ext.c
@@ -133,7 +133,7 @@ static BOOL STDMETHODCALLTYPE d3d12_command_list_vkd3d_ext_VerifyOpacityMicromap
     TRACE("iface %p, opacity_micromap_array %#"PRIx64".\n", iface, opacity_micromap_array);
 
     vkd3d_va_map_try_read_rtas(&list->device->memory_allocator.va_map, list->device,
-                opacity_micromap_array, &as, &rtas_kind);
+                opacity_micromap_array, &as, &rtas_kind, NULL);
     return as != VK_NULL_HANDLE && (rtas_kind == VKD3D_RTAS_KIND_NON_TLAS || rtas_kind == VKD3D_RTAS_KIND_MUTATED);
 }
 

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -279,7 +279,7 @@ bool vkd3d_acceleration_structure_resolve_omm_va_maps(struct d3d12_device *devic
             continue;
 
         omm_triangles_infos[i].micromap = vkd3d_va_map_place_acceleration_structure(
-                &device->memory_allocator.va_map, device, va, VKD3D_RTAS_KIND_NON_TLAS);
+                &device->memory_allocator.va_map, device, va, VKD3D_RTAS_KIND_NON_TLAS, NULL);
         if (omm_triangles_infos[i].micromap == VK_NULL_HANDLE)
             return false;
     }

--- a/libs/vkd3d/va_map.c
+++ b/libs/vkd3d/va_map.c
@@ -250,7 +250,7 @@ const struct vkd3d_unique_resource *vkd3d_va_map_deref(struct vkd3d_va_map *va_m
 void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
         struct d3d12_device *device, VkDeviceAddress va,
         VkAccelerationStructureKHR *acceleration_structure,
-        enum vkd3d_rtas_kind *rtas_kind)
+        enum vkd3d_rtas_kind *rtas_kind, uint32_t *rtas_meta)
 {
     const struct vkd3d_unique_resource *resource;
     struct vkd3d_view_map *view_map;
@@ -282,6 +282,9 @@ void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
     *acceleration_structure = view->vk_acceleration_structure;
     *rtas_kind = (enum vkd3d_rtas_kind)
         vkd3d_atomic_uint32_load_explicit(&view->info.buffer.rtas_kind, vkd3d_memory_order_relaxed);
+
+    if (rtas_meta)
+        *rtas_meta = vkd3d_atomic_uint32_load_explicit(&view->info.buffer.rtas_meta, vkd3d_memory_order_acquire);
 }
 
 const char *vkd3d_get_rtas_kind_string(enum vkd3d_rtas_kind rtas_kind)
@@ -299,7 +302,7 @@ const char *vkd3d_get_rtas_kind_string(enum vkd3d_rtas_kind rtas_kind)
 VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3d_va_map *va_map,
         struct d3d12_device *device,
         VkDeviceAddress va,
-        enum vkd3d_rtas_kind rtas_kind)
+        enum vkd3d_rtas_kind rtas_kind, uint32_t *rtas_meta)
 {
     enum vkd3d_rtas_kind previous_rtas_kind, expected_rtas_kind, desired_rtas_kind;
     struct vkd3d_unique_resource *resource;
@@ -350,6 +353,9 @@ VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3
     if (!view)
         return VK_NULL_HANDLE;
 
+    /* These states are updated on CPU record time, but CPU record time may not reflect true GPU submit time order.
+     * In practice, this should be good enough as a debugging tool to help guide investigations. */
+
     /* Atomic CAS loop maintaining the rtas_kind state machine:
      *   UNKNOWN -> TLAS | NON_TLAS  (upgrade on first known place)
      *   TLAS | NON_TLAS -> MUTATED  (collapse on cross-kind place)
@@ -382,6 +388,14 @@ VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3
             }
             break;
         }
+    }
+
+    if (rtas_meta)
+    {
+        if (*rtas_meta & VKD3D_RTAS_META_REPLACE)
+            *rtas_meta = vkd3d_atomic_uint32_exchange_explicit(&view->info.buffer.rtas_meta, *rtas_meta, vkd3d_memory_order_acq_rel);
+        else
+            *rtas_meta = vkd3d_atomic_uint32_load_explicit(&view->info.buffer.rtas_meta, vkd3d_memory_order_acquire);
     }
 
     return view->vk_acceleration_structure;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -398,6 +398,13 @@ struct vkd3d_va_map
     size_t sampler_mappings_size;
 };
 
+enum vkd3d_rtas_meta
+{
+    VKD3D_RTAS_META_ALLOW_UPDATE = 0x1,
+    VKD3D_RTAS_META_ALLOW_COMPACTION = 0x2,
+    VKD3D_RTAS_META_REPLACE = 0x10000, /* If set, replaces the current meta. */
+};
+
 const char *vkd3d_get_rtas_kind_string(enum vkd3d_rtas_kind rtas_kind);
 void vkd3d_va_map_insert(struct vkd3d_va_map *va_map, struct vkd3d_unique_resource *resource);
 void vkd3d_va_map_remove(struct vkd3d_va_map *va_map, const struct vkd3d_unique_resource *resource);
@@ -405,11 +412,11 @@ const struct vkd3d_unique_resource *vkd3d_va_map_deref(struct vkd3d_va_map *va_m
 void vkd3d_va_map_try_read_rtas(struct vkd3d_va_map *va_map,
         struct d3d12_device *device, VkDeviceAddress va,
         VkAccelerationStructureKHR *acceleration_structure,
-        enum vkd3d_rtas_kind *rtas_kind);
+        enum vkd3d_rtas_kind *rtas_kind, uint32_t *rtas_meta);
 VkAccelerationStructureKHR vkd3d_va_map_place_acceleration_structure(struct vkd3d_va_map *va_map,
         struct d3d12_device *device,
         VkDeviceAddress va,
-        enum vkd3d_rtas_kind rtas_kind);
+        enum vkd3d_rtas_kind rtas_kind, uint32_t *rtas_meta);
 void vkd3d_va_map_init(struct vkd3d_va_map *va_map);
 void vkd3d_va_map_cleanup(struct vkd3d_va_map *va_map);
 void vkd3d_va_map_insert_descriptor_heap(struct vkd3d_va_map *va_map,
@@ -1334,6 +1341,7 @@ struct vkd3d_view
             VkDeviceSize offset;
             VkDeviceSize size;
             uint32_t rtas_kind; /* not hashed; accessed atomically; stores vkd3d_rtas_kind */
+            uint32_t rtas_meta; /* debug tracking */
         } buffer;
         struct
         {
@@ -6919,7 +6927,7 @@ void vkd3d_acceleration_structure_copy(
         struct d3d12_command_list *list,
         D3D12_GPU_VIRTUAL_ADDRESS dst, VkAccelerationStructureKHR src_as,
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode,
-        enum vkd3d_rtas_kind rtas_kind);
+        enum vkd3d_rtas_kind rtas_kind, uint32_t rtas_meta);
 
 bool vkd3d_opacity_micromap_convert_inputs(const struct d3d12_device *device,
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *inputs,


### PR DESCRIPTION
Aims to keep track of when ALLOW_UPDATE/ALLOW_COMPACTION is missing. No known case of this breaking any game, but wrote the code so might as well keep it around.