### PR TITLE
Various CI stuff

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 
@@ -26,7 +26,7 @@ jobs:
 
     - name: Upload artifacts
       id: upload-artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: vkd3d-proton-${{ env.VERSION_NAME }}
         path: build/vkd3d-proton-${{ env.VERSION_NAME }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -12,20 +12,17 @@ jobs:
       run: pacman -Syu --needed --noconfirm git meson mingw-w64-gcc glslang wine
 
     - name: Checkout code
-      id: checkout-code
       uses: actions/checkout@v7
       with:
         submodules: recursive
 
     - name: Build release
-      id: build-release
       run: |
         export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"
         ./package-release.sh ${VERSION_NAME} build --no-package
         echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
 
     - name: Upload artifacts
-      id: upload-artifacts
       uses: actions/upload-artifact@v7
       with:
         name: vkd3d-proton-${{ env.VERSION_NAME }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -5,8 +5,12 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build-artifacts:
     runs-on: ubuntu-24.04
+    container: archlinux/archlinux:base-devel
 
     steps:
+    - name: Install dependencies
+      run: pacman -Syu --needed --noconfirm git meson mingw-w64-gcc glslang wine
+
     - name: Checkout code
       id: checkout-code
       uses: actions/checkout@v4
@@ -15,12 +19,10 @@ jobs:
 
     - name: Build release
       id: build-release
-      uses: WinterSnowfall/arch-mingw-github-action@v2
-      with:
-        command: |
-          export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"
-          ./package-release.sh ${VERSION_NAME} build --no-package
-          echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
+      run: |
+        export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"
+        ./package-release.sh ${VERSION_NAME} build --no-package
+        echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
 
     - name: Upload artifacts
       id: upload-artifacts

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -5,8 +5,12 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build-set-linux:
     runs-on: ubuntu-24.04
+    container: archlinux/archlinux:multilib-devel
 
     steps:
+    - name: Install dependencies
+      run: pacman -Syu --needed --noconfirm git meson mingw-w64-gcc clang glslang wine xcb-util xcb-util-keysyms xcb-util-wm
+    
     - name: Checkout code
       id: checkout-code
       uses: actions/checkout@v4
@@ -15,51 +19,40 @@ jobs:
 
     - name: Setup problem matcher
       uses: misyltoad/gcc-problem-matcher@v3
-
+      
     - name: Build MinGW x86
       id: build-mingw-x86
-      uses: WinterSnowfall/arch-mingw-github-action@v2
-      with:
-        command: |
-          meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win32.txt --buildtype release build-mingw-x86
-          ninja -C build-mingw-x86
+      run: |
+        meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win32.txt --buildtype release build-mingw-x86
+        ninja -C build-mingw-x86
 
     - name: Build MinGW x64
       id: build-mingw-x64
-      uses: WinterSnowfall/arch-mingw-github-action@v2
-      with:
-        command: |
-          meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win64.txt --buildtype release build-mingw-x64
-          ninja -C build-mingw-x64
+      run: |
+        meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win64.txt --buildtype release build-mingw-x64
+        ninja -C build-mingw-x64
 
     - name: Build Native GCC x86
       id: build-native-gcc-x86
-      uses: WinterSnowfall/arch-mingw-github-action@v2
-      with:
-        command: |
-          sudo pacman -Syu --noconfirm lib32-gcc-libs
-          export CC="gcc -m32"
-          export CXX="g++ -m32"
-          export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig"
-          meson setup -Denable_tests=True -Dc_args='-Wformat=2 -Wno-format-truncation -Wno-format-nonliteral' --buildtype release build-native-gcc-x86
-          ninja -C build-native-gcc-x86
+      run: |
+        export CC="gcc -m32"
+        export CXX="g++ -m32"
+        export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig"
+        meson setup -Denable_tests=True -Dc_args='-Wformat=2 -Wno-format-truncation -Wno-format-nonliteral' --buildtype release build-native-gcc-x86
+        ninja -C build-native-gcc-x86
 
     - name: Build Native GCC x64
       id: build-native-gcc-x64
-      uses: WinterSnowfall/arch-mingw-github-action@v2
-      with:
-        command: |
-          export CC="gcc"
-          export CXX="g++"
-          meson setup -Denable_tests=True -Denable_extras=True -Dc_args='-Wformat=2 -Wno-format-truncation -Wno-format-nonliteral' --buildtype release build-native-gcc-x64
-          ninja -C build-native-gcc-x64
+      run: |
+        export CC="gcc"
+        export CXX="g++"
+        meson setup -Denable_tests=True -Denable_extras=True -Dc_args='-Wformat=2 -Wno-format-truncation -Wno-format-nonliteral' --buildtype release build-native-gcc-x64
+        ninja -C build-native-gcc-x64
 
     - name: Build Native Clang x64
       id: build-native-clang-x64
-      uses: WinterSnowfall/arch-mingw-github-action@v2
-      with:
-        command: |
-          export CC="clang"
-          export CXX="clang++"
-          meson setup -Denable_tests=True -Denable_extras=True --buildtype release build-native-clang-x64
-          ninja -C build-native-clang-x64
+      run: |
+        export CC="clang"
+        export CXX="clang++"
+        meson setup -Denable_tests=True -Denable_extras=True --buildtype release build-native-clang-x64
+        ninja -C build-native-clang-x64

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -13,7 +13,7 @@ jobs:
     
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -12,7 +12,6 @@ jobs:
       run: pacman -Syu --needed --noconfirm git meson mingw-w64-gcc clang glslang wine xcb-util xcb-util-keysyms xcb-util-wm
     
     - name: Checkout code
-      id: checkout-code
       uses: actions/checkout@v7
       with:
         submodules: recursive
@@ -21,19 +20,16 @@ jobs:
       uses: misyltoad/gcc-problem-matcher@v3
       
     - name: Build MinGW x86
-      id: build-mingw-x86
       run: |
         meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win32.txt --buildtype release build-mingw-x86
         ninja -C build-mingw-x86
 
     - name: Build MinGW x64
-      id: build-mingw-x64
       run: |
         meson setup -Denable_tests=True -Denable_extras=True --cross-file=build-win64.txt --buildtype release build-mingw-x64
         ninja -C build-mingw-x64
 
     - name: Build Native GCC x86
-      id: build-native-gcc-x86
       run: |
         export CC="gcc -m32"
         export CXX="g++ -m32"
@@ -42,7 +38,6 @@ jobs:
         ninja -C build-native-gcc-x86
 
     - name: Build Native GCC x64
-      id: build-native-gcc-x64
       run: |
         export CC="gcc"
         export CXX="g++"
@@ -50,7 +45,6 @@ jobs:
         ninja -C build-native-gcc-x64
 
     - name: Build Native Clang x64
-      id: build-native-clang-x64
       run: |
         export CC="clang"
         export CXX="clang++"

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -8,7 +8,6 @@ jobs:
 
     steps:
     - name: Checkout code
-      id: checkout-code
       uses: actions/checkout@v7
       with:
         submodules: recursive

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 


### PR DESCRIPTION
1. Use the Arch multilib/base-devel containers directly and just install the few missing dependencies needed to build. (The reason for using multilib-devel instead of base-devel in the Linux test builds is that it comes with `lib32-gcc-libs` preinstalled.)
This saves a slight bit of CI time and makes us not dependent on a outside action having to update when some package needs to be added or removed. 
This is using the daily updated container https://gitlab.archlinux.org/archlinux/archlinux-docker

2. Update Github actions (rids some node 20 deprecation warnings)

3. Remove unnecessary step IDs. Nothing in the current workflows depend on them.