### PR TITLE
vkd3d-shader: Work around IL-2 tiled-light allocator

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -267,6 +267,7 @@ enum vkd3d_shader_interface_flag
     VKD3D_SHADER_INTERFACE_INLINE_REDZONE_CBV                  = 0x00002000u,
     VKD3D_SHADER_INTERFACE_RAYTRACING_OPACITY_MICROMAP         = 0x00004000u,
     VKD3D_SHADER_INTERFACE_RAY_QUERY_OMM_DEVICE_GLOBAL         = 0x00008000u,
+    VKD3D_SHADER_INTERFACE_TYPED_BUFFER_RAW_SSBO_ALIAS         = 0x00010000u,
 };
 
 struct vkd3d_shader_stage_io_entry
@@ -578,6 +579,9 @@ enum vkd3d_shader_target_extension
  * Used to workaround games where an image is rendered to while being sampled as an SRV,
  * which is highly illegal and only way out of it is to use filthy trickery. */
 #define VKD3D_SHADER_QUIRK_FORCE_FEEDBACK_LOOP (1ull << 38)
+
+/* Converts 32-bit atomics on typed UAVs to raw buffer atomics. */
+#define VKD3D_SHADER_QUIRK_TYPED_UAV_ATOMIC_AS_RAW (1ull << 39)
 
 typedef uint64_t vkd3d_shader_quirks_t;
 

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -710,6 +710,15 @@ static bool vkd3d_dxil_converter_set_quirks(dxil_spv_converter converter,
         }
     }
 
