### PR TITLE
android: allow native Android build using NDK

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -27,7 +27,7 @@ foreach idl_file : vkd3d_idl
   header_file = idl_generator.process(idl_file)
   vkd3d_header_files += header_file
 
-  if target_machine.system() == 'linux'
+  if vkd3d_platform == 'linux' or vkd3d_platform == 'android'
     header_name = idl_file.split('.')[0] + '.h'
     custom_target('install_' + header_name,
         input : header_file,

--- a/include/vkd3d_sonames.h
+++ b/include/vkd3d_sonames.h
@@ -24,6 +24,9 @@
 #if defined(_WIN32)
 #define SONAME_LIBVULKAN "vulkan-1.dll"
 #define SONAME_D3D12CORE "d3d12core.dll"
+#elif defined(__ANDROID__)
+#define SONAME_LIBVULKAN "libvulkan.so"
+#define SONAME_D3D12CORE "libvkd3d-proton-d3d12core.so"
 #elif defined(__linux__)
 #define SONAME_LIBVULKAN "libvulkan.so.1"
 #define SONAME_D3D12CORE "libvkd3d-proton-d3d12core.so"

--- a/libs/vkd3d-common/platform.c
+++ b/libs/vkd3d-common/platform.c
@@ -66,6 +66,9 @@ bool vkd3d_get_program_name(char program_name[VKD3D_PATH_MAX])
 {
     char *name, *p, *real_path = NULL;
 
+#ifdef __ANDROID__
+    name = getprogname();
+#else
     if ((name = strrchr(program_invocation_name, '/')))
     {
         real_path = realpath("/proc/self/exe", NULL);
@@ -87,6 +90,7 @@ bool vkd3d_get_program_name(char program_name[VKD3D_PATH_MAX])
     {
         name = program_invocation_name;
     }
+#endif
 
     strncpy(program_name, name, VKD3D_PATH_MAX);
     program_name[VKD3D_PATH_MAX - 1] = '\0';

--- a/meson.build
+++ b/meson.build
@@ -89,7 +89,7 @@ glsl_generator = generator(glsl_compiler,
 
 threads_dep = dependency('threads')
 
-if vkd3d_platform == 'linux'
+if vkd3d_platform == 'linux' or vkd3d_platform == 'android'
   lib_dl           = vkd3d_compiler.find_library('dl')
   vkd3d_extra_libs = [ lib_dl, threads_dep ]
 elif vkd3d_platform == 'windows'
@@ -130,7 +130,7 @@ if cpu_family == 'x86'
 
   # Need to link against libatomic for 64-bit atomic emulation on x86
   # when using clang.
-  if vkd3d_platform == 'linux'
+  if vkd3d_platform == 'linux' or vkd3d_platform == 'android'
     if vkd3d_is_clang
       lib_atomic = vkd3d_compiler.find_library('atomic')
       vkd3d_extra_libs += lib_atomic
@@ -188,7 +188,7 @@ else
   lib_d3d12 = d3d12_dep
 endif
 
-if vkd3d_platform == 'linux'
+if vkd3d_platform == 'linux' or vkd3d_platform == 'android'
   pkg = import('pkgconfig')
   pkg.generate(d3d12_lib, filebase : 'libvkd3d-proton-d3d12', subdirs : 'vkd3d-proton', description : 'The vkd3d-proton D3D12 implementation')
   install_headers('include/vkd3d_vk_includes.h', 'include/vkd3d_types.h', 'include/vkd3d_win32.h', 'include/vkd3d_windows.h', subdir : 'vkd3d-proton')


### PR DESCRIPTION
This is enough to run headless tests. It serves the same purpose as the native linux build and is for development purpose only.