### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Build release
       id: build-release
-      uses: misyltoad/arch-mingw-github-action@v8
+      uses: WinterSnowfall/arch-mingw-github-action@v2
       with:
         command: |
           export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Build MinGW x86
       id: build-mingw-x86
-      uses: misyltoad/arch-mingw-github-action@v8
+      uses: WinterSnowfall/arch-mingw-github-action@v2
       with:
         command: |
           meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win32.txt --buildtype release build-mingw-x86
@@ -26,7 +26,7 @@ jobs:
 
     - name: Build MinGW x64
       id: build-mingw-x64
-      uses: misyltoad/arch-mingw-github-action@v8
+      uses: WinterSnowfall/arch-mingw-github-action@v2
       with:
         command: |
           meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win64.txt --buildtype release build-mingw-x64
@@ -34,7 +34,7 @@ jobs:
 
     - name: Build Native GCC x86
       id: build-native-gcc-x86
-      uses: misyltoad/arch-mingw-github-action@v8
+      uses: WinterSnowfall/arch-mingw-github-action@v2
       with:
         command: |
           sudo pacman -Syu --noconfirm lib32-gcc-libs
@@ -46,7 +46,7 @@ jobs:
 
     - name: Build Native GCC x64
       id: build-native-gcc-x64
-      uses: misyltoad/arch-mingw-github-action@v8
+      uses: WinterSnowfall/arch-mingw-github-action@v2
       with:
         command: |
           export CC="gcc"
@@ -56,7 +56,7 @@ jobs:
 
     - name: Build Native Clang x64
       id: build-native-clang-x64
-      uses: misyltoad/arch-mingw-github-action@v8
+      uses: WinterSnowfall/arch-mingw-github-action@v2
       with:
         command: |
           export CC="clang"

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -41,7 +41,7 @@ jobs:
           export CC="gcc -m32"
           export CXX="g++ -m32"
           export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig"
-          meson setup -Denable_tests=True -Denable_extras=True -Dc_args='-Wformat=2 -Wno-format-truncation -Wno-format-nonliteral' --buildtype release build-native-gcc-x86
+          meson setup -Denable_tests=True -Dc_args='-Wformat=2 -Wno-format-truncation -Wno-format-nonliteral' --buildtype release build-native-gcc-x86
           ninja -C build-native-gcc-x86
 
     - name: Build Native GCC x64


### PR DESCRIPTION
Fixes CI failure since `lib32-xcb-util` got removed from the Arch repos.

Firstly switches Arch image to https://github.com/WinterSnowfall/arch-mingw-github-action which removed the package above from the install list. 
It is also a scaled down version of the current master of misyltoad's action without the extra 32bit glfw packages pulled from the aur. Since neither vkd3d-proton or dxvk use them in their CI builds.

Secondly this removes `-Denable_extras=True` from the native 32bit GCC build. Otherwise it would want to use `lib32-xcb-util` for building the demo.