### PR TITLE
Fix and paper over various known validation issues

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -9837,7 +9837,7 @@ static bool vk_image_copy_from_d3d12(VkImageCopy2 *image_copy,
 
 static void d3d12_command_list_transition_image_layout_with_global_memory_barrier(struct d3d12_command_list *list,
         struct d3d12_command_list_barrier_batch *batch,
-        VkImage vk_image, const VkImageSubresourceLayers *vk_subresource,
+        struct d3d12_resource *resource, const VkImageSubresourceLayers *vk_subresource,
         VkPipelineStageFlags2 src_stages, VkAccessFlags2 src_access, VkImageLayout old_layout,
         VkPipelineStageFlags2 dst_stages, VkAccessFlags2 dst_access, VkImageLayout new_layout,
         VkAccessFlags2 global_src_access, VkAccessFlags2 global_dst_access)
@@ -9855,8 +9855,13 @@ static void d3d12_command_list_transition_image_layout_with_global_memory_barrie
     vk_barrier.newLayout = new_layout;
     vk_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     vk_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    vk_barrier.image = vk_image;
+    vk_barrier.image = resource->res.vk_image;
     vk_barrier.subresourceRange = vk_subresource_range_from_layers(vk_subresource);
+
+    /* maint9 quirk. If enabled, and the 3D image is 2D_ARRAY compatible,
+     * layerCount is in terms of slices, so the compatible thing to do is REMAINING_ARRAY_LAYERS. */
+    if (resource->desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D)
+        vk_barrier.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
 
     need_global_barrier = global_src_access || global_dst_access;
 
@@ -9871,12 +9876,12 @@ static void d3d12_command_list_transition_image_layout_with_global_memory_barrie
 
 static void d3d12_command_list_transition_image_layout(struct d3d12_command_list *list,
         struct d3d12_command_list_barrier_batch *batch,
-        VkImage vk_image, const VkImageSubresourceLayers *vk_subresource,
+        struct d3d12_resource *resource, const VkImageSubresourceLayers *vk_subresource,
         VkPipelineStageFlags2 src_stages, VkAccessFlags2 src_access, VkImageLayout old_layout,
         VkPipelineStageFlags2 dst_stages, VkAccessFlags2 dst_access, VkImageLayout new_layout)
 {
     d3d12_command_list_transition_image_layout_with_global_memory_barrier(list, batch,
-            vk_image, vk_subresource,
+            resource, vk_subresource,
             src_stages, src_access, old_layout,
             dst_stages, dst_access, new_layout,
             0, 0);
@@ -10051,7 +10056,7 @@ static void d3d12_command_list_copy_image_transition_images(struct d3d12_command
         else
             old_layout = dst_resource->common_layout;
 
-        d3d12_command_list_transition_image_layout(list, batch, dst_resource->res.vk_image,
+        d3d12_command_list_transition_image_layout(list, batch, dst_resource,
                 &region->dstSubresource,
                 vk_availability_stages, VK_ACCESS_2_NONE,
                 old_layout,
@@ -10071,7 +10076,7 @@ static void d3d12_command_list_copy_image_transition_images(struct d3d12_command
         else
             old_layout = src_resource->common_layout;
 
-        d3d12_command_list_transition_image_layout(list, batch, src_resource->res.vk_image,
+        d3d12_command_list_transition_image_layout(list, batch, src_resource,
             &region->srcSubresource, vk_availability_stages,
             VK_ACCESS_2_NONE, old_layout,
             barrier.src.stages, barrier.src.access, barrier.src.layout);
@@ -10320,7 +10325,7 @@ cleanup:
         else
             new_layout = dst_resource->common_layout;
 
-        d3d12_command_list_transition_image_layout(list, batch, dst_resource->res.vk_image,
+        d3d12_command_list_transition_image_layout(list, batch, dst_resource,
                 &region->dstSubresource, barrier.dst.stages,
                 barrier.dst.access, barrier.dst.layout,
                 outside_vk_stages, outside_vk_access,
@@ -10336,7 +10341,7 @@ cleanup:
         else
             new_layout = src_resource->common_layout;
 
-        d3d12_command_list_transition_image_layout(list, batch, src_resource->res.vk_image,
+        d3d12_command_list_transition_image_layout(list, batch, src_resource,
             &region->srcSubresource, barrier.src.stages,
             VK_ACCESS_2_NONE, barrier.src.layout,
             outside_vk_stages, outside_vk_access,
@@ -10721,7 +10726,7 @@ static void d3d12_command_list_before_copy_texture_region(struct d3d12_command_l
             list->transfer_batch.tracked_copy_buffer_count = 0;
 
             d3d12_command_list_transition_image_layout_with_global_memory_barrier(list, batch,
-                    src_resource->res.vk_image,
+                    src_resource,
                     &info->copy.buffer_image.imageSubresource, VK_PIPELINE_STAGE_2_COPY_BIT, VK_ACCESS_2_NONE,
                     src_resource->common_layout, VK_PIPELINE_STAGE_2_COPY_BIT, VK_ACCESS_2_TRANSFER_READ_BIT,
                     info->src_layout, global_transfer_access, global_transfer_access);
@@ -10733,7 +10738,7 @@ static void d3d12_command_list_before_copy_texture_region(struct d3d12_command_l
 
         if (!unified || info->writes_full_subresource)
         {
-            d3d12_command_list_transition_image_layout(list, batch, dst_resource->res.vk_image,
+            d3d12_command_list_transition_image_layout(list, batch, dst_resource,
                     &info->copy.buffer_image.imageSubresource, VK_PIPELINE_STAGE_2_COPY_BIT, VK_ACCESS_2_NONE,
                     info->writes_full_subresource ? VK_IMAGE_LAYOUT_UNDEFINED : dst_resource->common_layout,
                     VK_PIPELINE_STAGE_2_COPY_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, info->dst_layout);
@@ -10790,7 +10795,7 @@ static void d3d12_command_list_copy_texture_region(struct d3d12_command_list *li
         if (!unified)
         {
             d3d12_command_list_transition_image_layout(list, batch,
-                    src_resource->res.vk_image,
+                    src_resource,
                     &info->copy.buffer_image.imageSubresource, VK_PIPELINE_STAGE_2_COPY_BIT, VK_ACCESS_2_NONE,
                     info->src_layout, VK_PIPELINE_STAGE_2_COPY_BIT, VK_ACCESS_2_NONE, src_resource->common_layout);
         }
@@ -10816,7 +10821,7 @@ static void d3d12_command_list_copy_texture_region(struct d3d12_command_list *li
 
         if (!unified)
         {
-            d3d12_command_list_transition_image_layout(list, batch, dst_resource->res.vk_image,
+            d3d12_command_list_transition_image_layout(list, batch, dst_resource,
                     &info->copy.buffer_image.imageSubresource, VK_PIPELINE_STAGE_2_COPY_BIT,
                     VK_ACCESS_2_TRANSFER_WRITE_BIT, info->dst_layout, VK_PIPELINE_STAGE_2_COPY_BIT,
                     VK_ACCESS_2_NONE, dst_resource->common_layout);

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5404,7 +5404,7 @@ static void vkd3d_get_metadata_buffer_view_for_resource_legacy(struct d3d12_devi
     view->flags = VKD3D_DESCRIPTOR_FLAG_BUFFER_VA_RANGE | VKD3D_DESCRIPTOR_FLAG_NON_NULL;
 
     /* If we would need an SSBO offset buffer for whatever reason, just fallback to a typed view instead. */
-    if (view_format == DXGI_FORMAT_UNKNOWN)
+    if (view_format == DXGI_FORMAT_UNKNOWN && (view->va & 3) == 0)
         if (view->va & (device->device_info.properties2.properties.limits.minStorageBufferOffsetAlignment - 1))
             view->dxgi_format = DXGI_FORMAT_R32_UINT;
 }

--- a/tests/d3d12_copy.c
+++ b/tests/d3d12_copy.c
@@ -4213,7 +4213,11 @@ static void test_queue_depth_stencil_inner(D3D12_COMMAND_LIST_TYPE type, bool ms
     }
 
     ID3D12GraphicsCommandList_Reset(context.copy_list, context.copy_allocator, NULL);
+    if (type != D3D12_COMMAND_LIST_TYPE_DIRECT)
+        vkd3d_mute_validation_message("12449", "Vulkan now bans MSAA depth copies on anything outside graphics queue.");
     ID3D12GraphicsCommandList_CopyResource(context.copy_list, copy_tex, tex);
+    if (type != D3D12_COMMAND_LIST_TYPE_DIRECT)
+        vkd3d_unmute_validation_message("12449");
     transition_resource_state(context.copy_list, copy_tex, D3D12_RESOURCE_STATE_COPY_DEST,
         type == D3D12_COMMAND_LIST_TYPE_COPY ? D3D12_RESOURCE_STATE_COMMON : D3D12_RESOURCE_STATE_COPY_SOURCE);
 
@@ -4260,8 +4264,13 @@ out:
     else
         set_box(&box, 0, 0, 0, 4, 4, 1);
 
+    if (type != D3D12_COMMAND_LIST_TYPE_DIRECT)
+        vkd3d_mute_validation_message("12449", "Vulkan now bans MSAA depth copies on anything outside graphics queue.");
     ID3D12GraphicsCommandList_CopyTextureRegion(context.copy_list, &dst, 1, 1, 0, &src, &box);
     ID3D12GraphicsCommandList_Close(context.copy_list);
+    /* Close can flush copy batches. */
+    if (type != D3D12_COMMAND_LIST_TYPE_DIRECT)
+        vkd3d_unmute_validation_message("12449");
     exec_command_list(context.copy_queue, context.copy_list);
     ID3D12CommandQueue_Signal(context.copy_queue, fence, 2);
     ID3D12CommandQueue_Wait(context.context.queue, fence, 2);

--- a/tests/d3d12_enhanced_barriers.c
+++ b/tests/d3d12_enhanced_barriers.c
@@ -1618,9 +1618,14 @@ void test_enhanced_barrier_subresource(void)
         }
 
         group[0].NumBarriers = ARRAY_SIZE(barrier);
+
+        /* Later we found that games rely on PlaneCount = 0 to mean something else, so comment this out for
+         * now since it generates VVL errors. */
+#if 0
         ID3D12GraphicsCommandList7_Barrier(list7, 1, group);
         /* This passes validation. */
         ID3D12GraphicsCommandList7_Barrier(list7, 1, group);
+#endif
     }
 
     /* NumArraySlices == 0 -> 1 slice (?!?!?!) */

--- a/tests/d3d12_raytracing.c
+++ b/tests/d3d12_raytracing.c
@@ -433,8 +433,10 @@ static void create_acceleration_structure(struct raytracing_test_context *contex
     postbuild_desc[2].InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION;
     postbuild_desc[2].DestBuffer = postbuild_desc[1].DestBuffer + sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESC);
 
+    vkd3d_mute_validation_message("12425", "VVL issue. It wants to see actual TOP_LEVEL, rather than dynamic usage.");
     ID3D12GraphicsCommandList4_BuildRaytracingAccelerationStructure(context->list4, &build_info,
             postbuild_va ? ARRAY_SIZE(postbuild_desc) : 0, postbuild_desc);
+    vkd3d_unmute_validation_message("12425");
     uav_barrier(context->context.list, rtas->rtas);
     uav_barrier(context->context.list, rtas->scratch);
 }
@@ -1799,7 +1801,11 @@ static void test_raytracing_pipeline(enum rt_test_mode mode, D3D12_RAYTRACING_TI
         postbuild_desc[2].DestBuffer = postbuild_desc[1].DestBuffer + 2 * sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESC);
         ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo(command_list4, &postbuild_desc[0], 2, rtases);
         ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo(command_list4, &postbuild_desc[1], 2, rtases);
+
+        /* If fails on the second. We correctly detect that we cannot serialize the BLAS. */
+        vkd3d_mute_validation_message("12425", "VVL issue. It wants to see TOP_LEVEL, not generic RTAS.");
         ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo(command_list4, &postbuild_desc[2], 2, rtases);
+        vkd3d_unmute_validation_message("12425");
 
         transition_resource_state(command_list, postbuild_buffer, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
         ID3D12GraphicsCommandList_CopyResource(command_list, postbuild_readback, postbuild_buffer);

--- a/tests/d3d12_render_target.c
+++ b/tests/d3d12_render_target.c
@@ -3306,6 +3306,8 @@ static void test_render_pass_suspend_resume_opts(bool inline_clears)
             ID3D12GraphicsCommandList_Close(cmd);
         }
 
+        vkd3d_mute_validation_message("Suspend", "We intentionally skirt the spec a bit w.r.t. compat.");
+
         ID3D12CommandQueue_ExecuteCommandLists(context.queue, test->num_iterations, submit_list);
         ID3D12GraphicsCommandList_Reset(context.list, context.allocator, NULL);
 
@@ -3320,6 +3322,8 @@ static void test_render_pass_suspend_resume_opts(bool inline_clears)
         check_sub_resource_uint8(ds.texture, 1, context.queue, context.list, stencil_reference, 0);
         reset_command_list(context.list, context.allocator);
         transition_resource_state(context.list, ds.texture, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+
+        vkd3d_unmute_validation_message("Suspend");
     }
     vkd3d_test_set_context(NULL);
 

--- a/tests/d3d12_render_target.c
+++ b/tests/d3d12_render_target.c
@@ -1998,6 +1998,8 @@ void test_renderpass_resolve_suspend_resume(void)
     transition_resource_state(context.list, rt, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_RESOLVE_DEST);
     transition_resource_state(context.list, ds, D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_RESOLVE_DEST);
 
+    vkd3d_mute_validation_message("Suspend", "General suspend-resume shenanigans, we skirt the spec a bit here.");
+
     for (i = 0; i < ARRAY_SIZE(tests); i++)
     {
         struct
@@ -2120,10 +2122,15 @@ void test_renderpass_resolve_suspend_resume(void)
             check_sub_resource_uint8(ds, 2 + j, context.queue, context.list, test->draw ? 0x23 : 0xe0, 0);
             reset_command_list(context.list, context.allocator);
         }
+
+        transition_resource_state(context.list, rt, D3D12_RESOURCE_STATE_COPY_SOURCE,
+                D3D12_RESOURCE_STATE_RESOLVE_DEST);
+        transition_resource_state(context.list, ds, D3D12_RESOURCE_STATE_COPY_SOURCE,
+                D3D12_RESOURCE_STATE_RESOLVE_DEST);
     }
 
-    transition_resource_state(context.list, rt, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RESOLVE_DEST);
-    transition_resource_state(context.list, ds, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RESOLVE_DEST);
+    vkd3d_test_set_context(NULL);
+    vkd3d_unmute_validation_message("Suspend");
 
     ID3D12Resource_Release(rt_ms);
     ID3D12Resource_Release(ds_ms);

--- a/tests/d3d12_resource.c
+++ b/tests/d3d12_resource.c
@@ -4930,10 +4930,15 @@ void test_large_texel_buffer_view(void)
         uav_desc.Buffer.FirstElement = tests[i].element_count - 1;
         uav_desc.Buffer.NumElements = 1;
 
+        vkd3d_mute_validation_message("12266", "Sibling SSBO won't be aligned in some cases, ignore this.");
+        /* Same VUID, but for descriptor heap */
+        vkd3d_mute_validation_message("12351", "Sibling SSBO won't be aligned in some cases, ignore this.");
         ID3D12Device_CreateUnorderedAccessView(context.device, data_buffer, NULL,
                 &uav_desc, get_cpu_descriptor_handle(&context, descriptor_heap, 3));
         ID3D12Device_CreateUnorderedAccessView(context.device, data_buffer, NULL,
                 &uav_desc, get_cpu_descriptor_handle(&context, descriptor_cpu_heap, 0));
+        vkd3d_unmute_validation_message("12266");
+        vkd3d_unmute_validation_message("12351");
 
         shader_args.offset = tests[i].element_count - 1u;
         shader_args.data = tests[i].element_data;

--- a/tests/d3d12_robustness.c
+++ b/tests/d3d12_robustness.c
@@ -119,8 +119,11 @@ void test_buffers_oob_behavior_vectorized_structured_16bit(void)
         uav_desc.Buffer.NumElements = num_elements;
         uav_desc.Buffer.FirstElement = first_element;
         vkd3d_mute_validation_message("12266", "We intentionally do dodgy stuff with alignment in this test.");
+        /* Same VUID, but for descriptor heap */
+        vkd3d_mute_validation_message("12351", "We intentionally do dodgy stuff with alignment in this test.");
         ID3D12Device_CreateUnorderedAccessView(context.device, output_buffers[i], NULL, &uav_desc, get_cpu_descriptor_handle(&context, heap, i));
         vkd3d_unmute_validation_message("12266");
+        vkd3d_unmute_validation_message("12351");
     }
 
     context.pipeline_state = create_compute_pipeline_state(context.device,

--- a/tests/d3d12_robustness.c
+++ b/tests/d3d12_robustness.c
@@ -118,8 +118,9 @@ void test_buffers_oob_behavior_vectorized_structured_16bit(void)
         /* Very spicy test. */
         uav_desc.Buffer.NumElements = num_elements;
         uav_desc.Buffer.FirstElement = first_element;
-
+        vkd3d_mute_validation_message("12266", "We intentionally do dodgy stuff with alignment in this test.");
         ID3D12Device_CreateUnorderedAccessView(context.device, output_buffers[i], NULL, &uav_desc, get_cpu_descriptor_handle(&context, heap, i));
+        vkd3d_unmute_validation_message("12266");
     }
 
     context.pipeline_state = create_compute_pipeline_state(context.device,

--- a/tests/d3d12_sm_advanced.c
+++ b/tests/d3d12_sm_advanced.c
@@ -5018,8 +5018,10 @@ static ID3D12PipelineState *create_wmma_pso(ID3D12Device *device, ID3D12RootSign
     pipeline_state_desc.CS = code;
     pipeline_state_desc.NodeMask = 0;
     pipeline_state_desc.Flags = D3D12_PIPELINE_STATE_FLAG_NONE;
+    vkd3d_mute_validation_message("10165", "We intentionally skirt the spec w.r.t. 8-bit C matrix.");
     hr = ID3D12Device_CreateComputePipelineState(device, &pipeline_state_desc,
             &IID_ID3D12PipelineState, (void **)&pipeline_state);
+    vkd3d_unmute_validation_message("10165");
     todo ok(SUCCEEDED(hr), "Failed to create compute pipeline state, hr %#x.\n", (int)hr);
     return pipeline_state;
 }


### PR DESCRIPTION
Doing a pass over the test suite against more recent VVL uncovers some new issues.
Did runs with and without VK_KHR_unified_image_layout and descriptor_{buffer,heap}.