### PR TITLE
Do not rewind a shared fence's timeline semaphore

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2149,9 +2149,44 @@ static HRESULT STDMETHODCALLTYPE d3d12_shared_fence_Signal(d3d12_fence_iface *if
     struct d3d12_shared_fence *fence = shared_impl_from_ID3D12Fence1(iface);
     const struct vkd3d_vk_device_procs *vk_procs = &fence->device->vk_procs;
     VkSemaphoreSignalInfo signal_info;
+    uint64_t completed_value;
     VkResult vr;
 
     TRACE("iface %p, value %#"PRIx64".\n", iface, value);
+
+    /* ID3D12Fence::Signal sets the fence to a value, and D3D12 is happy for that
+     * value to be lower than the current one - resetting a fence to 0 so it can be
+     * reused is an ordinary idiom, and Gears of War 4 does exactly that on the
+     * fence its video playback shares. A Vulkan timeline semaphore only moves
+     * forwards, and asking one to move backwards is not quietly ignored: on RADV
+     * the DRM syncobj signal fails and the device is marked lost, after which every
+     * call on it returns VK_ERROR_DEVICE_LOST and the title spins in a hot error
+     * loop. d3d12_fence has virtual values it can rewind; a shared fence is the raw
+     * timeline and has nowhere to rewind to, so leave it where it is. */
+    if ((vr = VK_CALL(vkGetSemaphoreCounterValue(fence->device->vk_device,
+            fence->timeline_semaphore, &completed_value))))
+    {
+        ERR("Failed to get shared fence counter value, vr %d.\n", vr);
+        return E_FAIL;
+    }
+
+    if (value <= completed_value)
+    {
+        /* Titles that do this do it thousands of times a second, so say it once. */
+        static bool warned;
+        if (!warned)
+        {
+            warned = true;
+            WARN("Ignoring attempt to rewind shared fence %p from %"PRIu64" to %"PRIu64". "
+                    "Further rewinds are logged at trace level.\n", fence, completed_value, value);
+        }
+        else
+        {
+            TRACE("Ignoring attempt to rewind shared fence %p from %"PRIu64" to %"PRIu64".\n",
+                    fence, completed_value, value);
+        }
+        return S_OK;
+    }
 
     signal_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
     signal_info.pNext = NULL;


### PR DESCRIPTION
### The problem

`ID3D12Fence::Signal` sets a fence to a value, and D3D12 places no ordering
requirement on that value — setting a fence back to 0 so it can be reused is an
ordinary idiom. Gears of War 4 (UWP) does it to the fence behind its Bink video
playback, thousands of times a second once a cutscene starts.

A Vulkan timeline semaphore only moves forwards. `d3d12_fence` absorbs a rewind
because it keeps virtual values of its own, but `d3d12_shared_fence` is the raw
exportable timeline and passes the value straight to `vkSignalSemaphore`.

That is not quietly ignored. On RADV the DRM syncobj signal fails,
`vk_device_set_lost()` fires, and from then on every call on the device returns
`VK_ERROR_DEVICE_LOST`. The title never sees a clean failure — it sits in a hot
loop of failing `Signal`/`GetCompletedValue` at ~64% CPU. In one run that was
185,814 error lines.

The single host signal that does it, from an instrumented build:

```
d3d12_shared_fence_Signal: shared fence ... host Signal(0), current 3.
```

### The fix

Query the counter first and leave the timeline alone when the requested value
would not move it forwards. The fence then reads higher than the title asked
for, which is wrong but harmless next to a dead device, and is the only
behaviour a shared timeline can offer. Warned once, because titles that do this
do it far too often to log every time.

### Reproducing without a game

The test below (standalone, no game needed) creates a `D3D12_FENCE_FLAG_SHARED`
fence, lets a queue signal of 3 retire, then calls `Signal(0)` from the CPU.

Before:

```
rewind: timeline settled at 3
err:vkd3d-proton:d3d12_shared_fence_Signal: Failed to signal shared fence, vr -4.
err:vkd3d-proton:d3d12_shared_fence_GetCompletedValue: ... error -4.
rewind: later queue Signal(4) hr 0 -> completed 0, removed 0
```

After:

```
rewind: timeline settled at 3, removed 0
rewind: CPU Signal(0) hr 0 -> completed 3, removed 0
rewind: later queue Signal(4) hr 0 -> completed 4, removed 0
```

The device survives and later signals still work.

### Known limitation

This does not cover the other way a host signal can be out of order — a value
*above* one already pending on a queue. RADV accepts those today and no title
has been observed to hit it, so I have left that alone rather than guess at the
right behaviour. Happy to extend it if you would rather it were handled here.

### Testing

- AMD Radeon RX 6600 XT, RADV, Mesa 26.2.2, Wine 11.0, DXVK 3.1 for dxgi.
- The four other host/queue signal orderings (plain, below, equal, above) were
  checked for regressions and are unchanged.
- Gears of War 4 gets past its first cutscene to the main menu with this
  applied; without it, it never leaves the cutscene.

<details>
<summary>sharedfence-order.c — the repro</summary>

```c
/* Which shared-fence ordering kills the Vulkan device?
 *
 * A D3D12_FENCE_FLAG_SHARED fence in vkd3d-proton is a raw exportable Vulkan
 * timeline semaphore -- no virtual-value bookkeeping, unlike a plain fence. A
 * Vulkan timeline only ever moves forward, and a host signal must land strictly
 * between the current value and any signal already pending on a queue. D3D12
 * makes no such promise: ID3D12Fence::Signal sets the value, full stop.
 *
 * Each case runs in its own process (one device loss poisons everything after
 * it). Pick one on the command line:
 *   below   queue signal 10 pending, then CPU Signal(5)
 *   above   queue signal 10 pending, then CPU Signal(20)
 *   equal   queue signal 10 pending, then CPU Signal(10)
 *   plain   the "below" case on a non-shared fence, for contrast
 *   rewind  let a queue signal of 3 retire, then CPU Signal(0) -- what Gears of
 *           War 4 does to the fence its video playback shares, and what killed
 *           the Vulkan device before the d3d12_shared_fence_Signal fix
 * Build with:
 *   x86_64-w64-mingw32-gcc -DINITGUID sharedfence-order.c -o ../bin/sharedfence-order.exe -ld3d12 -ldxgi
 */
#define COBJMACROS
#include <windows.h>
#include <d3d12.h>
#include <stdio.h>
#include <string.h>

int main(int argc, char **argv)
{
    const char *mode = argc > 1 ? argv[1] : "below";
    D3D12_COMMAND_QUEUE_DESC queue_desc = {0};
    ID3D12CommandQueue *queue;
    ID3D12Fence *gate, *fence;
    D3D12_FENCE_FLAGS flags;
    ID3D12Device *device;
    UINT64 cpu_value;
    HRESULT hr;

    flags = strcmp(mode, "plain") ? D3D12_FENCE_FLAG_SHARED : D3D12_FENCE_FLAG_NONE;
    cpu_value = !strcmp(mode, "above") ? 20 : !strcmp(mode, "equal") ? 10 : 5;

    hr = D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_11_0, &IID_ID3D12Device, (void **)&device);
    if (FAILED(hr)) { printf("D3D12CreateDevice hr %#lx\n", hr); return 1; }

    queue_desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
    hr = ID3D12Device_CreateCommandQueue(device, &queue_desc, &IID_ID3D12CommandQueue, (void **)&queue);
    if (FAILED(hr)) { printf("CreateCommandQueue hr %#lx\n", hr); return 1; }

    hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&gate);
    if (FAILED(hr)) { printf("CreateFence(gate) hr %#lx\n", hr); return 1; }
    hr = ID3D12Device_CreateFence(device, 0, flags, &IID_ID3D12Fence, (void **)&fence);
    if (FAILED(hr)) { printf("CreateFence(%s) hr %#lx\n", mode, hr); return 1; }

    if (!strcmp(mode, "rewind"))
    {
        UINT64 i;

        for (i = 1; i <= 3; i++)
            ID3D12CommandQueue_Signal(queue, fence, i);
        Sleep(300);
        printf("rewind: timeline settled at %llu, removed %#lx\n",
                (unsigned long long)ID3D12Fence_GetCompletedValue(fence),
                ID3D12Device_GetDeviceRemovedReason(device));

        hr = ID3D12Fence_Signal(fence, 0);
        printf("rewind: CPU Signal(0) hr %#lx -> completed %llu, removed %#lx\n", hr,
                (unsigned long long)ID3D12Fence_GetCompletedValue(fence),
                ID3D12Device_GetDeviceRemovedReason(device));

        /* The device does not die on the rewind itself, it dies for good: everything
         * afterwards returns DEVICE_REMOVED. Prove it with one more ordinary call. */
        hr = ID3D12CommandQueue_Signal(queue, fence, 4);
        Sleep(100);
        printf("rewind: later queue Signal(4) hr %#lx -> completed %llu, removed %#lx\n", hr,
                (unsigned long long)ID3D12Fence_GetCompletedValue(fence),
                ID3D12Device_GetDeviceRemovedReason(device));
        return 0;
    }

    /* Park the queue behind a fence nobody has signalled, so the signal of 10
     * below is submitted but cannot retire. */
    hr = ID3D12CommandQueue_Wait(queue, gate, 1);
    printf("%s: queue Wait(gate,1) hr %#lx\n", mode, hr);
    hr = ID3D12CommandQueue_Signal(queue, fence, 10);
    printf("%s: queue Signal(fence,10) hr %#lx\n", mode, hr);
    Sleep(300);
    printf("%s: completed value while pending %llu, removed %#lx\n", mode,
            (unsigned long long)ID3D12Fence_GetCompletedValue(fence),
            ID3D12Device_GetDeviceRemovedReason(device));

    hr = ID3D12Fence_Signal(fence, cpu_value);
    printf("%s: CPU Signal(%llu) hr %#lx -> completed %llu, removed %#lx\n", mode,
            (unsigned long long)cpu_value, hr,
            (unsigned long long)ID3D12Fence_GetCompletedValue(fence),
            ID3D12Device_GetDeviceRemovedReason(device));

    ID3D12Fence_Signal(gate, 1);
    Sleep(300);
    printf("%s: after release completed %llu, removed %#lx\n", mode,
            (unsigned long long)ID3D12Fence_GetCompletedValue(fence),
            ID3D12Device_GetDeviceRemovedReason(device));
    return 0;
}
```

</details>
