### PR TITLE
Allow FP8 shader metadata when FP8 is emulated.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -11868,8 +11868,12 @@ bool d3d12_device_validate_shader_meta(struct d3d12_device *device, const struct
     {
         if (!device->device_info.shader_float8_features.shaderFloat8CooperativeMatrix)
         {
+            #ifdef VKD3D_ENABLE_EXTENDED_EMULATION
+            WARN("Missing sufficient features to expose WMMA FP8 natively, proceeding with emulation workaround.\n");
+            #else
             ERR("Missing sufficient features to expose WMMA FP8.\n");
             return false;
+            #endif
         }
     }
 


### PR DESCRIPTION
VKD3D_SHADER_META_FLAG_USES_COOPERATIVE_MATRIX_FP8 currently causes PSO validation to fail when the Vulkan device does not expose native FP8 cooperative-matrix support.

This prevents the DXIL-SPIR-V RDNA 3 FP8 workaround from being used, since the shader is rejected before DXIL translation can apply the fallback.

Allow shaders using the FP8 metadata path to proceed when the corresponding FP8 operations can be lowered/emulated by the shader compiler, rather than requiring native Vulkan FP8 cooperative-matrix support at PSO validation time.

This is needed to make the existing RDNA 3 FP8 workaround usable for shaders which use FP8 scalar conversions in addition to FP8 matrix operations.

Tested with the FidelityFX Ray Regeneration workload on RDNA 3 / RADV.