### PR TITLE
vkd3d: Intel vendor hack DLL fix

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3918,7 +3918,7 @@ static void d3d12_device_init_vendor_hacks(struct d3d12_device *device)
         char sysdir[MAX_PATH], path[MAX_PATH];
         GetSystemDirectoryA(sysdir, sizeof(sysdir));
         snprintf(path, sizeof(path),
-                "%s\\DriverStore\\FileRepository\\intc_wine\\igd10iumd64.dll", sysdir);
+                "%s\\DriverStore\\FileRepository\\igd_faux.inf_1\\igd10iumd64.dll", sysdir);
         device->vendor_hacks.igd10iumd64 = LoadLibraryA(path);
         if (device->vendor_hacks.igd10iumd64)
             INFO("Loaded igd10iumd64.dll successfully.\n");


### PR DESCRIPTION
.inf file for an Intel device in Wine is named igd_faux.inf