### PR TITLE
vkd3d: validate D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER

### DIFF
--- a/libs/vkd3d/heap.c
+++ b/libs/vkd3d/heap.c
@@ -283,6 +283,15 @@ static HRESULT validate_heap_desc(struct d3d12_device *device, const D3D12_HEAP_
         return E_INVALIDARG;
     }
 
+    /* OpenExistingHeapFrom* maps to D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER,
+     * which in turn maps to VK_EXT_external_memory_host.
+     */
+    if ((desc->Flags & D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER) &&
+        !device->vk_info.EXT_external_memory_host) {
+        WARN("D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER is not supported.\n");
+        return E_INVALIDARG;
+    }
+
     if (FAILED(hr = d3d12_device_validate_custom_heap_type(device, &desc->Properties)))
         return hr;
 

--- a/libs/vkd3d/heap.c
+++ b/libs/vkd3d/heap.c
@@ -287,7 +287,8 @@ static HRESULT validate_heap_desc(struct d3d12_device *device, const D3D12_HEAP_
      * which in turn maps to VK_EXT_external_memory_host.
      */
     if ((desc->Flags & D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER) &&
-        !device->vk_info.EXT_external_memory_host) {
+        !device->vk_info.EXT_external_memory_host)
+    {
         WARN("D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER is not supported.\n");
         return E_INVALIDARG;
     }


### PR DESCRIPTION
Cyberpunk 2077 calls OpenExistingHeapFrom* without checking D3D12_FEATURE_EXISTING_HEAPS. Fail properly to allow the game to start on a vulkan implementation that lacks VK_EXT_external_memory_host.