### PR TITLE
Fix vk_swapchain_count accounting, so that Reflex continues to work after re-creating swapchains.

### DIFF
--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -583,6 +583,13 @@ static void dxgi_vk_swap_chain_cleanup_common(struct dxgi_vk_swap_chain *chain)
     for (i = 0; i < ARRAY_SIZE(chain->present.vk_swapchain_fences); i++)
         VK_CALL(vkDestroyFence(chain->queue->device->vk_device, chain->present.vk_swapchain_fences[i], NULL));
 
+    if (chain->queue->device->vk_info.NV_low_latency2 && chain->present.vk_swapchain)
+    {
+        spinlock_acquire(&chain->queue->device->low_latency_swapchain_spinlock);
+        chain->queue->device->swapchain_info.vk_swapchain_count--;
+        spinlock_release(&chain->queue->device->low_latency_swapchain_spinlock);
+    }
+
     VK_CALL(vkDestroySwapchainKHR(chain->queue->device->vk_device, chain->present.vk_swapchain, NULL));
 
     for (i = 0; i < ARRAY_SIZE(chain->user.backbuffers); i++)


### PR DESCRIPTION
vk_swapchain_count is not decremented when destroying a swapchain in this DX-swapchain-destruction path. This can result in Reflex getting shut down by the multi-swapchain disablement logic, even though only one swapchain currently exists.

With this change we decrement vk_swapchain_count alongside every call to vkDestroySwapchainKHR.

I hit this when toggling DLSS-FG on and off in Avatar Frontiers of Pandora. I confirmed that Reflex now continues to work with this fix.