### PR TITLE
vkd3d: vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR is optional.

### DIFF
--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -410,7 +410,7 @@ VK_DEVICE_EXT_PFN(vkGetLatencyTimingsNV)
 VK_DEVICE_EXT_PFN(vkQueueNotifyOutOfBandNV)
 
 /* VK_KHR_cooperative_matrix */
-VK_INSTANCE_PFN(vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR)
+VK_INSTANCE_EXT_PFN(vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR)
 
 /* VK_AMD_anti_lag */
 VK_DEVICE_EXT_PFN(vkAntiLagUpdateAMD)


### PR DESCRIPTION
Use VK_INSTANCE_EXT_PFN instead of VK_INSTANCE_PFN for the optional entrypoint.