+    if ((quirks & VKD3D_SHADER_QUIRK_TYPED_UAV_ATOMIC_AS_RAW) &&
+            (shader_interface_info->flags & VKD3D_SHADER_INTERFACE_TYPED_BUFFER_RAW_SSBO_ALIAS))
+    {
+        const dxil_spv_option_shader_quirk helper =
+                { { DXIL_SPV_OPTION_SHADER_QUIRK }, DXIL_SPV_SHADER_QUIRK_TYPED_UAV_ATOMIC_AS_RAW };
+        if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
+            return false;
+    }
+
     if (quirks & VKD3D_SHADER_QUIRK_FORCE_LOOP)
     {
         struct dxil_spv_option_branch_control helper = { { DXIL_SPV_OPTION_BRANCH_CONTROL } };

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1113,6 +1113,15 @@ static const struct vkd3d_shader_quirk_info empire_of_the_ants_quirks = {
     NULL, 0, VKD3D_SHADER_QUIRK_CLAMP_WAVE_SIZE_TO_THREAD_GROUP32,
 };
 
+static const struct vkd3d_shader_quirk_hash il2_korea_hashes[] = {
+    /* ComputeLightsFirstRef uses a 32-bit atomic through an R16_UINT UAV. */
+    { NULL, 0x7cefa1bc80bb4c70, VKD3D_SHADER_QUIRK_TYPED_UAV_ATOMIC_AS_RAW },
+};
+
+static const struct vkd3d_shader_quirk_info il2_korea_quirks = {
+    il2_korea_hashes, ARRAY_SIZE(il2_korea_hashes), 0,
+};
+
 static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* F1 2020 (1080110) */
     { VKD3D_STRING_COMPARE_EXACT, "F1_2020_dx12.exe", &f1_2019_2020_quirks },
@@ -1207,6 +1216,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     /* Empire of the Ants (2287330). With Terrain Tessellation on, some shaders
      * seem to assume Wave32 by mistake leading to GPU timeout. */
     { VKD3D_STRING_COMPARE_EXACT, "Empire-Win64-Shipping.exe", &empire_of_the_ants_quirks },
+    /* IL-2 Sturmovik: Korea (247970). */
+    { VKD3D_STRING_COMPARE_EXACT, "IL2Series.exe", &il2_korea_quirks },
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2290,6 +2290,9 @@ unsigned int d3d12_root_signature_get_shader_interface_flags(const struct d3d12_
         flags |= VKD3D_SHADER_INTERFACE_HEAP_LOWERING;
     if (root_signature->heap.redzone_style == VKD3D_ROOT_SIGNATURE_HEAP_REDZONE_STYLE_INLINE)
         flags |= VKD3D_SHADER_INTERFACE_INLINE_REDZONE_CBV;
+    if (d3d12_device_use_ssbo_raw_buffer(root_signature->device) &&
+            !(root_signature->device->bindless_state.flags & VKD3D_BINDLESS_MUTABLE_TYPE_RAW_SSBO))
+        flags |= VKD3D_SHADER_INTERFACE_TYPED_BUFFER_RAW_SSBO_ALIAS;
 
     if (vkd3d_atomic_uint32_load_explicit(&root_signature->device->vendor_hacks.force_ray_query_omm,
             vkd3d_memory_order_relaxed))


### PR DESCRIPTION
> [!IMPORTANT]
> This is a dependent draft. Its compiler-aware VKD3D-Proton integration depends on https://github.com/HansKristian-Work/dxil-spirv/pull/296 and pins its current public commit `afff4dfb3e51ab81a4d541011bcf7ec2f65e2ffa`. The dependency is not merged, so this PR remains draft and may need matching API adjustments during review.

## Summary

Fix the square lighting blocks and broad flicker reported in #3134 for IL-2: Korea.

The game performs a scalar 32-bit atomic through an `R16_UINT` typed UAV. The revised implementation separates mechanism from application policy:

- dxil-spirv generically lowers eligible `I32` and `U32` typed-UAV atomics.
- It temporarily requests raw-buffer remapping and accepts the lowering only when the remapper returns an SSBO.
- On failure or a non-SSBO result, it restores the typed binding and retries normally.
- It does not extend any public C callback structure.
- It excludes 64-bit atomics, sparse operations, non-atomic resources, and the SM 6.6 heap path.
- VKD3D-Proton enables the compiler quirk only for exact executable `IL2Series.exe`, shader `0x7cefa1bc80bb4c70`, and layouts satisfying `RAW_SSBO && !MUTABLE_TYPE_RAW_SSBO`.

The earlier `9b6e15be` implementation remains useful causal and visual evidence, but it is not the implementation proposed for merging.

## Validation

- Clean dxil-spirv resources suite.
- Full suite with only the baseline-reproduced `control-flow/switch-continue.frag` validator failure.
- Valid candidate, fallback, and baseline outputs for the private captured shader.
- Clean VKD3D-Proton x86-64 and x86 builds and complete package build.
- Remapper harness: capability ON produces `StorageBuffer` plus `OpAtomicIAdd`; capability OFF is byte-identical to the typed baseline.
- One verified-loaded RX 7800 XT/RADV game run with correct menu, short flight, terrain, map, lighting, and shadows, without the blocks or broad flicker.

The native-Windows film-grain effect is excluded. This is not yet cross-hardware validation.

## Before and after

The baseline still catches a relatively faint frame. The square blocks flashed and became more pronounced during normal runtime.

| Before, unmodified VKD3D-Proton | After, D49 compiler-aware candidate |
| --- | --- |
| ![Faint captured frame of the flashing tiled-light blocks](https://raw.githubusercontent.com/silv3rshi3ld/il2-korea-proton-investigation/main/docs/images/lighting-before-upstream-84c87c83.png) | ![D49 result without tiled-light blocks](https://raw.githubusercontent.com/silv3rshi3ld/il2-korea-proton-investigation/main/docs/images/lighting-after-d49-compiler-aware-731c4aae.png) |

Exact D49 provenance and evidence: https://github.com/silv3rshi3ld/il2-korea-proton-investigation/blob/main/docs/evidence-d49-compiler-aware-result.md

## Separate work

The terrain-page corruption was fixed independently by #3202. The Wine NUMA startup work is also independent and is not part of this PR.
