### PR TITLE
vkd3d: Unwrap potentially hooked queue interface before assuming that is our object.

### DIFF
--- a/include/vkd3d_device_vkd3d_ext.idl
+++ b/include/vkd3d_device_vkd3d_ext.idl
@@ -221,3 +221,16 @@ interface IAmdExtAntiLagApi : IUnknown
 {
     HRESULT UpdateAntiLagState(void *pData);
 }
+
+/* Used to get underlying vkd3d-proton own object from wrapped interface */
+[
+    uuid(cc1419e0-8ca3-4206-bc1f-064e7c7345cc),
+    object,
+    local,
+    pointer_default(unique)
+]
+interface ID3D12ExtDummyInterface
+{
+    /* This is to keep MSVC compilation happy. */
+    void dummy(void);
+}

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -22219,7 +22219,8 @@ HRESULT STDMETHODCALLTYPE d3d12_command_queue_QueryInterface(ID3D12CommandQueue 
             || IsEqualGUID(riid, &IID_ID3D12Pageable)
             || IsEqualGUID(riid, &IID_ID3D12DeviceChild)
             || IsEqualGUID(riid, &IID_ID3D12Object)
-            || IsEqualGUID(riid, &IID_IUnknown))
+            || IsEqualGUID(riid, &IID_IUnknown)
+            || IsEqualGUID(riid, &IID_ID3D12ExtDummyInterface))
     {
         ID3D12CommandQueue_AddRef(iface);
         *object = iface;

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -419,12 +419,18 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_vkd3d_ext_GetVulkanQueueInfoEx(d3d
     TRACE("iface %p, queue %p, vk_queue %p, vk_queue_index %p, vk_queue_flags %p vk_queue_family %p.\n",
             iface, queue, vk_queue, vk_queue_index, vk_queue_flags, vk_queue_family);
 
+    if (FAILED(ID3D12CommandQueue_QueryInterface(queue, &IID_ID3D12ExtDummyInterface, (void **)&queue)))
+    {
+        ERR("no ID3D12ExtDummyInterface.\n");
+        return E_FAIL;
+    }
     *vk_queue = vkd3d_lock_vk_queue(queue);
     vkd3d_unlock_vk_queue(queue);
 
     *vk_queue_index = vkd3d_get_vk_queue_index(queue);
     *vk_queue_flags = vkd3d_get_vk_queue_flags(queue);
     *vk_queue_family = vkd3d_get_vk_queue_family_index(queue);
+    ID3D12CommandQueue_Release(queue);
     return S_OK;
 }
 
@@ -915,10 +921,17 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_GetVulkanQueueInfo(d3
 {
     TRACE("iface %p, queue %p, vk_queue %p, vk_queue_family %p.\n", iface, queue, vk_queue, vk_queue_family);
 
+    if (FAILED(ID3D12CommandQueue_QueryInterface(queue, &IID_ID3D12ExtDummyInterface, (void **)&queue)))
+    {
+        ERR("no ID3D12ExtDummyInterface.\n");
+        return E_FAIL;
+    }
+
     *vk_queue = vkd3d_lock_vk_queue(queue);
     vkd3d_unlock_vk_queue(queue);
 
     *vk_queue_family = vkd3d_get_vk_queue_family_index(queue);
+    ID3D12CommandQueue_Release(queue);
     return S_OK;
 }
 
@@ -977,11 +990,18 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_LockCommandQueue(d3d1
 
     TRACE("iface %p, queue %p.\n", iface, queue);
 
+    if (FAILED(ID3D12CommandQueue_QueryInterface(queue, &IID_ID3D12ExtDummyInterface, (void **)&queue)))
+    {
+        ERR("no ID3D12ExtDummyInterface.\n");
+        return E_FAIL;
+    }
+
     /* Flushing the transfer queue adds a wait to all other queues, and the
      * acquire operation will drain the queue, ensuring that any pending clear
      * or upload happens before D3D11 submissions on the GPU timeline. */
     vkd3d_memory_transfer_queue_flush(&device->memory_transfers);
     vkd3d_acquire_vk_queue(queue);
+    ID3D12CommandQueue_Release(queue);
     return S_OK;
 }
 
@@ -989,7 +1009,14 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_UnlockCommandQueue(d3
 {
     TRACE("iface %p, queue %p.\n", iface, queue);
 
+    if (FAILED(ID3D12CommandQueue_QueryInterface(queue, &IID_ID3D12ExtDummyInterface, (void **)&queue)))
+    {
+        ERR("no ID3D12ExtDummyInterface.\n");
+        return E_FAIL;
+    }
+
     vkd3d_release_vk_queue(queue);
+    ID3D12CommandQueue_Release(queue);
     return S_OK;
 }
 
@@ -1067,7 +1094,14 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_LockVulkanQueue(d3d12
 {
     TRACE("iface %p, queue %p.\n", iface, queue);
 
+    if (FAILED(ID3D12CommandQueue_QueryInterface(queue, &IID_ID3D12ExtDummyInterface, (void **)&queue)))
+    {
+        ERR("no ID3D12ExtDummyInterface.\n");
+        return E_FAIL;
+    }
+
     vkd3d_lock_vk_queue(queue);
+    ID3D12CommandQueue_Release(queue);
     return S_OK;
 }
 
@@ -1075,7 +1109,14 @@ static HRESULT STDMETHODCALLTYPE d3d12_dxvk_interop_device_UnlockVulkanQueue(d3d
 {
     TRACE("iface %p, queue %p.\n", iface, queue);
 
+    if (FAILED(ID3D12CommandQueue_QueryInterface(queue, &IID_ID3D12ExtDummyInterface, (void **)&queue)))
+    {
+        ERR("no ID3D12ExtDummyInterface.\n");
+        return E_FAIL;
+    }
+
     vkd3d_unlock_vk_queue(queue);
+    ID3D12CommandQueue_Release(queue);
     return S_OK;
 }
 


### PR DESCRIPTION
That fixes HITMAN World of Assassination (1659040)  in VR mode which otherwise crashes. The queue which is passed through VR texture structure for IVRCompositor::Submit() is wrapped by sl.interposer, so using that as vkd3d-proton object in GetVulkanQueueInfo() doesn't work very well. Meanwhile, any sane wrapper would pass any unknown interface query to the wrapped object (like it happens in this case) and so we get our queue.

It could be made more idiomatic by, e. g., moving the queue related methods to a new queue extension interface, but it looks to me using an universal "canary" guid reduces a lot of unneeded boilerplate, the same uuid can be used for other objects once needed.