### PR TITLE
vkd3d: Implement batching of postbuild info

### DIFF
--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -355,7 +355,6 @@ static void vkd3d_acceleration_structure_end_query_barrier(struct d3d12_command_
 void vkd3d_acceleration_structure_write_postbuild_info(
         struct d3d12_command_list *list,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        VkDeviceSize desc_offset,
         VkAccelerationStructureKHR vk_acceleration_structure,
         VkDeviceAddress rtas_va,
         enum vkd3d_rtas_kind rtas_kind)
@@ -379,7 +378,6 @@ void vkd3d_acceleration_structure_write_postbuild_info(
 
     vk_buffer = resource->vk_buffer;
     offset = desc->DestBuffer - resource->va;
-    offset += desc_offset;
 
     if (desc->InfoType == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE)
     {
@@ -483,66 +481,66 @@ void vkd3d_acceleration_structure_write_postbuild_info(
     }
 }
 
-void vkd3d_acceleration_structure_emit_postbuild_info(
+static void vkd3d_acceleration_structure_emit_postbuild_info(
         struct d3d12_command_list *list,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        uint32_t count,
-        const D3D12_GPU_VIRTUAL_ADDRESS *addresses)
+        const D3D12_GPU_VIRTUAL_ADDRESS rtas_va)
 {
     VkAccelerationStructureKHR vk_acceleration_structure;
     enum vkd3d_rtas_kind rtas_kind;
-    VkDeviceSize stride;
-    uint32_t i;
 
-    vkd3d_acceleration_structure_begin_query_barrier(list, true);
+    vkd3d_va_map_try_read_rtas(&list->device->memory_allocator.va_map, list->device, rtas_va,
+            &vk_acceleration_structure, &rtas_kind);
 
-    stride = desc->InfoType == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION ?
-            2 * sizeof(uint64_t) : sizeof(uint64_t);
-
-    for (i = 0; i < count; i++)
+    if (vk_acceleration_structure == VK_NULL_HANDLE)
     {
-        vkd3d_va_map_try_read_rtas(&list->device->memory_allocator.va_map, list->device, addresses[i],
-                &vk_acceleration_structure, &rtas_kind);
-
-        if (vk_acceleration_structure == VK_NULL_HANDLE)
-        {
-            WARN("Emit postbuild placing unknown AS at #%" PRIx64 " future BLP queries may not be reliable.\n",
-                    addresses[i]);
-            rtas_kind = VKD3D_RTAS_KIND_UNKNOWN;
-            vk_acceleration_structure =
-                    vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device,
-                    addresses[i], rtas_kind);
-        }
-        if (vk_acceleration_structure == VK_NULL_HANDLE)
-        {
-            ERR("Invalid VA #%"PRIx64" for emit postbuild.\n", addresses[i]);
-            continue;
-        }
-
-        vkd3d_acceleration_structure_write_postbuild_info(list, desc, i * stride, vk_acceleration_structure,
-                addresses[i], rtas_kind);
+        WARN("Emit postbuild placing unknown AS at #%" PRIx64 " future BLP queries may not be reliable.\n", rtas_va);
+        rtas_kind = VKD3D_RTAS_KIND_UNKNOWN;
+        vk_acceleration_structure =
+                vkd3d_va_map_place_acceleration_structure(&list->device->memory_allocator.va_map, list->device,
+                rtas_va, rtas_kind);
     }
 
-    vkd3d_acceleration_structure_end_query_barrier(list);
+    if (vk_acceleration_structure == VK_NULL_HANDLE)
+    {
+        ERR("Invalid VA #%"PRIx64" for emit postbuild.\n", rtas_va);
+        return;
+    }
+
+    vkd3d_acceleration_structure_write_postbuild_info(list, desc, vk_acceleration_structure,
+            rtas_va, rtas_kind);
 }
 
-void vkd3d_acceleration_structure_emit_immediate_postbuild_info(
-        struct d3d12_command_list *list, uint32_t count,
-        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        VkAccelerationStructureKHR vk_acceleration_structure,
-        VkDeviceAddress va,
-        enum vkd3d_rtas_kind rtas_kind)
+void vkd3d_acceleration_structure_flush_postbuild_batch(struct d3d12_command_list *list,
+        const struct vk_acceleration_structure_postbuild_info *infos, size_t count)
 {
-    /* In D3D12 we are supposed to be able to emit without an explicit barrier,
-     * but we need to emit them for Vulkan. */
-    uint32_t i;
+    bool has_incoming_uav = false;
+    size_t i;
 
-    vkd3d_acceleration_structure_begin_query_barrier(list, false);
+    for (i = 0; i < count && !has_incoming_uav; i++)
+        has_incoming_uav = infos[i].rtas_vk == VK_NULL_HANDLE;
 
-    /* Could optimize a bit by batching more aggressively, but no idea if it's going to help in practice. */
+    vkd3d_acceleration_structure_begin_query_barrier(list, has_incoming_uav);
     for (i = 0; i < count; i++)
-        vkd3d_acceleration_structure_write_postbuild_info(list, &desc[i], 0, vk_acceleration_structure, va, rtas_kind);
+    {
+        const struct vk_acceleration_structure_postbuild_info *info = &infos[i];
 
+        if (info->rtas_vk == VK_NULL_HANDLE)
+        {
+            /* Generic query path. */
+            vkd3d_acceleration_structure_emit_postbuild_info(list, &info->desc, info->rtas_va);
+        }
+        else if (info->is_omm)
+        {
+            vkd3d_opacity_micromap_emit_immediate_postbuild_info(list, 1, &info->desc,
+                    info->rtas_va, info->rtas_vk);
+        }
+        else
+        {
+            vkd3d_acceleration_structure_write_postbuild_info(
+                    list, &info->desc, info->rtas_vk, info->rtas_va, info->rtas_kind);
+        }
+    }
     vkd3d_acceleration_structure_end_query_barrier(list);
 }
 

--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -357,7 +357,7 @@ void vkd3d_acceleration_structure_write_postbuild_info(
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
         VkDeviceSize desc_offset,
         VkAccelerationStructureKHR vk_acceleration_structure,
-        VkDeviceAddress va,
+        VkDeviceAddress rtas_va,
         enum vkd3d_rtas_kind rtas_kind)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
@@ -440,13 +440,13 @@ void vkd3d_acceleration_structure_write_postbuild_info(
             if (VKD3D_CONFIG_FLAG_IS_SET(ZERO_FILL_BLP))
             {
                 FIXME("Do not know the state of VA #%"PRIx64" (%s) assuming non-TLAS\n",
-                        va, vkd3d_get_rtas_kind_string(rtas_kind));
+                        rtas_va, vkd3d_get_rtas_kind_string(rtas_kind));
                 is_tlas = false;
             }
             else
             {
                 FIXME("Do not know the state of VA #%"PRIx64" (%s) assuming TLAS\n",
-                        va, vkd3d_get_rtas_kind_string(rtas_kind));
+                        rtas_va, vkd3d_get_rtas_kind_string(rtas_kind));
                 is_tlas = true;
             }
         }

