### PR TITLE
Compute copy fixes

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -91,6 +91,8 @@ static void d3d12_command_list_clear_rtas_batch(struct d3d12_command_list *list)
 
 static void d3d12_command_list_flush_query_resolves(struct d3d12_command_list *list);
 
+static void d3d12_command_allocator_ensure_compute_fallback(struct d3d12_command_allocator *allocator);
+
 static HRESULT vkd3d_create_binary_semaphore(struct d3d12_device *device, VkSemaphore *vk_semaphore)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
@@ -2468,7 +2470,13 @@ static void d3d12_command_list_begin_new_sequence(struct d3d12_command_list *lis
     VkResult vr;
 
     if (list->cmd.iteration_count >= VKD3D_MAX_COMMAND_LIST_SEQUENCES)
+    {
+        assert(!fallback);
         return;
+    }
+
+    if (fallback)
+        d3d12_command_allocator_ensure_compute_fallback(list->allocator);
 
     /* Any renderpass we start will be in second command buffer. */
     list->cmd.suspend_resume.block_resume = true;
@@ -2559,6 +2567,9 @@ static void d3d12_command_list_consider_new_sequence(struct d3d12_command_list *
 
 static void d3d12_command_list_copy_queue_fallback(struct d3d12_command_list *list)
 {
+    if (list->vk_queue_flags & VK_QUEUE_COMPUTE_BIT)
+        return;
+
     if (!list->cmd.iterations[list->cmd.iteration_count - 1].fallback)
     {
         d3d12_command_list_end_transfer_batch(list, false);
@@ -3289,6 +3300,33 @@ void d3d12_device_unmap_vkd3d_queue(struct vkd3d_queue *queue, struct d3d12_comm
     pthread_mutex_unlock(&queue->command_queue_mutex);
 }
 
+static void d3d12_command_allocator_ensure_compute_fallback(struct d3d12_command_allocator *allocator)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &allocator->device->vk_procs;
+    VkCommandPoolCreateInfo command_pool_info;
+    VkResult vr;
+
+    if (allocator->fallback_pool.vk_command_pool)
+        return;
+
+    assert(!(allocator->primary_pool.vk_queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)));
+
+    /* We may need to fallback to compute copies. Just reuse the internal magic queue. */
+    memset(&command_pool_info, 0, sizeof(command_pool_info));
+    command_pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    command_pool_info.queueFamilyIndex = allocator->device->queue_families[VKD3D_QUEUE_FAMILY_INTERNAL_COMPUTE]->vk_family_index;
+
+    ERR("Fallback queue: %u, %#x.\n", command_pool_info.queueFamilyIndex,
+        allocator->device->queue_families[VKD3D_QUEUE_FAMILY_INTERNAL_COMPUTE]->vk_queue_flags);
+
+    allocator->fallback_pool.vk_queue_flags = allocator->device->queue_families[VKD3D_QUEUE_FAMILY_INTERNAL_COMPUTE]->vk_queue_flags;
+    allocator->fallback_pool.vk_family_index = command_pool_info.queueFamilyIndex;
+
+    if ((vr = VK_CALL(vkCreateCommandPool(allocator->device->vk_device, &command_pool_info, NULL,
+            &allocator->fallback_pool.vk_command_pool))) < 0)
+        ERR("Failed to create fallback command pool, vr %d.\n", vr);
+}
+
 static HRESULT d3d12_command_allocator_init(struct d3d12_command_allocator *allocator,
         struct d3d12_device *device,
         D3D12_COMMAND_LIST_TYPE type,
@@ -3349,32 +3387,6 @@ static HRESULT d3d12_command_allocator_init(struct d3d12_command_allocator *allo
             return hresult_from_vk_result(vr);
         }
     }
-
-    if (type == D3D12_COMMAND_LIST_TYPE_COPY &&
-        (!device->concurrent_transfer_queue ||
-         !device->device_info.depth_aspect_copy_on_transfer ||
-         !device->device_info.stencil_aspect_copy_on_transfer ||
-         allocator->transfer_granularity.width != 1 || /* transfer granularity can be (0, 0, 0) which means full mip only. */
-         allocator->transfer_granularity.height != 1 ||
-         allocator->transfer_granularity.depth != 1) &&
-        (allocator->primary_pool.vk_queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT)) ==
-        VK_QUEUE_TRANSFER_BIT)
-    {
-        /* We may need to fallback to compute copies. Just reuse the internal magic queue. */
-        command_pool_info.queueFamilyIndex = device->queue_families[VKD3D_QUEUE_FAMILY_INTERNAL_COMPUTE]->vk_family_index;
-        allocator->fallback_pool.vk_queue_flags = device->queue_families[VKD3D_QUEUE_FAMILY_INTERNAL_COMPUTE]->vk_queue_flags;
-        allocator->fallback_pool.vk_family_index = command_pool_info.queueFamilyIndex;
-
-        if ((vr = VK_CALL(vkCreateCommandPool(device->vk_device, &command_pool_info, NULL,
-                &allocator->fallback_pool.vk_command_pool))) < 0)
-        {
-            WARN("Failed to create Vulkan command pool, vr %d.\n", vr);
-            vkd3d_private_store_destroy(&allocator->private_store);
-            return hresult_from_vk_result(vr);
-        }
-    }
-
-    /* GRAPHICS/COMPUTE queue must support (1, 1, 1) granularity. */
 
     d3d_destruction_notifier_init(&allocator->destruction_notifier,
             (IUnknown*)&allocator->ID3D12CommandAllocator_iface);

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -11163,12 +11163,16 @@ static void d3d12_command_list_copy_texture_region(struct d3d12_command_list *li
 
         if (info->needs_conversion)
         {
+            struct vkd3d_format_footprint footprint;
             VkDeviceSize scratch_buffer_size;
             VkExtent3D extent;
 
+            /* Assumes that the D3D format has the same block size as the Vulkan format */
+            footprint = vkd3d_format_footprint_for_plane(dst_resource->format,
+                    d3d12_plane_index_from_vk_aspect(region.imageSubresource.aspectMask));
+
             extent = info->copy.buffer_image.imageExtent;
-            scratch_buffer_size = info->dst_format->block_byte_count *
-                extent.width * extent.height * extent.depth;
+            scratch_buffer_size = footprint.block_byte_count * extent.width * extent.height * extent.depth;
 
             if (!d3d12_command_allocator_allocate_scratch_memory(list->allocator,
                     VKD3D_SCRATCH_POOL_KIND_DEVICE_STORAGE, scratch_buffer_size, 16, ~0u, &scratch))


### PR DESCRIPTION
Yay, more oversights, this time exposed by Company of Heroes 3.

- Compute fallback stuff is just created on demand now, this would previously assert because the logic wasn't aware of the D24 special case.
- My DXVK brain missed the fact that `block_byte_count` and `byte_count` are separate things here for some strange reason, so we were actually under-allocating scratch and that would cause GPU hangs.

And yes, this game is actually hammering buffer->D24 copies during intialization somehow. No idea *what* their plan is though, probably just zeroes or something because nobody has complained about issues so far.