### PR TITLE
vkd3d: Handle raw buffers in optimized ClearUAV path

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -16388,6 +16388,14 @@ static bool d3d12_command_list_clear_uav_builtin(struct d3d12_command_list *list
     else
         uint_format = vkd3d_get_format(list->device, DXGI_FORMAT_R32_UINT, false);
 
+    /* Raw buffer UAVs use DXGI_FORMAT_UNKNOWN, but their clear operations are
+     * R32_UINT-centric just like the descriptor-based fallback below. */
+    if (!format && !args->clear_dxgi_format && d3d12_resource_is_buffer(resource))
+        format = uint_format;
+
+    if (!format)
+        return false;
+
     if (d3d12_resource_is_buffer(resource))
     {
         VkDeviceAddress start_va, end_va;


### PR DESCRIPTION
Raw buffer UAV descriptors use DXGI_FORMAT_UNKNOWN.  The legacy clear path already interprets those descriptors as R32_UINT, but the optimized clear path added by 7f410b766e2f dereferences the result of looking up the unknown format. This causes a NULL dereference in d3d12_command_list_clear_uav_builtin(), seen while The Witcher 3 initializes its DX12 renderer.

Use the same R32_UINT format selected for raw buffers by the fallback path and reject any other unrecognized format before accessing it.

Fixes: https://github.com/GloriousEggroll/proton-ge-custom/issues/720
Proton: Witcher 3 (and others)

Cherry-picked Proton-GE patch.

Fixes #3245