--- a/libs/vkd3d/acceleration_structure.c
+++ b/libs/vkd3d/acceleration_structure.c
@@ -301,7 +301,35 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
     return true;
 }
 
-static void vkd3d_acceleration_structure_end_barrier(struct d3d12_command_list *list)
+static void vkd3d_acceleration_structure_begin_query_barrier(struct d3d12_command_list *list, bool uav_incoming)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
+    VkDependencyInfo dep_info;
+    VkMemoryBarrier2 barrier;
+
+    /* We resolve the query in TRANSFER, but DXR expects UNORDERED_ACCESS. */
+    memset(&barrier, 0, sizeof(barrier));
+    barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
+    barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
+    /* The query accesses STRUCTURE_READ_BIT in BUILD_BIT stage. */
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR | VK_PIPELINE_STAGE_2_COPY_BIT;
+    barrier.dstAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_2_TRANSFER_WRITE_BIT;
+
+    /* If we're doing the query outside an RTAS build, we don't know which shader stage we might depend on
+     * and a UAV barrier would not have synchronized with COPY stage. */
+    if (uav_incoming)
+        barrier.srcStageMask |= vk_queue_shader_stages(list->device, list->vk_queue_flags);
+
+    memset(&dep_info, 0, sizeof(dep_info));
+    dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+    dep_info.memoryBarrierCount = 1;
+    dep_info.pMemoryBarriers = &barrier;
+
+    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
+}
+
+static void vkd3d_acceleration_structure_end_query_barrier(struct d3d12_command_list *list)
 {
     /* We resolve the query in TRANSFER, but DXR expects UNORDERED_ACCESS. */
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
@@ -312,7 +340,9 @@ static void vkd3d_acceleration_structure_end_barrier(struct d3d12_command_list *
     barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
     barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
     barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-    barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+
+    /* If there is a future UAV barrier, make sure it picks up transient sync from COPY stage. */
+    barrier.dstStageMask = vk_queue_shader_stages(list->device, list->vk_queue_flags);
 
     memset(&dep_info, 0, sizeof(dep_info));
     dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
@@ -459,27 +489,12 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
         uint32_t count,
         const D3D12_GPU_VIRTUAL_ADDRESS *addresses)
 {
-    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     VkAccelerationStructureKHR vk_acceleration_structure;
     enum vkd3d_rtas_kind rtas_kind;
-    VkDependencyInfo dep_info;
-    VkMemoryBarrier2 barrier;
     VkDeviceSize stride;
     uint32_t i;
 
-    /* We resolve the query in TRANSFER, but DXR expects UNORDERED_ACCESS. */
-    memset(&barrier, 0, sizeof(barrier));
-    barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
-    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
-    barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-
-    memset(&dep_info, 0, sizeof(dep_info));
-    dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
-    dep_info.memoryBarrierCount = 1;
-    dep_info.pMemoryBarriers = &barrier;
-
-    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
+    vkd3d_acceleration_structure_begin_query_barrier(list, true);
 
     stride = desc->InfoType == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION ?
             2 * sizeof(uint64_t) : sizeof(uint64_t);
@@ -508,7 +523,7 @@ void vkd3d_acceleration_structure_emit_postbuild_info(
                 addresses[i], rtas_kind);
     }
 
-    vkd3d_acceleration_structure_end_barrier(list);
+    vkd3d_acceleration_structure_end_query_barrier(list);
 }
 
 void vkd3d_acceleration_structure_emit_immediate_postbuild_info(
@@ -520,35 +535,15 @@ void vkd3d_acceleration_structure_emit_immediate_postbuild_info(
 {
     /* In D3D12 we are supposed to be able to emit without an explicit barrier,
      * but we need to emit them for Vulkan. */
-
-    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
-    VkDependencyInfo dep_info;
-    VkMemoryBarrier2 barrier;
     uint32_t i;
 
-    memset(&barrier, 0, sizeof(barrier));
-    barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
-    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
-    /* The query accesses STRUCTURE_READ_BIT in BUILD_BIT stage. */
-    barrier.dstStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR | VK_PIPELINE_STAGE_2_COPY_BIT;
-    barrier.dstAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_2_TRANSFER_WRITE_BIT;
-
-    /* Writing to the result buffer is supposed to happen in UNORDERED_ACCESS on DXR for
-     * some bizarre reason, so we have to satisfy a transfer barrier.
-     * Have to basically do a full stall to make this work ... */
-    memset(&dep_info, 0, sizeof(dep_info));
-    dep_info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
-    dep_info.memoryBarrierCount = 1;
-    dep_info.pMemoryBarriers = &barrier;
-
-    VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
+    vkd3d_acceleration_structure_begin_query_barrier(list, false);
 
     /* Could optimize a bit by batching more aggressively, but no idea if it's going to help in practice. */
     for (i = 0; i < count; i++)
         vkd3d_acceleration_structure_write_postbuild_info(list, &desc[i], 0, vk_acceleration_structure, va, rtas_kind);
 
-    vkd3d_acceleration_structure_end_barrier(list);
+    vkd3d_acceleration_structure_end_query_barrier(list);
 }
 
 static bool convert_copy_mode(

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4727,7 +4727,7 @@ static void d3d12_command_list_load_attachment(struct d3d12_command_list *list, 
     d3d12_command_list_debug_mark_end_region(list);
 }
 
-static VkPipelineStageFlags2 vk_queue_shader_stages(struct d3d12_device *device, VkQueueFlags vk_queue_flags)
+VkPipelineStageFlags2 vk_queue_shader_stages(struct d3d12_device *device, VkQueueFlags vk_queue_flags)
 {
     VkPipelineStageFlags2 queue_shader_stages = 0;
 

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -20619,6 +20619,7 @@ static void d3d12_command_list_free_rtas_batch(struct d3d12_command_list *list)
     vkd3d_free(rtas_batch->omm_build_infos);
     vkd3d_free(rtas_batch->omm_usage_infos);
     vkd3d_free(rtas_batch->scratch_usage);
+    vkd3d_free(rtas_batch->postbuild_infos);
 }
 
 static bool d3d12_command_list_register_rtas_scratch_range(
@@ -20768,6 +20769,7 @@ static void d3d12_command_list_clear_rtas_batch(struct d3d12_command_list *list)
     rtas_batch->omm_build_info_count = 0;
     rtas_batch->omm_usage_info_count = 0;
     rtas_batch->scratch_usage_count = 0;
+    rtas_batch->postbuild_infos_count = 0;
 }
 
 static void d3d12_command_list_fixup_rtas_batch(struct d3d12_command_list *list)
@@ -20860,24 +20862,40 @@ static void d3d12_command_list_flush_rtas_batch(struct d3d12_command_list *list)
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     struct d3d12_rtas_batch_state *rtas_batch = &list->rtas_batch;
 
-    if (!rtas_batch->build_info_count)
-        return;
+    if (rtas_batch->build_info_count)
+    {
+        d3d12_command_list_check_end_of_command_list_cleanup(list);
 
-    d3d12_command_list_check_end_of_command_list_cleanup(list);
+        TRACE("list %p, build_info_count %zu.\n", list,
+                rtas_batch->build_info_count);
 
-    TRACE("list %p, build_info_count %zu.\n", list,
-            rtas_batch->build_info_count);
+        d3d12_command_list_fixup_rtas_batch(list);
+        d3d12_command_list_end_current_render_pass(list, true);
+        d3d12_command_list_end_transfer_batch(list, false);
 
-    d3d12_command_list_fixup_rtas_batch(list);
-    d3d12_command_list_end_current_render_pass(list, true);
-    d3d12_command_list_end_transfer_batch(list, false);
+        VK_CALL(vkCmdBuildAccelerationStructuresKHR(list->cmd.vk_command_buffer,
+                rtas_batch->build_info_count, rtas_batch->build_infos, rtas_batch->range_ptrs));
 
-    VK_CALL(vkCmdBuildAccelerationStructuresKHR(list->cmd.vk_command_buffer,
-            rtas_batch->build_info_count, rtas_batch->build_infos, rtas_batch->range_ptrs));
+        VKD3D_BREADCRUMB_COMMAND(BUILD_RTAS);
+    }
+
+    if (rtas_batch->postbuild_infos_count)
+    {
+        d3d12_command_list_check_end_of_command_list_cleanup(list);
+
+        TRACE("list %p, postbuild_infos_count %zu.\n", list,
+                rtas_batch->postbuild_infos_count);
+
+        d3d12_command_list_end_current_render_pass(list, true);
+        d3d12_command_list_end_transfer_batch(list, false);
+
+        vkd3d_acceleration_structure_flush_postbuild_batch(list,
+                rtas_batch->postbuild_infos, rtas_batch->postbuild_infos_count);
+
+        VKD3D_BREADCRUMB_COMMAND(EMIT_RTAS_POSTBUILD);
+    }
 
     d3d12_command_list_clear_rtas_batch(list);
-
-    VKD3D_BREADCRUMB_COMMAND(BUILD_RTAS);
 }
 
 static void d3d12_command_list_flush_rtas_barrier(struct d3d12_command_list *list)
@@ -20992,13 +21010,20 @@ static void d3d12_command_list_build_raytracing_opacity_micromap_array(struct d3
 
     if (num_postbuild_info_descs)
     {
-        /* This doesn't seem to get used very often, so just record the build command
-         * for now. If this ever becomes a performance issue, we can add postbuild info
-         * to the batch. */
-        d3d12_command_list_flush_rtas_batch(list);
+        uint32_t i;
+        vkd3d_array_reserve((void**)&list->rtas_batch.postbuild_infos, &list->rtas_batch.postbuild_infos_size,
+                            list->rtas_batch.postbuild_infos_count + num_postbuild_info_descs,
+                            sizeof(*list->rtas_batch.postbuild_infos));
 
-        vkd3d_opacity_micromap_emit_immediate_postbuild_info(list, num_postbuild_info_descs, postbuild_info_descs,
-                desc->DestAccelerationStructureData, micromap);
+        for (i = 0; i < num_postbuild_info_descs; i++)
+        {
+            struct vk_acceleration_structure_postbuild_info *info =
+                    &list->rtas_batch.postbuild_infos[list->rtas_batch.postbuild_infos_count++];
+            info->desc = postbuild_info_descs[i];
+            info->rtas_vk = micromap;
+            info->rtas_va = 0;
+            info->is_omm = true;
+        }
     }
 
     VKD3D_BREADCRUMB_COMMAND(BUILD_OMM);
@@ -21174,16 +21199,24 @@ static void d3d12_command_list_build_raytracing_blas_and_tlas(struct d3d12_comma
 
     if (num_postbuild_info_descs)
     {
-        /* This doesn't seem to get used very often, so just record the build command
-         * for now. If this ever becomes a performance issue, we can add postbuild info
-         * to the batch. */
-        d3d12_command_list_flush_rtas_batch(list);
+        uint32_t i;
+        vkd3d_array_reserve((void**)&list->rtas_batch.postbuild_infos, &list->rtas_batch.postbuild_infos_size,
+                            list->rtas_batch.postbuild_infos_count + num_postbuild_info_descs, sizeof(*list->rtas_batch.postbuild_infos));
 
-        vkd3d_acceleration_structure_emit_immediate_postbuild_info(list,
-                num_postbuild_info_descs, postbuild_info_descs,
-                build_info->dstAccelerationStructure,
-                desc->DestAccelerationStructureData,
-                rtas_kind);
+        /* Postbuild happens in UAV state, so we don't have to consider sync in general.
+         * The only guarantee we get from spec when using this immediate mode of query
+         * is that implementation takes care of the RTAS build -> query write sync internally.
+         * We handle that implicitly when resolving the query since there's a UAV -> TRANSFER barrier. */
+        for (i = 0; i < num_postbuild_info_descs; i++)
+        {
+            struct vk_acceleration_structure_postbuild_info *info =
+                    &list->rtas_batch.postbuild_infos[list->rtas_batch.postbuild_infos_count++];
+            info->desc = postbuild_info_descs[i];
+            info->rtas_vk = build_info->dstAccelerationStructure;
+            info->rtas_va = desc->DestAccelerationStructureData;
+            info->is_omm = false;
+            info->rtas_kind = rtas_kind;
+        }
     }
 }
 
@@ -21252,7 +21285,12 @@ static void STDMETHODCALLTYPE d3d12_command_list_EmitRaytracingAccelerationStruc
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc, UINT num_acceleration_structures,
         const D3D12_GPU_VIRTUAL_ADDRESS *src_data)
 {
+    VkDeviceSize stride =
+            desc->InfoType == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION ?
+            2 * sizeof(uint64_t) : sizeof(uint64_t);
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList(iface);
+    uint32_t i;
+
     TRACE("iface %p, desc %p, num_acceleration_structures %u, src_data %p\n",
             iface, desc, num_acceleration_structures, src_data);
 
@@ -21268,10 +21306,21 @@ static void STDMETHODCALLTYPE d3d12_command_list_EmitRaytracingAccelerationStruc
     list->cmd.estimated_cost += VKD3D_COMMAND_COST_LOW;
 
     d3d12_command_list_end_current_render_pass(list, true);
-    vkd3d_acceleration_structure_emit_postbuild_info(list,
-            desc, num_acceleration_structures, src_data);
 
-    VKD3D_BREADCRUMB_COMMAND(EMIT_RTAS_POSTBUILD);
+    vkd3d_array_reserve((void**)&list->rtas_batch.postbuild_infos, &list->rtas_batch.postbuild_infos_size,
+                        list->rtas_batch.postbuild_infos_count + num_acceleration_structures,
+                        sizeof(*list->rtas_batch.postbuild_infos));
+
+    for (i = 0; i < num_acceleration_structures; i++)
+    {
+        struct vk_acceleration_structure_postbuild_info *info =
+                &list->rtas_batch.postbuild_infos[list->rtas_batch.postbuild_infos_count++];
+        info->desc = *desc;
+        info->desc.DestBuffer += i * stride;
+        info->rtas_va = src_data[i];
+        info->rtas_vk = VK_NULL_HANDLE;
+        info->is_omm = false;
+    }
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_CopyRaytracingAccelerationStructure(d3d12_command_list_iface *iface,

--- a/libs/vkd3d/opacity_micromap.c
+++ b/libs/vkd3d/opacity_micromap.c
@@ -192,7 +192,7 @@ void vkd3d_opacity_micromap_emit_immediate_postbuild_info(
     VK_CALL(vkCmdPipelineBarrier2(list->cmd.vk_command_buffer, &dep_info));
 
     for (i = 0; i < count; i++)
-        vkd3d_acceleration_structure_write_postbuild_info(list, &desc[i], 0, vk_opacity_micromap, va,
+        vkd3d_acceleration_structure_write_postbuild_info(list, &desc[i], vk_opacity_micromap, va,
                 VKD3D_RTAS_KIND_NON_TLAS);
 
     vkd3d_opacity_micromap_end_barrier(list);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -5950,6 +5950,8 @@ void d3d12_device_return_query_pool(struct d3d12_device *device, const struct vk
 uint64_t d3d12_device_get_descriptor_heap_gpu_va(struct d3d12_device *device, D3D12_DESCRIPTOR_HEAP_TYPE type);
 void d3d12_device_return_descriptor_heap_gpu_va(struct d3d12_device *device, uint64_t va);
 
+VkPipelineStageFlags2 vk_queue_shader_stages(struct d3d12_device *device, VkQueueFlags vk_queue_flags);
+
 static inline bool d3d12_device_uses_descriptor_buffers(const struct d3d12_device *device)
 {
     return device->global_descriptor_buffer.resource.va != 0;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3143,6 +3143,15 @@ struct d3d12_wbi_batch_state
     size_t batch_len;
 };
 
+struct vk_acceleration_structure_postbuild_info
+{
+    VkAccelerationStructureKHR rtas_vk;
+    D3D12_GPU_VIRTUAL_ADDRESS rtas_va; /* Should always be set. If rtas_vk is set, this is just used for debug. */
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC desc;
+    bool is_omm; /* Only used for rtas_vk if not null handle. */
+    enum vkd3d_rtas_kind rtas_kind; /* Only used for immediate BLAS or TLAS build. */
+};
+
 struct d3d12_rtas_batch_state
 {
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE build_type;
@@ -3181,6 +3190,10 @@ struct d3d12_rtas_batch_state
     } *scratch_usage;
     size_t scratch_usage_count;
     size_t scratch_usage_size;
+
+    struct vk_acceleration_structure_postbuild_info *postbuild_infos;
+    size_t postbuild_infos_size;
+    size_t postbuild_infos_count;
 };
 
 union vkd3d_descriptor_heap_state
@@ -6999,19 +7012,10 @@ bool vkd3d_acceleration_structure_convert_inputs(struct d3d12_device *device,
 bool vkd3d_acceleration_structure_resolve_omm_va_maps(struct d3d12_device *device,
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *desc,
         VkAccelerationStructureTrianglesOpacityMicromapKHR *omm_triangles_infos);
+void vkd3d_acceleration_structure_flush_postbuild_batch(struct d3d12_command_list *list,
+        const struct vk_acceleration_structure_postbuild_info *infos, size_t count);
 void vkd3d_acceleration_structure_write_postbuild_info(
         struct d3d12_command_list *list,
-        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        VkDeviceSize desc_offset,
-        VkAccelerationStructureKHR vk_acceleration_structure,
-        VkDeviceAddress va,
-        enum vkd3d_rtas_kind rtas_kind);
-void vkd3d_acceleration_structure_emit_postbuild_info(
-        struct d3d12_command_list *list,
-        const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
-        uint32_t count, const D3D12_GPU_VIRTUAL_ADDRESS *addresses);
-void vkd3d_acceleration_structure_emit_immediate_postbuild_info(
-        struct d3d12_command_list *list, uint32_t count,
         const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *desc,
         VkAccelerationStructureKHR vk_acceleration_structure,
         VkDeviceAddress va,

--- a/tests/d3d12_raytracing.c
+++ b/tests/d3d12_raytracing.c
@@ -436,8 +436,8 @@ static void create_acceleration_structure(struct raytracing_test_context *contex
     vkd3d_mute_validation_message("12425", "VVL issue. It wants to see actual TOP_LEVEL, rather than dynamic usage.");
     ID3D12GraphicsCommandList4_BuildRaytracingAccelerationStructure(context->list4, &build_info,
             postbuild_va ? ARRAY_SIZE(postbuild_desc) : 0, postbuild_desc);
-    vkd3d_unmute_validation_message("12425");
     uav_barrier(context->context.list, rtas->rtas);
+    vkd3d_unmute_validation_message("12425");
     uav_barrier(context->context.list, rtas->scratch);
 }
 
@@ -843,6 +843,7 @@ static void init_rt_geometry(struct raytracing_test_context *context, struct tes
      * We test the compacted size later. */
     rt_geom->top_acceleration_structures[0] = rt_geom->top_rtas.rtas;
     ID3D12Resource_AddRef(rt_geom->top_rtas.rtas);
+
     rt_geom->top_acceleration_structures[1] = duplicate_acceleration_structure(context,
             rt_geom->top_acceleration_structures[0], D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
     rt_geom->top_acceleration_structures[2] = duplicate_acceleration_structure(context,
@@ -1805,9 +1806,9 @@ static void test_raytracing_pipeline(enum rt_test_mode mode, D3D12_RAYTRACING_TI
         /* If fails on the second. We correctly detect that we cannot serialize the BLAS. */
         vkd3d_mute_validation_message("12425", "VVL issue. It wants to see TOP_LEVEL, not generic RTAS.");
         ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo(command_list4, &postbuild_desc[2], 2, rtases);
-        vkd3d_unmute_validation_message("12425");
 
         transition_resource_state(command_list, postbuild_buffer, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
+        vkd3d_unmute_validation_message("12425");
         ID3D12GraphicsCommandList_CopyResource(command_list, postbuild_readback, postbuild_buffer);
     }
 


### PR DESCRIPTION
CP77 hits this in some bad ways that obliterates perf. Batch postbuilds since we have evidence of this being important now. The postbuild writes are considered UAV, so we can be quite loose with synchronization.