### PR TITLE
vkd3d: Disable suballocation when EXT_pageable_device_local_memory is supported

### DIFF
--- a/libs/vkd3d/heap.c
+++ b/libs/vkd3d/heap.c
@@ -293,6 +293,7 @@ static HRESULT d3d12_heap_init(struct d3d12_heap *heap, struct d3d12_device *dev
         const D3D12_HEAP_DESC *desc, void* host_address)
 {
     struct vkd3d_allocate_heap_memory_info alloc_info;
+    bool accept_small_image_heaps;
     HRESULT hr;
 
     memset(heap, 0, sizeof(*heap));
@@ -320,8 +321,18 @@ static HRESULT d3d12_heap_init(struct d3d12_heap *heap, struct d3d12_device *dev
     alloc_info.heap_desc = heap->desc;
     alloc_info.host_ptr = host_address;
 
+    /* If we have pageable support, we want to be able to take advantage of that for smaller heaps,
+     * since it seems to matter for memory management on e.g. Steam Machine.
+     * RADV only recently started supporting pageable.
+     * Also gate it behind zero initial device memory since would have no other way to zero clear the memory
+     * ourselves. */
+    accept_small_image_heaps =
+            device->device_info.zero_initialize_device_memory_features.zeroInitializeDeviceMemory &&
+            device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory;
+
     if ((alloc_info.heap_desc.Flags & D3D12_HEAP_FLAG_DENY_BUFFERS) &&
-            device->d3d12_caps.options.ResourceHeapTier >= D3D12_RESOURCE_HEAP_TIER_2)
+        !accept_small_image_heaps &&
+        device->d3d12_caps.options.ResourceHeapTier >= D3D12_RESOURCE_HEAP_TIER_2)
     {
         alloc_info.extra_allocation_flags = VKD3D_ALLOCATION_FLAG_ALLOW_IMAGE_SUBALLOCATION;
     }

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -2072,13 +2072,6 @@ static bool vkd3d_memory_info_allow_suballocate(struct d3d12_device *device,
     if (device->d3d12_caps.options.ResourceHeapTier < D3D12_RESOURCE_HEAP_TIER_2)
         return false;
 
-    /* For image-only heaps where heaps are small, it's possible the application wants to use fine-grained memory priorities.
-     * Nixxes ports tend to do that for example. */
-
-    /* Disable suballocation if EXT_pageable is supported, to give apps control over memory priorities. */
-    if (device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory)
-        return false;
-
     if (is_cpu_accessible_system_memory_heap(&info->heap_properties) ||
             !(info->flags & VKD3D_ALLOCATION_FLAG_ALLOW_IMAGE_SUBALLOCATION))
     {

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -2075,8 +2075,9 @@ static bool vkd3d_memory_info_allow_suballocate(struct d3d12_device *device,
     /* For image-only heaps where heaps are small, it's possible the application wants to use fine-grained memory priorities.
      * Nixxes ports tend to do that for example. */
 
-    /* We may or may not want to disable this workaround if EXT_pageable is supported,
-     * but it's good to not have two different allocation paths on NVIDIA and RADV for now. */
+    /* Disable suballocation if EXT_pageable is supported, to give apps control over memory priorities. */
+    if (device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory)
+        return false;
 
     if (is_cpu_accessible_system_memory_heap(&info->heap_properties) ||
             !(info->flags & VKD3D_ALLOCATION_FLAG_ALLOW_IMAGE_SUBALLOCATION))

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4420,10 +4420,18 @@ HRESULT d3d12_resource_create_committed(struct d3d12_device *device, const D3D12
         }
         else
         {
-            /* We want to allow suballocations and we need the allocation to
-             * be cleared to zero, which only works if we allow buffers */
-            allocate_info.flags = VKD3D_ALLOCATION_FLAG_GLOBAL_BUFFER |
-                    VKD3D_ALLOCATION_FLAG_ALLOW_IMAGE_SUBALLOCATION;
+            if (!device->device_info.zero_initialize_device_memory_features.zeroInitializeDeviceMemory ||
+                !device->device_info.pageable_device_memory_features.pageableDeviceLocalMemory)
+            {
+                /* We want to allow suballocations and we need the allocation to
+                 * be cleared to zero, which only works if we allow buffers */
+                allocate_info.flags = VKD3D_ALLOCATION_FLAG_GLOBAL_BUFFER |
+                        VKD3D_ALLOCATION_FLAG_ALLOW_IMAGE_SUBALLOCATION;
+
+                /* For suballocations, we only care about being able to clear the memory,
+                 * not anything else. */
+                allocate_info.explicit_global_buffer_usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+            }
 
             /* If image suballocation is allowed force the memory alignment to respect
              * the device buffer image granularity to prevent resource aliasing */
@@ -4431,10 +4439,6 @@ HRESULT d3d12_resource_create_committed(struct d3d12_device *device, const D3D12
                     device->device_info.properties2.properties.limits.bufferImageGranularity);
             allocate_info.memory_requirements.size = align(allocate_info.memory_requirements.size,
                     device->device_info.properties2.properties.limits.bufferImageGranularity);
-
-            /* For suballocations, we only care about being able to clear the memory,
-             * not anything else. */
-            allocate_info.explicit_global_buffer_usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
         }
 
         if (FAILED(hr = vkd3d_allocate_memory(device, &device->memory_allocator, &allocate_info, allocation)))


### PR DESCRIPTION
Apps having full control over their priorities can significantly improve perf (as well as making good perf not a matter of luck) when VRAM ends up being contended. Suballocation removes the ability to set prios, so don't do suballocation when prios are relevant.

Marked as draft because while I think this could be useful, I want to be more sure it doesn't regress gameplay experience if apps spam allocations.