### PR TITLE
Attribute queue submits to the right VK_NV_low_latency2 frame ID.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -23582,6 +23582,52 @@ out:
     return ret;
 }
 
+/* Returns the low-latency frame id to attribute submissions on this queue to. */
+static uint64_t d3d12_command_queue_latency_frame_id(struct d3d12_command_queue *command_queue)
+{
+    struct vkd3d_device_frame_markers *markers;
+    UINT64 best, id;
+    unsigned int i;
+
+    if (command_queue->out_of_band_queue_type == VK_OUT_OF_BAND_QUEUE_TYPE_RENDER_NV)
+    {
+        return vkd3d_atomic_uint64_load_explicit(
+                &command_queue->device->frame_markers.out_of_band_render, vkd3d_memory_order_acquire);
+    }
+    if (command_queue->out_of_band_queue_type == VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV)
+    {
+        return 0;
+    }
+
+    markers = &command_queue->device->frame_markers;
+    spinlock_acquire(&command_queue->device->low_latency_swapchain_spinlock);
+    if (markers->new_frame)
+    {
+        /* This is the first submit in a new frame. The application chooses
+         * the ID of the new frame, and we unfortunately do not know what ID
+         * they will choose next at the PRESENT_END delimiter.
+         *
+         * We'll choose the frame ID of the next SIMULATION_START marker
+         * with an ID greater than the last PRESENT_END marker's ID (which
+         * triggered the new_frame).
+         *
+         * If unknown, we fallback to incrementing the ID by 1, which matches
+         * the behaviour of most applications. */
+        best = 0;
+        for (i = 0; i < VKD3D_RECENT_SIM_STARTS_COUNT; ++i)
+        {
+            id = markers->recent_sim_starts[i];
+            if (id > markers->present_end && (best == 0 || id < best))
+                best = id;
+        }
+        markers->submission = best ? best : markers->present_end + 1;
+        markers->new_frame = false;
+    }
+    id = markers->submission;
+    spinlock_release(&command_queue->device->low_latency_swapchain_spinlock);
+    return id;
+}
+
 VKD3D_METHODENTRY(void) d3d12_command_queue_ExecuteCommandLists(ID3D12CommandQueue *iface,
         UINT command_list_count, ID3D12CommandList * const *command_lists)
 {
@@ -23981,7 +24027,7 @@ VKD3D_METHODENTRY(void) d3d12_command_queue_ExecuteCommandLists(ID3D12CommandQue
     sub.execute.num_command_allocators = command_list_count;
     for (i = 0; i < command_list_count; i++)
         d3d12_command_allocator_inc_ref(allocators[i]);
-    sub.execute.low_latency_frame_id = command_queue->device->frame_markers.render;
+    sub.execute.low_latency_frame_id = d3d12_command_queue_latency_frame_id(command_queue);
 #ifdef VKD3D_ENABLE_BREADCRUMBS
     sub.execute.breadcrumb_indices = breadcrumb_indices;
     sub.execute.breadcrumb_indices_count = breadcrumb_indices ? command_list_count : 0;
@@ -25203,7 +25249,6 @@ static void d3d12_command_queue_execute(struct d3d12_command_queue *command_queu
     VkSubmitInfo2 submit_desc[2], *submit;
     bool need_fallback_wait_semaphore;
     VKD3D_UNUSED bool debug_capture;
-    uint64_t consumed_present_id;
     bool serialize_transition;
     uint32_t num_submits;
     VkFence proxy_fence;
@@ -25384,15 +25429,9 @@ static void d3d12_command_queue_execute(struct d3d12_command_queue *command_queu
             spinlock_acquire(&command_queue->device->low_latency_swapchain_spinlock);
             if ((low_latency_swapchain = command_queue->device->swapchain_info.low_latency_swapchain))
                 dxgi_vk_swap_chain_incref(low_latency_swapchain);
-            consumed_present_id = command_queue->device->frame_markers.consumed_present_id;
             spinlock_release(&command_queue->device->low_latency_swapchain_spinlock);
 
-            /* If we have submitted a swapchain blit to Vulkan,
-             * it is not possible for a present ID to keep contributing to the frame's completion.
-             * The likely case here is that application just forgot to signal present ID.
-             * Don't bother trying to mark submission present ID if application isn't bothering to set markers properly. */
-            if (low_latency_swapchain && exec->low_latency_frame_id > consumed_present_id &&
-                    dxgi_vk_swap_chain_low_latency_enabled(low_latency_swapchain))
+            if (low_latency_swapchain && exec->low_latency_frame_id)
             {
                 latency_submit_present_info.sType = VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV;
                 latency_submit_present_info.pNext = NULL;
@@ -26259,6 +26298,7 @@ static HRESULT d3d12_command_queue_init(struct d3d12_command_queue *queue,
         queue->desc.NodeMask = 0x1;
 
     queue->vkd3d_queue = d3d12_device_allocate_vkd3d_queue(family_info, queue);
+    queue->out_of_band_queue_type = VK_OUT_OF_BAND_QUEUE_TYPE_MAX_ENUM_NV;
     queue->submissions = NULL;
     queue->submissions_count = 0;
     queue->submissions_size = 0;
@@ -26448,7 +26488,7 @@ void vkd3d_enqueue_initial_transition(ID3D12CommandQueue *queue, ID3D12Resource 
 
     memset(&sub, 0, sizeof(sub));
     sub.type = VKD3D_SUBMISSION_EXECUTE;
-    sub.execute.low_latency_frame_id = d3d12_queue->device->frame_markers.render;
+    sub.execute.low_latency_frame_id = d3d12_command_queue_latency_frame_id(d3d12_queue);
     sub.execute.transition_count = 1;
     sub.execute.transitions = vkd3d_malloc(sizeof(*sub.execute.transitions));
     sub.execute.transitions[0].type = VKD3D_INITIAL_TRANSITION_TYPE_RESOURCE;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -23590,14 +23590,11 @@ static uint64_t d3d12_command_queue_latency_frame_id(struct d3d12_command_queue 
     unsigned int i;
 
     if (command_queue->out_of_band_queue_type == VK_OUT_OF_BAND_QUEUE_TYPE_RENDER_NV)
-    {
         return vkd3d_atomic_uint64_load_explicit(
                 &command_queue->device->frame_markers.out_of_band_render, vkd3d_memory_order_acquire);
-    }
+
     if (command_queue->out_of_band_queue_type == VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV)
-    {
         return 0;
-    }
 
     markers = &command_queue->device->frame_markers;
     spinlock_acquire(&command_queue->device->low_latency_swapchain_spinlock);
@@ -23607,9 +23604,14 @@ static uint64_t d3d12_command_queue_latency_frame_id(struct d3d12_command_queue 
          * the ID of the new frame, and we unfortunately do not know what ID
          * they will choose next at the PRESENT_END delimiter.
          *
-         * We'll choose the frame ID of the next SIMULATION_START marker
-         * with an ID greater than the last PRESENT_END marker's ID (which
-         * triggered the new_frame).
+         * We will look at SIMULATION_START marker IDs to make this decision, as
+         * they are expected to be sent at the beginning of each frame ahead of any
+         * rendering. We'll track a ringbuffer of the most recent SIMULATION_START
+         * IDs to handle edge cases such as frame N+1's simulation beginning before
+         * frame N's first submission.
+         *
+         * We'll choose the smallest SIMULATION_START marker ID greater than the
+         * previous PRESENT_END marker's ID.
          *
          * If unknown, we fallback to incrementing the ID by 1, which matches
          * the behaviour of most applications. */

--- a/libs/vkd3d/command_queue_vkd3d_ext.c
+++ b/libs/vkd3d/command_queue_vkd3d_ext.c
@@ -96,6 +96,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_command_queue_vkd3d_ext_NotifyOutOfBandCo
 
             vkd3d_set_queue_out_of_band(command_queue->device, out_of_band_queue, vk_queue_type);
             command_queue->vkd3d_queue = out_of_band_queue;
+            command_queue->out_of_band_queue_type = vk_queue_type;
             break;
         }
     }

--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -1274,7 +1274,6 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_l
     struct dxgi_vk_swap_chain *low_latency_swapchain;
     VkLatencyMarkerNV vk_marker;
     struct d3d12_device *device;
-    uint64_t internal_frame_id;
 
     device = d3d12_device_from_ID3DLowLatencyDevice(iface);
     vk_marker = (VkLatencyMarkerNV)markerType;
@@ -1288,30 +1287,35 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_l
         return S_OK;
     }
 
-    /* Skip ahead. If application does not set frame counter, we'll still internally increment over time to fill in the gap.
-     * If application starts to use the frame IDs appropriately again, we'll catch up almost instantly,
-     * where low_latency_frame_id should overtake internal present ID counter.
-     * Frame marker needs to be device level monotonic. */
-    internal_frame_id = frameID;
-
     switch (vk_marker)
     {
-        case VK_LATENCY_MARKER_RENDERSUBMIT_START_NV:
-            if (internal_frame_id < device->frame_markers.render)
-            {
-                WARN("RENDERSUBMIT_START_NV is non-monotonic %"PRIu64" < %"PRIu64".\n",
-                        internal_frame_id, device->frame_markers.render);
-            }
-            device->frame_markers.render = internal_frame_id;
+        case VK_LATENCY_MARKER_SIMULATION_START_NV:
+        {
+            struct vkd3d_device_frame_markers *markers = &device->frame_markers;
+            spinlock_acquire(&device->low_latency_swapchain_spinlock);
+            markers->recent_sim_starts[markers->recent_sim_starts_index] = frameID;
+            markers->recent_sim_starts_index = (markers->recent_sim_starts_index + 1) % VKD3D_RECENT_SIM_STARTS_COUNT;
+            spinlock_release(&device->low_latency_swapchain_spinlock);
+            break;
+        }
+        case VK_LATENCY_MARKER_PRESENT_END_NV:
+            spinlock_acquire(&device->low_latency_swapchain_spinlock);
+            device->frame_markers.present_end = frameID;
+            device->frame_markers.new_frame = true;
+            spinlock_release(&device->low_latency_swapchain_spinlock);
             break;
         case VK_LATENCY_MARKER_PRESENT_START_NV:
-            if (internal_frame_id < device->frame_markers.present)
+            if (frameID < device->frame_markers.present)
             {
                 WARN("PRESENT_START_NV is non-monotonic %"PRIu64" < %"PRIu64".\n",
-                        internal_frame_id, device->frame_markers.present);
+                        frameID, device->frame_markers.present);
             }
             vkd3d_atomic_uint64_store_explicit(
-                    &device->frame_markers.present, internal_frame_id, vkd3d_memory_order_release);
+                    &device->frame_markers.present, frameID, vkd3d_memory_order_release);
+            break;
+        case VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_START_NV:
+            vkd3d_atomic_uint64_store_explicit(
+                    &device->frame_markers.out_of_band_render, frameID, vkd3d_memory_order_release);
             break;
         default:
             break;
@@ -1324,7 +1328,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_l
 
     if (low_latency_swapchain)
     {
-        dxgi_vk_swap_chain_set_latency_marker(low_latency_swapchain, internal_frame_id, vk_marker, true);
+        dxgi_vk_swap_chain_set_latency_marker(low_latency_swapchain, frameID, vk_marker, true);
         dxgi_vk_swap_chain_decref(low_latency_swapchain);
     }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3896,6 +3896,8 @@ struct d3d12_command_queue
     D3D12_COMMAND_QUEUE_DESC desc;
 
     struct vkd3d_queue *vkd3d_queue;
+    /* VK_OUT_OF_BAND_QUEUE_TYPE_MAX_ENUM_NV indicates this is not an out-of-band queue. */
+    VkOutOfBandQueueTypeNV out_of_band_queue_type;
 
     struct d3d12_device *device;
 
@@ -5494,10 +5496,17 @@ struct vkd3d_device_swapchain_info
     };
 };
 
+#define VKD3D_RECENT_SIM_STARTS_COUNT 8
+
 struct vkd3d_device_frame_markers
 {
-    UINT64 render;
     UINT64 present;
+    UINT64 submission; /* ID we'll assign to incoming DX work submissions */
+    UINT64 present_end;
+    UINT64 recent_sim_starts[VKD3D_RECENT_SIM_STARTS_COUNT];
+    uint32_t recent_sim_starts_index;
+    bool new_frame;
+    UINT64 out_of_band_render;
     UINT64 out_of_band_present;
     UINT64 consumed_present_id;
 };


### PR DESCRIPTION
This change tweaks the frame ID passed in VkLatencySubmissionPresentIdNV to match the frame-attribution rules added in VK_NV_low_latency2 revision 3.

NVIDIA's DirectX driver follows the implicit attribution scheme described in the spec. Vkd3d-proton violates the implicit attribution scheme by deferring its submissions onto background threads. Instead, vkd3d-proton will compute each submission's frame ID during the app's foreground thread calls, and then pass that explicit ID to the corresponding background thread submission.

Workloads are now delimited by PRESENT_END rather than by the RENDERSUBMIT_START marker.

OUT_OF_BAND_RENDER queues are delimited by OUT_OF_BAND_RENDERSUBMIT_START markers.

### Testing:

This has been confirmed to improve latency/stutter with DLSS-FG and NVIDIA Smooth Motion in many games when combined with a driver advertising VK_NV_low_latency2 revision 3. Including:
 - Cyberpunk 2077
 - Dying Light 2: Reloaded Edition
 - The Last of Us Part II
 - Marvel Rivals