### PR TITLE
Add wave32 workarounds for Dragon's Dogma 2 and Onimusha: Way of the Sword

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1244,6 +1244,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "MONSTER_HUNTER_STORIES_3_TWISTED_REFLECTION.exe", &re_engine_quirks },
     /* Onimusha: Way of the Sword DEMO (3974650) */
     { VKD3D_STRING_COMPARE_EXACT, "OnimushaWotS_Demo.exe", &re_engine_quirks },
+    /* Dragon's Dogma 2 (2054970) */
+    { VKD3D_STRING_COMPARE_EXACT, "DD2.exe", &re_engine_quirks },
     /* Unreal Engine 4 */
     { VKD3D_STRING_COMPARE_ENDS_WITH, "-Shipping.exe", &ue4_quirks },
     { VKD3D_STRING_COMPARE_NEVER, NULL, NULL },

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1244,6 +1244,8 @@ static const struct vkd3d_shader_quirk_meta application_shader_quirks[] = {
     { VKD3D_STRING_COMPARE_EXACT, "MONSTER_HUNTER_STORIES_3_TWISTED_REFLECTION.exe", &re_engine_quirks },
     /* Onimusha: Way of the Sword DEMO (3974650) */
     { VKD3D_STRING_COMPARE_EXACT, "OnimushaWotS_Demo.exe", &re_engine_quirks },
+    /* Onimusha: Way of the Sword (2638890) */
+    { VKD3D_STRING_COMPARE_EXACT, "OnimushaWotS.exe", &re_engine_quirks },
     /* Dragon's Dogma 2 (2054970) */
     { VKD3D_STRING_COMPARE_EXACT, "DD2.exe", &re_engine_quirks },
     /* Unreal Engine 4 */


### PR DESCRIPTION
Tested with simulated wave64 on RDNA2 like the previous RE engine fixes. Turns out the issue also affects older games like DD2. Also added the Onimusha fix for the full game now that it's out.