### PR TITLE
vkd3d: Load Intel vendor hack DLLs similar to amdxc64.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3909,6 +3909,17 @@ static void d3d12_device_init_vendor_hacks(struct d3d12_device *device)
         if (device->vendor_hacks.amdxc64)
             INFO("Loaded amdxc64.dll successfully.\n");
     }
+
+    if (device->device_info.properties2.properties.vendorID == VKD3D_VENDOR_ID_INTEL)
+    {
+        char sysdir[MAX_PATH], path[MAX_PATH];
+        GetSystemDirectoryA(sysdir, sizeof(sysdir));
+        snprintf(path, sizeof(path),
+                "%s\\DriverStore\\FileRepository\\intc_wine\\igd10iumd64.dll", sysdir);
+        device->vendor_hacks.igd10iumd64 = LoadLibraryA(path);
+        if (device->vendor_hacks.igd10iumd64)
+            INFO("Loaded igd10iumd64.dll successfully.\n");
+    }
 #endif
 }
 
@@ -3919,6 +3930,8 @@ static void d3d12_device_cleanup_vendor_hacks(struct d3d12_device *device)
 #ifdef _WIN64
     if (device->vendor_hacks.amdxc64)
         FreeLibrary(device->vendor_hacks.amdxc64);
+    if (device->vendor_hacks.igd10iumd64)
+        FreeLibrary(device->vendor_hacks.igd10iumd64);
 #endif
 }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5853,6 +5853,7 @@ struct d3d12_device
     {
 #ifdef _WIN64
         HMODULE amdxc64;
+        HMODULE igd10iumd64;
 #endif
         struct vkd3d_nv_shader nv_shader;
 


### PR DESCRIPTION
On request from Intel.